### PR TITLE
Replace black with ruff and use it also as pylint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,16 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    name: MTUI tests + lint + format
     steps:
       - uses: actions/checkout@v4
+      - uses:  astral-sh/ruff-action@v3
+        with:
+          args: "--version"
+      - name: Check ruff style 
+        run: ruff format --check --diff ./mtui
+      - name: Check ruff lint
+        run: ruff check --diff ./mtui
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -23,11 +31,8 @@ jobs:
             python3-pytest-cov \
             python3-coverage \
             python3-looseversion \
-            black
-      - name: Run tests + cov report
+      - name: Run tests 
         run: python3 -m pytest -v --cov=./mtui --cov-report=xml --cov-report=term
-      - name: Check style
-        run: make checkstyle
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ only-test:
 
 .PHONY: checkstyle
 checkstyle:
-	black --check ./
+	ruff format --check ./
 
 .PHONY: tidy
 tidy:

--- a/mtui/commands/terms.py
+++ b/mtui/commands/terms.py
@@ -16,7 +16,7 @@ class Terms(Command):
     If no termname is given, all available terminal scripts are shown.
     """
 
-    command: str  = "terms"
+    command: str = "terms"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/mtui/commands/terms.py
+++ b/mtui/commands/terms.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 from subprocess import check_call
 from traceback import format_exc
-from typing import Any
 
 from mtui.argparse import ArgumentParser
 from mtui.commands import Command
@@ -17,7 +16,7 @@ class Terms(Command):
     If no termname is given, all available terminal scripts are shown.
     """
 
-    command = "terms"
+    command: str  = "terms"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -335,7 +335,6 @@ class HostsGroup(UserDict):
         }
 
         try:
-
             self.run(commands)
             for t in self.data.values():
                 t.get_updater_check()(

--- a/mtui/xdg.py
+++ b/mtui/xdg.py
@@ -1,4 +1,3 @@
-from os.path import join
 from xdg.BaseDirectory import save_cache_path as x_save_cache_path  # type: ignore
 from pathlib import Path
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,14 @@
+paramiko
+rpm
+pyxdg
+requests
+ruamel.yaml
+osc
+looseversion
+openqa-client
+
+pytest
+pytest-cov
+coverage
+responses
+ruff

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "requests",
         "rpm",
         "looseversion",
+        "openqa-client",
     ],
     include_package_data=True,
     # dependencies not on cheeseshop:


### PR DESCRIPTION
Originally, I wanted to use `actions/setup-python` and test in a matrix on supported Python versions in SUSE distributions ( Python 3.11 and 3.13 ). Unfortunately, MTUI depends on the RPM Python binding, which has only an empty meta package in Pypi and breaks tests.

So as a minimal viable change, I decided to use the `astral-sh/ruff` action which provides ruff nicely and straightforwardly.