### PR TITLE
Store RPMVersion in Package instead of strings

### DIFF
--- a/mtui/commands/downgrade.py
+++ b/mtui/commands/downgrade.py
@@ -48,9 +48,10 @@ class Downgrade(Command):
                     target.packages[package].before = target.packages[package].after
                     target.packages[package].after = target.packages[package].current
                     if (
-                        target.packages[package].before
+                        target.packages[package].after is not None
+                        and target.packages[package].before is not None
+                        and target.packages[package].before
                         == target.packages[package].after
-                        and target.packages[package].after is not None
                     ):
                         message = "downgrade not completed"
                         break

--- a/mtui/commands/listpackages.py
+++ b/mtui/commands/listpackages.py
@@ -1,10 +1,12 @@
-from mtui.argparse import ArgumentParser
-from . import Command
+from typing import final
+
 from .. import messages
-from ..types import RPMVersion
+from ..argparse import ArgumentParser
 from ..utils import blue, complete_choices, green, red, requires_update, yellow
+from . import Command
 
 
+@final
 class ListPackages(Command):
     command = "list_packages"
 
@@ -63,19 +65,18 @@ class ListPackages(Command):
             raise messages.MissingPackagesError()
 
         for target, pvs in hosts.query_versions(pkgs):
-            self.println(
-                "packages on {0} ({1}):".format(target.hostname, target.system)
-            )
+            self.println(f"packages on {target.hostname} ({target.system}):")
             column_size = [30, 20]
             host_output = []
             for p, v in list(pvs.items()):
                 if self.metadata:
                     try:
-                        wanted = target.packages[p].required
+                        # if package p is in target.packages it alwas has set required --> from metadata
+                        wanted = target.packages[p].required  # type: ignore
                     except KeyError:
                         state = None
                     else:
-                        state = self._vers2state(v, RPMVersion(wanted))
+                        state = self._vers2state(v, wanted)
                 else:
                     state = "" if v else self.state_map[None]
 

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -4,7 +4,7 @@ import os.path
 from pathlib import Path
 import re
 
-from ..types import FileList, RPMVersion
+from ..types import FileList
 from .base import BaseExport
 
 logger = getLogger("mtui.export.manual")
@@ -191,9 +191,7 @@ class ManualExport(BaseExport):
                     versions["after"][package] is not None
                     and versions["before"][package] is not None
                 ):
