### PR TITLE
Replace distutils.version with looseversion module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
             python3-pytest \
             python3-pytest-cov \
             python3-coverage \
+            python3-looseversion \
             black
       - name: Run tests + cov report
         run: python3 -m pytest -v --cov=./mtui --cov-report=xml --cov-report=term

--- a/mtui/__init__.py
+++ b/mtui/__init__.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 __version__ = "13.4.0"
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,14 @@ setup(
     url="http://www.suse.com",
     download_url="http://qam.suse.de/infrastructure/mtui/",
     version=str(loose_version),
-    install_requires=["paramiko", "pyxdg", "ruamel.yaml", "requests", "rpm"],
+    install_requires=[
+        "paramiko",
+        "pyxdg",
+        "ruamel.yaml",
+        "requests",
+        "rpm",
+        "looseversion",
+    ],
     include_package_data=True,
     # dependencies not on cheeseshop:
     # osc (http://en.opensuse.org/openSUSE:OSC)


### PR DESCRIPTION
distutils was droped from stdlib since py3.12 ( deprecated for much longer time)