### PR TITLE
Don't add 'connect' and 'disconnect' events to history logs

### DIFF
--- a/mtui/target/__init__.py
+++ b/mtui/target/__init__.py
@@ -407,7 +407,6 @@ class Target:
 
             if self.connection.is_active():
                 self.connection.timeout = 15
-                self.add_history(["disconnect"])
                 self.unlock()
         except Exception:
             # ignore if the connection seems to be lost

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -330,7 +330,6 @@ class TestReport(metaclass=ABCMeta):
                 timeout=self.config.connection_timeout,
             )
             target.connect()
-            target.add_history(["connect"])
             new_system = target.get_system()
         except KeyboardInterrupt:
             logger.warning("Connection to {} canceled by user".format(host))


### PR DESCRIPTION
This information isn't interesting and can cause problems when network connection is unstable