-                    if not RPMVersion(versions["before"][package]) < RPMVersion(
-                        versions["after"][package]
-                    ):
+                    if not versions["before"][package] < versions["after"][package]:
                         failed = True
             if failed:
                 logger.warning(

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -12,9 +12,8 @@ class UserMessage(BaseException, ABC):
     def __eq__(self, x: object) -> bool:
         return str(self) == str(x)
 
-    @classmethod
-    def __hash__(cls) -> int:  # type: ignore
-        return hash(cls)
+    def __hash__(self) -> int:  # type: ignore
+        return hash(self)
 
 
 class ErrorMessage(UserMessage, RuntimeError):

--- a/mtui/parsemeta.py
+++ b/mtui/parsemeta.py
@@ -1,8 +1,10 @@
 import re
+from typing import final
 
 from .types import RequestReviewID
 
 
+@final
 class ReducedMetadataParser:
     hostnames = re.compile(r".* \(reference host: (\S+).*\)")
     jira = re.compile(r'Jira ([A-Z]+-\d+) \("(.*)"\):')
@@ -23,6 +25,7 @@ class ReducedMetadataParser:
             results.bugs[match.group(1)] = match.group(2)
 
 
+@final
 class MetadataParser:
     products = re.compile(r"Products: (.+)")
     category = re.compile(r"Category: (.+)")

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -3,14 +3,14 @@
 #
 import copy
 import errno
-from logging import getLogger
 import os
-from pathlib import Path
 import re
 import time
+from logging import getLogger
+from pathlib import Path
 from traceback import format_exc
+from typing import final
 from urllib.request import urlopen
-from typing import Type
 
 from ruamel.yaml import YAML
 
@@ -21,6 +21,7 @@ from .xdg import save_cache_path
 logger = getLogger("mtui.refhost")
 
 
+@final
 class Attributes:
     """
     Host attributes.
@@ -362,7 +363,7 @@ class _RefhostsFactory:
         urlopener,
         file_writer,
         cache_path,
-        refhosts_factory: Type[Refhosts] = Refhosts,
+        refhosts_factory: type[Refhosts] = Refhosts,
     ) -> None:
         self._time_now = time_now_getter
         self._stat = statter

--- a/mtui/types/package.py
+++ b/mtui/types/package.py
@@ -1,3 +1,9 @@
+from typing import final
+
+from .rpmver import RPMVersion
+
+
+@final
 class Package:
     __slots__ = [
         "name",
@@ -8,40 +14,61 @@ class Package:
     ]
 
     def __init__(self, name: str) -> None:
-        self.name = name
-        self._before: str | None = None
-        self._after: str | None = None
-        self._required: str | None = None
-        self._current: str | None = None
+        self.name: str = name
+        self._before: RPMVersion | None = None
+        self._after: RPMVersion | None = None
+        self._required: RPMVersion | None = None
+        self._current: RPMVersion | None = None
 
     @property
-    def before(self) -> str | None:
+    def before(self) -> RPMVersion | None:
         return self._before
 
     @before.setter
-    def before(self, ver: str | None) -> None:
-        self._before = ver
+    def before(self, ver: str | RPMVersion | None) -> None:
+        if isinstance(ver, str):
+            self._before = RPMVersion(ver)
+        elif isinstance(ver, RPMVersion):
+            self._before = ver
 
     @property
-    def after(self) -> str | None:
+    def after(self) -> RPMVersion | None:
         return self._after
 
     @after.setter
-    def after(self, ver: str | None) -> None:
-        self._after = ver
+    def after(self, ver: str | RPMVersion | None) -> None:
+        if isinstance(ver, str):
+            self._after = RPMVersion(ver)
+        elif isinstance(ver, RPMVersion):
+            self._after = ver
 
     @property
-    def required(self) -> str | None:
+    def required(self) -> RPMVersion | None:
         return self._required
 
     @required.setter
-    def required(self, ver: str | None) -> None:
-        self._required = ver
+    def required(self, ver: str | RPMVersion | None) -> None:
+        if isinstance(ver, str):
+            self._required = RPMVersion(ver)
+        elif isinstance(ver, RPMVersion):
+            self._required = ver
 
     @property
-    def current(self) -> str | None:
+    def current(self) -> RPMVersion | None:
         return self._current
 
     @current.setter
-    def current(self, ver: str | None) -> None:
-        self._current = ver
+    def current(self, ver: str | RPMVersion | None) -> None:
+        if isinstance(ver, str):
+            self._current = RPMVersion(ver)
+        elif isinstance(ver, RPMVersion):
+            self._current = ver
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return f"<Package: {self.name}>"
+
+    def __hash__(self) -> int:
+        return hash(self.name)

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -1,8 +1,11 @@
 """Quering and comparing tags of RPM file names"""
 
+from typing import final
+
 import rpm  # type: ignore
 
 
+@final
 class RPMVersion:
     """RPMVersion holds an rpm version-release string
 
@@ -38,35 +41,35 @@ class RPMVersion:
             self.ver = ver
             self.rel = "0"
 
-    def __lt__(self, other) -> bool:
+    def __lt__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel)) < 0
         )
 
-    def __gt__(self, other) -> bool:
+    def __gt__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel)) > 0
         )
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             == 0
         )
 
-    def __le__(self, other) -> bool:
+    def __le__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             <= 0
         )
 
-    def __ge__(self, other) -> bool:
+    def __ge__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             >= 0
         )
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: "RPMVersion") -> bool:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             != 0
@@ -77,3 +80,6 @@ class RPMVersion:
         if self.rel != "0":
             s += "-" + str(self.rel)
         return s
+
+    def __repr__(self) -> str:
+        return f"<RPMVersion: {self}>"


### PR DESCRIPTION
This allows us to compare `pkg.before < pkg.after` instead of `RPMVersion(pkg.before) < RPMVersion(pkg.after)`