### PR TITLE
Add config and cmdline option for GITEA_TOKEN

### DIFF
--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -339,6 +339,18 @@ Prefix to the ``Testreport`` field value in ``list_metadata``
 command output.
 
 
+``gitea.token``
+~~~~~~~~~~~~~~~
+
+  | **type**
+  |     string
+  | **default**
+  |     `os.getenv('GITEA_TOKEN','')`__
+
+Gitea API access token, this config has higher prio than environment
+variable. Token must have full access to the issue API.
+
+
 Example
 =======
 
@@ -360,3 +372,6 @@ Example
 
   [openqa]
   openqa = https://openqa.suse.de
+
+  [gitea]
+  token = s3cr3t_token

--- a/Documentation/cli.rst
+++ b/Documentation/cli.rst
@@ -124,3 +124,12 @@ Prints MTUI version and exits.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Overrides the ``mtui.connection_timeout`` configuration.
+
+
+``-g string,  --gitea_token string``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Overrides the ``gitea.token`` configuration.
+
+``GITEA_TOKEN`` is secret token for gitea api access.
+Token must have full access to issue api.

--- a/mtui/args.py
+++ b/mtui/args.py
@@ -61,6 +61,7 @@ def get_parser(sys) -> ArgumentParser:
         "-c", "--config", type=Path, default=None, help="Override default config path"
     )
     parser.add_argument("--smelt_api", type=str, help="SMELT graphQL API endpoint")
+    parser.add_argument("-g", "--gitea_token", type=str, help="Gitea Access Token")
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "-a",

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -197,6 +197,7 @@ class Config:
             # process location last as that needs to access
             # RefhostsFactory which need access to parts of config.
             ("location", ("mtui", "location"), "default"),
+            ("gitea_token", ("gitea", "token"), getenv("GITEA_TOKEN", "")),
         ]
 
         def add_normalizer(x):
@@ -271,3 +272,6 @@ class Config:
 
         if args.smelt_api:
             self.smelt_api = args.smelt_api
+
+        if args.gitea_token:
+            self.gitea_token = args.gitea_token


### PR DESCRIPTION
This is prerequisite for Assign/Approve/Reject operations in Gitea based workflows