### PR TITLE
fix: exclude data files from being treated as Python packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 keyring = ["keyring"]
 norpm = ["version_utils"]
+notify = ["notify"]
 
 [dependency-groups]
 dev = [
@@ -50,11 +51,21 @@ mtui = "mtui.main:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["mtui*"]
 exclude = [
     "*.tests",
     "*.tests.*", 
     "tests.*",
     "tests"
+]
+
+[tool.setuptools.package-data]
+mtui = [
+    "terms/*",
+    "scripts/*",
+    "helper/*",
+    "Documentation/*",
+    "*.rst",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Why this change was needed:
The terms/, scripts/, helper/, and Documentation/ directories were being included as Python packages (treated as modules), which is incorrect. These are data/resources that should
only be included via package-data.
The notify dependency was also missing.

What changed:
- Added include = ["mtui*"] to explicitly limit package discovery to mtui
- Added tool.setuptools.package-data to include data files without treating the directories as packages
- Added notify as optional dependency

Problem solved:
Data files are now correctly included as resources, not as Python packages.