### PR TITLE
Add some cosmetics to identify the ReviewRequest ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ only-test:
 checkstyle:
 	black --check ./
 
+.PHONY: tidy-diff
+tidy-diff:
+	black --diff ./
+
 .PHONY: tidy
 tidy:
 	black ./

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from subprocess import CalledProcessError
+import setproctitle
 
 from mtui.args import get_parser
 from mtui.config import Config
@@ -11,6 +12,7 @@ from mtui.systemcheck import detect_system
 
 from .argparse import ArgsParseFailure
 from .colorlog import create_logger
+from .utils import get_short_rrid
 
 
 def main():
@@ -33,7 +35,6 @@ def main():
 
 
 def run_mtui(sys, config, logger, Prompt, Display, args):
-
     if args.debug:
         logger.setLevel(level=logging.DEBUG)
 
@@ -45,6 +46,9 @@ def run_mtui(sys, config, logger, Prompt, Display, args):
 
     prompt = Prompt(config, logger, sys, Display)
     if args.update:
+        short_rrid = get_short_rrid(str(args.update.id))
+        # helps to set window/tab title with reviewid
+        setproctitle.setproctitle("mtui-" + short_rrid)
         if args.update.kind == "kernel":
             config.kernel = True
             config.auto = False

--- a/mtui/parsemetajson.py
+++ b/mtui/parsemetajson.py
@@ -12,6 +12,7 @@ class JSONParser:
 
         results.rrid = RequestReviewID(data.get("rrid"))
         results.packager = data.get("packager")
+        results.srpms = data.get("SRCRPMs")
         results.rating = data.get("rating")
         results.repository = data.get("repository")
         results.category = data.get("category")

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -14,6 +14,7 @@ import mtui.notification as notification
 from . import commands, messages
 from .argparse import ArgsParseFailure
 from .template.nulltestreport import NullTestReport
+from .utils import get_short_rrid
 
 logger = getLogger("mtui.prompt")
 
@@ -221,16 +222,17 @@ class CommandPrompt(cmd.Cmd):
 
     def set_prompt(self, session=None):
         self.session = session
-        session = ":" + str(session) if session else ""
+        session = str(session) + "/" if session else ""
         mode = "mtui"
         if self.config.auto and not self.config.kernel:
             mode += "-auto"
         elif self.config.kernel:
             mode += "-kernel"
-        self.prompt = f"{mode}{session}> "
+        self.prompt = f"{session}{mode}> "
 
     def load_update(self, update, autoconnect):
         tr = update.make_testreport(self.config, autoconnect=autoconnect)
         self.metadata = tr
         self.targets = tr.targets
-        self.set_prompt(None)
+        short_rrid = get_short_rrid(str(update.id))
+        self.set_prompt(short_rrid)

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -85,6 +85,7 @@ class TestReport(metaclass=ABCMeta):
         self.reviewer = ""
         self.repository = None
         self.packages = {}
+        self.srpms = []
 
         self._attrs = [
             "products",
@@ -92,6 +93,7 @@ class TestReport(metaclass=ABCMeta):
             "packager",
             "reviewer",
             "packages",
+            "srpms",
             "bugs",
             "repository",
         ]
@@ -160,7 +162,6 @@ class TestReport(metaclass=ABCMeta):
         self._warn_missing_fields()
 
     def _parse_json(self, data, tpl: str) -> None:
-
         if self.path:
             raise TestReportAlreadyLoaded(self.path)
 
@@ -430,6 +431,14 @@ class TestReport(metaclass=ABCMeta):
     def list_bugs(self, sink, arg):
         return sink(self.bugs, self.jira, arg)
 
+    def _get_result_links(self):
+        incident_id = self.repository.rstrip("/").split("/")[-1]
+        dboard_burl = "http://dashboard.qam.suse.de/incident/"
+        openqa_burl = "https://openqa.suse.de/tests/overview?build=:"
+        dboard_lnk = dboard_burl + incident_id
+        openqa_lnk = openqa_burl + incident_id + ":" + self.srpms[0]
+        return (dboard_lnk, openqa_lnk)
+
     def _show_yourself_data(self):
         return (
             [
@@ -443,6 +452,8 @@ class TestReport(metaclass=ABCMeta):
                 ("Build checks", self._testreport_url()[:-3] + "build_checks"),
                 ("Testreport", self._testreport_url()),
                 ("Repository", self.repository),
+                ("DashBoard Link", self._get_result_links()[0]),
+                ("OpenQA Link", self._get_result_links()[1]),
             ]
             + [("Testplatform", x) for x in self.testplatforms]
             + [("Products", x) for x in self.products]

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -333,3 +333,7 @@ def walk(inc):
             if isinstance(inc[key], (list, dict)):
                 inc[key] = walk(inc[key])
     return inc
+
+
+def get_short_rrid(id_str):
+    return id_str.replace("SUSE", "S").replace("Maintenance", "M")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from mtui.utils import ensure_dir_exists
 from mtui.utils import chdir
 from mtui.utils import atomic_write_file
 from mtui.utils import SUTParse
+from mtui.utils import get_short_rrid
 
 import os
 
@@ -18,7 +19,6 @@ def create_temp(tmpdir_factory):
 
 
 class TestEnsureDirExists(object):
-
     _callback_paths = []
 
     def test_create(self, create_temp):
@@ -83,3 +83,11 @@ def test_atomic_write(create_temp):
 
 def test_sutparse():
     pass
+
+
+def test_get_short_rrid():
+    id = "10010:200200"
+    arb_rrid = "SUSE:Maintenance:" + id
+    short_rrid = get_short_rrid(arb_rrid)
+
+    assert short_rrid == "S:M:" + id


### PR DESCRIPTION
1.  Changes mtui prompt to include the review id.  Ex `S:M:xxxxx:yyyyyy/mtui-auto>`. This requires `python311-settproctitle`.
2.  Sets the process name to include the review id. This helps to identify the window/tab of most of the terminal emulators title.

Would like to get more insights and comments.