### PR TITLE
chore(lint): enable comprehensive ruff lint rules across 4 phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
         run: ruff format --check --diff ./mtui
       - name: Check ruff lint
         run: ruff check --diff ./mtui
+  typecheck:
+    runs-on: ubuntu-latest
+    name: MTUI typecheck
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Run ty check
+        run: uv run ty check
   test:
     runs-on: ubuntu-latest
     name: MTUI tests + coverage

--- a/mtui/actions/downgrade.py
+++ b/mtui/actions/downgrade.py
@@ -11,6 +11,7 @@ def zypper() -> dict[str, Template]:
 
     Returns:
         A dictionary of command templates.
+
     """
     list_command_template = r"""
 for p in $packages; do \
@@ -35,6 +36,7 @@ def slmicro() -> dict[str, Template]:
 
     Returns:
         A dictionary of command templates.
+
     """
     list_command_template = r"""
 for p in $packages; do \

--- a/mtui/actions/prepare.py
+++ b/mtui/actions/prepare.py
@@ -15,6 +15,7 @@ def zypper_prepare(force: bool = False, testing: bool = False) -> dict[str, Temp
 
     Returns:
         A dictionary of command templates.
+
     """
     parameter = "--force-resolution" if force else ""
 
@@ -35,6 +36,7 @@ def yum_prepare(force: bool = False, testing: bool = False) -> dict[str, Templat
 
     Returns:
         A dictionary of command templates.
+
     """
     # TODO: check adding repos to RH based distros and check how really it looks
     # also if needed expand detection and look into dnf packager
@@ -56,6 +58,7 @@ def slm_prepare(force: bool = False, testing: bool = False) -> dict[str, Templat
 
     Returns:
         A dictionary of command templates.
+
     """
     parameter = "--force-resolution" if force else ""
     return {

--- a/mtui/argparse.py
+++ b/mtui/argparse.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 
-class ArgsParseFailure(RuntimeError):
+class ArgsParseFailureError(RuntimeError):
     """Exception raised when argument parsing fails."""
 
     def __init__(self, status: int = 0) -> None:
@@ -54,10 +54,10 @@ class ArgumentParser(argparse.ArgumentParser):
         """
         super().print_usage(self.sys.stdout)
 
-    def exit(self, status: int = 0, message: str | None = None) -> None:  # type: ignore
+    def exit(self, status: int = 0, message: str | None = None) -> None:
         """Overrides the default exit behavior to raise an exception.
 
-        This method raises an `ArgsParseFailure` exception instead of
+        This method raises an `ArgsParseFailureError` exception instead of
         calling `sys.exit`.
 
         Args:
@@ -68,4 +68,4 @@ class ArgumentParser(argparse.ArgumentParser):
         if message:
             self._print_message(message, self.sys.stderr)
 
-        raise ArgsParseFailure(status)
+        raise ArgsParseFailureError(status)

--- a/mtui/argparse.py
+++ b/mtui/argparse.py
@@ -12,6 +12,7 @@ class ArgsParseFailure(RuntimeError):
 
         Args:
             status: The exit status code.
+
         """
         self.status = status
         super().__init__()
@@ -26,6 +27,7 @@ class ArgumentParser(argparse.ArgumentParser):
         Args:
             *a: Arguments to pass to the parent constructor.
             **kw: Keyword arguments to pass to the parent constructor.
+
         """
         self.sys = kw.get("sys_", sys)
         kw.pop("sys_", None)
@@ -37,6 +39,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         Args:
             file: This argument is ignored.
+
         """
         # also takes care of default _HelpAction calling
         # print_help
@@ -47,6 +50,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         Args:
             file: This argument is ignored.
+
         """
         super().print_usage(self.sys.stdout)
 
@@ -59,6 +63,7 @@ class ArgumentParser(argparse.ArgumentParser):
         Args:
             status: The exit status code.
             message: The error message to print.
+
         """
         if message:
             self._print_message(message, self.sys.stderr)

--- a/mtui/argparse.py
+++ b/mtui/argparse.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+from typing import NoReturn
 
 
 class ArgsParseFailureError(RuntimeError):
@@ -54,7 +55,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """
         super().print_usage(self.sys.stdout)
 
-    def exit(self, status: int = 0, message: str | None = None) -> None:
+    def exit(self, status: int = 0, message: str | None = None) -> NoReturn:
         """Overrides the default exit behavior to raise an exception.
 
         This method raises an `ArgsParseFailureError` exception instead of

--- a/mtui/args.py
+++ b/mtui/args.py
@@ -17,6 +17,7 @@ def get_parser(sys) -> ArgumentParser:
 
     Returns:
         A configured `ArgumentParser` instance.
+
     """
     parser = ArgumentParser(sys_=sys)
     parser.add_argument(

--- a/mtui/checks/downgrade.py
+++ b/mtui/checks/downgrade.py
@@ -20,6 +20,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
 
     Raises:
         UpdateError: If an error is found in the output.
+
     """
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(

--- a/mtui/checks/install.py
+++ b/mtui/checks/install.py
@@ -20,10 +20,11 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
 
     Raises:
         UpdateError: If an error is found in the output.
+
     """
     if exitcode in [0, 100, 101, 102, 103, 106]:
         return
-    elif exitcode in (104, 4, 5, 8):
+    if exitcode in (104, 4, 5, 8):
         logger.critical(
             '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
             hostname,
@@ -32,7 +33,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
             stderr,
         )
         raise UpdateError("package not found", hostname)
-    elif (
+    if (
         "A ZYpp transaction is already in progress." in stderr
         or "System management is locked" in stderr
     ):
@@ -44,7 +45,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
             stderr,
         )
         raise UpdateError("update stack locked", hostname)
-    elif "Error:" in stderr:
+    if "Error:" in stderr:
         logger.critical(
             '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
             hostname,
@@ -53,22 +54,21 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
             stderr,
         )
         raise UpdateError("RPM Error", hostname)
-    elif "(c): c" in stdout:
+    if "(c): c" in stdout:
         logger.critical(
             "%s: unresolved dependency problem. please resolve manually:\n%s",
             hostname,
             stdout,
         )
         raise UpdateError("Dependency Error", hostname)
-    else:
-        logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
-            hostname,
-            stdin,
-            stdout,
-            stderr,
-        )
-        raise UpdateError("Unknown Error", hostname)
+    logger.critical(
+        '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+        hostname,
+        stdin,
+        stdout,
+        stderr,
+    )
+    raise UpdateError("Unknown Error", hostname)
 
 
 #: A dictionary that maps system configurations to install check functions.

--- a/mtui/checks/prepare.py
+++ b/mtui/checks/prepare.py
@@ -49,7 +49,11 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("Dependency Error", hostname)
     if "Error:" in stderr:
         logger.critical(
-            f'{hostname!s}: command "{stdin!s}" failed:\nstdin:\n{stdout!s}\nstderr:\n{stderr!s}'
+            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            hostname,
+            stdin,
+            stdout,
+            stderr,
         )
         raise UpdateError("RPM Error", hostname)
 

--- a/mtui/checks/prepare.py
+++ b/mtui/checks/prepare.py
@@ -20,6 +20,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
 
     Raises:
         UpdateError: If an error is found in the output.
+
     """
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(

--- a/mtui/checks/update.py
+++ b/mtui/checks/update.py
@@ -21,6 +21,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
 
     Raises:
         UpdateError: If an error is found in the output.
+
     """
     if "zypper" in stdin and exitcode == 104:
         logger.critical(

--- a/mtui/checks/update.py
+++ b/mtui/checks/update.py
@@ -39,7 +39,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         marker = "Additional rpm output:"
         start = stdout.find(marker) + len(marker)
         end = stdout.find("Retrieving", start)
-        print(stdout[start:end].replace("warning", yellow("warning")))
+        print(stdout[start:end].replace("warning", yellow("warning")))  # noqa: T201
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
             '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
@@ -79,7 +79,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         marker = "The following package is not supported by its vendor:\n"
         start = stdout.find(marker)
         end = stdout.find("\n\n", start)
-        print(stdout[start:end])
+        print(stdout[start:end])  # noqa: T201
 
 
 #: A dictionary that maps system configurations to update check functions.

--- a/mtui/colorlog.py
+++ b/mtui/colorlog.py
@@ -25,6 +25,7 @@ class ColorFormatter(logging.Formatter):
 
         Args:
             msg: The format string to use.
+
         """
         logging.Formatter.__init__(self, msg)
 
@@ -36,6 +37,7 @@ class ColorFormatter(logging.Formatter):
 
         Returns:
             The colorized log level name.
+
         """
         if levelname == "DEBUG":
             caller = inspect.currentframe()
@@ -49,13 +51,12 @@ class ColorFormatter(logging.Formatter):
                 + f" [{module!s}:{function!s}]"
                 + RESET_SEQ
             )
-        else:
-            return (
-                "\033[2K"
-                + COLOR_SEQ.format(30 + COLORS[levelname])
-                + levelname.lower()
-                + RESET_SEQ
-            )
+        return (
+            "\033[2K"
+            + COLOR_SEQ.format(30 + COLORS[levelname])
+            + levelname.lower()
+            + RESET_SEQ
+        )
 
     def format(self, record: logging.LogRecord) -> str:
         """Formats the log record.
@@ -65,6 +66,7 @@ class ColorFormatter(logging.Formatter):
 
         Returns:
             The formatted log record as a string.
+
         """
         record.message = record.getMessage()
         if self._fmt and self._fmt.find("%(levelname)") >= 0:
@@ -82,6 +84,7 @@ def create_logger(name: str, level: str = "INFO") -> logging.Logger:
 
     Returns:
         A configured `logging.Logger` instance.
+
     """
     out = logging.getLogger(name) if name else logging.getLogger()
     out.setLevel(level)

--- a/mtui/commands/__init__.py
+++ b/mtui/commands/__init__.py
@@ -29,7 +29,7 @@ for pth in _rootdir.glob("*.py"):
         logger.debug("loading command module %s", modname)
         module = importlib.import_module("." + modname, "mtui.commands")
     except BaseException:
-        logger.exception("loading command module %s failed", modname)
+        logger.error("loading command module %s failed", modname)
         continue
 
     # register classes

--- a/mtui/commands/__init__.py
+++ b/mtui/commands/__init__.py
@@ -29,7 +29,7 @@ for pth in _rootdir.glob("*.py"):
         logger.debug("loading command module %s", modname)
         module = importlib.import_module("." + modname, "mtui.commands")
     except BaseException:
-        logger.error("loading command module %s failed", modname)
+        logger.exception("loading command module %s failed", modname)
         continue
 
     # register classes

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -174,7 +174,7 @@ class Command(ABC):
                 targets = self.targets.select(enabled=enabled)
         except HostIsNotConnectedError as e:
             if e.host == "all":
-                logger.exception(e)
+                logger.error(e)
                 logger.info("Using all hosts. Warning: option 'all' is deprecated")
 
                 targets = self.targets.select(enabled=enabled)

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -174,7 +174,7 @@ class Command(ABC):
                 targets = self.targets.select(enabled=enabled)
         except HostIsNotConnectedError as e:
             if e.host == "all":
-                logger.error(e)
+                logger.exception(e)
                 logger.info("Using all hosts. Warning: option 'all' is deprecated")
 
                 targets = self.targets.select(enabled=enabled)

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -44,6 +44,7 @@ class Command(ABC):
             config: The application configuration.
             sys: The sys module.
             prompt: The command prompt object.
+
         """
         self.args = args
         self.sys = sys
@@ -63,6 +64,7 @@ class Command(ABC):
 
         Returns:
             A namespace containing the parsed arguments.
+
         """
         arg = [] if args == "" else args.split()
         p = cls.argparser(sys)
@@ -79,6 +81,7 @@ class Command(ABC):
 
         Args:
             parser: The argument parser.
+
         """
 
     @classmethod
@@ -90,6 +93,7 @@ class Command(ABC):
 
         Returns:
             The argument parser for the command.
+
         """
         p = ArgumentParser(
             sys_=sys,
@@ -114,8 +118,8 @@ class Command(ABC):
 
         Returns:
             A list of possible completions.
-        """
 
+        """
         return []
 
     @abstractmethod
@@ -128,8 +132,8 @@ class Command(ABC):
 
         Args:
             xs: The string to print.
-        """
 
+        """
         self.sys.stdout.write(xs + "\n")
         self.sys.stdout.flush()
 
@@ -139,6 +143,7 @@ class Command(ABC):
 
         Args:
             parser: The argument parser.
+
         """
         parser.add_argument(
             "-t",
@@ -160,6 +165,7 @@ class Command(ABC):
 
         Returns:
             A `HostsGroup` object containing the selected hosts.
+
         """
         try:
             if self.args.hosts:

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -110,7 +110,7 @@ class Approve(BaseApiCall):
                 gitea.approve(self.args.user)
 
         except GiteaError as e:
-            logger.error(e)
+            logger.exception(e)
 
 
 @final
@@ -143,7 +143,7 @@ class Assign(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.assign(self.args.user, self.args.force)
         except GiteaError as e:
-            logger.error(e)
+            logger.exception(e)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
@@ -172,7 +172,7 @@ class Unassign(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.unassign(self.args.user)
         except GiteaError as e:
-            logger.error(e)
+            logger.exception(e)
 
 
 @final
@@ -221,7 +221,7 @@ class Reject(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.reject(self.args.reason, self.args.user, self.args.message)
         except GiteaError as e:
-            logger.error(e)
+            logger.exception(e)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
@@ -270,4 +270,4 @@ class Comment(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.comment(comment)
         except GiteaError as e:
-            logger.error(e)
+            logger.exception(e)

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -15,7 +15,7 @@ from typing import final
 from ..argparse import ArgumentParser
 from ..commands import Command
 from ..connector import OSC, Gitea
-from ..exceptions import GiteaError, InvalidGiteaHash
+from ..exceptions import GiteaError, InvalidGiteaHashError
 from ..utils import complete_choices, prompt_user, requires_update
 
 logger = getLogger("mtui.command.apicalls")
@@ -103,7 +103,7 @@ class Approve(BaseApiCall):
                 ):
                     gitea.approve(self.args.user)
                 else:
-                    raise InvalidGiteaHash(
+                    raise InvalidGiteaHashError(
                         self.metadata.id, self.metadata.giteacohash, new_hash
                     )
             else:

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -110,7 +110,7 @@ class Approve(BaseApiCall):
                 gitea.approve(self.args.user)
 
         except GiteaError as e:
-            logger.exception(e)
+            logger.error(e)
 
 
 @final
@@ -143,7 +143,7 @@ class Assign(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.assign(self.args.user, self.args.force)
         except GiteaError as e:
-            logger.exception(e)
+            logger.error(e)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
@@ -172,7 +172,7 @@ class Unassign(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.unassign(self.args.user)
         except GiteaError as e:
-            logger.exception(e)
+            logger.error(e)
 
 
 @final
@@ -221,7 +221,7 @@ class Reject(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.reject(self.args.reason, self.args.user, self.args.message)
         except GiteaError as e:
-            logger.exception(e)
+            logger.error(e)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
@@ -270,4 +270,4 @@ class Comment(BaseApiCall):
             gitea = Gitea(self.config, self.metadata.giteaprapi)
             gitea.comment(comment)
         except GiteaError as e:
-            logger.exception(e)
+            logger.error(e)

--- a/mtui/commands/checkout.py
+++ b/mtui/commands/checkout.py
@@ -2,7 +2,6 @@
 
 from logging import getLogger
 from subprocess import check_call
-from traceback import format_exc
 
 from mtui.commands import Command
 from mtui.utils import requires_update
@@ -21,5 +20,4 @@ class Checkout(Command):
         try:
             check_call(["svn", "up"], cwd=self.metadata.report_wd())
         except Exception:
-            logger.error("updating template failed")
-            logger.debug(format_exc())
+            logger.exception("updating template failed")

--- a/mtui/commands/commit.py
+++ b/mtui/commands/commit.py
@@ -53,7 +53,7 @@ class Commit(Command):
             subprocess.check_call(["svn", "up"], cwd=checkout)
             subprocess.check_call(["svn", "ci", *msg], cwd=checkout)
 
-            logger.info("Testreport in: %s", self.metadata._fancy_report_url())
+            logger.info("Testreport in: %s", self.metadata.fancy_report_url())
 
         except Exception:
             logger.exception("committing template.failed")

--- a/mtui/commands/commit.py
+++ b/mtui/commands/commit.py
@@ -3,7 +3,6 @@
 import subprocess
 from argparse import REMAINDER
 from logging import getLogger
-from traceback import format_exc
 
 from mtui.commands import Command
 from mtui.utils import complete_choices, requires_update
@@ -54,11 +53,10 @@ class Commit(Command):
             subprocess.check_call(["svn", "up"], cwd=checkout)
             subprocess.check_call(["svn", "ci", *msg], cwd=checkout)
 
-            logger.info(f"Testreport in: {self.metadata._fancy_report_url()}")
+            logger.info("Testreport in: %s", self.metadata._fancy_report_url())
 
         except Exception:
-            logger.error("committing template.failed")
-            logger.debug(format_exc())
+            logger.exception("committing template.failed")
 
     @staticmethod
     def complete(state, text, line, begidx, endidx):

--- a/mtui/commands/downgrade.py
+++ b/mtui/commands/downgrade.py
@@ -16,6 +16,7 @@ class Downgrade(Command):
 
     Warning:
         This command cannot work for new packages.
+
     """
 
     command = "downgrade"

--- a/mtui/commands/edit.py
+++ b/mtui/commands/edit.py
@@ -35,7 +35,7 @@ class Edit(Command):
 
     def __call__(self) -> None:
         """Executes the `edit` command."""
-        path = self.args.filename if self.args.filename else self._template()
+        path = self.args.filename or self._template()
 
         editor = getenv("EDITOR", "vim")
 

--- a/mtui/commands/edit.py
+++ b/mtui/commands/edit.py
@@ -3,7 +3,6 @@
 from logging import getLogger
 from os import getenv
 from subprocess import check_call
-from traceback import format_exc
 
 from mtui.argparse import ArgumentParser
 from mtui.commands import Command
@@ -43,8 +42,7 @@ class Edit(Command):
             logger.debug("call %s on %s", editor, path)
             check_call([editor, path])
         except Exception:
-            logger.error("failed to run %s", editor)
-            logger.debug(format_exc())
+            logger.exception("failed to run %s", editor)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/export.py
+++ b/mtui/commands/export.py
@@ -1,6 +1,6 @@
 """The `export` command."""
 
-from logging import DEBUG, getLogger
+from logging import getLogger
 from pathlib import Path
 
 from mtui.argparse import ArgumentParser
@@ -72,10 +72,8 @@ class Export(Command):
                 ).run(targets)
                 text.clear()
                 text.extend(template)
-            except Exception as e:
-                if logger.getEffectiveLevel() == DEBUG:
-                    logger.exception("traceback of export")
-                logger.error(f"While exporting template was thrown exception {e}")
+            except Exception:
+                logger.exception("While exporting template was thrown exception")
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/export.py
+++ b/mtui/commands/export.py
@@ -44,9 +44,7 @@ class Export(Command):
     def __call__(self) -> None:
         """Executes the `export` command."""
         targets: list[str] = list(self.parse_hosts().keys())
-        filename = (
-            self.args.filename if self.args.filename else Path(self.metadata.path)
-        )
+        filename = self.args.filename or Path(self.metadata.path)
         exporters: dict[tuple[bool, bool], type[BaseExport]] = {
             (True, False): AutoExport,
             (False, True): KernelExport,

--- a/mtui/commands/hostslock.py
+++ b/mtui/commands/hostslock.py
@@ -20,6 +20,7 @@ class HostLock(Command):
     Enabled locks are automatically removed when exiting the session.
     To lock the run command on other sessions as well, it's necessary
     to set a comment.
+
     """
 
     command = "lock"

--- a/mtui/commands/hoststate.py
+++ b/mtui/commands/hoststate.py
@@ -41,11 +41,11 @@ class HostState(Command):
             elif state == "parallel":
                 exclusive = False
             for target in targets:
-                logger.info(f"Setting host {target} mode to {state}")
+                logger.info("Setting host %s mode to %s", target, state)
                 targets[target].exclusive = exclusive
         else:
             for target in targets:
-                logger.info(f"Setting host {target} state to {state}")
+                logger.info("Setting host %s state to %s", target, state)
                 targets[target].state = state
 
     @staticmethod

--- a/mtui/commands/listpackages.py
+++ b/mtui/commands/listpackages.py
@@ -1,6 +1,6 @@
 """The `list_packages` command."""
 
-from typing import final
+from typing import ClassVar, final
 
 from .. import messages
 from ..argparse import ArgumentParser
@@ -14,7 +14,7 @@ class ListPackages(Command):
 
     command = "list_packages"
 
-    state_map: dict[None | int, str] = {
+    state_map: ClassVar[dict[None | int, str]] = {
         None: blue("not installed"),
         -1: yellow("update needed"),
         0: green("updated"),
@@ -89,7 +89,7 @@ class ListPackages(Command):
                 if self.metadata:
                     try:
                         # if package p is in target.packages it alwas has set required --> from metadata
-                        wanted = target.packages[p].required  # type: ignore
+                        wanted = target.packages[p].required
                     except KeyError:
                         state = None
                     else:

--- a/mtui/commands/listpackages.py
+++ b/mtui/commands/listpackages.py
@@ -30,6 +30,7 @@ class ListPackages(Command):
 
         Returns:
             A string representing the state of the package.
+
         """
         if not current:
             return self.state_map[None]
@@ -117,6 +118,7 @@ class ListPackages(Command):
             version: The version of the package.
             state: The state of the package.
             format_output: The format string to use.
+
         """
         self.println(format_output.format(package, version, state))
 

--- a/mtui/commands/quit.py
+++ b/mtui/commands/quit.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 
 from mtui.argparse import ArgumentParser
 from mtui.commands import Command
-from mtui.target import Target
 from mtui.utils import complete_choices
 
 

--- a/mtui/commands/quit.py
+++ b/mtui/commands/quit.py
@@ -34,6 +34,7 @@ class Quit(Command):
         Args:
             target: The target host to close.
             args: A list of arguments to pass to the close method.
+
         """
         self.targets[target].close(*args)
         self.targets.pop(target)

--- a/mtui/commands/quit.py
+++ b/mtui/commands/quit.py
@@ -28,11 +28,11 @@ class Quit(Command):
             help="reboot or poweroff refhosts",
         )
 
-    def _close_target(self, target: Target, args) -> None:
+    def _close_target(self, target: str, args) -> None:
         """Closes the connection to a single target host.
 
         Args:
-            target: The target host to close.
+            target: The hostname of the target host to close.
             args: A list of arguments to pass to the close method.
 
         """

--- a/mtui/commands/removehost.py
+++ b/mtui/commands/removehost.py
@@ -13,6 +13,7 @@ class RemoveHost(Command):
     Warning:
         The host log is purged as well. If no parameters are provided,
         this command removes all hosts.
+
     """
 
     command = "remove_host"
@@ -27,6 +28,7 @@ class RemoveHost(Command):
 
         Args:
             target: The target host to remove.
+
         """
         self.targets[target].close()
         self.targets.pop(target)

--- a/mtui/commands/reportbug.py
+++ b/mtui/commands/reportbug.py
@@ -44,8 +44,7 @@ class ReportBug(Command):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 raise messages.SystemCommandNotFoundError(args[0])
-            else:
-                raise
+            raise
 
         # xdg-open starts the appropriate command and waits for it
         # to exit.

--- a/mtui/commands/reportbug.py
+++ b/mtui/commands/reportbug.py
@@ -43,7 +43,7 @@ class ReportBug(Command):
             )
         except OSError as e:
             if e.errno == errno.ENOENT:
-                raise messages.SystemCommandNotFoundError(args[0])
+                raise messages.SystemCommandNotFoundError(args[0]) from e
             raise
 
         # xdg-open starts the appropriate command and waits for it

--- a/mtui/commands/run.py
+++ b/mtui/commands/run.py
@@ -63,15 +63,13 @@ class Run(Command):
                     output.append(
                         f"{target!s}:-> {targets[target].lastin()!s} [{targets[target].lastexit()!s}]"
                     )
-                    for line in targets[target].lastout().split("\n"):
-                        output.append(line)
+                    output.extend(targets[target].lastout().split("\n"))
                     if targets[target].lasterr():
                         output.append("stderr:")
-                        for line in targets[target].lasterr().split("\n"):
-                            output.append(line)
+                        output.extend(targets[target].lasterr().split("\n"))
 
         except TargetLockedError as e:
-            logger.error("Target %s", e)
+            logger.exception("Target %s", e)
             return
 
         page(output, self.prompt.interactive)

--- a/mtui/commands/run.py
+++ b/mtui/commands/run.py
@@ -69,7 +69,7 @@ class Run(Command):
                         output.extend(targets[target].lasterr().split("\n"))
 
         except TargetLockedError as e:
-            logger.exception("Target %s", e)
+            logger.error("Target %s", e)
             return
 
         page(output, self.prompt.interactive)

--- a/mtui/commands/run.py
+++ b/mtui/commands/run.py
@@ -25,6 +25,7 @@ class Run(Command):
 
     Note:
         No interactive commands can be run with this procedure.
+
     """
 
     command = "run"

--- a/mtui/commands/setrepo.py
+++ b/mtui/commands/setrepo.py
@@ -49,7 +49,7 @@ class SetRepo(Command):
                 for t in [self.targets[x] for x in hosts]:
                     t.set_repo(operation, self.metadata)
         except TargetLockedError as err:
-            logger.error("Target locked %s", err)
+            logger.exception("Target locked %s", err)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/setrepo.py
+++ b/mtui/commands/setrepo.py
@@ -49,7 +49,7 @@ class SetRepo(Command):
                 for t in [self.targets[x] for x in hosts]:
                     t.set_repo(operation, self.metadata)
         except TargetLockedError as err:
-            logger.exception("Target locked %s", err)
+            logger.error("Target locked %s", err)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/sftpcmd.py
+++ b/mtui/commands/sftpcmd.py
@@ -43,8 +43,9 @@ class SFTPPut(Command):
             elif file.is_dir():
                 # Path.walk is from 3.12
                 for root, _, folder_files in os.walk(file):
-                    for folder_file in folder_files:
-                        transversed_files.append(Path(root) / folder_file)
+                    transversed_files.extend(
+                        Path(root) / folder_file for folder_file in folder_files
+                    )
             else:
                 logger.warning("Filename %s isn't file", file)
                 continue

--- a/mtui/commands/showdiff.py
+++ b/mtui/commands/showdiff.py
@@ -54,9 +54,9 @@ class AnalyzeDiff(Command):
         if spec_apply == [x[0] for x in spec_patches]:
             logger.warning(
                 "Patches changes found in spec files arent same as application"
-                + "of patches\n It can be false warning if is used %autosetup"
-                + "macro or other \n more complicated way to apply patches ,eg"
-                + " kernel packages\n"
+                "of patches\n It can be false warning if is used %autosetup"
+                "macro or other \n more complicated way to apply patches ,eg"
+                " kernel packages\n"
             )
 
         changes_patches = []

--- a/mtui/commands/simplelists.py
+++ b/mtui/commands/simplelists.py
@@ -1,5 +1,7 @@
 """A collection of simple "list" commands."""
 
+from typing import ClassVar
+
 from mtui.argparse import ArgumentParser
 from mtui.commands import Command
 from mtui.utils import complete_choices, page, requires_update
@@ -176,7 +178,13 @@ class ListHistory(Command):
 
     command = "list_history"
 
-    filters = {"connect", "disconnect", "install", "update", "downgrade"}
+    filters: ClassVar[set[str]] = {
+        "connect",
+        "disconnect",
+        "install",
+        "update",
+        "downgrade",
+    }
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -35,7 +35,7 @@ class SessionName(Command):
 
     def __call__(self) -> None:
         """Executes the `set_session_name` command."""
-        session = self.args.name if self.args.name else self.metadata.id
+        session = self.args.name or self.metadata.id
         self.prompt.session = session
         self.prompt.set_prompt(session)
 
@@ -182,67 +182,63 @@ class SetWorkflow(Command):
                 for oq in self.metadata.openqa["kernel"]:
                     oq.run()
                 return
-            else:
-                logger.info("Setting workflow to '%s'", state)
-                self.config.auto = False
-                self.config.kernel = True
-                self.metadata.openqa["auto"] = AutoOpenQA(
+            logger.info("Setting workflow to '%s'", state)
+            self.config.auto = False
+            self.config.kernel = True
+            self.metadata.openqa["auto"] = AutoOpenQA(
+                self.config,
+                self.config.openqa_instance,
+                self.metadata.smelt,
+                self.metadata.id,
+            ).run()
+            self.metadata.openqa["kernel"] = []
+            self.metadata.openqa["kernel"].append(
+                KernelOpenQA(
                     self.config,
                     self.config.openqa_instance,
                     self.metadata.smelt,
                     self.metadata.id,
                 ).run()
-                self.metadata.openqa["kernel"] = []
-                self.metadata.openqa["kernel"].append(
-                    KernelOpenQA(
-                        self.config,
-                        self.config.openqa_instance,
-                        self.metadata.smelt,
-                        self.metadata.id,
-                    ).run()
-                )
-                self.metadata.openqa["kernel"].append(
-                    KernelOpenQA(
-                        self.config,
-                        self.config.openqa_instance_baremetal,
-                        self.metadata.smelt,
-                        self.metadata.id,
-                    ).run()
-                )
-                return
-        elif state == "auto":
+            )
+            self.metadata.openqa["kernel"].append(
+                KernelOpenQA(
+                    self.config,
+                    self.config.openqa_instance_baremetal,
+                    self.metadata.smelt,
+                    self.metadata.id,
+                ).run()
+            )
+            return
+        if state == "auto":
             if self.config.auto:
                 logger.info("Desired workflow %s is same as current", state)
                 self.metadata.openqa["auto"].run()
                 return
-            else:
-                logger.info("Setting workflow to '%s'", state)
-                self.config.auto = True
-                self.config.kernel = False
-                self.metadata.openqa["auto"] = AutoOpenQA(
-                    self.config,
-                    self.config.openqa_instance,
-                    self.metadata.smelt,
-                    self.metadata.id,
-                ).run()
-                self.metadata.openqa["kernel"] = []
-                if self.metadata.openqa["auto"].results is None:
-                    logger.warning("No install jobs or install jobs failed")
-                    logger.info("Switch mode to manual")
-                    self.config.auto = False
-                return
-        else:
-            if not self.config.auto and not self.config.kernel:
-                logger.info("Desired workflow %s is same as current", state)
-                self.metadata.openqa["auto"].run()
-                return
-            else:
-                logger.info("Setting workflow to '%s'", state)
+            logger.info("Setting workflow to '%s'", state)
+            self.config.auto = True
+            self.config.kernel = False
+            self.metadata.openqa["auto"] = AutoOpenQA(
+                self.config,
+                self.config.openqa_instance,
+                self.metadata.smelt,
+                self.metadata.id,
+            ).run()
+            self.metadata.openqa["kernel"] = []
+            if self.metadata.openqa["auto"].results is None:
+                logger.warning("No install jobs or install jobs failed")
+                logger.info("Switch mode to manual")
                 self.config.auto = False
-                self.config.kernel = False
-                self.metadata.openqa["auto"].run()
-                self.metadata.openqa["kernel"] = []
-                return
+            return
+        if not self.config.auto and not self.config.kernel:
+            logger.info("Desired workflow %s is same as current", state)
+            self.metadata.openqa["auto"].run()
+            return
+        logger.info("Setting workflow to '%s'", state)
+        self.config.auto = False
+        self.config.kernel = False
+        self.metadata.openqa["auto"].run()
+        self.metadata.openqa["kernel"] = []
+        return
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -63,7 +63,7 @@ class SetLocation(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         loc = RefhostsFactory(state["config"]).get_locations()
-        locations = [[x for x in loc]]
+        locations = [list(loc)]
 
         return complete_choices(locations, line, text)
 
@@ -103,7 +103,7 @@ class SetLogLevel(Command):
 
         self.prompt.log.setLevel(level=levels[new])
 
-        logger.info(f"Log level is set to {new}")
+        logger.info("Log level is set to %s", new)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -63,7 +63,7 @@ class SetLocation(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         loc = RefhostsFactory(state["config"]).get_locations()
-        locations = [list(loc)]
+        locations = [tuple(loc)]
 
         return complete_choices(locations, line, text)
 

--- a/mtui/commands/terms.py
+++ b/mtui/commands/terms.py
@@ -52,7 +52,7 @@ class Terms(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         t = ("-t", "--target")
-        a = ()  # type: ignore
+        a = ()
         for x in state["config"].termnames:
             a += (x,)
 

--- a/mtui/commands/terms.py
+++ b/mtui/commands/terms.py
@@ -2,7 +2,6 @@
 
 from logging import getLogger
 from subprocess import check_call
-from traceback import format_exc
 
 from mtui.argparse import ArgumentParser
 from mtui.commands import Command
@@ -41,8 +40,7 @@ class Terms(Command):
                 try:
                     check_call([path, *hosts])
                 except Exception:
-                    logger.error("running %s failed", filename)
-                    logger.debug(format_exc())
+                    logger.exception("running %s failed", filename)
             else:
                 logger.error("Term script not found")
                 logger.info("Aviable term scripts: %s", " ".join(self.config.termnames))
@@ -54,7 +52,7 @@ class Terms(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         t = ("-t", "--target")
-        a = tuple()  # type: ignore
+        a = ()  # type: ignore
         for x in state["config"].termnames:
             a += (x,)
 

--- a/mtui/commands/zypper.py
+++ b/mtui/commands/zypper.py
@@ -78,7 +78,7 @@ class Uninstall(Command):
             return
         except Exception as e:
             logger.critical("failed to uninstall packages")
-            logger.exception("Error - %s", e)
+            logger.error("Error - %s", e)
             return
 
         logger.info("Done")

--- a/mtui/commands/zypper.py
+++ b/mtui/commands/zypper.py
@@ -78,7 +78,7 @@ class Uninstall(Command):
             return
         except Exception as e:
             logger.critical("failed to uninstall packages")
-            logger.error("Error - %s", e)
+            logger.exception("Error - %s", e)
             return
 
         logger.info("Done")

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -35,6 +35,7 @@ class Config:
         Args:
             path: An optional path to a specific config file.
             refhosts: The factory to use for creating refhosts.
+
         """
         self.refhosts = refhosts
         self.__location = "default"
@@ -74,6 +75,7 @@ class Config:
 
         Args:
             x: The new location.
+
         """
         try:
             self.refhosts(self).check_location_sanity(x)
@@ -239,6 +241,7 @@ class Config:
 
         Returns:
             True if the option name is valid, False otherwise.
+
         """
         return opt in (x[0] for x in self.data)
 
@@ -255,6 +258,7 @@ class Config:
 
         Raises:
             InvalidOptionNameError: If opt is not a valid option name.
+
         """
         # FIXME: ^ remove warning (add type safety)
         if not self._has_option(opt):
@@ -276,11 +280,12 @@ class Config:
 
         Returns:
             The value of the option.
+
         """
         try:
             return getter(*secopt)
         except (configparser.NoSectionError, configparser.NoOptionError):
-            msg = "Config option {0}.{1} not found.".format(*secopt)
+            msg = "Config option {}.{} not found.".format(*secopt)
             logger.debug(msg)
             raise
         except Exception:
@@ -293,8 +298,8 @@ class Config:
 
         Args:
             args: The parsed command-line arguments.
-        """
 
+        """
         if args.location:
             self.location = args.location
 

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -62,7 +62,7 @@ class Config:
         try:
             self.config.read(self.configfiles)
         except configparser.Error as e:
-            logger.error(e)
+            logger.exception(e)
 
     @property
     def location(self) -> str:
@@ -80,10 +80,12 @@ class Config:
         try:
             self.refhosts(self).check_location_sanity(x)
         except InvalidLocationError as e:
-            logger.error(e)
+            logger.exception(e)
             return
         except RefhostsResolveFailed:
-            logger.error("Can't read `refhosts.yml` file, no valid refhosts database")
+            logger.exception(
+                "Can't read `refhosts.yml` file, no valid refhosts database"
+            )
             return
 
         self.__location = x
@@ -290,7 +292,7 @@ class Config:
             raise
         except Exception:
             msg = "Config option {0}.{1} extraction from {2} " + "failed."
-            logger.error(msg.format((*secopt, self.configfiles)))
+            logger.exception(msg.format((*secopt, self.configfiles)))
             raise
 
     def merge_args(self, args: Namespace) -> None:

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from .datafiles import terms_path
 from .messages import InvalidLocationError
-from .refhost import RefhostsFactory, RefhostsResolveFailed
+from .refhost import RefhostsFactory, RefhostsResolveFailedError
 
 logger = getLogger("mtui.config")
 
@@ -82,7 +82,7 @@ class Config:
         except InvalidLocationError as e:
             logger.exception(e)
             return
-        except RefhostsResolveFailed:
+        except RefhostsResolveFailedError:
             logger.exception(
                 "Can't read `refhosts.yml` file, no valid refhosts database"
             )

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -27,6 +27,40 @@ class InvalidOptionNameError(RuntimeError):
 class Config:
     """Read and store the variables from mtui config files."""
 
+    # -- Attributes set dynamically by _parse_config() via setattr() --
+    template_dir: Path
+    local_tempdir: Path
+    session_user: str
+    install_logs: Path
+    connection_timeout: int
+    svn_path: str
+    bugzilla_url: str
+    reports_url: str
+    fancy_reports_url: str
+    smelt_api: str
+    target_tempdir: Path
+    chdir_to_template_dir: bool
+    refhosts_resolvers: str
+    refhosts_https_uri: str
+    refhosts_https_expiration: int
+    refhosts_path: Path
+    use_keyring: bool
+    report_bug_url: str
+    openqa_instance: str
+    openqa_instance_baremetal: str
+    openqa_install_distri: str
+    openqa_install_logs: str
+    openqa_kernel_install_logs: str
+    threshold: int
+    gitea_token: str
+
+    # -- Attributes set externally in main.py --
+    kernel: bool
+    auto: bool
+    distro: str
+    distro_ver: str
+    distro_kernel: str
+
     def __init__(self, path: Path | None, refhosts=RefhostsFactory) -> None:
         """Initializes the configuration object.
 

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -62,7 +62,7 @@ class Config:
         try:
             self.config.read(self.configfiles)
         except configparser.Error as e:
-            logger.exception(e)
+            logger.error(e)
 
     @property
     def location(self) -> str:
@@ -80,12 +80,10 @@ class Config:
         try:
             self.refhosts(self).check_location_sanity(x)
         except InvalidLocationError as e:
-            logger.exception(e)
+            logger.error(e)
             return
         except RefhostsResolveFailedError:
-            logger.exception(
-                "Can't read `refhosts.yml` file, no valid refhosts database"
-            )
+            logger.error("Can't read `refhosts.yml` file, no valid refhosts database")
             return
 
         self.__location = x
@@ -292,7 +290,7 @@ class Config:
             raise
         except Exception:
             msg = "Config option {0}.{1} extraction from {2} " + "failed."
-            logger.exception(msg.format((*secopt, self.configfiles)))
+            logger.error(msg.format((*secopt, self.configfiles)))
             raise
 
     def merge_args(self, args: Namespace) -> None:

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -43,6 +43,7 @@ class CommandTimeout(Exception):
 
         Args:
             command: The command that timed out.
+
         """
         self.command = command
 
@@ -75,6 +76,7 @@ class Connection:
             hostname: The hostname or IP address of the remote host.
             port: The port number to connect to.
             timeout: The timeout for remote commands.
+
         """
         self.hostname = hostname
 
@@ -189,6 +191,7 @@ class Connection:
             retry: The number of times to retry the connection.
             timeout: The timeout for each connection attempt.
             backoff: Whether to use exponential backoff for retries.
+
         """
         count = 0
         rtimeout = timeout
@@ -219,6 +222,7 @@ class Connection:
 
         Returns:
             A new session object, or None if a session could not be opened.
+
         """
         logger.debug("creating new session at %s:%s", self.hostname, self.port)
         try:
@@ -249,6 +253,7 @@ class Connection:
 
         Args:
             session: The session to close.
+
         """
         if session:
             try:
@@ -266,6 +271,7 @@ class Connection:
 
         Returns:
             A session instance with the running command, or None on failure.
+
         """
         try:
             if session := self.new_session():
@@ -290,6 +296,7 @@ class Connection:
 
         Returns:
             The exit code of the command.
+
         """
         self.stdin = command
         self.stdout = ""
@@ -376,6 +383,7 @@ class Connection:
 
         Returns:
             A session with an open shell, or None on failure.
+
         """
         try:
             if session := self.new_session():
@@ -432,6 +440,7 @@ class Connection:
 
         Returns:
             An SFTP client object, or None on failure.
+
         """
         try:
             sftp = self.client.open_sftp()
@@ -446,6 +455,7 @@ class Connection:
 
         Returns:
             An active SFTP client object.
+
         """
         sftp = self.__sftp_open()
         counter = 0
@@ -465,8 +475,8 @@ class Connection:
         Args:
             local: The local file to transfer.
             remote: The remote path to transfer the file to.
-        """
 
+        """
         path = ""
         sftp = self.__sftp_reconnect()
 
@@ -510,6 +520,7 @@ class Connection:
         Args:
             remote: The remote file to transfer.
             local: The local path to transfer the file to.
+
         """
         sftp = self.__sftp_reconnect()
 
@@ -532,6 +543,7 @@ class Connection:
         Args:
             remote: The remote folder to transfer.
             local: The local path to transfer the folder to.
+
         """
         sftp = self.__sftp_reconnect()
         try:
@@ -551,7 +563,7 @@ class Connection:
         finally:
             sftp.close()
 
-    def sftp_listdir(self, path: Path = Path(".")) -> list[str]:
+    def sftp_listdir(self, path: Path = Path()) -> list[str]:
         """Gets a directory listing of the remote host.
 
         Args:
@@ -559,6 +571,7 @@ class Connection:
 
         Returns:
             A list of filenames in the directory.
+
         """
         logger.debug(
             f"getting {self.hostname!s}:{self.port!s}:{path!s} listing",
@@ -581,6 +594,7 @@ class Connection:
 
         Returns:
             An SFTPFile object.
+
         """
         logger.debug("%s open(%s, %s)", repr(self), filename, mode)
         logger.debug("  -> self.client.open_sftp")
@@ -606,6 +620,7 @@ class Connection:
 
         Args:
             path: The path to the remote file to delete.
+
         """
         logger.debug("deleting file %s:%s:%s", self.hostname, self.port, path)
         sftp = self.__sftp_reconnect()
@@ -622,6 +637,7 @@ class Connection:
 
         Args:
             path: The path to the remote directory to delete.
+
         """
         logger.debug("deleting dir %s:%s:%s", self.hostname, self.port, path)
         sftp = self.__sftp_reconnect()
@@ -644,6 +660,7 @@ class Connection:
 
         Returns:
             The target of the symbolic link.
+
         """
         logger.debug("read link %s:%s:%s", self.hostname, self.port, path)
         sftp = self.__sftp_reconnect()
@@ -658,6 +675,7 @@ class Connection:
 
         Returns:
             True if the connection is active, False otherwise.
+
         """
         return self.client._transport.is_active()  # type: ignore
 

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -680,7 +680,10 @@ class Connection:
             True if the connection is active, False otherwise.
 
         """
-        return self.client._transport.is_active()  # noqa: SLF001
+        transport = self.client._transport  # noqa: SLF001
+        if transport is None:
+            return False
+        return transport.is_active()
 
     def close(self) -> None:
         """Closes the SSH channel and disconnects."""

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -176,7 +176,7 @@ class Connection:
             raise
 
         except OSError:
-            logger.exception("No valid connection to %s:%s", self.hostname, self.port)
+            logger.error("No valid connection to %s:%s", self.hostname, self.port)
         except Exception as e:
             # general Exception
             logger.debug("%s: %s", self.hostname, e)

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -176,7 +176,7 @@ class Connection:
             raise
 
         except OSError:
-            logger.error("No valid connection to %s:%s", self.hostname, self.port)
+            logger.exception("No valid connection to %s:%s", self.hostname, self.port)
         except Exception as e:
             # general Exception
             logger.debug("%s: %s", self.hostname, e)
@@ -574,7 +574,10 @@ class Connection:
 
         """
         logger.debug(
-            f"getting {self.hostname!s}:{self.port!s}:{path!s} listing",
+            "getting %s:%s:%s listing",
+            self.hostname,
+            self.port,
+            path,
         )
         sftp = self.__sftp_reconnect()
 

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -35,7 +35,7 @@ if not sys.warnoptions:
     warnings.filterwarnings("ignore", module="cryptography")
 
 
-class CommandTimeout(Exception):
+class CommandTimeoutError(Exception):
     """Exception raised when a remote command times out."""
 
     def __init__(self, command=None) -> None:
@@ -335,9 +335,9 @@ class Connection:
                         f'command "{command}" timed out on {self.hostname}. wait? (Y/n) ',
                     ).lower() not in ("no", "n", "ne", "nein"):
                         continue
-                    # if the user don't want to wait, raise CommandTimeout
+                    # if the user don't want to wait, raise CommandTimeoutError
                     # and procceed
-                    raise CommandTimeout
+                    raise CommandTimeoutError
                 finally:
                     # release lock to allow other command threads to write to
                     # stdout
@@ -680,7 +680,7 @@ class Connection:
             True if the connection is active, False otherwise.
 
         """
-        return self.client._transport.is_active()  # type: ignore
+        return self.client._transport.is_active()  # noqa: SLF001
 
     def close(self) -> None:
         """Closes the SSH channel and disconnects."""

--- a/mtui/connector/gitea.py
+++ b/mtui/connector/gitea.py
@@ -95,6 +95,7 @@ class Gitea:
 
         Raises:
             MissingGiteaToken: If the Gitea API token is not found in the config.
+
         """
         if not config.gitea_token:  # type: ignore
             raise MissingGiteaToken("Gitea API token is empty, can't access API")
@@ -133,6 +134,7 @@ class Gitea:
 
         Raises:
             FailedGiteaCall: If the API call fails.
+
         """
         try:
             logger.debug("Requesting %s on %s", method, url)
@@ -186,6 +188,7 @@ class Gitea:
 
         Returns:
             The assignment state.
+
         """
         # Always reload comments to get the most up-to-date state.
         comments = sorted(self.__get_all_comments())
@@ -231,8 +234,9 @@ class Gitea:
         Raises:
             GiteaAssignInvalid: If the PR is not assigned to the specified user.
             GiteaNoReview: If the PR was already approved/rejected.
+
         """
-        a_user = other if other else self.user
+        a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
             raise GiteaAssignInvalid(assign_state, a_user)
@@ -257,8 +261,9 @@ class Gitea:
         Raises:
             GiteaAssignInvalid: If the PR is not assigned to the specified user.
             GiteaNoReview: If the PR was already approved/rejected.
+
         """
-        a_user = other if other else self.user
+        a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
             raise GiteaAssignInvalid(assign_state, a_user)
@@ -284,8 +289,9 @@ class Gitea:
         Raises:
             GiteaNoReview: If a review has not been requested and `force` is False.
             GiteaAssignInvalid: If the PR is not in an unassigned state.
+
         """
-        a_user = other if other else self.user
+        a_user = other or self.user
         if not self.__has_review() and not force:
             raise GiteaNoReview(f"There is no review for {self.group}-review")
 
@@ -308,8 +314,9 @@ class Gitea:
 
         Raises:
             GiteaAssignInvalid: If the PR is not assigned to the specified user.
+
         """
-        a_user = other if other else self.user
+        a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
             raise GiteaAssignInvalid(assign_state, a_user)
@@ -323,6 +330,7 @@ class Gitea:
 
         Args:
             body: The text content of the comment.
+
         """
         logger.info("Posting a comment to Gitea PR")
         self.__request(method.POST, self.prissues, json={"body": body})

--- a/mtui/connector/gitea.py
+++ b/mtui/connector/gitea.py
@@ -148,8 +148,8 @@ class Gitea:
                 verify=verify,
             )
         except requests.exceptions.RequestException as e:
-            logger.error("API call to Gitea failed: %s", e, exc_info=True)
-            raise FailedGiteaCall(f"{method} - {url}")
+            logger.exception("API call to Gitea failed: %s", e)
+            raise FailedGiteaCall(f"{method} - {url}") from e
 
         if not rsp.ok:
             logger.warning(

--- a/mtui/connector/gitea.py
+++ b/mtui/connector/gitea.py
@@ -20,10 +20,10 @@ from urllib3.exceptions import InsecureRequestWarning
 # ignore type checker warnings when accessing them.
 from ..config import Config
 from ..exceptions import (
-    FailedGiteaCall,
-    GiteaAssignInvalid,
-    GiteaNoReview,
-    MissingGiteaToken,
+    FailedGiteaCallError,
+    GiteaAssignInvalidError,
+    GiteaNoReviewError,
+    MissingGiteaTokenError,
 )
 from ..types import assignment, method
 
@@ -47,6 +47,10 @@ class Comment:
         if not isinstance(other, Comment):
             return NotImplemented
         return self.date == other.date
+
+    def __hash__(self) -> int:
+        """Hashes the comment by serial."""
+        return hash(self.serial)
 
     def __gt__(self, other: object, /) -> bool:
         """Checks if this comment is greater than another."""
@@ -94,13 +98,13 @@ class Gitea:
             group: The review group this instance is operating on behalf of.
 
         Raises:
-            MissingGiteaToken: If the Gitea API token is not found in the config.
+            MissingGiteaTokenError: If the Gitea API token is not found in the config.
 
         """
-        if not config.gitea_token:  # type: ignore
-            raise MissingGiteaToken("Gitea API token is empty, can't access API")
+        if not config.gitea_token:
+            raise MissingGiteaTokenError("Gitea API token is empty, can't access API")
 
-        self.user: str = config.session_user  # type: ignore
+        self.user: str = config.session_user
         self.headers = {"Authorization": f"token {config.gitea_token}"}
         self.group = group
 
@@ -133,7 +137,7 @@ class Gitea:
             The JSON response from the API.
 
         Raises:
-            FailedGiteaCall: If the API call fails.
+            FailedGiteaCallError: If the API call fails.
 
         """
         try:
@@ -149,7 +153,7 @@ class Gitea:
             )
         except requests.exceptions.RequestException as e:
             logger.exception("API call to Gitea failed: %s", e)
-            raise FailedGiteaCall(f"{method} - {url}") from e
+            raise FailedGiteaCallError(f"{method} - {url}") from e
 
         if not rsp.ok:
             logger.warning(
@@ -161,7 +165,9 @@ class Gitea:
                     logger.debug("Gitea error message: %s", msg)
             except requests.exceptions.JSONDecodeError:
                 logger.debug("No JSON error message in response.")
-            raise FailedGiteaCall(f"{method} - {url} returned status {rsp.status_code}")
+            raise FailedGiteaCallError(
+                f"{method} - {url} returned status {rsp.status_code}"
+            )
 
         # For 204 No Content, there is no body to decode.
         if rsp.status_code == 204:
@@ -232,17 +238,17 @@ class Gitea:
             other: Username to act on behalf of. Defaults to the session user.
 
         Raises:
-            GiteaAssignInvalid: If the PR is not assigned to the specified user.
-            GiteaNoReview: If the PR was already approved/rejected.
+            GiteaAssignInvalidError: If the PR is not assigned to the specified user.
+            GiteaNoReviewError: If the PR was already approved/rejected.
 
         """
         a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
-            raise GiteaAssignInvalid(assign_state, a_user)
+            raise GiteaAssignInvalidError(assign_state, a_user)
 
         if self.__is_done():
-            raise GiteaNoReview("PR was already approved/rejected")
+            raise GiteaNoReviewError("PR was already approved/rejected")
 
         logger.info("Approving PR as %s for group %s", a_user, self.group)
         msg = f"@{self.group}-review: LGTM"
@@ -259,17 +265,17 @@ class Gitea:
             message: Message from user.
 
         Raises:
-            GiteaAssignInvalid: If the PR is not assigned to the specified user.
-            GiteaNoReview: If the PR was already approved/rejected.
+            GiteaAssignInvalidError: If the PR is not assigned to the specified user.
+            GiteaNoReviewError: If the PR was already approved/rejected.
 
         """
         a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
-            raise GiteaAssignInvalid(assign_state, a_user)
+            raise GiteaAssignInvalidError(assign_state, a_user)
 
         if self.__is_done():
-            raise GiteaNoReview("PR was already approved/rejected")
+            raise GiteaNoReviewError("PR was already approved/rejected")
 
         logger.info("Rejecting PR as %s for group %s", a_user, self.group)
         msg = f"@{self.group}-review: decline"
@@ -287,20 +293,20 @@ class Gitea:
             force: If True, bypasses the check for an existing review request.
 
         Raises:
-            GiteaNoReview: If a review has not been requested and `force` is False.
-            GiteaAssignInvalid: If the PR is not in an unassigned state.
+            GiteaNoReviewError: If a review has not been requested and `force` is False.
+            GiteaAssignInvalidError: If the PR is not in an unassigned state.
 
         """
         a_user = other or self.user
         if not self.__has_review() and not force:
-            raise GiteaNoReview(f"There is no review for {self.group}-review")
+            raise GiteaNoReviewError(f"There is no review for {self.group}-review")
 
         if self.__is_done():
-            raise GiteaNoReview("PR was already approved/rejected")
+            raise GiteaNoReviewError("PR was already approved/rejected")
 
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.UNASSIGNED:
-            raise GiteaAssignInvalid(assign_state, a_user)
+            raise GiteaAssignInvalidError(assign_state, a_user)
 
         logger.info("Assigning PR to %s for group %s", a_user, self.group)
         msg = self.ASSIGN_TEMPLATE % (a_user, self.group)
@@ -313,13 +319,13 @@ class Gitea:
             other: The username to unassign. Defaults to the session user.
 
         Raises:
-            GiteaAssignInvalid: If the PR is not assigned to the specified user.
+            GiteaAssignInvalidError: If the PR is not assigned to the specified user.
 
         """
         a_user = other or self.user
         assign_state = self.__check_assign(a_user)
         if assign_state != assignment.ASSIGNED_USER:
-            raise GiteaAssignInvalid(assign_state, a_user)
+            raise GiteaAssignInvalidError(assign_state, a_user)
 
         logger.info("Unassigning user %s for group %s", a_user, self.group)
         msg = self.UNASSIGN_TEMPLATE % (a_user, self.group)

--- a/mtui/connector/openqa/base.py
+++ b/mtui/connector/openqa/base.py
@@ -53,16 +53,16 @@ class OpenQA(ABC):
             A list of jobs, or None if the request fails.
 
         """
-        logger.debug(f"Get data from openQA - {self.host}")
+        logger.debug("Get data from openQA - %s", self.host)
 
         try:
             jobs = self.client.openqa_request("GET", "jobs", self.params)["jobs"]
         except openqa_client.exceptions.RequestError as e:
-            logger.debug(f"Openqa returned code: {e.args[2]!s}")
+            logger.debug("Openqa returned code: %s", e.args[2])
             return None
         except openqa_client.exceptions.ConnectionError as e:
-            logger.error(f"Cannont connect to openQA - {self.host}")
-            logger.debug(f"openqa_client returned: {e}")
+            logger.exception("Cannont connect to openQA - %s", self.host)
+            logger.debug("openqa_client returned: %s", e)
             return None
 
         return jobs

--- a/mtui/connector/openqa/base.py
+++ b/mtui/connector/openqa/base.py
@@ -26,6 +26,7 @@ class OpenQA(ABC):
             host: The openQA instance host.
             smelt: The SMELT connector instance.
             rrid: The RequestReviewID of the current update.
+
         """
         logger.debug("init openQA client")
         self.host = host
@@ -50,6 +51,7 @@ class OpenQA(ABC):
 
         Returns:
             A list of jobs, or None if the request fails.
+
         """
         logger.debug(f"Get data from openQA - {self.host}")
 

--- a/mtui/connector/openqa/base.py
+++ b/mtui/connector/openqa/base.py
@@ -61,7 +61,7 @@ class OpenQA(ABC):
             logger.debug("Openqa returned code: %s", e.args[2])
             return None
         except openqa_client.exceptions.ConnectionError as e:
-            logger.exception("Cannont connect to openQA - %s", self.host)
+            logger.error("Cannont connect to openQA - %s", self.host)
             logger.debug("openqa_client returned: %s", e)
             return None
 

--- a/mtui/connector/openqa/kernel.py
+++ b/mtui/connector/openqa/kernel.py
@@ -23,6 +23,7 @@ class KernelOpenQA(OpenQA):
 
         Returns:
             A generator of kernel-related jobs.
+
         """
         if jobs is None:
             return None
@@ -41,6 +42,7 @@ class KernelOpenQA(OpenQA):
 
         Returns:
             A list of `Test` objects, or None if there are no jobs.
+
         """
         if jobs is None:
             return None
@@ -79,6 +81,7 @@ class KernelOpenQA(OpenQA):
 
         Returns:
             A list of formatted strings representing the test results.
+
         """
         if not self:
             return []
@@ -107,6 +110,7 @@ class KernelOpenQA(OpenQA):
 
         Returns:
             A list of formatted strings representing the test results.
+
         """
         matrix = []
         for test in testresults:

--- a/mtui/connector/openqa/standard.py
+++ b/mtui/connector/openqa/standard.py
@@ -68,8 +68,10 @@ class AutoOpenQA(OpenQA):
             ]
             if failed_modules:
                 ret.append("    Failed modules:\n")
-                for mod in failed_modules:
-                    ret.append("      Module: {} in category {} failed\n".format(*mod))
+                ret.extend(
+                    "      Module: {} in category {} failed\n".format(*mod)
+                    for mod in failed_modules
+                )
                 ret.append("\n")
 
         return ret

--- a/mtui/connector/openqa/standard.py
+++ b/mtui/connector/openqa/standard.py
@@ -23,6 +23,7 @@ class AutoOpenQA(OpenQA):
 
         Returns:
             True if all install jobs have passed, False otherwise.
+
         """
         if jobs is None:
             return False
@@ -46,6 +47,7 @@ class AutoOpenQA(OpenQA):
 
         Returns:
             A list of formatted strings representing the job results.
+
         """
         jobs = args[0]
         if not jobs:
@@ -80,6 +82,7 @@ class AutoOpenQA(OpenQA):
 
         Returns:
             A list of `URLs` objects, or None if there are no jobs.
+
         """
         if not jobs:
             return None

--- a/mtui/connector/oscqam.py
+++ b/mtui/connector/oscqam.py
@@ -22,6 +22,7 @@ class OSC:
         Args:
             config: An instance of the application's Config class.
             rrid: A RequestReviewID object representing the target review.
+
         """
         self.config = config
         self.rrid = rrid
@@ -45,6 +46,7 @@ class OSC:
             reason: The reason for a rejection.
             message: The message to include with the operation.
             comment: A comment to add to the request.
+
         """
         # Start with the base command components that are always present.
         base_cmd = ["osc", "-A", API, "qam", operation]
@@ -109,6 +111,7 @@ class OSC:
 
         Args:
             group: A list of group names to approve the request for.
+
         """
         self.__operation("approve", group)
 
@@ -117,6 +120,7 @@ class OSC:
 
         Args:
             group: A list of group names to assign the request to.
+
         """
         self.__operation("assign", group)
 
@@ -125,6 +129,7 @@ class OSC:
 
         Args:
             group: A list of group names to unassign the request from.
+
         """
         self.__operation("unassign", group)
 
@@ -133,6 +138,7 @@ class OSC:
 
         Args:
             comment: The comment to add.
+
         """
         self.__operation("comment", [], comment=comment)
 
@@ -143,5 +149,6 @@ class OSC:
             group: A list of group names to reject the request for.
             reason: The reason for the rejection.
             message: The rejection message.
+
         """
         self.__operation("reject", group, reason=reason, message=message)

--- a/mtui/connector/oscqam.py
+++ b/mtui/connector/oscqam.py
@@ -97,14 +97,16 @@ class OSC:
             check_call(command)
 
         except CalledProcessError:
-            logger.error(
+            logger.exception(
                 "'%s' operation failed. The command returned a non-zero exit code.",
                 operation,
             )
             logger.debug("Call stack trace:", stack_info=True)
 
         except FileNotFoundError:
-            logger.error("'osc' command not found. Is it installed and in your PATH?")
+            logger.exception(
+                "'osc' command not found. Is it installed and in your PATH?"
+            )
 
     def approve(self, group: list[str]) -> None:
         """Approves a review request for one or more groups.

--- a/mtui/connector/oscqam.py
+++ b/mtui/connector/oscqam.py
@@ -97,16 +97,14 @@ class OSC:
             check_call(command)
 
         except CalledProcessError:
-            logger.exception(
+            logger.error(
                 "'%s' operation failed. The command returned a non-zero exit code.",
                 operation,
             )
             logger.debug("Call stack trace:", stack_info=True)
 
         except FileNotFoundError:
-            logger.exception(
-                "'osc' command not found. Is it installed and in your PATH?"
-            )
+            logger.error("'osc' command not found. Is it installed and in your PATH?")
 
     def approve(self, group: list[str]) -> None:
         """Approves a review request for one or more groups.

--- a/mtui/connector/smelt.py
+++ b/mtui/connector/smelt.py
@@ -97,14 +97,14 @@ class SMELT:
                 self.apiurl, params={"query": query_incident}, verify=False
             ).json()
         except (requests.exceptions.ConnectionError, JSONDecodeError) as e:
-            logger.debug(f"Problem {e} during retrriving incident")
+            logger.debug("Problem %s during retrriving incident", e)
             return None
         if not inc:
             return None
         try:
             inc = walk(inc["data"]["incidents"]["edges"][0]["node"])
         except Exception as e:
-            logger.debug(f"Problem {e} during normalize incident")
+            logger.debug("Problem %s during normalize incident", e)
             return None
         return inc
 
@@ -121,7 +121,9 @@ class SMELT:
             return None
 
         links = [
-            z.rstrip(")__").split("(")[-1] for z in links if z.startswith("__Group")
+            z.rstrip(")__").split("(")[-1]  # noqa: B005 - strips individual chars ')' and '_'
+            for z in links
+            if z.startswith("__Group")
         ]
         logger.info("openQA jobs found")
         return links

--- a/mtui/connector/smelt.py
+++ b/mtui/connector/smelt.py
@@ -1,6 +1,5 @@
 """A connector for the SMELT GraphQL API."""
 
-from collections.abc import Collection
 from datetime import datetime
 from itertools import chain
 from json.decoder import JSONDecodeError
@@ -34,9 +33,9 @@ class SMELT:
         """
         self.rrid = rrid
         self.apiurl = apiurl
-        self.data: Collection[Any] | None = self._get_data()
+        self.data: dict[str, Any] | None = self._get_data()
 
-    def _get_data(self) -> Collection[Any] | None:
+    def _get_data(self) -> dict[str, Any] | None:
         """Gets data from the SMELT API.
 
         Returns:
@@ -106,7 +105,7 @@ class SMELT:
         except Exception as e:
             logger.debug("Problem %s during normalize incident", e)
             return None
-        return inc
+        return inc  # type: ignore[return-value]  # ty: ignore[invalid-return-type]  # walk returns dict|list, narrowed to dict at runtime
 
     def openqa_links(self) -> list[str] | None:
         """Gets openQA links from comments in IBS.
@@ -198,9 +197,10 @@ class SMELT:
             The incident name, or None if it cannot be determined.
 
         """
-        if not self:
+        if not self or not self.data:
             return None
-        return sorted([pkg["name"] for pkg in self.data["packages"]], key=len)[0]
+        names = sorted([pkg["name"] for pkg in self.data["packages"]], key=len)
+        return str(names[0])
 
     def get_version(self) -> str | None:
         """Gets the version from the SMELT data.
@@ -212,7 +212,7 @@ class SMELT:
             The version string, or None if it cannot be determined.
 
         """
-        if not self:
+        if not self or not self.data:
             return None
         # take first repo ..
         base = self.data["repositories"][0]["name"].split(":")[-2].split("-")

--- a/mtui/connector/smelt.py
+++ b/mtui/connector/smelt.py
@@ -200,7 +200,7 @@ class SMELT:
         """
         if not self:
             return None
-        return sorted([pkg["name"] for pkg in self.data["packages"]], key=len)[0]  # type: ignore
+        return sorted([pkg["name"] for pkg in self.data["packages"]], key=len)[0]
 
     def get_version(self) -> str | None:
         """Gets the version from the SMELT data.
@@ -215,7 +215,7 @@ class SMELT:
         if not self:
             return None
         # take first repo ..
-        base = self.data["repositories"][0]["name"].split(":")[-2].split("-")  # type: ignore
+        base = self.data["repositories"][0]["name"].split(":")[-2].split("-")
         return f"{base[0]}-{base[1]}"
 
     def __bool__(self) -> bool:

--- a/mtui/connector/smelt.py
+++ b/mtui/connector/smelt.py
@@ -30,6 +30,7 @@ class SMELT:
         Args:
             rrid: The RequestReviewID of the current update.
             apiurl: The URL of the SMELT GraphQL API.
+
         """
         self.rrid = rrid
         self.apiurl = apiurl
@@ -41,6 +42,7 @@ class SMELT:
         Returns:
             A collection of data from the SMELT API, or None if the
             request fails.
+
         """
         query_incident = f"""{{
   incidents(incidentId: {self.rrid.maintenance_id} ) {{
@@ -111,6 +113,7 @@ class SMELT:
 
         Returns:
             A list of openQA links, or None if no links are found.
+
         """
         links = self._comments(self.data)
         if not links:
@@ -128,6 +131,7 @@ class SMELT:
 
         Returns:
             A list of formatted strings representing the openQA links.
+
         """
         links = self._comments(self.data)
         if not links:
@@ -155,6 +159,7 @@ class SMELT:
 
         Returns:
             A list of comments, or None if no comments are found.
+
         """
         if not data:
             return None
@@ -189,6 +194,7 @@ class SMELT:
 
         Returns:
             The incident name, or None if it cannot be determined.
+
         """
         if not self:
             return None
@@ -202,8 +208,8 @@ class SMELT:
 
         Returns:
             The version string, or None if it cannot be determined.
-        """
 
+        """
         if not self:
             return None
         # take first repo ..

--- a/mtui/datafiles.py
+++ b/mtui/datafiles.py
@@ -16,7 +16,6 @@ def _package_data_path() -> Path:
     This is the root from which ``scripts/``, ``helper/``, and
     ``terms/`` subdirectories can be reached.
     """
-
     pkg = files("mtui")
 
     # importlib.resources.files() returns a Traversable; for packages

--- a/mtui/display.py
+++ b/mtui/display.py
@@ -17,6 +17,7 @@ class CommandPromptDisplay:
 
         Args:
             output: The output stream to write to.
+
         """
         self.output = output
 
@@ -26,6 +27,7 @@ class CommandPromptDisplay:
         Args:
             msg: The message to print.
             eol: The end-of-line character to use.
+
         """
         self.output.write(msg + eol)
 
@@ -36,6 +38,7 @@ class CommandPromptDisplay:
             bugs: A dictionary of bug IDs and summaries.
             jira: A dictionary of Jira issue IDs and summaries.
             url: The base URL for the bug tracker.
+
         """
         ids = sorted(bugs.keys())
         if ids == [""]:
@@ -64,6 +67,7 @@ class CommandPromptDisplay:
             hostname: The name of the host.
             system: The system information for the host.
             lines: A list of history log lines.
+
         """
         self.println(f"history from {hostname} ({system}):")
         lines.reverse()
@@ -97,6 +101,7 @@ class CommandPromptDisplay:
             transactional: Whether the host is transactional.
             state: The state of the host (enabled, disabled, or dryrun).
             exclusive: Whether the host is in exclusive mode.
+
         """
         mode = "serial" if exclusive else "parallel"
 
@@ -120,13 +125,14 @@ class CommandPromptDisplay:
             hostname: The name of the host.
             system: The system information for the host.
             lock: The lock object for the host.
+
         """
         if lock.is_locked():
             lockedby: str = "me" if lock.is_mine() else lock.locked_by()
 
             self.println(
                 eol="",
-                msg="{0:20} {1:20}: {2}".format(
+                msg="{:20} {:20}: {}".format(
                     hostname,
                     str(system),
                     yellow(f"since {lock.time()} by {lockedby}"),
@@ -139,7 +145,7 @@ class CommandPromptDisplay:
                 self.println()
         else:
             self.println(
-                "{0:20} {1:20}: {2}".format(hostname, str(system), green("not locked"))
+                "{:20} {:20}: {}".format(hostname, str(system), green("not locked"))
             )
 
     def list_sessions(self, hostname: str, system: System, stdout: str) -> None:
@@ -149,6 +155,7 @@ class CommandPromptDisplay:
             hostname: The name of the host.
             system: The system information for the host.
             stdout: The output of the session listing command.
+
         """
         self.println(f"sessions on {hostname} ({system}):")
         self.println(stdout)
@@ -160,8 +167,9 @@ class CommandPromptDisplay:
             hostname: The name of the host.
             system: The system information for the host.
             timeout: The command timeout in seconds.
+
         """
-        self.println("{0:20} {1:20}: {2}s".format(hostname, f"({system!s})", timeout))
+        self.println("{:20} {:20}: {}s".format(hostname, f"({system!s})", timeout))
 
     def list_versions(self, targets: HostsGroup, hosts_pvs) -> None:
         """Displays the version history of packages on a host.
@@ -169,6 +177,7 @@ class CommandPromptDisplay:
         Args:
             targets: The group of target hosts.
             hosts_pvs: A dictionary mapping hosts to package versions.
+
         """
         for hs, pvs in list(hosts_pvs.items()):
             if len(hosts_pvs) > 1:
@@ -191,6 +200,7 @@ class CommandPromptDisplay:
         Args:
             hostname: The name of the host.
             system: The system information for the host.
+
         """
         self.println("{}: {}".format(green("Referenece host"), yellow(hostname)))
         for x in system.pretty():
@@ -203,6 +213,7 @@ class CommandPromptDisplay:
         Args:
             repos: A dictionary of repositories.
             update_id: The ID of the update.
+
         """
         for p, r in repos.items():
             self.println(
@@ -227,6 +238,7 @@ class CommandPromptDisplay:
             hostname: The name of the host.
             hostlog: A list of log entries.
             sink: The function to use for printing the log.
+
         """
         sink(f"log from {hostname!s}:")
         for cmdline, stdout, stderr, exitcode, _ in hostlog:

--- a/mtui/exceptions.py
+++ b/mtui/exceptions.py
@@ -22,6 +22,7 @@ class RequestReviewIDParseError(ValueError, ArgumentTypeError):
 
         Args:
             message: The error message.
+
         """
         super().__init__("OBS Request Review ID: " + message)
 
@@ -34,6 +35,7 @@ class TooManyComponentsError(RequestReviewIDParseError):
 
         Args:
             limit: The maximum number of components allowed.
+
         """
         super().__init__(f"Too many components (> {limit})")
 
@@ -44,6 +46,7 @@ class TooManyComponentsError(RequestReviewIDParseError):
         Args:
             xs: The sequence to check.
             limit: The maximum number of components allowed.
+
         """
         if len(xs) > limit:
             raise cls(limit)
@@ -58,6 +61,7 @@ class InternalParseError(RequestReviewIDParseError):
         Args:
             f: The function where the error occurred.
             cnt: The context of the error.
+
         """
         super().__init__(f"Internal error: f: {f!r} cnt: {cnt!r}")
 
@@ -71,6 +75,7 @@ class MissingComponent(RequestReviewIDParseError):
         Args:
             index: The index of the missing component.
             expected: The expected component.
+
         """
         super().__init__(f"Missing {index}. component. Expected: {expected}")
 
@@ -85,6 +90,7 @@ class ComponentParseError(RequestReviewIDParseError):
             index: The index of the component that failed to parse.
             expected: The expected component.
             got: The component that was received.
+
         """
         super().__init__(
             f"Failed to parse {index}. component. Expected {expected}. Got: {got!r}"
@@ -100,6 +106,7 @@ class UpdateError(Exception):
         Args:
             reason: The reason for the update error.
             host: The host where the error occurred.
+
         """
         self.reason: str = reason
         self.host: str | None = host
@@ -148,6 +155,7 @@ class GiteaAssignInvalid(GiteaError):
         Args:
             assign_status: The assignment status.
             user: The user involved in the assignment.
+
         """
         self.assign_status = assign_status
         self.user = user

--- a/mtui/exceptions.py
+++ b/mtui/exceptions.py
@@ -66,7 +66,7 @@ class InternalParseError(RequestReviewIDParseError):
         super().__init__(f"Internal error: f: {f!r} cnt: {cnt!r}")
 
 
-class MissingComponent(RequestReviewIDParseError):
+class MissingComponentError(RequestReviewIDParseError):
     """Raised when a component of an OBS Request Review ID is missing."""
 
     def __init__(self, index, expected) -> None:
@@ -122,19 +122,19 @@ class GiteaError(BaseException):
     """Base exception for Gitea-related errors."""
 
 
-class MissingGiteaToken(GiteaError):
+class MissingGiteaTokenError(GiteaError):
     """Raised when a Gitea token is missing."""
 
 
-class FailedGiteaCall(GiteaError):
+class FailedGiteaCallError(GiteaError):
     """Raised when a call to the Gitea API fails."""
 
 
-class GiteaNoReview(GiteaError):
+class GiteaNoReviewError(GiteaError):
     """Raised when a Gitea pull request has no review."""
 
 
-class InvalidGiteaHash(GiteaError):
+class InvalidGiteaHashError(GiteaError):
     """Raised when Gitea has different hash than testreport metadata"""
 
     def __init__(self, rrid: "RequestReviewID", old: str, new: str):
@@ -146,7 +146,7 @@ class InvalidGiteaHash(GiteaError):
         return f"Testreport for {self.id} has different hash than GiteaPR. Testreport: {self.old} - repo {self.new}"
 
 
-class GiteaAssignInvalid(GiteaError):
+class GiteaAssignInvalidError(GiteaError):
     """Raised when there is an issue with Gitea pull request assignment."""
 
     def __init__(self, assign_status: assignment, user: str):

--- a/mtui/exceptions.py
+++ b/mtui/exceptions.py
@@ -137,7 +137,7 @@ class GiteaNoReviewError(GiteaError):
 class InvalidGiteaHashError(GiteaError):
     """Raised when Gitea has different hash than testreport metadata."""
 
-    def __init__(self, rrid: "RequestReviewID", old: str, new: str):
+    def __init__(self, rrid: "RequestReviewID | str", old: str, new: str):
         self.id = rrid
         self.old = old
         self.new = new

--- a/mtui/exceptions.py
+++ b/mtui/exceptions.py
@@ -135,7 +135,7 @@ class GiteaNoReviewError(GiteaError):
 
 
 class InvalidGiteaHashError(GiteaError):
-    """Raised when Gitea has different hash than testreport metadata"""
+    """Raised when Gitea has different hash than testreport metadata."""
 
     def __init__(self, rrid: "RequestReviewID", old: str, new: str):
         self.id = rrid

--- a/mtui/export/auto.py
+++ b/mtui/export/auto.py
@@ -59,7 +59,7 @@ class AutoExport(BaseExport):
                 t = log.readlines()
             return [x.decode() for x in t]
         except (RemoteDisconnected, HTTPError, URLError):
-            logger.exception("log %s failed to download", url.url)
+            logger.error("log %s failed to download", url.url)
             return []
 
     def run(self, *args, **kwds) -> FileList | list[str]:

--- a/mtui/export/auto.py
+++ b/mtui/export/auto.py
@@ -26,6 +26,7 @@ class AutoExport(BaseExport):
 
         Returns:
             A list of paths to the log files.
+
         """
         filepath = self.config.template_dir / str(self.rrid) / self.config.install_logs
         ilogs = zip_longest(
@@ -50,6 +51,7 @@ class AutoExport(BaseExport):
 
         Returns:
             A list of strings representing the log content.
+
         """
         # input is URLs instance
         try:
@@ -69,6 +71,7 @@ class AutoExport(BaseExport):
 
         Returns:
             The exported template.
+
         """
         self.install_results()
         self.inject_openqa()

--- a/mtui/export/auto.py
+++ b/mtui/export/auto.py
@@ -58,8 +58,8 @@ class AutoExport(BaseExport):
             with urlopen(url.url) as log:
                 t = log.readlines()
             return [x.decode() for x in t]
-        except (RemoteDisconnected, HTTPError, URLError) as e:
-            logger.error("log %s failed to download - %s", url.url, e)
+        except (RemoteDisconnected, HTTPError, URLError):
+            logger.exception("log %s failed to download", url.url)
             return []
 
     def run(self, *args, **kwds) -> FileList | list[str]:

--- a/mtui/export/base.py
+++ b/mtui/export/base.py
@@ -62,9 +62,9 @@ class BaseExport(ABC):
         to_write = "\n".join(data)
         if fn.exists() and not self.force:
             if to_write == fn.read_text():
-                logger.info(f"Log {fn} exists and is same as export")
+                logger.info("Log %s exists and is same as export", fn)
                 return
-            logger.warning(f"file {fn} exists.")
+            logger.warning("file %s exists.", fn)
             if not prompt_user(
                 f"Should I overwrite {fn} (y/N) ",
                 ["y", "Y", "yes", "Yes", "YES"],
@@ -77,8 +77,8 @@ class BaseExport(ABC):
         try:
             with fn.open(mode="w", encoding="utf-8") as f:
                 f.write(to_write)
-        except OSError as e:
-            logger.error("Failed to write %s: %s", fn, e.strerror)
+        except OSError:
+            logger.exception("Failed to write %s", fn)
 
     def installlogs_lines(self, filenames) -> None:
         """Adds install log links to the template.

--- a/mtui/export/base.py
+++ b/mtui/export/base.py
@@ -78,7 +78,7 @@ class BaseExport(ABC):
             with fn.open(mode="w", encoding="utf-8") as f:
                 f.write(to_write)
         except OSError:
-            logger.exception("Failed to write %s", fn)
+            logger.error("Failed to write %s", fn)
 
     def installlogs_lines(self, filenames) -> None:
         """Adds install log links to the template.

--- a/mtui/export/base.py
+++ b/mtui/export/base.py
@@ -40,6 +40,7 @@ class BaseExport(ABC):
             rrid: The RequestReviewID of the current update.
             interactive: Whether to run in interactive mode.
             **kwargs: Additional keyword arguments.
+
         """
         self.config = config
         self.openqa = openqa
@@ -56,6 +57,7 @@ class BaseExport(ABC):
         Args:
             fn: The path to the file to write to.
             data: The data to write.
+
         """
         to_write = "\n".join(data)
         if fn.exists() and not self.force:
@@ -83,6 +85,7 @@ class BaseExport(ABC):
 
         Args:
             filenames: A list of filenames to add.
+
         """
         o = 0
         for line in self.template:

--- a/mtui/export/downloader.py
+++ b/mtui/export/downloader.py
@@ -26,9 +26,9 @@ def _subdl(oqa_path: str, l_path: str, test: dict, errormode: str) -> None:
         logger.info("Downloading log %s", oqa_path)
         urlretrieve(oqa_path, l_path)
     except urllib.error.HTTPError:
-        logger.error("Download from %s failed", oqa_path)
+        logger.exception("Download from %s failed", oqa_path)
         if errormode == "full":
-            raise ResultsMissingError(test["name"], test["arch"])
+            raise ResultsMissingError(test["name"], test["arch"]) from None
 
 
 def _emptylog(host, test, *args, **kwds) -> None:

--- a/mtui/export/downloader.py
+++ b/mtui/export/downloader.py
@@ -26,7 +26,7 @@ def _subdl(oqa_path: str, l_path: str, test: dict, errormode: str) -> None:
         logger.info("Downloading log %s", oqa_path)
         urlretrieve(oqa_path, l_path)
     except urllib.error.HTTPError:
-        logger.exception("Download from %s failed", oqa_path)
+        logger.error("Download from %s failed", oqa_path)
         if errormode == "full":
             raise ResultsMissingError(test["name"], test["arch"]) from None
 

--- a/mtui/export/downloader.py
+++ b/mtui/export/downloader.py
@@ -20,6 +20,7 @@ def _subdl(oqa_path: str, l_path: str, test: dict, errormode: str) -> None:
         l_path: The local path to save the log file to.
         test: A dictionary containing information about the test.
         errormode: The error mode to use if the download fails.
+
     """
     try:
         logger.info("Downloading log %s", oqa_path)
@@ -38,6 +39,7 @@ def _emptylog(host, test, *args, **kwds) -> None:
         test: A dictionary containing information about the test.
         *args: Additional arguments (not used).
         **kwds: Additional keyword arguments (not used).
+
     """
     logger.debug("No log to download for test: %s on %s", test["name"], host)
 
@@ -51,6 +53,7 @@ def _resultlog(host, test, resultsdir, _, errormode) -> None:
         resultsdir: The directory to save the results to.
         _: An unused argument.
         errormode: The error mode to use if the download fails.
+
     """
     oqa_path = os.path.join(
         host, "tests", str(test["test_id"]), "file", "result_array.json"
@@ -72,6 +75,7 @@ def _installlog(host, test, _, installlogsdir, errormode) -> None:
         _: An unused argument.
         installlogsdir: The directory to save the install logs to.
         errormode: The error mode to use if the download fails.
+
     """
     oqa_path = os.path.join(
         host, "tests", str(test["test_id"]), "file", "update_kernel-zypper.log"
@@ -99,6 +103,7 @@ def download_logs(oqa, resultsdir, installogsdir, errormode: str) -> None:
         resultsdir: The directory to save the results to.
         installogsdir: The directory to save the install logs to.
         errormode: The error mode to use if a download fails.
+
     """
     results_matrix: list[tuple[str, str, str, str]] = []
     for host in oqa:

--- a/mtui/export/kernel.py
+++ b/mtui/export/kernel.py
@@ -51,7 +51,7 @@ class KernelExport(BaseExport):
                     + 1
                 )
             except ValueError:
-                line = line = self.template.index("regression tests:\n") + 1
+                line = self.template.index("regression tests:\n") + 1
 
             e_line = self.template.index("build log review:\n")
             del self.template[line:e_line]

--- a/mtui/export/kernel.py
+++ b/mtui/export/kernel.py
@@ -25,6 +25,7 @@ class KernelExport(BaseExport):
 
         Returns:
             A list of paths to the log files.
+
         """
         in_path = self.config.template_dir / str(self.rrid) / self.config.install_logs
         res_path = self.config.template_dir / str(self.rrid) / "results"
@@ -80,6 +81,7 @@ class KernelExport(BaseExport):
 
         Returns:
             The exported template.
+
         """
         self.install_results()
         self.inject_openqa()

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -87,7 +87,7 @@ class ManualExport(BaseExport):
                         except ValueError:
                             # no hostsection found and no starting point for insertion,
                             # bail out and try the next host
-                            logger.error("update results section not found")
+                            logger.exception("update results section not found")
                             break
 
                     # insert new package version log at position i.
@@ -140,7 +140,7 @@ class ManualExport(BaseExport):
             except ValueError:
                 # host section not found (this should really not happen)
                 # proceed with the next one.
-                logger.warning(f"host section {hostname} not found")
+                logger.warning("host section %s not found", hostname)
                 continue
             for state in ["before", "after"]:
                 versions[state] = {}
@@ -150,7 +150,7 @@ class ManualExport(BaseExport):
                     try:
                         index = self.template.index(f"{state}:\n", index) + 1
                     except ValueError:
-                        logger.error(f"{state} packages section not found")
+                        logger.exception("%s packages section not found", state)
                         continue
 
                 for package in host.packages.values():
@@ -200,7 +200,8 @@ class ManualExport(BaseExport):
                     failed = True
             if failed:
                 logger.warning(
-                    f"installation test result on {hostname} set to FAILED as some packages were not updated. please override manually."
+                    "installation test result on %s set to FAILED as some packages were not updated. please override manually.",
+                    hostname,
                 )
 
             # temporary variable to avoid repeating the same script. We only want the

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -100,7 +100,7 @@ class ManualExport(BaseExport):
                     #
                     # => PASSED/FAILED
                     #
-                    # comment: (none)
+                    # comment: (none)  # noqa: ERA001
                     #
                     self.template.insert(index, "\n")
                     index += 1
@@ -215,7 +215,7 @@ class ManualExport(BaseExport):
                 #                       2 INTERNAL ERROR
                 #                       3 NOT RUN
                 try:
-                    # name == command, exitcode == exitcode
+                    # name == command, exitcode == exitcode  # noqa: ERA001
                     name = cmdlog.command
                     exitcode = cmdlog.exitcode
 

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -25,6 +25,7 @@ class ManualExport(BaseExport):
 
         Returns:
             A list of paths to the log files.
+
         """
         filepath = self.config.template_dir / str(self.rrid) / self.config.install_logs
         ilogs = zip_longest(hosts, map(self._host_installog_to_template, hosts))
@@ -168,13 +169,12 @@ class ManualExport(BaseExport):
                                 self.template[index] = (
                                     f"\tpackage {name} is not installed\n"
                                 )
+                        elif version is not None:
+                            self.template.insert(index, f"\t{name}-{version}\n")
                         else:
-                            if version is not None:
-                                self.template.insert(index, f"\t{name}-{version}\n")
-                            else:
-                                self.template.insert(
-                                    index, f"\tpackage {name} is not installed\n"
-                                )
+                            self.template.insert(
+                                index, f"\tpackage {name} is not installed\n"
+                            )
                         index += 1
                     except Exception:
                         pass
@@ -268,6 +268,7 @@ class ManualExport(BaseExport):
 
         Returns:
             A list of strings representing the log content.
+
         """
         t = []
         try:
@@ -316,6 +317,7 @@ class ManualExport(BaseExport):
 
         Returns:
             The exported template.
+
         """
         self.install_results()
         self.inject_openqa()

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -46,7 +46,7 @@ class ManualExport(BaseExport):
         # if the location isn't found, it's considered that it doesn't exist.
         # in this case, a whole new host section including the systemname is added.
         # --- self.results --- is injected from BaseExport.__init__ keyword argument
-        for host in self.results:  # type: ignore
+        for host in self.results:
             hostname = host.hostname
             systemtype = host.system
             # systemname/reference host string in the maintenance template
@@ -127,7 +127,7 @@ class ManualExport(BaseExport):
                     self.template.insert(index, "\n")
 
         # add package version log and script results for each host to the template
-        for host in self.results:  # type: ignore
+        for host in self.results:
             versions = {}
             hostname = host.hostname
             systemtype = host.system
@@ -273,7 +273,7 @@ class ManualExport(BaseExport):
         """
         t = []
         try:
-            host_log = [host for host in self.results if host.hostname == target][0]  # type: ignore
+            host_log = [host for host in self.results if host.hostname == target][0]
         except IndexError:
             return []
 
@@ -287,7 +287,7 @@ class ManualExport(BaseExport):
 
     def install_results(self) -> None:
         """Adds installation results to the template."""
-        hosts = [h.hostname for h in self.results]  # type: ignore
+        hosts = [h.hostname for h in self.results]
         c_host = None
         tmp_template = []
         for line in self.template:

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -87,7 +87,7 @@ class ManualExport(BaseExport):
                         except ValueError:
                             # no hostsection found and no starting point for insertion,
                             # bail out and try the next host
-                            logger.exception("update results section not found")
+                            logger.error("update results section not found")
                             break
 
                     # insert new package version log at position i.
@@ -150,7 +150,7 @@ class ManualExport(BaseExport):
                     try:
                         index = self.template.index(f"{state}:\n", index) + 1
                     except ValueError:
-                        logger.exception("%s packages section not found", state)
+                        logger.error("%s packages section not found", state)
                         continue
 
                 for package in host.packages.values():

--- a/mtui/export/manual.py
+++ b/mtui/export/manual.py
@@ -5,6 +5,7 @@ import re
 from itertools import zip_longest
 from logging import getLogger
 from pathlib import Path
+from typing import Any
 
 from ..types import FileList
 from .base import BaseExport
@@ -14,6 +15,9 @@ logger = getLogger("mtui.export.manual")
 
 class ManualExport(BaseExport):
     """An exporter for the manual workflow."""
+
+    # Injected via BaseExport.__init__(**kwargs)
+    results: Any
 
     def get_logs(self, hosts, *args, **kwds) -> list[Path]:
         """Gets the logs from the target hosts.

--- a/mtui/hooks.py
+++ b/mtui/hooks.py
@@ -136,7 +136,7 @@ class PreScript(Script):
                     f.write(t.lastout())
                     f.write(t.lasterr())
             except OSError as e:
-                log.error(messages.FailedToWriteScriptResult(fname, e))
+                log.exception(messages.FailedToWriteScriptResult(fname, e))
 
 
 class PostScript(PreScript):
@@ -183,6 +183,7 @@ class CompareScript(Script):
                 argv,
                 capture_output=True,
                 text=True,
+                check=False,
             )
         except OSError as e:
             t.out.append([" ".join(argv), "", "", 0x100, 0])

--- a/mtui/hooks.py
+++ b/mtui/hooks.py
@@ -196,8 +196,8 @@ class CompareScript(Script):
             return
 
         if ret.returncode == 2:
-            logger, msg = log.critical, messages.CompareScriptCrashed
+            logger, msg = log.critical, messages.CompareScriptCrashedError
         else:
-            logger, msg = log.warning, messages.CompareScriptFailed  # type: ignore
+            logger, msg = log.warning, messages.CompareScriptFailedError
 
         logger(msg(argv, ret.stdout, ret.stderr, ret.returncode))

--- a/mtui/hooks.py
+++ b/mtui/hooks.py
@@ -34,6 +34,7 @@ class Script(ABC):
         Args:
             tr: The test report object.
             path: The absolute path to the script.
+
         """
         self.path = path
         self.name = path.parent
@@ -56,6 +57,7 @@ class Script(ABC):
 
         Returns:
             The path to the result file.
+
         """
         return self.testreport.report_wd(
             *cls.result_parts(bname, t.hostname), filepath=True
@@ -67,6 +69,7 @@ class Script(ABC):
 
         Args:
             targets: The group of target hosts.
+
         """
         ...
 
@@ -79,6 +82,7 @@ class Script(ABC):
 
         Returns:
             A tuple containing the parts of the result path.
+
         """
         return ("output/scripts", ".".join((cls.subdir, *basename)))
 
@@ -87,6 +91,7 @@ class Script(ABC):
 
         Args:
             targets: The group of target hosts.
+
         """
         try:
             log.info("running %s", self)
@@ -105,6 +110,7 @@ class PreScript(Script):
 
         Args:
             targets: The group of target hosts.
+
         """
         rname: Path = self.testreport.target_wd(f"{self.subdir!s}.{self.bname!s}")
         targets.sftp_put(self.path, rname)
@@ -149,6 +155,7 @@ class CompareScript(Script):
 
         Args:
             targets: The group of target hosts.
+
         """
         for t in targets.values():
             self._run_single_target(t)
@@ -158,6 +165,7 @@ class CompareScript(Script):
 
         Args:
             t: The target host.
+
         """
         bcheck = self.bname.replace("compare_", "check_")
         argv = [
@@ -173,8 +181,7 @@ class CompareScript(Script):
         try:
             ret = subprocess.run(
                 argv,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 text=True,
             )
         except OSError as e:

--- a/mtui/hooks.py
+++ b/mtui/hooks.py
@@ -136,7 +136,7 @@ class PreScript(Script):
                     f.write(t.lastout())
                     f.write(t.lasterr())
             except OSError as e:
-                log.exception(messages.FailedToWriteScriptResult(fname, e))
+                log.error(messages.FailedToWriteScriptResult(fname, e))
 
 
 class PostScript(PreScript):

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -84,7 +84,7 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
             CalledProcessError,
             MetadataNotLoadedError,
         ) as e:
-            logger.error(e)
+            logger.exception(e)
             return 1
 
     if args.sut:

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -84,7 +84,7 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
             CalledProcessError,
             MetadataNotLoadedError,
         ) as e:
-            logger.exception(e)
+            logger.error(e)
             return 1
 
     if args.sut:

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from subprocess import CalledProcessError
 from typing import Literal
 
-from .argparse import ArgsParseFailure
+from .argparse import ArgsParseFailureError
 from .args import get_parser
 from .colorlog import create_logger
 from .config import Config
@@ -32,7 +32,7 @@ def main() -> int:
     p = get_parser(sys)
     try:
         args = p.parse_args(sys.argv[1:])
-    except ArgsParseFailure as e:
+    except ArgsParseFailureError as e:
         return e.status
 
     if args.noninteractive and not args.prerun:
@@ -61,20 +61,20 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
         logger.setLevel(level=logging.DEBUG)
 
     config.merge_args(args)
-    config.kernel = False  # type: ignore
-    config.auto = False  # type: ignore
+    config.kernel = False
+    config.auto = False
 
-    config.distro, config.distro_ver, config.distro_kernel = detect_system()  # type: ignore
+    config.distro, config.distro_ver, config.distro_kernel = detect_system()
 
     prompt = CommandPrompt(config, logger, sys, CommandPromptDisplay)
     prompt.interactive = not args.noninteractive
     if args.update:
         if args.update.kind == "kernel":
-            config.kernel = True  # type: ignore
-            config.auto = False  # type: ignore
+            config.kernel = True
+            config.auto = False
         elif args.update.kind == "auto":
-            config.auto = True  # type: ignore
-            config.kernel = False  # type: ignore
+            config.auto = True
+            config.kernel = False
         else:
             pass
         try:

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -25,6 +25,7 @@ def main() -> int:
 
     Returns:
         The exit code of the application.
+
     """
     logger = create_logger("mtui")
 
@@ -54,6 +55,7 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
 
     Returns:
         0 on success, 1 on failure.
+
     """
     if args.debug:
         logger.setLevel(level=logging.DEBUG)

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -13,16 +13,16 @@ class UserMessage(BaseException, ABC):
     """An abstract base class for messages to be displayed to the user."""
 
     def __str__(self) -> str:
-        return self.message  # type: ignore
+        return self.message
 
     def __eq__(self, x: object) -> bool:
         return str(self) == str(x)
 
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return hash(self)
 
 
-class ErrorMessage(UserMessage, RuntimeError):
+class ErrorMessage(UserMessage, RuntimeError):  # noqa: N818
     """A program error message to be displayed to the user."""
 
 
@@ -188,7 +188,7 @@ class CompareScriptError(UserMessage):
         raise NotImplementedError
 
 
-class CompareScriptFailed(CompareScriptError):
+class CompareScriptFailedError(CompareScriptError):
     """A message for when a compare script fails."""
 
     def __str__(self) -> str:
@@ -197,7 +197,7 @@ class CompareScriptFailed(CompareScriptError):
         )
 
 
-class CompareScriptCrashed(CompareScriptError):
+class CompareScriptCrashedError(CompareScriptError):
     """A message for when a compare script crashes."""
 
     def __str__(self) -> str:

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -12,6 +12,8 @@ from abc import ABC
 class UserMessage(BaseException, ABC):
     """An abstract base class for messages to be displayed to the user."""
 
+    message: str
+
     def __str__(self) -> str:
         return self.message
 
@@ -231,6 +233,8 @@ class PackageRevisionHasntChangedWarning(UserMessage):
 
 class MissingDoerError(ErrorMessage):
     """Base class for missing "doer" errors."""
+
+    name: str  # Set by subclasses as a class variable
 
     def __init__(self, release) -> None:
         self.release = release

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -293,7 +293,7 @@ class ReConnectFailed(ErrorMessage):
 
 
 class RepositoryError(ErrorMessage):
-    """failed to read IBS Repository"""
+    """failed to read IBS Repository."""
 
     def __init__(self, repo) -> None:
         self.repo = repo
@@ -301,14 +301,14 @@ class RepositoryError(ErrorMessage):
 
 
 class openQAError(ErrorMessage):
-    """openQA related Errors"""
+    """openQA related Errors."""
 
     def __init__(self) -> None:
         self.message = "Something wrong with openQA connection"
 
 
 class ResultsMissingError(ErrorMessage):
-    """missing results json file"""
+    """missing results json file."""
 
     def __init__(self, test, arch) -> None:
         self.test = test
@@ -317,14 +317,14 @@ class ResultsMissingError(ErrorMessage):
 
 
 class SMELTError(ErrorMessage):
-    """SMELT related Errors"""
+    """SMELT related Errors."""
 
     def __init__(self) -> None:
         self.message = "Sommething wrong with SMELT connection"
 
 
 class SVNError(ErrorMessage):
-    """SVN related Errors"""
+    """SVN related Errors."""
 
     def __init__(self, cmd) -> None:
         self.cmd = cmd

--- a/mtui/notification.py
+++ b/mtui/notification.py
@@ -21,12 +21,12 @@ def display(
     global __impl
     if __impl is None:
         try:
-            import pynotify as __impl  # type: ignore
+            import pynotify as __impl
         except ImportError:
             __impl = False
             logger.debug("pynotify not installed. notification disabled.")
         else:
-            if not __impl.init("mtui"):  # type: ignore
+            if not __impl.init("mtui"):
                 __impl = False
                 logger.debug("failed to initialize pynotify")
 
@@ -35,6 +35,6 @@ def display(
 
     logger.debug('displaying notify message "%s"', text)
     try:
-        __impl.Notification(summary, text, icon).show()  # type: ignore
+        __impl.Notification(summary, text, icon).show()
     except Exception:
         logger.debug("failed to display notification")

--- a/mtui/notification.py
+++ b/mtui/notification.py
@@ -16,6 +16,7 @@ def display(
         summary: The summary text of the notification.
         text: The body text of the notification.
         icon: The icon to display in the notification.
+
     """
     global __impl
     if __impl is None:

--- a/mtui/notification.py
+++ b/mtui/notification.py
@@ -21,7 +21,7 @@ def display(
     global __impl
     if __impl is None:
         try:
-            import pynotify as __impl
+            import pynotify as __impl  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
         except ImportError:
             __impl = False
             logger.debug("pynotify not installed. notification disabled.")

--- a/mtui/parsemeta.py
+++ b/mtui/parsemeta.py
@@ -19,6 +19,7 @@ class ReducedMetadataParser:
         Args:
             results: An object to store the parsed results.
             line: The line of text to parse.
+
         """
         if (match := re.search(cls.hostnames, line)) and "?" not in match.group(1):
             results.hostnames.add(match.group(1))

--- a/mtui/parsemetajson.py
+++ b/mtui/parsemetajson.py
@@ -13,6 +13,7 @@ class JSONParser:
         Args:
             results: An object to store the parsed results.
             data: The JSON object to parse.
+
         """
         for i in data.get("jira"):
             results.jira[i] = "Description not available"

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -11,7 +11,6 @@ import subprocess
 from collections.abc import Callable
 from logging import getLogger
 from pathlib import Path
-from traceback import format_exc
 from typing import Any
 
 from mtui import notification
@@ -211,7 +210,7 @@ class CommandPrompt(cmd.Cmd):
             except (messages.UserMessage, subprocess.CalledProcessError) as e:
                 logger.exception(e)
             except Exception:
-                logger.exception(format_exc())
+                logger.exception("Unexpected error")
 
     def postcmd(self, stop: bool, line: str) -> bool:
         """A hook that is called after a command is executed.

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -47,7 +47,7 @@ class CmdQueue(list):
         self.term = term
         list.__init__(self, iterable)
 
-    def pop(self, i) -> Any:
+    def pop(self, i=-1, /) -> Any:  # type: ignore[override]
         """Pops a command from the queue and echoes it to the terminal.
 
         Args:

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -17,14 +17,14 @@ from typing import Any
 from mtui import notification
 
 from . import commands, messages
-from .argparse import ArgsParseFailure
+from .argparse import ArgsParseFailureError
 from .commands import Command
 from .template.nulltestreport import NullTestReport
 
 logger = getLogger("mtui.prompt")
 
 
-class QuitLoop(RuntimeError):
+class QuitLoopError(RuntimeError):
     """Exception raised to exit the command loop."""
 
 
@@ -48,7 +48,7 @@ class CmdQueue(list):
         self.term = term
         list.__init__(self, iterable)
 
-    def pop(self, i) -> Any:  # type: ignore
+    def pop(self, i) -> Any:
         """Pops a command from the queue and echoes it to the terminal.
 
         Args:
@@ -206,7 +206,7 @@ class CommandPrompt(cmd.Cmd):
                 self.cmdqueue = []
                 # make the new prompt to be printed on new line
                 self.println()
-            except QuitLoop:
+            except QuitLoopError:
                 return
             except (messages.UserMessage, subprocess.CalledProcessError) as e:
                 logger.exception(e)
@@ -256,7 +256,7 @@ class CommandPrompt(cmd.Cmd):
                 def do(arg) -> None:
                     try:
                         args = c.parse_args(arg, self.sys)
-                    except ArgsParseFailure:
+                    except ArgsParseFailureError:
                         return
                     c(args, self.config, self.sys, self)()
 

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -42,6 +42,7 @@ class CmdQueue(list):
             iterable: An iterable of commands.
             prompt: The command prompt string.
             term: The terminal object.
+
         """
         self.prompt = prompt
         self.term = term
@@ -55,6 +56,7 @@ class CmdQueue(list):
 
         Returns:
             The popped command.
+
         """
         val = list.pop(self, i)
         self.echo_prompt(val)
@@ -65,6 +67,7 @@ class CmdQueue(list):
 
         Args:
             val: The command to echo.
+
         """
         self.term.stdout.write(f"{self.prompt}{val}\n")
 
@@ -105,6 +108,7 @@ class CommandPrompt(cmd.Cmd):
             log: The logger instance.
             sys: The sys module.
             display_factory: A factory for creating display objects.
+
         """
         self.sys = sys
 
@@ -145,6 +149,7 @@ class CommandPrompt(cmd.Cmd):
         Args:
             msg: The message to display.
             class_: The notification class.
+
         """
         notification.display("MTUI", msg, class_)
 
@@ -154,6 +159,7 @@ class CommandPrompt(cmd.Cmd):
         Args:
             msg: The message to print.
             eol: The end-of-line character.
+
         """
         self.stdout.write(msg + eol)
 
@@ -169,6 +175,7 @@ class CommandPrompt(cmd.Cmd):
 
         Args:
             cmd: The command class to add.
+
         """
         if cmd.command in self.commands:
             raise CommandAlreadyBoundError(cmd.command)
@@ -179,6 +186,7 @@ class CommandPrompt(cmd.Cmd):
 
         Args:
             queue: A list of commands to run.
+
         """
         q = queue[:]
         if not self.interactive:
@@ -215,12 +223,12 @@ class CommandPrompt(cmd.Cmd):
 
         Returns:
             Whether to stop the command loop.
+
         """
         if isinstance(self.metadata, NullTestReport):
             return stop
-        else:
-            self.set_prompt(session=self.__dict__.get("session", None))
-            return stop
+        self.set_prompt(session=self.__dict__.get("session", None))
+        return stop
 
     def get_names(self) -> list[str]:
         """Returns a list of all command names."""
@@ -289,6 +297,7 @@ class CommandPrompt(cmd.Cmd):
 
         Args:
             session: The current session name.
+
         """
         self.session = session
         session = ":" + str(session) if session else ""
@@ -305,6 +314,7 @@ class CommandPrompt(cmd.Cmd):
         Args:
             update: The update to load.
             autoconnect: Whether to automatically connect to hosts.
+
         """
         tr = update.make_testreport(self.config, autoconnect, self.interactive)
         self.metadata = tr

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -168,7 +168,7 @@ class CommandPrompt(cmd.Cmd):
         try:
             readline.read_history_file(f"{self.homedir!s}/.mtui_history")
         except OSError as e:
-            logger.debug(f"failed to open history file: {e!s}")
+            logger.debug("failed to open history file: %s", e)
 
     def _add_subcommand(self, cmd: type[Command]) -> None:
         """Adds a subcommand to the prompt.
@@ -209,10 +209,9 @@ class CommandPrompt(cmd.Cmd):
             except QuitLoop:
                 return
             except (messages.UserMessage, subprocess.CalledProcessError) as e:
-                logger.error(e)
-                logger.debug(format_exc())
+                logger.exception(e)
             except Exception:
-                logger.error(format_exc())
+                logger.exception(format_exc())
 
     def postcmd(self, stop: bool, line: str) -> bool:
         """A hook that is called after a command is executed.
@@ -280,8 +279,7 @@ class CommandPrompt(cmd.Cmd):
                             **kw,
                         )
                     except Exception as e:
-                        logger.error(e)
-                        logger.debug(format_exc())
+                        logger.exception(e)
                         raise e
 
                 return complete

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -342,7 +342,7 @@ class Refhosts:
         return set(self.data.keys())
 
 
-class RefhostsResolveFailed(RuntimeError):
+class RefhostsResolveFailedError(RuntimeError):
     """Raised when a `refhosts.yml` file cannot be resolved."""
 
 
@@ -398,7 +398,7 @@ class _RefhostsFactory:
                 logger.warning("Refhosts: resolver %s failed", resolver)
                 logger.debug(format_exc())
 
-        raise RefhostsResolveFailed()
+        raise RefhostsResolveFailedError()
 
     def _resolve_one(self, name, config):
         """Resolves a `Refhosts` instance from a single source.

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -91,9 +91,9 @@ class Attributes:
         """
         attributes_list = []
         # typical string:
-        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11,minor=sp4)
+        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11,minor=sp4)  # noqa: ERA001
         # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11,minor=)
-        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11)
+        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11)  # noqa: ERA001
         attribute = Attributes()
         arch_list = []
         for pattern in testplatform.split(";"):

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -100,7 +100,7 @@ class Attributes:
             try:
                 property_name, content = pattern.split("=", 1)
             except ValueError:
-                logger.exception('error when parsing line "%s"', testplatform)
+                logger.error('error when parsing line "%s"', testplatform)
                 continue
             # special case: arch
             # *- arch because is a list so it will create a list of several attributes
@@ -174,7 +174,7 @@ class Refhosts:
 
         except Exception:
             # nothing to do for us if we can't load the hosts
-            logger.exception("failed to parse refhosts.yml")
+            logger.error("failed to parse refhosts.yml")
             raise
 
     def search(self, attributes) -> list[str]:

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -41,7 +41,6 @@ class Attributes:
 
     def __str__(self) -> str:
         """Returns a human-readable string representation of the attributes."""
-
         product: str = ""
         if "name" in self.product:
             product = self.product["name"]
@@ -88,6 +87,7 @@ class Attributes:
 
         Returns:
             A list of Attributes objects.
+
         """
         attributes_list = []
         # typical string:
@@ -151,8 +151,8 @@ class Refhosts:
         Args:
             hostmap: The path to the `refhosts.yml` file.
             location: The location to load hosts from.
-        """
 
+        """
         # default refhosts location is 'default' which is basically fallback
         if location is None:
             self.location = self._default_location
@@ -166,6 +166,7 @@ class Refhosts:
 
         Args:
             hostmap: The path to the `refhosts.yml` file.
+
         """
         try:
             with hostmap.open() as f:
@@ -184,6 +185,7 @@ class Refhosts:
 
         Returns:
             A list of hostnames that match the given attributes.
+
         """
         results: list[str] = []
 
@@ -215,12 +217,13 @@ class Refhosts:
 
         Returns:
             True if the candidate matches the attributes, False otherwise.
+
         """
         for key in vars(attribute):
             if getattr(attribute, key):
                 if key not in candidate:
                     return False
-                elif key == "addons":
+                if key == "addons":
                     if not self._includes_addons_list(
                         candidate[key], getattr(attribute, key)
                     ):
@@ -230,11 +233,10 @@ class Refhosts:
                 ):  # scalar options. Options that are non iterable
                     if getattr(attribute, key) != candidate[key]:
                         return False
-                else:
-                    if not self._includes_simple_attributes(
-                        candidate[key], getattr(attribute, key)
-                    ):
-                        return False
+                elif not self._includes_simple_attributes(
+                    candidate[key], getattr(attribute, key)
+                ):
+                    return False
 
         return True
 
@@ -247,12 +249,12 @@ class Refhosts:
 
         Returns:
             True if the attributes match, False otherwise.
-        """
 
+        """
         for k in attribute:
             if k not in candidate:
                 return False
-            elif k == "version":
+            if k == "version":
                 if not self._includes_version(
                     candidate["version"], attribute["version"]
                 ):
@@ -271,6 +273,7 @@ class Refhosts:
 
         Returns:
             True if the versions match, False otherwise.
+
         """
         if "minor" in element and element["minor"] != "":
             if "minor" not in candidate or element["minor"] != candidate["minor"]:
@@ -290,19 +293,18 @@ class Refhosts:
 
         Returns:
             True if the addons match, False otherwise.
-        """
 
+        """
         element_addons_map = {addon["name"]: addon for addon in element_addons}
         candidate_addons_map = {addon["name"]: addon for addon in candidate_addons}
 
         for addon in element_addons_map:
             if addon not in candidate_addons_map:
                 return False
-            else:
-                if not self._includes_simple_attributes(
-                    candidate_addons_map[addon], element_addons_map[addon]
-                ):
-                    return False
+            if not self._includes_simple_attributes(
+                candidate_addons_map[addon], element_addons_map[addon]
+            ):
+                return False
         return True
 
     def _location_hosts(self, location: str):
@@ -313,6 +315,7 @@ class Refhosts:
 
         Returns:
             A list of host elements for the given location.
+
         """
         return self.data[location]
 
@@ -324,6 +327,7 @@ class Refhosts:
 
         Raises:
             messages.InvalidLocationError: If the location is not valid.
+
         """
         if location not in self.data:
             raise messages.InvalidLocationError(location, self.get_locations())
@@ -333,8 +337,8 @@ class Refhosts:
 
         Returns:
             A set of location names.
-        """
 
+        """
         return set(self.data.keys())
 
 
@@ -367,6 +371,7 @@ class _RefhostsFactory:
             file_writer: A function that writes to a file.
             cache_path: The path to the cache file.
             refhosts_factory: The factory for creating `Refhosts` instances.
+
         """
         self._time_now = time_now_getter
         self._stat = statter
@@ -384,6 +389,7 @@ class _RefhostsFactory:
 
         Returns:
             A `Refhosts` instance.
+
         """
         for resolver in [x.strip() for x in config.refhosts_resolvers.split(",")]:
             try:
@@ -403,6 +409,7 @@ class _RefhostsFactory:
 
         Returns:
             A `Refhosts` instance.
+
         """
         try:
             resolver = getattr(self, f"resolve_{name}")
@@ -418,6 +425,7 @@ class _RefhostsFactory:
         Args:
             path: The path to the cache file.
             config: The application configuration.
+
         """
         if self._is_https_cache_refresh_needed(path, config.refhosts_https_expiration):
             self.refresh_https_cache(path, config.refhosts_https_uri)
@@ -431,14 +439,14 @@ class _RefhostsFactory:
 
         Returns:
             True if the cache needs to be refreshed, False otherwise.
+
         """
         try:
             statinfo = self._stat(path)
         except OSError as e:
             if e.errno == errno.ENOENT:
                 return True
-            else:
-                raise
+            raise
 
         return self._time_now() - statinfo.st_mtime > expiration
 
@@ -448,6 +456,7 @@ class _RefhostsFactory:
         Args:
             path: The path to the cache file.
             uri: The URI to fetch the cache from.
+
         """
         self._write_file(self._urlopen(uri).read(), path)
 
@@ -459,6 +468,7 @@ class _RefhostsFactory:
 
         Returns:
             A `Refhosts` instance.
+
         """
         f = self.refhosts_cache_path
         self.refresh_https_cache_if_needed(f, config)
@@ -473,6 +483,7 @@ class _RefhostsFactory:
 
         Returns:
             A `Refhosts` instance.
+
         """
         return self.refhosts_factory(config.refhosts_path, config.location)
 

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -100,7 +100,7 @@ class Attributes:
             try:
                 property_name, content = pattern.split("=", 1)
             except ValueError:
-                logger.error(f'error when parsing line "{testplatform!s}"')
+                logger.exception('error when parsing line "%s"', testplatform)
                 continue
             # special case: arch
             # *- arch because is a list so it will create a list of several attributes
@@ -172,9 +172,9 @@ class Refhosts:
             with hostmap.open() as f:
                 self.data = YAML(typ="safe").load(f)
 
-        except Exception as error:
+        except Exception:
             # nothing to do for us if we can't load the hosts
-            logger.error("failed to parse refhosts.yml: %s", error)
+            logger.exception("failed to parse refhosts.yml")
             raise
 
     def search(self, attributes) -> list[str]:
@@ -395,7 +395,7 @@ class _RefhostsFactory:
             try:
                 return self._resolve_one(resolver, config)
             except BaseException:
-                logger.warning(f"Refhosts: resolver {resolver} failed")
+                logger.warning("Refhosts: resolver %s failed", resolver)
                 logger.debug(format_exc())
 
         raise RefhostsResolveFailed()
@@ -414,7 +414,7 @@ class _RefhostsFactory:
         try:
             resolver = getattr(self, f"resolve_{name}")
         except AttributeError:
-            logger.warning(f"Refhosts: invalid resolver: {name}")
+            logger.warning("Refhosts: invalid resolver: %s", name)
             raise
         else:
             return resolver(config)

--- a/mtui/repoparse.py
+++ b/mtui/repoparse.py
@@ -23,6 +23,7 @@ def _read_project(path: Path) -> ET.Element:
 
     Returns:
         An XML element representing the project.
+
     """
     xml = path.joinpath("project.xml").read_text()
     return ET.fromstringlist(xml)
@@ -36,6 +37,7 @@ def _xmlparse(xml):
 
     Returns:
         A generator of repository information.
+
     """
     return (
         (x.find("releasetarget").attrib["project"].split(":")[-3:], x.attrib["name"])
@@ -53,6 +55,7 @@ def obsrepoparse(repository: str, path: Path) -> dict[Product, str]:
 
     Returns:
         A dictionary mapping `Product` objects to repository URLs.
+
     """
     project = _xmlparse(_read_project(path))
     return {
@@ -69,6 +72,7 @@ def _parse_product(product: str) -> list[Product]:
 
     Returns:
         A list of `Product` objects.
+
     """
     b, a = product.split(" (")
     arch: list[str] = a.rstrip(")").split(", ")
@@ -85,6 +89,7 @@ def slrepoparse(repository: str, products: list[str]) -> dict[Product, str]:
 
     Returns:
         A dictionary mapping `Product` objects to repository URLs.
+
     """
     return {
         x: join(repository, "images/repo", f"{x.name}-{x.version}-{x.arch}/")
@@ -101,6 +106,7 @@ def gitrepoparse(repository: str, products: list[str]) -> dict[Product, str]:
 
     Returns:
         A dictionary mapping `Product` objects to repository URLs.
+
     """
     return {
         x: join(repository, "standard")
@@ -119,6 +125,7 @@ def reporepoparse(
 
     Returns:
         A dictionary mapping `Product` objects to repository URLs.
+
     """
     return {
         normalize_16(ps): repo

--- a/mtui/systemcheck.py
+++ b/mtui/systemcheck.py
@@ -2,7 +2,7 @@
 
 import re
 
-from paramiko import __version__ as paramiko_version  # type: ignore
+from paramiko import __version__ as paramiko_version
 
 from mtui import __version__ as mtui_version
 

--- a/mtui/systemcheck.py
+++ b/mtui/systemcheck.py
@@ -12,6 +12,7 @@ def detect_system() -> tuple[str, str, str]:
 
     Returns:
         A tuple containing the distribution, version ID, and kernel version.
+
     """
     _distro = re.compile(r'NAME=["|](.*)["|]')
     _v_id = re.compile(r'VERSION_ID=["|](.*)["|]')
@@ -20,7 +21,7 @@ def detect_system() -> tuple[str, str, str]:
     kernel = ""
 
     try:
-        with open("/etc/os-release", mode="r", encoding="utf-8") as f:
+        with open("/etc/os-release", encoding="utf-8") as f:
             for line in f:
                 if d := _distro.match(line):
                     distro = d.group(1)
@@ -33,7 +34,7 @@ def detect_system() -> tuple[str, str, str]:
         distro = "Unknown"
 
     try:
-        with open("/proc/version", mode="r", encoding="utf-8") as f:
+        with open("/proc/version", encoding="utf-8") as f:
             kernel = f.readline().split(" ")[2]
     except Exception:
         kernel = "Unknown"
@@ -52,6 +53,7 @@ def system_info(distro: str, verid: str, kernel: str, user: str) -> str:
 
     Returns:
         A formatted string containing the system information.
+
     """
     string = f"## export MTUI:{mtui_version}, paramiko {paramiko_version} on {distro}-{verid} (kernel: {kernel}) by {user}\n"
     return string

--- a/mtui/target/actions.py
+++ b/mtui/target/actions.py
@@ -241,7 +241,7 @@ class RunCommand:
                 queue.join()
 
         except KeyboardInterrupt:
-            print("stopping command queue, please wait.")
+            print("stopping command queue, please wait.")  # noqa: T201
             try:
                 while queue.unfinished_tasks:
                     spinner(lock)
@@ -253,7 +253,7 @@ class RunCommand:
                     thread.queue.task_done()
 
             queue.join()
-            print()
+            print()  # noqa: T201
             raise
 
 

--- a/mtui/target/actions.py
+++ b/mtui/target/actions.py
@@ -6,8 +6,8 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
-from contextlib import suppress
 from collections.abc import Callable, ValuesView
+from contextlib import suppress
 from pathlib import Path
 from queue import Queue
 from threading import Lock
@@ -27,6 +27,7 @@ class ThreadedMethod(threading.Thread):
 
         Args:
             queue: The queue to get methods from.
+
         """
         threading.Thread.__init__(self)
         self.queue = queue
@@ -56,6 +57,7 @@ class ThreadedTargetGroup(ABC):
 
         Args:
             targets: A list of targets to perform actions on.
+
         """
         self.targets = targets
 
@@ -99,6 +101,7 @@ class FileDelete(ThreadedTargetGroup):
         Args:
             targets: A list of targets to delete the file from.
             path: The path to the file to delete.
+
         """
         super().__init__(targets)
         self.path = path
@@ -111,6 +114,7 @@ class FileDelete(ThreadedTargetGroup):
 
         Returns:
             A tuple containing the method to execute and its arguments.
+
         """
         return (t.sftp_remove, [self.path])
 
@@ -127,6 +131,7 @@ class FileUpload(ThreadedTargetGroup):
             targets: A list of targets to upload the file to.
             local: The local path to the file to upload.
             remote: The remote path to upload the file to.
+
         """
         super().__init__(targets)
         self.local = local
@@ -140,6 +145,7 @@ class FileUpload(ThreadedTargetGroup):
 
         Returns:
             A tuple containing the method to execute and its arguments.
+
         """
         return (t.sftp_put, [self.local, self.remote])
 
@@ -156,6 +162,7 @@ class FileDownload(ThreadedTargetGroup):
             targets: A list of targets to download the file from.
             remote: The remote path to the file to download.
             local: The local path to save the downloaded file to.
+
         """
         super().__init__(targets)
 
@@ -170,6 +177,7 @@ class FileDownload(ThreadedTargetGroup):
 
         Returns:
             A tuple containing the method to execute and its arguments.
+
         """
         return (t.sftp_get, [self.remote, self.local])
 
@@ -185,6 +193,7 @@ class RunCommand:
         Args:
             targets: A dictionary of targets to run the command on.
             command: The command to run.
+
         """
         self.targets = targets
         self.command = command
@@ -253,8 +262,8 @@ def spinner(lock: Lock | None = None) -> None:
 
     Args:
         lock: An optional lock to use when printing to the console.
-    """
 
+    """
     for pos in ["|", "/", "-", "\\"]:
         if lock:
             lock.acquire()

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -109,9 +109,9 @@ class HostsGroup(UserDict[str, Target]):
             object and a dictionary of package versions.
 
         """
-        rs: list[tuple[Target, dict[str, RPMVersion | None]]] = []
-        for x in self.data.values():
-            rs.append((x, x.query_package_versions(packages)))
+        rs: list[tuple[Target, dict[str, RPMVersion | None]]] = [
+            (x, x.query_package_versions(packages)) for x in self.data.values()
+        ]
         return rs
 
     def add_history(self, data) -> None:
@@ -340,7 +340,7 @@ class HostsGroup(UserDict[str, Target]):
             self._reboot(reboot)
 
         except Exception:
-            logger.error("Error during prepare operation", exc_info=True)
+            logger.exception("Error during prepare operation")
         finally:
             self.unlock()
 
@@ -397,7 +397,7 @@ class HostsGroup(UserDict[str, Target]):
 
                 for name in release:
                     version = sorted(release[name], key=RPMVersion, reverse=True)[0]
-                    versions.setdefault(hn, dict()).update({name: version})
+                    versions.setdefault(hn, {}).update({name: version})
 
             if init_snapshot:
                 self.run(init_snapshot)

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -192,17 +192,19 @@ class HostsGroup(UserDict[str, Target]):
         """Locks all hosts in the group for an update."""
         skipped = False
         for t in self.data.values():
-            if t.is_locked() and not t._lock.is_mine():
+            if t.is_locked() and not t._lock.is_mine():  # noqa: SLF001
                 skipped = True
                 logger.warning(
                     "host %s is locked since %s by %s. skipping.",
                     t.hostname,
-                    t._lock.time(),
-                    t._lock.locked_by(),
+                    t._lock.time(),  # noqa: SLF001
+                    t._lock.locked_by(),  # noqa: SLF001
                 )
-                if t._lock.comment():
+                if t._lock.comment():  # noqa: SLF001
                     logger.info(
-                        "%s's comment: %s", t._lock.locked_by(), t._lock.comment()
+                        "%s's comment: %s",
+                        t._lock.locked_by(),  # noqa: SLF001
+                        t._lock.comment(),  # noqa: SLF001
                     )
             else:
                 t.lock()
@@ -456,7 +458,7 @@ class HostsGroup(UserDict[str, Target]):
 
                     if not before:
                         not_installed.append(pkg)
-                    elif before >= required:  # type: ignore
+                    elif before >= required:
                         logger.warning(
                             "%s: package is too recent: %s (%s, target version is %s)",
                             hn,
@@ -469,7 +471,7 @@ class HostsGroup(UserDict[str, Target]):
                         logger.warning(
                             "%s: package was not updated: %s (%s)", hn, pkg, after
                         )
-                    if after and after < required:  # type: ignore
+                    if after and after < required:
                         logger.warning(
                             "%s: package does not match required version: %s (%s, required %s)",
                             hn,

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -458,7 +458,11 @@ class HostsGroup(UserDict[str, Target]):
 
                     if not before:
                         not_installed.append(pkg)
-                    elif before >= required:
+                    elif (
+                        isinstance(before, RPMVersion)
+                        and isinstance(required, RPMVersion)
+                        and before >= required
+                    ):
                         logger.warning(
                             "%s: package is too recent: %s (%s, target version is %s)",
                             hn,
@@ -471,7 +475,11 @@ class HostsGroup(UserDict[str, Target]):
                         logger.warning(
                             "%s: package was not updated: %s (%s)", hn, pkg, after
                         )
-                    if after and after < required:
+                    if (
+                        isinstance(after, RPMVersion)
+                        and isinstance(required, RPMVersion)
+                        and after < required
+                    ):
                         logger.warning(
                             "%s: package does not match required version: %s (%s, required %s)",
                             hn,

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -39,6 +39,7 @@ class HostsGroup(UserDict[str, Target]):
         All the given hosts are expected to be enabled. The lifetime
         of the object should be the same as the execution of one
         command given from the user.
+
     """
 
     def __init__(self, hosts: list[Target]) -> None:
@@ -46,6 +47,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             hosts: A list of `Target` objects.
+
         """
         super().__init__({h.hostname: h for h in hosts})
 
@@ -61,6 +63,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Returns:
             A new `HostsGroup` object containing the selected hosts.
+
         """
         if not hosts:
             if enabled:
@@ -104,6 +107,7 @@ class HostsGroup(UserDict[str, Target]):
         Returns:
             A list of tuples, where each tuple contains a `Target`
             object and a dictionary of package versions.
+
         """
         rs: list[tuple[Target, dict[str, RPMVersion | None]]] = []
         for x in self.data.values():
@@ -115,6 +119,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             data: The history entry to add.
+
         """
         for tgt in self.data.values():
             tgt.add_history(data)
@@ -129,6 +134,7 @@ class HostsGroup(UserDict[str, Target]):
         Args:
             remote: The remote path to the file to download.
             local: The local path to save the downloaded file to.
+
         """
         return FileDownload(self.data.values(), remote, local).run()
 
@@ -138,6 +144,7 @@ class HostsGroup(UserDict[str, Target]):
         Args:
             local: The local path to the file to upload.
             remote: The remote path to upload the file to.
+
         """
         return FileUpload(self.data.values(), local, remote).run()
 
@@ -146,6 +153,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             path: The path to the file to delete.
+
         """
         return FileDelete(self.data.values(), path).run()
 
@@ -154,6 +162,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             cmd: The command to run.
+
         """
         return self._run(cmd)
 
@@ -162,6 +171,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             cmd: The command to run.
+
         """
         return RunCommand(self.data, cmd).run()
 
@@ -170,6 +180,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             reboot: A dictionary of reboot commands.
+
         """
         if reboot:
             logger.info("Rebooting transactional hosts %s", reboot.keys())
@@ -210,6 +221,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             packages: A list of packages to install.
+
         """
         commands = {
             t.hostname: t.get_installer()["command"].substitute(
@@ -239,6 +251,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             packages: A list of packages to uninstall.
+
         """
         commands = {
             t.hostname: t.get_uninstaller()["command"].substitute(
@@ -270,6 +283,7 @@ class HostsGroup(UserDict[str, Target]):
             packages: A list of packages to prepare.
             testreport: The test report object.
             **kw: Additional keyword arguments.
+
         """
         operation = "add" if kw.get("testing", False) else "remove"
         force = kw.get("force", False)
@@ -336,6 +350,7 @@ class HostsGroup(UserDict[str, Target]):
         Args:
             packages: A list of packages to downgrade.
             testreport: The test report object.
+
         """
         ver_re = re.compile(r"(.*) = (.*)")
         versions: dict[str, dict[str, str]] = {}
@@ -418,6 +433,7 @@ class HostsGroup(UserDict[str, Target]):
         Args:
             testreport: The test report object.
             params: A list of update parameters.
+
         """
 
         def package_check(post: bool = False) -> None:
@@ -440,15 +456,14 @@ class HostsGroup(UserDict[str, Target]):
 
                     if not before:
                         not_installed.append(pkg)
-                    else:
-                        if before >= required:  # type: ignore
-                            logger.warning(
-                                "%s: package is too recent: %s (%s, target version is %s)",
-                                hn,
-                                pkg,
-                                before,
-                                required,
-                            )
+                    elif before >= required:  # type: ignore
+                        logger.warning(
+                            "%s: package is too recent: %s (%s, target version is %s)",
+                            hn,
+                            pkg,
+                            before,
+                            required,
+                        )
 
                     if after and before and before == after:
                         logger.warning(
@@ -525,6 +540,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             sink: The function to use for reporting.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_self(sink)
@@ -536,6 +552,7 @@ class HostsGroup(UserDict[str, Target]):
             sink: The function to use for reporting.
             count: The number of history entries to report.
             events: A list of event types to filter by.
+
         """
         if events:
             self._run(
@@ -554,6 +571,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             sink: The function to use for reporting.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_locks(sink)
@@ -563,6 +581,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             sink: The function to use for reporting.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_timeout(sink)
@@ -572,6 +591,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             sink: The function to use for reporting.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_sessions(sink)
@@ -582,6 +602,7 @@ class HostsGroup(UserDict[str, Target]):
         Args:
             sink: The function to use for reporting.
             arg: An additional argument to pass to the reporting function.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_log(sink, arg)
@@ -591,6 +612,7 @@ class HostsGroup(UserDict[str, Target]):
 
         Args:
             sink: The function to use for reporting.
+
         """
         for hn in sorted(self.data.keys()):
             self.data[hn].report_products(sink)

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -127,7 +127,7 @@ class TargetLock:
 
         """
         self.connection = connection
-        self.i_am_user = config.session_user  # type: ignore
+        self.i_am_user = config.session_user
         self.i_am_pid = os.getpid()
         """
     :type timestampFactory: callable

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -33,6 +33,7 @@ class RemoteLock:
 
         Returns:
             A string representation of the lock.
+
         """
         xs: list[str] = [self.timestamp, self.user, str(self.pid)]
         if self.comment:
@@ -54,6 +55,7 @@ class RemoteLock:
 
         Returns:
             A `RemoteLock` instance.
+
         """
         self = cls()
 
@@ -84,6 +86,7 @@ class LockedTargets:
 
         Args:
             targets: A list of targets to lock.
+
         """
         self.targets = targets
 
@@ -121,6 +124,7 @@ class TargetLock:
         Args:
             connection: The connection to the target host.
             config: The application configuration.
+
         """
         self.connection = connection
         self.i_am_user = config.session_user  # type: ignore
@@ -155,6 +159,7 @@ class TargetLock:
 
         Returns:
             True if the target is locked, False otherwise.
+
         """
         self.load()
         return bool(self._lock.user)
@@ -167,6 +172,7 @@ class TargetLock:
 
         Raises:
             TargetLockedError: If the target is already locked.
+
         """
         # NOTE: there is a slight race between getting the state of the
         # lock on target host and setting the lock.
@@ -200,6 +206,7 @@ class TargetLock:
 
         Returns:
             A "locked by" message.
+
         """
         self.load()
         return f"{self.connection.hostname} is {self._lock}"
@@ -209,6 +216,7 @@ class TargetLock:
 
         Returns:
             The user who locked the target.
+
         """
         self.load()
         return self._lock.user
@@ -218,6 +226,7 @@ class TargetLock:
 
         Returns:
             The comment for the lock.
+
         """
         self.load()
         return self._lock.comment
@@ -227,6 +236,7 @@ class TargetLock:
 
         Returns:
             The time the lock was created.
+
         """
         self.load()
         time = datetime.fromtimestamp(float(self._lock.timestamp))
@@ -237,6 +247,7 @@ class TargetLock:
 
         Args:
             force: If True, removes locks owned by anyone.
+
         """
         if not self.is_locked():
             return
@@ -260,6 +271,7 @@ class TargetLock:
 
         Returns:
             True if the lock is owned by the current user, False otherwise.
+
         """
         if not self._lock.user:
             raise RuntimeError("not locked")

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -196,7 +196,7 @@ class TargetLock:
             lockfile.write(rl.to_lockfile())
             lockfile.close()
         except Exception:
-            logger.exception("failed to open lockfile")
+            logger.error("failed to open lockfile")
             raise
 
         self._lock = rl
@@ -261,7 +261,7 @@ class TargetLock:
             if e.errno == errno.ENOENT:
                 pass
         except Exception:
-            logger.exception("failed to remove lockfile")
+            logger.error("failed to remove lockfile")
             raise
 
         self._lock = RemoteLock()

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -138,7 +138,7 @@ class TargetLock:
     # TODO: some cache needed
     def load(self) -> None:
         """Loads the lock state from the remote host."""
-        logger.debug(f"{self.connection.hostname}: getting mtui lock state")
+        logger.debug("%s: getting mtui lock state", self.connection.hostname)
 
         self._lock = RemoteLock()  # make sure lock is reset.
 
@@ -195,8 +195,8 @@ class TargetLock:
             lockfile = self.connection.sftp_open(self.filename, "w+")
             lockfile.write(rl.to_lockfile())
             lockfile.close()
-        except Exception as e:
-            logger.error("failed to open lockfile: %s", e)
+        except Exception:
+            logger.exception("failed to open lockfile")
             raise
 
         self._lock = rl
@@ -260,8 +260,8 @@ class TargetLock:
         except OSError as e:
             if e.errno == errno.ENOENT:
                 pass
-        except Exception as e:
-            logger.error("failed to remove lockfile: %s", e)
+        except Exception:
+            logger.exception("failed to remove lockfile")
             raise
 
         self._lock = RemoteLock()

--- a/mtui/target/parsers/product.py
+++ b/mtui/target/parsers/product.py
@@ -13,6 +13,7 @@ def parse_product(prod: SFTPFile) -> tuple[str, str, str]:
 
     Returns:
         A tuple containing the product name, version, and architecture.
+
     """
     root = ET.fromstringlist(prod)
     name: str = root.findtext("./name", "")
@@ -39,6 +40,7 @@ def parse_os_release(f: SFTPFile) -> tuple[str, str, str]:
 
     Returns:
         A tuple containing the OS ID, version ID, and architecture.
+
     """
     osinfo: dict[str, str] = {
         a.split("=")[0]: a.split("=")[1].rstrip("\n").translate({34: None})

--- a/mtui/target/parsers/product.py
+++ b/mtui/target/parsers/product.py
@@ -15,7 +15,7 @@ def parse_product(prod: SFTPFile) -> tuple[str, str, str]:
         A tuple containing the product name, version, and architecture.
 
     """
-    root = ET.fromstringlist(prod)
+    root = ET.fromstringlist(prod)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # SFTPFile is file-like
     name: str = root.findtext("./name", "")
     arch: str = root.findtext("./arch", "")
 

--- a/mtui/target/parsers/system.py
+++ b/mtui/target/parsers/system.py
@@ -20,6 +20,7 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
     Returns:
         A tuple containing a `System` object and a boolean indicating
         whether the system is transactional.
+
     """
     transactional = False
     files: list[str] = []

--- a/mtui/target/parsers/system.py
+++ b/mtui/target/parsers/system.py
@@ -71,7 +71,7 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
     try:
         _ = connection.sftp_open(Path("/usr/etc/transactional-update.conf"))
         transactional = True
-        logger.info(f"Host: {connection.hostname} is transactional system")
+        logger.info("Host: %s is transactional system", connection.hostname)
     except FileNotFoundError:
         transactional = False
 

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -292,7 +292,9 @@ class Target:
                 return
             except Exception:
                 # failed to run command
-                logger.error('%s: failed to run command "%s"', self.hostname, command)
+                logger.exception(
+                    '%s: failed to run command "%s"', self.hostname, command
+                )
                 exitcode = -1
 
             time_after = timestamp()
@@ -321,7 +323,7 @@ class Target:
             self.connection.shell()
         except Exception:
             # failed to spawn shell
-            logger.error("%s: failed to spawn shell", self.hostname)
+            logger.exception("%s: failed to spawn shell", self.hostname)
 
     def sftp_put(self, local: Path, remote: Path) -> None:
         """Uploads a file to the target host.
@@ -335,12 +337,10 @@ class Target:
             logger.debug('%s: sending "%s"', self.hostname, local)
             try:
                 return self.connection.sftp_put(local, remote)
-            except OSError as error:
-                logger.error(
-                    "%s: failed to send %s: %s", self.hostname, local, error.strerror
-                )
+            except OSError:
+                logger.exception("%s: failed to send %s", self.hostname, local)
         elif self.state == "dryrun":
-            logger.info(f"dryrun: put {local} {self.hostname}:{remote}")
+            logger.info("dryrun: put %s %s:%s", local, self.hostname, remote)
 
     def sftp_get(self, remote: Path, local: Path) -> None:
         """Downloads a file from the target host.
@@ -365,13 +365,12 @@ class Target:
             )
             try:
                 f(remote, local)
-            except OSError as error:
-                logger.error(
-                    "%s: failed to get %s %s: %s",
+            except OSError:
+                logger.exception(
+                    "%s: failed to get %s %s",
                     self.hostname,
                     s,
                     remote,
-                    error.strerror,
                 )
         elif self.state == "dryrun":
             logger.info("dryrun: get %s %s:%s %s", self.hostname, s, remote, local)
@@ -468,8 +467,8 @@ class Target:
             try:
                 filename = Path("/var/log/mtui.log")
                 historyfile = self.connection.sftp_open(filename, "a+")
-            except Exception as error:
-                logger.error("failed to open history file: %s", error)
+            except Exception:
+                logger.exception("failed to open history file")
                 return
 
             now = timestamp()

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -57,6 +57,7 @@ class Target:
             exclusive: Whether the target is in exclusive mode.
             lock: The lock class to use for the target.
             connection: The connection class to use for the target.
+
         """
         self.config = config
         self.host, _, self.port = hostname.partition(":")
@@ -81,6 +82,7 @@ class Target:
 
         Returns:
             A dictionary of `Package` objects.
+
         """
         ret: dict[str, Package] = {}
         base_version = self.system.get_base().version
@@ -124,6 +126,7 @@ class Target:
         Args:
             retry: The number of times to retry the connection.
             backoff: Whether to use exponential backoff for retries.
+
         """
         self.connection.reconnect(retry, backoff)
 
@@ -145,6 +148,7 @@ class Target:
         Args:
             packages: A list of packages to query. If None, all packages
                 for the target are queried.
+
         """
         if packages is None:
             packages = list(self.packages.keys())
@@ -168,6 +172,7 @@ class Target:
 
         Returns:
             A dictionary mapping package names to `RPMVersion` objects.
+
         """
         if self.system.get_base().name != "ubuntu":
             self.run(
@@ -200,6 +205,7 @@ class Target:
 
         Args:
             repo: The name of the repository to disable.
+
         """
         logger.debug("%s: disabling repo %s", self.hostname, repo)
         self.run(f"zypper mr -d {repo}")
@@ -209,6 +215,7 @@ class Target:
 
         Args:
             repo: The name of the repository to enable.
+
         """
         logger.debug("%s: enabling repo %s", self.hostname, repo)
         self.run(f"zypper mr -e {repo}")
@@ -218,6 +225,7 @@ class Target:
 
         Args:
             value: The timeout in seconds.
+
         """
         logger.debug("%s: setting timeout to %d", self.hostname, value)
         self.connection.timeout = value
@@ -229,6 +237,7 @@ class Target:
         Args:
             operation: The operation to perform ("add" or "remove").
             testreport: The test report object.
+
         """
         logger.debug("%s: changing %s repos", self.hostname, operation)
         testreport.set_repo(self, operation)
@@ -240,6 +249,7 @@ class Target:
             cmd: The `zypper` command to run.
             repos: A dictionary of repositories.
             rrid: The RequestReviewID of the current update.
+
         """
         # ur - generator returning tuple with product, repopart
         ur = ((x, y) for x, y in repos.items() if x in self.system.flatten())
@@ -266,6 +276,7 @@ class Target:
         Args:
             command: The command to run.
             lock: An optional lock to use.
+
         """
         if self.state == "enabled":
             logger.debug('%s: running "%s"', self.hostname, command)
@@ -318,6 +329,7 @@ class Target:
         Args:
             local: The local path to the file to upload.
             remote: The remote path to upload the file to.
+
         """
         if self.state == "enabled":
             logger.debug('%s: sending "%s"', self.hostname, local)
@@ -336,6 +348,7 @@ class Target:
         Args:
             remote: The remote path to the file to download.
             local: The local path to save the downloaded file to.
+
         """
         if str(remote).endswith("/"):
             f = self.connection.sftp_get_folder
@@ -368,6 +381,7 @@ class Target:
 
         Returns:
             The last command that was run.
+
         """
         try:
             return self.out[-1][0]
@@ -379,6 +393,7 @@ class Target:
 
         Returns:
             The last stdout from a command.
+
         """
         try:
             return self.out[-1][1]
@@ -390,6 +405,7 @@ class Target:
 
         Returns:
             The last stderr from a command.
+
         """
         try:
             return self.out[-1][2]
@@ -401,6 +417,7 @@ class Target:
 
         Returns:
             The last exit code from a command.
+
         """
         try:
             return self.out[-1][3]
@@ -412,6 +429,7 @@ class Target:
 
         Returns:
             True if the target is locked, False otherwise.
+
         """
         return self._lock.is_locked()
 
@@ -420,6 +438,7 @@ class Target:
 
         Args:
             comment: An optional comment for the lock.
+
         """
         self._lock.lock(comment)
 
@@ -429,6 +448,7 @@ class Target:
         Args:
             force: If True, unlocks the target even if it is locked
                 by another user.
+
         """
         try:
             self._lock.unlock(force)
@@ -441,6 +461,7 @@ class Target:
 
         Args:
             comment: The history entry to add.
+
         """
         if self.state == "enabled":
             logger.debug("%s: adding history entry", self.hostname)
@@ -467,6 +488,7 @@ class Target:
 
         Returns:
             A list of filenames in the directory.
+
         """
         try:
             return self.connection.sftp_listdir(path)
@@ -480,6 +502,7 @@ class Target:
 
         Args:
             path: The path to the file or directory to delete.
+
         """
         try:
             self.connection.sftp_remove(path)
@@ -499,6 +522,7 @@ class Target:
         Args:
             action: An optional action to perform before closing the
                 connection ("reboot" or "poweroff").
+
         """
         try:
             if self.connection and self.connection.is_active():
@@ -525,6 +549,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system, self.transactional, self.state, self.exclusive)
 
@@ -533,6 +558,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system, self.lastout().split("\n"))
 
@@ -541,6 +567,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system, self._lock)
 
@@ -549,6 +576,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system, self.connection.timeout)
 
@@ -557,6 +585,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system, self.lastout())
 
@@ -566,6 +595,7 @@ class Target:
         Args:
             sink: The function to use for reporting.
             arg: An additional argument to pass to the reporting function.
+
         """
         sink(self.hostname, self.out, arg)
 
@@ -574,6 +604,7 @@ class Target:
 
         Args:
             sink: The function to use for reporting.
+
         """
         sink(self.hostname, self.system)
 
@@ -582,6 +613,7 @@ class Target:
 
         Returns:
             A dictionary of installer command templates.
+
         """
         return installer[(self.system.get_release(), self.transactional)]
 
@@ -590,6 +622,7 @@ class Target:
 
         Returns:
             The installer check function.
+
         """
         return install_checks.get(
             (self.system.get_release(), self.transactional), _no_checks
@@ -600,6 +633,7 @@ class Target:
 
         Returns:
             A dictionary of uninstaller command templates.
+
         """
         return uninstaller[(self.system.get_release(), self.transactional)]
 
@@ -608,6 +642,7 @@ class Target:
 
         Returns:
             The uninstaller check function.
+
         """
         return install_checks.get(
             (self.system.get_release(), self.transactional), _no_checks
@@ -618,6 +653,7 @@ class Target:
 
         Returns:
             A dictionary of downgrader command templates.
+
         """
         return downgrader[(self.system.get_release(), self.transactional)]
 
@@ -626,6 +662,7 @@ class Target:
 
         Returns:
             The downgrader check function.
+
         """
         return downgrade_checks.get(
             (self.system.get_release(), self.transactional), _no_checks
@@ -636,6 +673,7 @@ class Target:
 
         Returns:
             A dictionary of updater command templates.
+
         """
         return updater[(self.system.get_release(), self.transactional)]
 
@@ -644,6 +682,7 @@ class Target:
 
         Returns:
             The updater check function.
+
         """
         return update_checks.get(
             (self.system.get_release(), self.transactional), _no_checks
@@ -660,6 +699,7 @@ class Target:
 
         Returns:
             A dictionary of preparer command templates.
+
         """
         return preparer[(self.system.get_release(), self.transactional)](force, testing)
 
@@ -668,6 +708,7 @@ class Target:
 
         Returns:
             The preparer check function.
+
         """
         return prepare_checks.get(
             (self.system.get_release(), self.transactional), _no_checks

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -296,9 +296,7 @@ class Target:
                 return
             except Exception:
                 # failed to run command
-                logger.exception(
-                    '%s: failed to run command "%s"', self.hostname, command
-                )
+                logger.error('%s: failed to run command "%s"', self.hostname, command)
                 exitcode = -1
 
             time_after = timestamp()
@@ -327,7 +325,7 @@ class Target:
             self.connection.shell()
         except Exception:
             # failed to spawn shell
-            logger.exception("%s: failed to spawn shell", self.hostname)
+            logger.error("%s: failed to spawn shell", self.hostname)
 
     def sftp_put(self, local: Path, remote: Path) -> None:
         """Uploads a file to the target host.
@@ -342,7 +340,7 @@ class Target:
             try:
                 return self.connection.sftp_put(local, remote)
             except OSError:
-                logger.exception("%s: failed to send %s", self.hostname, local)
+                logger.error("%s: failed to send %s", self.hostname, local)
         elif self.state == "dryrun":
             logger.info("dryrun: put %s %s:%s", local, self.hostname, remote)
 
@@ -370,7 +368,7 @@ class Target:
             try:
                 f(remote, local)
             except OSError:
-                logger.exception(
+                logger.error(
                     "%s: failed to get %s %s",
                     self.hostname,
                     s,
@@ -472,7 +470,7 @@ class Target:
                 filename = Path("/var/log/mtui.log")
                 historyfile = self.connection.sftp_open(filename, "a+")
             except Exception:
-                logger.exception("failed to open history file")
+                logger.error("failed to open history file")
                 return
 
             now = timestamp()

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -13,7 +13,7 @@ from .. import messages
 from ..actions import downgrader, installer, preparer, uninstaller, updater
 from ..checks import downgrade_checks, install_checks, prepare_checks, update_checks
 from ..config import Config
-from ..connection import CommandTimeout, Connection
+from ..connection import CommandTimeoutError, Connection
 from ..target.parsers import parse_system
 from ..types import HostLog, Package, System
 from ..types.rpmver import RPMVersion
@@ -137,6 +137,10 @@ class Target:
     def __eq__(self, other) -> bool:
         """Checks if two `Target` objects are equal."""
         return self.system == other.system
+
+    def __hash__(self) -> int:
+        """Hashes the target by hostname."""
+        return hash(self.hostname)
 
     def __ne__(self, other) -> bool:
         """Checks if two `Target` objects are not equal."""
@@ -283,7 +287,7 @@ class Target:
             time_before = timestamp()
             try:
                 exitcode = self.connection.run(command, lock)
-            except CommandTimeout:
+            except CommandTimeoutError:
                 logger.critical('%s: command "%s" timed out', self.hostname, command)
                 exitcode = -1
             except AssertionError:
@@ -472,7 +476,7 @@ class Target:
                 return
 
             now = timestamp()
-            user: str = self.config.session_user  # type: ignore
+            user: str = self.config.session_user
             try:
                 historyfile.write("{}:{}:{}\n".format(now, user, ":".join(comment)))
                 historyfile.close()

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -198,10 +198,12 @@ class Target:
                 continue
             p, v = line.split()
             # Make sure that it shows to the user the highest version
+            new_ver = RPMVersion(v)
             if p in pkgs:
-                pkgs[p] = max(pkgs[p], RPMVersion(v))
+                existing = pkgs[p]
+                pkgs[p] = max(existing, new_ver) if existing is not None else new_ver
             else:
-                pkgs[p] = RPMVersion(v)
+                pkgs[p] = new_ver
         return pkgs
 
     def disable_repo(self, repo: str) -> None:

--- a/mtui/template/__init__.py
+++ b/mtui/template/__init__.py
@@ -40,7 +40,7 @@ def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:
         try:
             subprocess.check_call(["svn", "co", uri])
         except KeyboardInterrupt:
-            raise SvnCheckoutInterruptedError(uri)
+            raise SvnCheckoutInterruptedError(uri) from None
         except subprocess.CalledProcessError:
             f_url = join(config.fancy_reports_url, str(rrid))
-            raise SvnCheckoutFailed(uri, f_url)
+            raise SvnCheckoutFailed(uri, f_url) from None

--- a/mtui/template/__init__.py
+++ b/mtui/template/__init__.py
@@ -15,7 +15,7 @@ class TemplateIOError(IOError):
     """Exception raised for recoverable I/O errors when reading a template."""
 
 
-class TestReportAlreadyLoaded(RuntimeError):
+class TestReportAlreadyLoadedError(RuntimeError):
     """Exception raised when a test report is already loaded."""
 
 

--- a/mtui/template/__init__.py
+++ b/mtui/template/__init__.py
@@ -26,6 +26,7 @@ def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:
         config: The application configuration.
         path: The base path of the SVN repository.
         rrid: The RequestReviewID of the test report.
+
     """
     ensure_dir_exists(
         config.template_dir,

--- a/mtui/template/nulltestreport.py
+++ b/mtui/template/nulltestreport.py
@@ -42,6 +42,7 @@ class NullTestReport(TestReport):
 
         Returns:
             The path to the working directory.
+
         """
         return self.config.target_tempdir.joinpath(*paths)  # type: ignore
 

--- a/mtui/template/nulltestreport.py
+++ b/mtui/template/nulltestreport.py
@@ -44,7 +44,7 @@ class NullTestReport(TestReport):
             The path to the working directory.
 
         """
-        return self.config.target_tempdir.joinpath(*paths)  # type: ignore
+        return self.config.target_tempdir.joinpath(*paths)
 
     def _parser(self) -> dict[str, Any]:
         """Returns an empty dictionary."""

--- a/mtui/template/obstestreport.py
+++ b/mtui/template/obstestreport.py
@@ -62,6 +62,7 @@ class OBSTestReport(TestReport):
         Args:
             target: The target host.
             operation: The operation to perform ("add" or "remove").
+
         """
         if operation == "add":
             target.run_zypper("-n ar -ckn", self.update_repos, self.rrid)
@@ -76,6 +77,7 @@ class OBSTestReport(TestReport):
         Args:
             targets: The target hosts.
             display: The display function to use.
+
         """
         packages = self.get_package_list()
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"

--- a/mtui/template/pitestreport.py
+++ b/mtui/template/pitestreport.py
@@ -65,6 +65,7 @@ class PITestReport(TestReport):
         Args:
             target: The target host.
             operation: The operation to perform ("add" or "remove").
+
         """
         if operation == "add":
             target.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
@@ -79,6 +80,7 @@ class PITestReport(TestReport):
         Args:
             targets: The target hosts.
             display: The display function to use.
+
         """
         packages = self.get_package_list()
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"

--- a/mtui/template/products/__init__.py
+++ b/mtui/template/products/__init__.py
@@ -20,6 +20,7 @@ def normalize_16(x: Product) -> Product:
 
     Returns:
         Normalized Product named tuple
+
     """
     if x.name == "SLES-SAP":
         return Product("SLES_SAP", x.version, x.arch)
@@ -36,6 +37,7 @@ def normalize(x):
 
     Returns:
         The normalized product information.
+
     """
     # SLERT must be before version based comparsion
     if x[0][0] == "SLE-RT":

--- a/mtui/template/products/misc.py
+++ b/mtui/template/products/misc.py
@@ -9,6 +9,7 @@ def normalize_ses(x):
 
     Returns:
         The normalized product information.
+
     """
     x[0][0] = "ses"
     return x
@@ -22,6 +23,7 @@ def normalize_rt(x):
 
     Returns:
         The normalized product information.
+
     """
     x[0][0] = "SUSE-Linux-Enterprise-RT"
     return x
@@ -35,6 +37,7 @@ def normalize_manager(x):
 
     Returns:
         The normalized product information.
+
     """
     if x[0][0] == "SLE-Manager-Tools":
         x[0][0] = "sle-manager-tools"
@@ -50,6 +53,7 @@ def normalize_osle(x):
 
     Returns:
         The normalized product information.
+
     """
     x[0][0] = "leap"
     x[0][1] = x[0][2]

--- a/mtui/template/products/sle11.py
+++ b/mtui/template/products/sle11.py
@@ -9,6 +9,7 @@ def normalize_sle11(x):
 
     Returns:
         The normalized product information.
+
     """
     if x[0][0] == "SLE-SDK":
         x[0][0] = "sle-sdk"

--- a/mtui/template/products/sle12.py
+++ b/mtui/template/products/sle12.py
@@ -9,6 +9,7 @@ def normalize_sle12(x):
 
     Returns:
         The normalized product information.
+
     """
     if x[0][0] == "SLE-SERVER" and "LTSS-Extended-Security" in x[0][1]:
         x[0][0] = "SLES-LTSS-Extended-Security"

--- a/mtui/template/products/sle15.py
+++ b/mtui/template/products/sle15.py
@@ -9,6 +9,7 @@ def normalize_sle15(x):
 
     Returns:
         The normalized product information.
+
     """
     if x[0][0] == "SLE-Product-SLES" and "LTSS-TERADATA" in x[0][1]:
         x[0][0] = "SLES-LTSS-TERADATA"

--- a/mtui/template/sltestreport.py
+++ b/mtui/template/sltestreport.py
@@ -64,7 +64,7 @@ class SLTestReport(TestReport):
         """Returns a dictionary of update repositories."""
         if self.repositories:
             return reporepoparse(self.repositories, self.products)
-        elif self.rrid.maintenance_id == "1.1":
+        if self.rrid.maintenance_id == "1.1":
             return slrepoparse(self.repository, self.products)
 
         return gitrepoparse(self.repository, self.products)
@@ -88,6 +88,7 @@ class SLTestReport(TestReport):
         Args:
             target: The target host.
             operation: The operation to perform ("add" or "remove").
+
         """
         if operation == "add":
             target.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
@@ -102,6 +103,7 @@ class SLTestReport(TestReport):
         Args:
             targets: The target hosts.
             display: The display function to use.
+
         """
         packages = self.get_package_list()
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -135,8 +135,7 @@ class TestReport(ABC):
         except FileNotFoundError as e:
             args = [*list(e.args), e.filename]
             e_new = TemplateIOError(*args)
-            e_new.__cause__ = e  # PEP 3134
-            raise e_new
+            raise e_new from e
 
         data = None
         if metadata.exists() and metadata.is_file():
@@ -144,7 +143,7 @@ class TestReport(ABC):
             try:
                 data = loads(data)
             except JSONDecodeError:
-                raise MetadataNotLoadedError
+                raise MetadataNotLoadedError from None
         else:
             raise MetadataNotLoadedError
 
@@ -220,8 +219,7 @@ class TestReport(ABC):
         """
         ret = []
         for key in self.packages:
-            for k in self.packages[key]:
-                ret.append(k)
+            ret.extend(self.packages[key])
         # deduplicate list
         ret = list(set(ret))
 
@@ -266,8 +264,8 @@ class TestReport(ABC):
 
         try:
             targets.perform_update(self, params)
-        except UpdateError as e:
-            logger.error("Update failed: %s", e)
+        except UpdateError:
+            logger.exception("Update failed")
             logger.warning("Error while updating. Rolling back changes")
             self.perform_downgrade(targets)
 
@@ -331,7 +329,7 @@ class TestReport(ABC):
 
         """
         try:
-            logger.debug(f"Copying scripts: {src} -> {dst}")
+            logger.debug("Copying scripts: %s -> %s", src, dst)
             shutil.copytree(src, dst, ignore=ignore)
         except OSError as e:
             # this should not happen but was already noticed once or
@@ -340,9 +338,8 @@ class TestReport(ABC):
             msg = "Copy scripts {0} -> {1} failed. reason:"
             msg = msg.format(src, dst)
             if e.errno == ENOENT:
-                logger.error(msg)
-                logger.error(str(e))
-                logger.error("copy scripts manually")
+                logger.exception(msg)
+                logger.exception("copy scripts manually")
                 logger.debug(format_exc())
             elif e.errno == EEXIST:
                 logger.info("Scripts are in place")
@@ -468,7 +465,7 @@ class TestReport(ABC):
                 del self.targets[hostname]
             if hostname in self.systems:
                 del self.systems[hostname]
-            logger.warning(f"failed to add host {hostname} to target list")
+            logger.warning("failed to add host %s to target list", hostname)
             logger.debug(format_exc())
 
     def refhosts_from_tp(self, testplatform) -> None:
@@ -729,8 +726,9 @@ class TestReport(ABC):
         else:
             targets = self.targets.values()
 
-        for t in targets:
-            results.append(TargetMeta(t.hostname, str(t.system), t.packages, t.out))
+        results.extend(
+            TargetMeta(t.hostname, str(t.system), t.packages, t.out) for t in targets
+        )
 
         return results
 

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -265,7 +265,7 @@ class TestReport(ABC):
         try:
             targets.perform_update(self, params)
         except UpdateError:
-            logger.exception("Update failed")
+            logger.error("Update failed")
             logger.warning("Error while updating. Rolling back changes")
             self.perform_downgrade(targets)
 
@@ -338,8 +338,8 @@ class TestReport(ABC):
             msg = "Copy scripts {0} -> {1} failed. reason:"
             msg = msg.format(src, dst)
             if e.errno == ENOENT:
-                logger.exception(msg)
-                logger.exception("copy scripts manually")
+                logger.error(msg)
+                logger.error("copy scripts manually")
                 logger.debug(format_exc())
             elif e.errno == EEXIST:
                 logger.info("Scripts are in place")

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -44,6 +44,10 @@ class TestReport(ABC):
 
     refhostsFactory = RefhostsFactory
 
+    # -- Attributes set dynamically by UpdateID subclasses --
+    smelt: Any
+    updateid: Any
+
     @property
     @abstractmethod
     def _type(self) -> str:

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -19,12 +19,12 @@ from urllib.request import urlopen
 
 from ..config import Config
 from ..datafiles import scripts_path
-from ..exceptions import InvalidGiteaHash, UpdateError
+from ..exceptions import InvalidGiteaHashError, UpdateError
 from ..messages import MetadataNotLoadedError
-from ..refhost import Attributes, RefhostsFactory, RefhostsResolveFailed
+from ..refhost import Attributes, RefhostsFactory, RefhostsResolveFailedError
 from ..target import Target
 from ..target.hostgroup import HostsGroup
-from ..template import TemplateIOError, TestReportAlreadyLoaded
+from ..template import TemplateIOError, TestReportAlreadyLoadedError
 from ..types import Product, TargetMeta
 from ..utils import ensure_dir_exists
 
@@ -159,14 +159,14 @@ class TestReport(ABC):
         self._open_and_parse(path)
         self.path = path.resolve()
         self._update_repos_parse()
-        if self.config.chdir_to_template_dir:  # type: ignore
+        if self.config.chdir_to_template_dir:
             os.chdir(path.parent)
 
         self.copy_scripts()
 
         result = self.check_hash()
         if not result[0]:
-            raise InvalidGiteaHash(self.id, result[1], result[2])
+            raise InvalidGiteaHashError(self.id, result[1], result[2])
 
     @abstractmethod
     def check_hash(self) -> tuple[bool, str, str]:
@@ -190,7 +190,7 @@ class TestReport(ABC):
 
         """
         if self.path:
-            raise TestReportAlreadyLoaded(self.path)
+            raise TestReportAlreadyLoadedError(self.path)
 
         parser_json = self._parser()["json"]
         parser_hosts = self._parser()["hosts"]
@@ -415,7 +415,7 @@ class TestReport(ABC):
             for future in done:
                 host = connections[future]
                 # TODO: how to type annatate this or how to change it to be compactible with type hints?
-                targets[host], new_systems[host] = future.result()  # type: ignore
+                targets[host], new_systems[host] = future.result()
         except KeyboardInterrupt:
             for future in connections:
                 future.cancel()
@@ -477,7 +477,7 @@ class TestReport(ABC):
         """
         try:
             refhosts = self.refhostsFactory(self.config)
-        except RefhostsResolveFailed:
+        except RefhostsResolveFailedError:
             return
 
         try:
@@ -546,11 +546,11 @@ class TestReport(ABC):
 
     def _testreport_url(self) -> str:
         """Returns the URL for the test report."""
-        return "/".join([self.config.reports_url, str(self.id), "log"])  # type: ignore
+        return "/".join([self.config.reports_url, str(self.id), "log"])
 
-    def _fancy_report_url(self) -> str:
+    def fancy_report_url(self) -> str:
         """Returns the URL for the fancy test report."""
-        return "/".join([self.config.fancy_reports_url, str(self.id), "log"])  # type: ignore
+        return "/".join([self.config.fancy_reports_url, str(self.id), "log"])
 
     def local_wd(self, *paths) -> Path:
         """Returns the local working directory.
@@ -562,7 +562,7 @@ class TestReport(ABC):
             The path to the local working directory.
 
         """
-        return self._wd(self.config.local_tempdir, str(self.id), *paths)  # type: ignore
+        return self._wd(self.config.local_tempdir, str(self.id), *paths)
 
     def report_wd(self, *paths, **kw) -> Path:
         """Returns the working directory relative to the test report checkout.
@@ -603,7 +603,7 @@ class TestReport(ABC):
             The path to the remote working directory.
 
         """
-        return self.config.target_tempdir.joinpath(str(self.id), *paths)  # type: ignore
+        return self.config.target_tempdir.joinpath(str(self.id), *paths)
 
     def scripts_wd(self, *paths):
         """Returns the path to the scripts directory.

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -170,7 +170,7 @@ class TestReport(ABC):
 
     @abstractmethod
     def check_hash(self) -> tuple[bool, str, str]:
-        """An abstract method for checking git hash of gitea based testreports,
+        """An abstract method for checking git hash of gitea based testreports,.
 
         return: bool
                 True if hash is same or if it isn't supported
@@ -683,7 +683,7 @@ class TestReport(ABC):
         #   line = PKKGNAME +SP PKGVER
         #   input = *(line EOL)
 
-        # by_host_pkg[hostname][package] = [version, ...]
+        # by_host_pkg[hostname][package] = [version, ...]  # noqa: ERA001
         by_host_pkg: dict[str, Any] = {}
         for hn, t in targets.items():
             by_host_pkg[hn] = {}
@@ -694,13 +694,13 @@ class TestReport(ABC):
                 else:
                     continue
 
-        # by_pkg_vers[package][(version, ...)] = [hostname, ...]
+        # by_pkg_vers[package][(version, ...)] = [hostname, ...]  # noqa: ERA001
         by_pkg_vers: dict[str, Any] = {}
         for hn, pvs in by_host_pkg.items():
             for pkg, vs in pvs.items():
                 by_pkg_vers.setdefault(pkg, {}).setdefault(tuple(vs), []).append(hn)
 
-        # by_hosts_pkg[(hostname, ...)] = [(package, (version, ...)), ...]
+        # by_hosts_pkg[(hostname, ...)] = [(package, (version, ...)), ...]  # noqa: ERA001
         by_hosts_pkg: dict[tuple[str, ...], Any] = {}
         for pkg, vshs in by_pkg_vers.items():
             for vs, hs in vshs.items():

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -56,12 +56,11 @@ class TestReport(ABC):
         Args:
             config: The application configuration.
             scripts_src_dir: The source directory for scripts.
+
         """
         self.config: Config = config
 
-        self._scripts_src_dir: Path = (
-            scripts_src_dir if scripts_src_dir else scripts_path()
-        )
+        self._scripts_src_dir: Path = scripts_src_dir or scripts_path()
 
         self.directory: Path = config.template_dir
 
@@ -128,6 +127,7 @@ class TestReport(ABC):
 
         Args:
             path: The path to the test report file.
+
         """
         metadata = path.parent / "metadata.json"
         try:
@@ -155,6 +155,7 @@ class TestReport(ABC):
 
         Args:
             path: The path to the test report file.
+
         """
         self._open_and_parse(path)
         self.path = path.resolve()
@@ -187,6 +188,7 @@ class TestReport(ABC):
         Args:
             data: The JSON object to parse.
             tpl: The test report string to parse.
+
         """
         if self.path:
             raise TestReportAlreadyLoaded(self.path)
@@ -214,6 +216,7 @@ class TestReport(ABC):
 
         Returns:
             A list of all packages in the test report.
+
         """
         ret = []
         for key in self.packages:
@@ -235,6 +238,7 @@ class TestReport(ABC):
         Args:
             targets: The targets to perform the operation on.
             remote: The remote path to get.
+
         """
         local = self.report_wd("downloads", remote.name, filepath=True)
 
@@ -246,6 +250,7 @@ class TestReport(ABC):
         Args:
             targets: The targets to perform the operation on.
             **kw: Additional keyword arguments.
+
         """
         targets.perform_prepare(self.get_package_list(), self, **kw)
 
@@ -255,13 +260,14 @@ class TestReport(ABC):
         Args:
             targets: The targets to perform the operation on.
             params: A list of update parameters.
+
         """
         targets.add_history(["update", str(self.id), " ".join(self.get_package_list())])
 
         try:
             targets.perform_update(self, params)
         except UpdateError as e:
-            logger.error("Update failed: %s" % e)
+            logger.error("Update failed: %s", e)
             logger.warning("Error while updating. Rolling back changes")
             self.perform_downgrade(targets)
 
@@ -270,6 +276,7 @@ class TestReport(ABC):
 
         Args:
             targets: The targets to perform the operation on.
+
         """
         targets.add_history(
             ["downgrade", str(self.id), " ".join(self.get_package_list())]
@@ -282,6 +289,7 @@ class TestReport(ABC):
         Args:
             targets: The targets to perform the operation on.
             packages: The packages to install.
+
         """
         targets.add_history(["install", packages])
 
@@ -293,6 +301,7 @@ class TestReport(ABC):
         Args:
             targets: The targets to perform the operation on.
             packages: The packages to uninstall.
+
         """
         targets.add_history(["uninstall", packages])
         targets.perform_uninstall(packages)
@@ -319,6 +328,7 @@ class TestReport(ABC):
             src: The source directory.
             dst: The destination directory.
             ignore: A function that returns a set of files to ignore.
+
         """
         try:
             logger.debug(f"Copying scripts: {src} -> {dst}")
@@ -345,6 +355,7 @@ class TestReport(ABC):
 
         Args:
             pattern: A glob pattern for the files to make executable.
+
         """
         for i in glob.glob(pattern):
             # make sure the compare scripts (which run localy) are
@@ -364,6 +375,7 @@ class TestReport(ABC):
         Returns:
             A tuple containing the `Target` object and the system
             string, or `(False, False)` if the connection fails.
+
         """
         try:
             target = Target(
@@ -393,7 +405,7 @@ class TestReport(ABC):
         hosts: set[str] = {host for host in self.hostnames if host not in self.targets}
 
         if hosts:
-            logger.info("Adding %s" % hosts)
+            logger.info("Adding %s", hosts)
         else:
             logger.info("No refhosts to add")
 
@@ -437,6 +449,7 @@ class TestReport(ABC):
 
         Args:
             hostname: The hostname of the target to add.
+
         """
         if hostname in self.targets:
             logger.warning(
@@ -463,6 +476,7 @@ class TestReport(ABC):
 
         Args:
             testplatform: The test platform to get reference hosts from.
+
         """
         try:
             refhosts = self.refhostsFactory(self.config)
@@ -487,6 +501,7 @@ class TestReport(ABC):
         Args:
             sink: The function to use for listing the bugs.
             arg: An additional argument to pass to the sink function.
+
         """
         return sink(self.bugs, self.jira, arg)
 
@@ -514,6 +529,7 @@ class TestReport(ABC):
 
         Args:
             writer: The writer to write the metadata to.
+
         """
         self._aligned_write(writer, self._show_yourself_data())
 
@@ -524,6 +540,7 @@ class TestReport(ABC):
         Args:
             writer: The writer to write the data to.
             data: A list of key-value pairs to write.
+
         """
         for x in sorted(data):
             name, value = x
@@ -546,6 +563,7 @@ class TestReport(ABC):
 
         Returns:
             The path to the local working directory.
+
         """
         return self._wd(self.config.local_tempdir, str(self.id), *paths)  # type: ignore
 
@@ -558,6 +576,7 @@ class TestReport(ABC):
 
         Returns:
             The path to the working directory.
+
         """
         assert self.path, "empty path"
 
@@ -573,6 +592,7 @@ class TestReport(ABC):
 
         Returns:
             The path to the working directory.
+
         """
         return ensure_dir_exists(*paths, **kwargs)
 
@@ -584,6 +604,7 @@ class TestReport(ABC):
 
         Returns:
             The path to the remote working directory.
+
         """
         return self.config.target_tempdir.joinpath(str(self.id), *paths)  # type: ignore
 
@@ -595,6 +616,7 @@ class TestReport(ABC):
 
         Returns:
             The path to the scripts directory.
+
         """
         return self.report_wd().joinpath(*["scripts", *list(paths)])
 
@@ -608,8 +630,8 @@ class TestReport(ABC):
         Args:
             s: The script class to run.
             targets: The targets to run the scripts on.
-        """
 
+        """
         d = self.scripts_wd(s.subdir)
 
         # os.walk returns path as string and list of string with filenames
@@ -625,6 +647,7 @@ class TestReport(ABC):
         Args:
             from_: The URL to download the file from.
             into: The path to save the downloaded file to.
+
         """
         logger.info("Downloading %s", from_)
         from contextlib import closing
@@ -639,6 +662,7 @@ class TestReport(ABC):
             sink: The function to use for listing the versions.
             targets: The targets to list the versions for.
             packages: The packages to list the versions for.
+
         """
         query = r"""
             for p in {!s}; do \
@@ -696,6 +720,7 @@ class TestReport(ABC):
 
         Returns:
             A list of `TargetMeta` objects.
+
         """
         results = []
 

--- a/mtui/types/commandlog.py
+++ b/mtui/types/commandlog.py
@@ -12,6 +12,7 @@ class CommandLog(NamedTuple):
         stderr: The standard error of the command.
         exitcode: The exit code of the command.
         runtime: The runtime of the command in seconds.
+
     """
 
     command: str

--- a/mtui/types/filelist.py
+++ b/mtui/types/filelist.py
@@ -31,11 +31,11 @@ class FileList(UserList):
         if isinstance(path, str):
             path = Path(path)
         instance = super().__new__(cls, *args, **kwds)
-        instance._file = path  # type: ignore
+        instance._file = path
         with path.open(mode="r", encoding="utf-8", errors="replace") as text:
-            instance.data = text.readlines()  # type: ignore
+            instance.data = text.readlines()
 
-        instance._hash = hash("".join(instance.data))  # type: ignore
+        instance._hash = hash("".join(instance.data))
         return instance
 
     def read(self) -> None:
@@ -43,7 +43,7 @@ class FileList(UserList):
 
     def write(self) -> None:
         """Writes the `FileList` to a file."""
-        atomic_write_file("".join(self.data), self._file)  # type: ignore
+        atomic_write_file("".join(self.data), self._file)
 
     def __enter__(self, *args) -> Self:
         """Enters a context manager.
@@ -56,6 +56,6 @@ class FileList(UserList):
 
     def __exit__(self, *args) -> None:
         """Exits a context manager, writing the file if it has been modified."""
-        if self._hash != hash("".join(self.data)):  # type: ignore
-            logger.debug("Writing template to %s", self._file)  # type: ignore
+        if self._hash != hash("".join(self.data)):
+            logger.debug("Writing template to %s", self._file)
             self.write()

--- a/mtui/types/filelist.py
+++ b/mtui/types/filelist.py
@@ -26,6 +26,7 @@ class FileList(UserList):
 
         Returns:
             A `FileList` instance.
+
         """
         if isinstance(path, str):
             path = Path(path)
@@ -49,6 +50,7 @@ class FileList(UserList):
 
         Returns:
             The `FileList` instance.
+
         """
         return self
 

--- a/mtui/types/filelist.py
+++ b/mtui/types/filelist.py
@@ -15,6 +15,9 @@ class FileList(UserList):
 
     __slots__ = ["_file", "_hash", "data"]
 
+    _file: Path
+    _hash: int
+
     @classmethod
     def load(cls, path: Path | str, *args, **kwds) -> Self:
         """Loads a `FileList` from a file.

--- a/mtui/types/hostlog.py
+++ b/mtui/types/hostlog.py
@@ -11,11 +11,11 @@ def to_string(item: str | bytes) -> str:
 
     Returns:
         The converted string.
+
     """
     if isinstance(item, bytes):
         return item.decode()
-    else:
-        return item
+    return item
 
 
 class HostLog(list):
@@ -32,6 +32,7 @@ class HostLog(list):
 
         Args:
             *args: The command log entry to append.
+
         """
         # there is awfull exceptation *args will expand into one  variable
         if len(args) == 1 and isinstance(*args, list | tuple | set):
@@ -69,6 +70,7 @@ class HostLog(list):
         Args:
             pos: The position to insert the entry at.
             *args: The command log entry to insert.
+
         """
         if len(args) == 1 and isinstance(*args, list | tuple | set):
             if len(*args) != 5:

--- a/mtui/types/hostlog.py
+++ b/mtui/types/hostlog.py
@@ -35,9 +35,9 @@ class HostLog(list):
 
         """
         # there is awfull exceptation *args will expand into one  variable
-        if len(args) == 1 and isinstance(*args, list | tuple | set):
-            if len(*args) != 5:
-                raise ValueError(f"it need 5 args, got {len(*args)}")
+        if len(args) == 1 and isinstance(args[0], list | tuple | set):
+            if len(args[0]) != 5:
+                raise ValueError(f"it need 5 args, got {len(args[0])}")
             items = args[0]
             command = to_string(items[0])
             stdout = to_string(items[1])
@@ -72,14 +72,14 @@ class HostLog(list):
             *args: The command log entry to insert.
 
         """
-        if len(args) == 1 and isinstance(*args, list | tuple | set):
-            if len(*args) != 5:
-                raise ValueError(f"it need 5 args, got {len(*args)}")
-            command = to_string(*args[0])
-            stdout = to_string(*args[1])
-            stderr = to_string(*args[2])
-            exitcode = int(*args[3])
-            runtime = int(*args[4])
+        if len(args) == 1 and isinstance(args[0], list | tuple | set):
+            if len(args[0]) != 5:
+                raise ValueError(f"it need 5 args, got {len(args[0])}")
+            command = to_string(args[0][0])
+            stdout = to_string(args[0][1])
+            stderr = to_string(args[0][2])
+            exitcode = int(args[0][3])
+            runtime = int(args[0][4])
         else:
             if len(args) != 5:
                 raise ValueError(f"it need 5 args, got {len(*args)}")

--- a/mtui/types/package.py
+++ b/mtui/types/package.py
@@ -22,6 +22,7 @@ class Package:
 
         Args:
             name: The name of the package.
+
         """
         self.name: str = name
         self._before: str | RPMVersion | None = None

--- a/mtui/types/product.py
+++ b/mtui/types/product.py
@@ -10,6 +10,7 @@ class Product(NamedTuple):
         name: The name of the product.
         version: The version of the product.
         arch: The architecture of the product.
+
     """
 
     name: str

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -1,9 +1,9 @@
 """A class for comparing RPM version strings."""
 
-from typing import final
+from typing import ClassVar, final
 
 try:
-    import rpm  # type: ignore
+    import rpm
 except ImportError:
     try:
         from version_utils import rpm
@@ -22,7 +22,7 @@ class RPMVersion:
     if a specific RPM version is lower or higher than another one.
     """
 
-    _arch_suffixes = [
+    _arch_suffixes: ClassVar[list[str]] = [
         "noarch",
         "x86_64",
         "s390x",
@@ -66,6 +66,10 @@ class RPMVersion:
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel)) > 0
         )
+
+    def __hash__(self) -> int:
+        """Hashes the version by version and release."""
+        return hash((self.ver, self.rel))
 
     def __eq__(self, other: "RPMVersion") -> bool:
         """Checks if this version is equal to another."""

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -6,7 +6,7 @@ try:
     import rpm  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
 except ImportError:
     try:
-        from version_utils import rpm  # type: ignore[import-not-found]
+        from version_utils import rpm  # type: ignore[import-not-found]  # noqa: I001  # ty: ignore[unresolved-import]
     except ImportError:
         raise ImportError(
             "No RPM version comparison backend found. "

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -40,6 +40,7 @@ class RPMVersion:
 
         Args:
             ver: The version string to parse.
+
         """
         if not ver:
             raise ValueError

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -11,7 +11,7 @@ except ImportError:
         raise ImportError(
             "No RPM version comparison backend found. "
             "Install mtui[rpm] or mtui[norpm] to provide one."
-        )
+        ) from None
 
 
 @final

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -3,10 +3,10 @@
 from typing import ClassVar, final
 
 try:
-    import rpm
+    import rpm  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
 except ImportError:
     try:
-        from version_utils import rpm
+        from version_utils import rpm  # type: ignore[import-not-found]
     except ImportError:
         raise ImportError(
             "No RPM version comparison backend found. "
@@ -71,8 +71,10 @@ class RPMVersion:
         """Hashes the version by version and release."""
         return hash((self.ver, self.rel))
 
-    def __eq__(self, other: "RPMVersion") -> bool:
+    def __eq__(self, other: object) -> bool:
         """Checks if this version is equal to another."""
+        if not isinstance(other, RPMVersion):
+            return NotImplemented
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             == 0
@@ -92,8 +94,10 @@ class RPMVersion:
             >= 0
         )
 
-    def __ne__(self, other: "RPMVersion") -> bool:
+    def __ne__(self, other: object) -> bool:
         """Checks if this version is not equal to another."""
+        if not isinstance(other, RPMVersion):
+            return NotImplemented
         return (
             rpm.labelCompare(("1", self.ver, self.rel), ("1", other.ver, other.rel))
             != 0

--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -9,7 +9,7 @@ def apply_parser(f, x, cnt):
     from ..exceptions import (
         ComponentParseError,
         InternalParseError,
-        MissingComponent,
+        MissingComponentError,
     )
 
     """A helper function that applies a parser to a value.
@@ -24,14 +24,14 @@ def apply_parser(f, x, cnt):
 
     Raises:
         InternalParseError: If the parser or count is not valid.
-        MissingComponent: If the value is missing.
+        MissingComponentError: If the value is missing.
         ComponentParseError: If the value cannot be parsed.
     """
     if not f or not cnt:
         raise InternalParseError(f, cnt)
 
     if not x:
-        raise MissingComponent(cnt, f)
+        raise MissingComponentError(cnt, f)
 
     try:
         return f(x)

--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -37,8 +37,7 @@ def apply_parser(f, x, cnt):
         return f(x)
     except Exception as e:
         new = ComponentParseError(cnt, f, x)
-        new.__cause__ = e
-        raise new
+        raise new from e
 
 
 class check_eq:

--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -53,6 +53,7 @@ class check_eq:
 
         Args:
             *x: The expected values.
+
         """
         self.x: Sequence[Any] = x
 
@@ -68,6 +69,7 @@ class check_eq:
         Raises:
             ValueError: If the value is not equal to any of the
                 expected values.
+
         """
         if y not in self.x:
             raise ValueError(f"Expected: {self.x!r}, got: {y!r}")
@@ -94,6 +96,7 @@ class check_type:
 
         Args:
             *x: The expected types.
+
         """
         self.x: Sequence[Any] = x
 
@@ -109,6 +112,7 @@ class check_type:
         Raises:
             ValueError: If the value cannot be converted to any of the
                 expected types.
+
         """
         err = False
         for f in self.x:
@@ -139,6 +143,7 @@ class RequestReviewID:
 
         Args:
             rrid: The fully qualified Request Review ID string.
+
         """
         xs: list[str] = [x for x in rrid.split(":") if x]
         parsers: list[Callable[[str], str | int]] = [

--- a/mtui/types/systems.py
+++ b/mtui/types/systems.py
@@ -20,6 +20,7 @@ class System:
         Args:
             base: The base product of the system.
             addons: A set of addons for the system.
+
         """
         # TODO: check for correctness of base and addons types
         self.__base = base
@@ -33,13 +34,14 @@ class System:
 
         Raises:
             UnknownSystemError: If the system is unknown.
+
         """
         name: str = self.__base.name
         if name == "SUSE-Manager-Server":
             return "15"
-        elif name == "rhel":
+        if name == "rhel":
             return "YUM"
-        elif name in (
+        if name in (
             "SLES",
             "SLED",
             "SUSE_SLES",
@@ -50,11 +52,11 @@ class System:
             "SLE_RT",
         ):
             return self.__base.version[:2]
-        elif name == "openSUSE":
+        if name == "openSUSE":
             return "15"
-        elif name == "sle-studioonsite":
+        if name == "sle-studioonsite":
             return "11"
-        elif name == "SL-Micro":
+        if name == "SL-Micro":
             return "slmicro"
         raise UnknownSystemError(name)
 
@@ -89,6 +91,7 @@ class System:
 
         Returns:
             A set of `Product` objects representing the addons.
+
         """
         return self.__addons
 
@@ -97,6 +100,7 @@ class System:
 
         Returns:
             A `Product` object representing the base product.
+
         """
         return self.__base
 
@@ -105,6 +109,7 @@ class System:
 
         Returns:
             A set of `Product` objects representing all products in the system.
+
         """
         flat = {self.__base}
         flat.update(self.__addons)

--- a/mtui/types/systems.py
+++ b/mtui/types/systems.py
@@ -14,7 +14,7 @@ class System:
     used for pretty-printing and for correct update handling.
     """
 
-    def __init__(self, base: Product, addons: set[Product] = set()) -> None:
+    def __init__(self, base: Product, addons: set[Product] | None = None) -> None:
         """Initializes the `System` object.
 
         Args:
@@ -23,6 +23,8 @@ class System:
 
         """
         # TODO: check for correctness of base and addons types
+        if addons is None:
+            addons = set()
         self.__base = base
         self.__addons = addons
 

--- a/mtui/types/systems.py
+++ b/mtui/types/systems.py
@@ -84,9 +84,13 @@ class System:
             ]
         return msg
 
+    def __hash__(self) -> int:
+        """Hashes the system by base and addons."""
+        return hash((self.__base, frozenset(self.__addons)))
+
     def __eq__(self, other) -> bool:
         """Checks if two `System` objects are equal."""
-        return self.__base == other.__base and self.__addons == self.__addons
+        return self.__base == other.__base and self.__addons == other.__addons
 
     def get_addons(self) -> set[Product]:
         """Gets the addons of the system.

--- a/mtui/types/targetmeta.py
+++ b/mtui/types/targetmeta.py
@@ -13,6 +13,7 @@ class TargetMeta(NamedTuple):
         system: The system information of the target.
         packages: A dictionary of packages for the target.
         hostlog: A list of command log entries for the target.
+
     """
 
     hostname: str

--- a/mtui/types/test.py
+++ b/mtui/types/test.py
@@ -12,6 +12,7 @@ class Test(NamedTuple):
         test_id: The ID of the test.
         arch: The architecture of the test.
         modules: A dictionary of modules for the test.
+
     """
 
     name: str

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -72,20 +72,20 @@ class UpdateID(ABC):
             try:
                 self._vcs_checkout(config, config.svn_path, self.id)  # type: ignore
             except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
-                logger.error(e)
-                raise TestReportNotLoadedError
+                logger.exception("SVN checkout failed")
+                raise TestReportNotLoadedError from e
             else:
                 try:
                     tr.read(trpath)
                 except Exception as e:
                     raise e
-        except (MissingGiteaToken, FailedGiteaCall) as e:
-            logger.error(e)
+        except (MissingGiteaToken, FailedGiteaCall):
+            logger.exception("Gitea error")
             logger.warning("TestReport ins't loaded")
-            raise TestReportNotLoadedError
+            raise TestReportNotLoadedError from None
 
-        except InvalidGiteaHash as e:
-            logger.error(e)
+        except InvalidGiteaHash:
+            logger.exception("Invalid Gitea hash")
             logger.info(
                 "TestReport has different hash than GiteaPR, please regenerate template"
             )
@@ -96,7 +96,7 @@ class UpdateID(ABC):
             if not prompt_user(
                 "Force continue loading template ? [Y/N]: ", ["yes", "y"], interactive
             ):
-                raise TestReportNotLoadedError
+                raise TestReportNotLoadedError from None
             logger.warning("Template is loaded, but hash differs")
 
         return tr

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -7,7 +7,11 @@ from logging import getLogger
 from pathlib import Path
 from typing import final
 
-from mtui.exceptions import FailedGiteaCall, InvalidGiteaHash, MissingGiteaToken
+from mtui.exceptions import (
+    FailedGiteaCallError,
+    InvalidGiteaHashError,
+    MissingGiteaTokenError,
+)
 
 from ..config import Config
 from ..connector import SMELT
@@ -70,7 +74,7 @@ class UpdateID(ABC):
             if e.errno != ENOENT:
                 raise
             try:
-                self._vcs_checkout(config, config.svn_path, self.id)  # type: ignore
+                self._vcs_checkout(config, config.svn_path, self.id)
             except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
                 logger.exception("SVN checkout failed")
                 raise TestReportNotLoadedError from e
@@ -79,12 +83,12 @@ class UpdateID(ABC):
                     tr.read(trpath)
                 except Exception as e:
                     raise e
-        except (MissingGiteaToken, FailedGiteaCall):
+        except (MissingGiteaTokenError, FailedGiteaCallError):
             logger.exception("Gitea error")
             logger.warning("TestReport ins't loaded")
             raise TestReportNotLoadedError from None
 
-        except InvalidGiteaHash:
+        except InvalidGiteaHashError:
             logger.exception("Invalid Gitea hash")
             logger.info(
                 "TestReport has different hash than GiteaPR, please regenerate template"
@@ -174,20 +178,20 @@ class AutoOBSUpdateID(UpdateID):
             return NullTestReport(config)
 
         self._create_installogs_dir(config)
-        tr.smelt = SMELT(self.id, config.smelt_api)  # type: ignore
+        tr.smelt = SMELT(self.id, config.smelt_api)
 
         logger.info("Getting data from openQA")
         tr.openqa["auto"] = AutoOpenQA(
             config,
-            config.openqa_instance,  # type: ignore
-            tr.smelt,  # type: ignore
+            config.openqa_instance,
+            tr.smelt,
             self.id,
         ).run()
 
         if tr.openqa["auto"].results is None:
             logger.warning("No install jobs or install jobs failed")
             logger.info("Switch mode to manual")
-            tr.config.auto = False  # type: ignore
+            tr.config.auto = False
 
             if autoconnect:
                 logger.info("Connect refhosts from testreport")
@@ -200,7 +204,7 @@ class AutoOBSUpdateID(UpdateID):
                 logger.info("Connect refhosts from TestPlatform")
                 tr.connect_targets()
 
-        tr.updateid = self  # type: ignore
+        tr.updateid = self
         return tr
 
 
@@ -252,20 +256,20 @@ class KernelOBSUpdateID(UpdateID):
 
         self._create_installogs_dir(config)
         self.create_results_dir(config)
-        tr.smelt = SMELT(self.id, config.smelt_api)  # type: ignore
-        tr.updateid = self  # type: ignore
+        tr.smelt = SMELT(self.id, config.smelt_api)
+        tr.updateid = self
         tr.openqa["auto"] = AutoOpenQA(
             config,
-            config.openqa_instance,  # type: ignore
-            tr.smelt,  # type: ignore
+            config.openqa_instance,
+            tr.smelt,
             self.id,
-        ).run()  # type: ignore
-        kernel = KernelOpenQA(config, config.openqa_instance, tr.smelt, self.id).run()  # type: ignore
+        ).run()
+        kernel = KernelOpenQA(config, config.openqa_instance, tr.smelt, self.id).run()
         baremetal = KernelOpenQA(
             config,
-            config.openqa_instance_baremetal,  # type: ignore
-            tr.smelt,  # type: ignore
-            self.id,  # type: ignore
+            config.openqa_instance_baremetal,
+            tr.smelt,
+            self.id,
         ).run()
         tr.openqa["kernel"] = [kernel, baremetal]
 

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -45,6 +45,7 @@ class UpdateID(ABC):
             id_: The `RequestReviewID` of the update.
             testreport_factory: The factory for creating `TestReport` instances.
             testreport_svn_checkout: The function for checking out test reports.
+
         """
         self.id = id_
         self.testreport_factory = testreport_factory
@@ -58,6 +59,7 @@ class UpdateID(ABC):
 
         Returns:
             A `TestReport` instance.
+
         """
         tr = self.testreport_factory(config)
         trpath: Path = config.template_dir / str(self.id) / "log"
@@ -104,6 +106,7 @@ class UpdateID(ABC):
 
         Args:
             config: The application configuration.
+
         """
         directory: Path = config.template_dir / str(self.id) / config.install_logs
         directory.mkdir(parents=False, exist_ok=True)
@@ -124,6 +127,7 @@ class UpdateID(ABC):
 
         Returns:
             The `TestReport` class for the given ID.
+
         """
         if id_.kind == "SLFO":
             return SLTestReport
@@ -145,6 +149,7 @@ class AutoOBSUpdateID(UpdateID):
             rrid: The Request Review ID string.
             *args: Additional arguments.
             **kwds: Additional keyword arguments.
+
         """
         id_ = RequestReviewID(rrid)
 
@@ -161,6 +166,7 @@ class AutoOBSUpdateID(UpdateID):
 
         Returns:
             A `TestReport` instance.
+
         """
         try:
             tr = self._checkout(config, interactive)
@@ -211,6 +217,7 @@ class KernelOBSUpdateID(UpdateID):
             rrid: The Request Review ID string.
             *args: Additional arguments.
             **kw: Additional keyword arguments.
+
         """
         id_ = RequestReviewID(rrid)
         super().__init__(id_, self.tr_factory(id_), testreport_svn_checkout)
@@ -220,6 +227,7 @@ class KernelOBSUpdateID(UpdateID):
 
         Args:
             config: The application configuration.
+
         """
         directory: Path = config.template_dir / str(self.id) / "results"
         directory.mkdir(parents=False, exist_ok=True)
@@ -235,6 +243,7 @@ class KernelOBSUpdateID(UpdateID):
 
         Returns:
             A `TestReport` instance.
+
         """
         try:
             tr = self._checkout(config, interactive)

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -76,7 +76,7 @@ class UpdateID(ABC):
             try:
                 self._vcs_checkout(config, config.svn_path, self.id)
             except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
-                logger.exception("SVN checkout failed")
+                logger.error("SVN checkout failed")
                 raise TestReportNotLoadedError from e
             else:
                 try:
@@ -84,12 +84,12 @@ class UpdateID(ABC):
                 except Exception as e:
                     raise e
         except (MissingGiteaTokenError, FailedGiteaCallError):
-            logger.exception("Gitea error")
+            logger.error("Gitea error")
             logger.warning("TestReport ins't loaded")
             raise TestReportNotLoadedError from None
 
         except InvalidGiteaHashError:
-            logger.exception("Invalid Gitea hash")
+            logger.error("Invalid Gitea hash")
             logger.info(
                 "TestReport has different hash than GiteaPR, please regenerate template"
             )

--- a/mtui/types/urls.py
+++ b/mtui/types/urls.py
@@ -11,6 +11,7 @@ class URLs(NamedTuple):
         arch: The architecture.
         version: The version.
         url: The URL.
+
     """
 
     distri: str

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -28,6 +28,7 @@ def edit_text(text: str) -> str:
 
     Returns:
         The edited text.
+
     """
     editor = os.getenv("EDITOR", "vim")
     tmpfile = tempfile.NamedTemporaryFile()  # noqa: SIM115
@@ -37,7 +38,7 @@ def edit_text(text: str) -> str:
 
     subprocess.check_call((editor, tmpfile.name))
 
-    with open(tmpfile.name, "r") as tmp:
+    with open(tmpfile.name) as tmp:
         text = tmp.read().strip("\n")
         text = text.replace("'", '"')
 
@@ -56,6 +57,7 @@ if os.getenv("COLOR", "always") == "always":
 
         Returns:
             The colorized string.
+
         """
         return f"\033[1;32m{xs!s}\033[1;m\033[0m"
 
@@ -67,6 +69,7 @@ if os.getenv("COLOR", "always") == "always":
 
         Returns:
             The colorized string.
+
         """
         return f"\033[1;31m{xs!s}\033[1;m\033[0m"
 
@@ -78,6 +81,7 @@ if os.getenv("COLOR", "always") == "always":
 
         Returns:
             The colorized string.
+
         """
         return f"\033[1;33m{xs!s}\033[1;m\033[0m"
 
@@ -89,6 +93,7 @@ if os.getenv("COLOR", "always") == "always":
 
         Returns:
             The colorized string.
+
         """
         return f"\033[1;34m{xs!s}\033[1;m\033[0m"
 
@@ -106,6 +111,7 @@ def prompt_user(text: str, options: Collection[str], interactive: bool = True) -
 
     Returns:
         True if the user's response is in `options`, False otherwise.
+
     """
     result = False
     response = ""
@@ -136,6 +142,7 @@ def termsize() -> tuple[int, int]:
 
     Returns:
         A tuple containing the width and height of the terminal.
+
     """
     try:
         x = fcntl.ioctl(0, termios.TIOCGWINSZ, b"1234")
@@ -162,6 +169,7 @@ def filter_ansi(text: str) -> str:
 
     Returns:
         The string with ANSI escape codes removed.
+
     """
     text = re.sub(chr(27), "", text)
     text = re.sub(r"\[[0-9;]*[mA]", "", text)
@@ -176,6 +184,7 @@ def page(text: list[str], interactive: bool = True) -> None:
     Args:
         text: A list of strings to display.
         interactive: If False, the function does nothing.
+
     """
     if not interactive:
         return
@@ -206,11 +215,10 @@ def page(text: list[str], interactive: bool = True) -> None:
             if linelist:
                 line = "".join(linelist)
                 continue
-            else:
-                try:
-                    line = filter_ansi(text.pop().rstrip("\r\n"))
-                except IndexError:
-                    return
+            try:
+                line = filter_ansi(text.pop().rstrip("\r\n"))
+            except IndexError:
+                return
 
         if prompt_user(prompt, ("q",)):
             return
@@ -224,6 +232,7 @@ def requires_update(fn: Callable) -> Callable:
 
     Returns:
         The decorated function.
+
     """
 
     @wraps(fn)
@@ -246,6 +255,7 @@ class DictWithInjections(dict):
             **kw: Keyword arguments to pass to the dict constructor.
                 'key_error' is a special keyword argument that specifies
                 the exception to raise on a key error.
+
         """
         self.key_error = kw.pop("key_error", KeyError)
 
@@ -266,6 +276,7 @@ class SUTParse:
 
         Args:
             args: A comma-separated string of SUTs.
+
         """
         suts = args.split(",")
         targets = [f"-t {i!s}" for i in suts]
@@ -276,6 +287,7 @@ class SUTParse:
 
         Returns:
             The formatted string.
+
         """
         return self.args
 
@@ -297,8 +309,8 @@ def complete_choices(
 
     Returns:
         A list of possible completion strings.
-    """
 
+    """
     if not hostnames:
         hostnames = []
 
@@ -346,6 +358,7 @@ def complete_choices_filelist(
     Returns:
         A list of possible completion strings, including file and
         directory names.
+
     """
     dirname = ""
     filename = ""
@@ -371,6 +384,7 @@ def timestamp() -> str:
 
     Returns:
         The current time as a string.
+
     """
     # remove fractional part
     return str(int(time.time()))
@@ -382,6 +396,7 @@ def chdir(newpath: Path):
 
     Args:
         newpath: The path to change to.
+
     """
     storedpath = Path().cwd()
     os.chdir(newpath)
@@ -401,6 +416,7 @@ def ensure_dir_exists(*path, **kwargs) -> Path:
 
     Returns:
         The Path object for the created directory.
+
     """
 
     def empty(*args, **kwds) -> None:  # type: ignore
@@ -425,6 +441,7 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
     Args:
         data: The data to write, as bytes or a string.
         path: The path to the file.
+
     """
     if isinstance(data, bytes):
         data = data.decode("utf-8")
@@ -448,6 +465,7 @@ def walk(inc: Collection) -> Collection:
 
     Returns:
         The modified collection.
+
     """
     if isinstance(inc, list):
         for i, j in enumerate(inc):
@@ -456,7 +474,7 @@ def walk(inc: Collection) -> Collection:
         if len(inc) == 1:
             if "edges" in inc:
                 return walk(inc["edges"])
-            elif "node" in inc:
+            if "node" in inc:
                 tmp = deepcopy(inc["node"])
                 del inc["node"]
                 inc.update(tmp)

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import termios
 import time
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from functools import wraps
@@ -293,7 +293,7 @@ class SUTParse:
 
 
 def complete_choices(
-    synonyms: list[tuple[str, ...]],
+    synonyms: Sequence[tuple[str, ...]],
     line: str,
     text: str,
     hostnames: list[str] | None = None,
@@ -453,7 +453,7 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
     move(fname, path)
 
 
-def walk(inc: Collection) -> Collection:
+def walk(inc: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
     """Recursively walks through a nested data structure.
 
     This function is designed to simplify nested data structures,
@@ -469,7 +469,8 @@ def walk(inc: Collection) -> Collection:
     """
     if isinstance(inc, list):
         for i, j in enumerate(inc):
-            inc[i] = walk(j)
+            if isinstance(j, list | dict):
+                inc[i] = walk(j)
     if isinstance(inc, dict):
         if len(inc) == 1:
             if "edges" in inc:

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -117,7 +117,7 @@ def prompt_user(text: str, options: Collection[str], interactive: bool = True) -
     response = ""
 
     if not interactive:
-        print(text)
+        print(text)  # noqa: T201
         return False
 
     try:
@@ -208,7 +208,7 @@ def page(text: list[str], interactive: bool = True) -> None:
                 linelist = [""]
             lines2print = min(len(linelist), linesleft)
             for i in range(lines2print):
-                print(linelist[i])
+                print(linelist[i])  # noqa: T201
             linesleft -= lines2print
             linelist = linelist[lines2print:]
 
@@ -265,7 +265,7 @@ class DictWithInjections(dict):
         try:
             return super().__getitem__(x)
         except KeyError:
-            raise self.key_error(x)
+            raise self.key_error(x) from None
 
 
 class SUTParse:

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -419,7 +419,7 @@ def ensure_dir_exists(*path, **kwargs) -> Path:
 
     """
 
-    def empty(*args, **kwds) -> None:  # type: ignore
+    def empty(*args, **kwds) -> None:
         pass
 
     on_create: Callable = kwargs.get("on_create", empty)

--- a/mtui/xdg.py
+++ b/mtui/xdg.py
@@ -15,5 +15,6 @@ def save_cache_path(*args: str) -> Path:
 
     Returns:
         A `Path` object representing the full path to the file.
+
     """
     return Path(x_save_cache_path(app)).joinpath(*args)

--- a/mtui/xdg.py
+++ b/mtui/xdg.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from xdg.BaseDirectory import save_cache_path as x_save_cache_path  # type: ignore
+from xdg.BaseDirectory import save_cache_path as x_save_cache_path
 
 app = "mtui"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,13 @@ select = [
     "PLW1510",# subprocess.run without check
     "PLW1641",# __eq__ without __hash__
     "TRY400", # logging.error() in except (use logging.exception())
+    "D200",   # single-line docstrings should fit on one line
     "D202",   # no blank lines after function docstring
+    "D212",   # multi-line summary should start on first line
+    "D400",   # first line should end with a period
     "D413",   # missing blank line after last docstring section
+    "D415",   # first line should end with punctuation
+    "ERA001", # no commented-out code
     "PTH201", # Path(".") -> Path()
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,27 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = [
-    "E",     # pycodestyle errors
-    "F",     # pyflakes
-    "PT",    # flake8-pytest-style
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "I",      # isort (import sorting)
+    "PT",     # flake8-pytest-style
     "B027",   # empty method in abstract class without @abstractmethod
     "RUF005", # use iterable unpacking instead of concatenation
     "SIM",    # flake8-simplify
-    "UP007",  # use X | Y for unions
+    "UP",     # pyupgrade (modernize syntax for py311+)
+    "FURB110",# if-exp instead of or-operator
+    "RET505", # superfluous else after return
+    "RET506", # superfluous else after raise
+    "RET507", # superfluous else after continue
+    "PLR5501",# collapsible else-if
+    "D202",   # no blank lines after function docstring
+    "D413",   # missing blank line after last docstring section
+    "PTH201", # Path(".") -> Path()
 ]
 ignore = [
-    "E501",  # line-too-long (handled by formatter)
+    "E501",   # line-too-long (handled by formatter)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S108", "ARG", "SLF001"]
+"Documentation/conf.py" = ["INP001", "ERA001", "A001", "D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,15 @@ select = [
     "I",      # isort (import sorting)
     "B",      # flake8-bugbear (bug detection)
     "G",      # flake8-logging-format
+    "N818",   # exception names should end in Error
+    "PGH003", # blanket type: ignore (require specific codes)
     "PT",     # flake8-pytest-style
     "C4",     # flake8-comprehensions
     "PERF",   # perflint (performance)
     "T20",    # flake8-print (no print statements)
     "RUF005", # use iterable unpacking instead of concatenation
+    "RUF012", # mutable class defaults need ClassVar
+    "SLF001", # private member access
     "SIM",    # flake8-simplify
     "UP",     # pyupgrade (modernize syntax for py311+)
     "FURB110",# if-exp instead of or-operator
@@ -79,6 +83,7 @@ select = [
     "PLR5501",# collapsible else-if
     "PLW0127",# self-assigning variable
     "PLW1510",# subprocess.run without check
+    "PLW1641",# __eq__ without __hash__
     "TRY400", # logging.error() in except (use logging.exception())
     "D202",   # no blank lines after function docstring
     "D413",   # missing blank line after last docstring section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,12 @@ select = [
     "E",      # pycodestyle errors
     "F",      # pyflakes
     "I",      # isort (import sorting)
+    "B",      # flake8-bugbear (bug detection)
+    "G",      # flake8-logging-format
     "PT",     # flake8-pytest-style
-    "B027",   # empty method in abstract class without @abstractmethod
+    "C4",     # flake8-comprehensions
+    "PERF",   # perflint (performance)
+    "T20",    # flake8-print (no print statements)
     "RUF005", # use iterable unpacking instead of concatenation
     "SIM",    # flake8-simplify
     "UP",     # pyupgrade (modernize syntax for py311+)
@@ -73,6 +77,9 @@ select = [
     "RET506", # superfluous else after raise
     "RET507", # superfluous else after continue
     "PLR5501",# collapsible else-if
+    "PLW0127",# self-assigning variable
+    "PLW1510",# subprocess.run without check
+    "TRY400", # logging.error() in except (use logging.exception())
     "D202",   # no blank lines after function docstring
     "D413",   # missing blank line after last docstring section
     "PTH201", # Path(".") -> Path()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ select = [
     "PLW0127",# self-assigning variable
     "PLW1510",# subprocess.run without check
     "PLW1641",# __eq__ without __hash__
-    "TRY400", # logging.error() in except (use logging.exception())
+
     "D200",   # single-line docstrings should fit on one line
     "D202",   # no blank lines after function docstring
     "D212",   # multi-line summary should start on first line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def mock_target(mock_config, mock_connection, mock_system):
     """A Target-like mock with realistic attributes and methods."""
     from mtui.target import Target
 
-    target = Target(mock_config, "host1.example.com")
+    target = Target(mock_config, "host1.example.com")  # type: ignore[arg-type]
     target.connection = mock_connection
     target._lock = MagicMock()
     target._lock.is_locked.return_value = False
@@ -105,7 +105,7 @@ def mock_target_pair(mock_config, mock_system):
     from mtui.target import Target
 
     def make_target(hostname):
-        t = Target(mock_config, hostname)
+        t = Target(mock_config, hostname)  # type: ignore[arg-type]
         conn = MagicMock()
         conn.hostname = hostname
         conn.port = 22

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from json import loads
 from pathlib import Path
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -8,9 +8,7 @@ from mtui.argparse import ArgsParseFailureError
 
 
 def test_get_parser():
-    """
-    Test get_parser
-    """
+    """Test get_parser."""
     parser = args.get_parser(sys)
     assert parser is not None
 
@@ -23,9 +21,7 @@ def test_get_parser():
 
 
 def test_get_parser_args():
-    """
-    Test get_parser with arguments
-    """
+    """Test get_parser with arguments."""
     parser = args.get_parser(sys)
 
     # Test short arguments

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from mtui import args
-from mtui.argparse import ArgsParseFailure
+from mtui.argparse import ArgsParseFailureError
 
 
 def test_get_parser():
@@ -15,10 +15,10 @@ def test_get_parser():
     assert parser is not None
 
     # Check for help argument
-    with pytest.raises(ArgsParseFailure):
+    with pytest.raises(ArgsParseFailureError):
         parser.parse_args(["-h"])
 
-    with pytest.raises(ArgsParseFailure):
+    with pytest.raises(ArgsParseFailureError):
         parser.parse_args(["--help"])
 
 
@@ -99,5 +99,5 @@ def test_get_parser_args():
     assert str(parsed_args.update.id) == "SUSE:Maintenance:2:2"
 
     # Test mutually exclusive group
-    with pytest.raises(ArgsParseFailure):
+    with pytest.raises(ArgsParseFailureError):
         parser.parse_args(["-a", "SUSE:Maintenance:1:1", "-k", "SUSE:Maintenance:2:2"])

--- a/tests/test_colorlog.py
+++ b/tests/test_colorlog.py
@@ -2,9 +2,7 @@ from mtui import colorlog
 
 
 def test_create_logger(capsys):
-    """
-    Test create_logger
-    """
+    """Test create_logger."""
     logger = colorlog.create_logger("test_logger", "DEBUG")
     logger.info("test info message")
     logger.debug("test debug message")

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -127,7 +127,7 @@ class TestParseHosts:
         t1.state = "enabled"
         t2.state = "enabled"
 
-        prompt.targets = HostsGroup([t1, t2])
+        prompt.targets = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         prompt.metadata = MagicMock()
         prompt.display = MagicMock()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,9 +16,7 @@ class MockRefhosts:
 
 
 def test_default_config(tmpdir):
-    """
-    Test default config
-    """
+    """Test default config."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("")
     cfg = config.Config(config_file, refhosts=MockRefhosts)
@@ -27,9 +25,7 @@ def test_default_config(tmpdir):
 
 
 def test_override_default_config(tmpdir):
-    """
-    Test override config
-    """
+    """Test override config."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text(
         "[mtui]\nlocation = test_location\nconnection_timeout = 600\n"
@@ -40,9 +36,7 @@ def test_override_default_config(tmpdir):
 
 
 def test_merge_args(tmpdir):
-    """
-    Test merge_args
-    """
+    """Test merge_args."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("")
     cfg = config.Config(config_file, refhosts=MockRefhosts)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -63,7 +63,7 @@ def test_connection_init_auth_fallback(mock_ssh_client, mock_ssh_config, mock_pa
         None,  # second call succeeds
     ]
     with patch("getpass.getpass", return_value="password") as mock_getpass:
-        conn = Connection("test_host", 22, 300)
+        Connection("test_host", 22, 300)
 
         assert mock_getpass.call_count == 1
         assert mock_ssh_client.connect.call_count == 2
@@ -110,7 +110,9 @@ def test_run_command_timeout(mock_ssh_client, mock_ssh_config, mock_path):
     mock_session = MagicMock()
     mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
 
-    with patch("select.select", return_value=([], [], [])):
-        with patch("builtins.input", return_value="n"):
-            with pytest.raises(CommandTimeout):
-                conn.run("sleep 10")
+    with (
+        patch("select.select", return_value=([], [], [])),
+        patch("builtins.input", return_value="n"),
+        pytest.raises(CommandTimeout),
+    ):
+        conn.run("sleep 10")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import paramiko
 import pytest
 
-from mtui.connection import CommandTimeout, Connection
+from mtui.connection import CommandTimeoutError, Connection
 
 
 @pytest.fixture
@@ -113,6 +113,6 @@ def test_run_command_timeout(mock_ssh_client, mock_ssh_config, mock_path):
     with (
         patch("select.select", return_value=([], [], [])),
         patch("builtins.input", return_value="n"),
-        pytest.raises(CommandTimeout),
+        pytest.raises(CommandTimeoutError),
     ):
         conn.run("sleep 10")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -13,9 +13,7 @@ class MockSystem(System):
 
 
 def test_println():
-    """
-    Test println
-    """
+    """Test println."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     d.println("test message")
@@ -23,9 +21,7 @@ def test_println():
 
 
 def test_list_bugs():
-    """
-    Test list_bugs
-    """
+    """Test list_bugs."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     bugs = {"123": "Test bug"}
@@ -38,9 +34,7 @@ def test_list_bugs():
 
 
 def test_list_history():
-    """
-    Test list_history
-    """
+    """Test list_history."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
@@ -52,9 +46,7 @@ def test_list_history():
 
 
 def test_list_host():
-    """
-    Test list_host
-    """
+    """Test list_host."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
@@ -89,9 +81,7 @@ class MockLock:
 
 
 def test_list_locks():
-    """
-    Test list_locks
-    """
+    """Test list_locks."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
@@ -103,9 +93,7 @@ def test_list_locks():
 
 
 def test_list_sessions():
-    """
-    Test list_sessions
-    """
+    """Test list_sessions."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
@@ -116,9 +104,7 @@ def test_list_sessions():
 
 
 def test_list_timeout():
-    """
-    Test list_timeout
-    """
+    """Test list_timeout."""
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
@@ -128,9 +114,7 @@ def test_list_timeout():
 
 
 def test_show_log():
-    """
-    Test show_log
-    """
+    """Test show_log."""
     output = StringIO()
 
     def sink(msg):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -16,8 +16,8 @@ def test_request_review_id_parse_error():
     with pytest.raises(exceptions.InternalParseError, match="Internal error"):
         raise exceptions.InternalParseError("func", "context")
 
-    with pytest.raises(exceptions.MissingComponent, match="Missing 1. component"):
-        raise exceptions.MissingComponent(1, "expected")
+    with pytest.raises(exceptions.MissingComponentError, match="Missing 1. component"):
+        raise exceptions.MissingComponentError(1, "expected")
 
     with pytest.raises(
         exceptions.ComponentParseError, match="Failed to parse 2. component"
@@ -45,14 +45,14 @@ def test_gitea_error():
     with pytest.raises(exceptions.GiteaError):
         raise exceptions.GiteaError()
 
-    with pytest.raises(exceptions.MissingGiteaToken):
-        raise exceptions.MissingGiteaToken()
+    with pytest.raises(exceptions.MissingGiteaTokenError):
+        raise exceptions.MissingGiteaTokenError()
 
-    with pytest.raises(exceptions.FailedGiteaCall):
-        raise exceptions.FailedGiteaCall()
+    with pytest.raises(exceptions.FailedGiteaCallError):
+        raise exceptions.FailedGiteaCallError()
 
-    with pytest.raises(exceptions.GiteaNoReview):
-        raise exceptions.GiteaNoReview()
+    with pytest.raises(exceptions.GiteaNoReviewError):
+        raise exceptions.GiteaNoReviewError()
 
-    with pytest.raises(exceptions.GiteaAssignInvalid, match="different user"):
-        raise exceptions.GiteaAssignInvalid(assignment.ASSIGNED_OTHER, "test_user")
+    with pytest.raises(exceptions.GiteaAssignInvalidError, match="different user"):
+        raise exceptions.GiteaAssignInvalidError(assignment.ASSIGNED_OTHER, "test_user")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,9 +4,7 @@ from mtui import exceptions
 
 
 def test_request_review_id_parse_error():
-    """
-    Test RequestReviewIDParseError and its subclasses
-    """
+    """Test RequestReviewIDParseError and its subclasses."""
     with pytest.raises(exceptions.RequestReviewIDParseError, match="test message"):
         raise exceptions.RequestReviewIDParseError("test message")
 
@@ -26,9 +24,7 @@ def test_request_review_id_parse_error():
 
 
 def test_update_error():
-    """
-    Test UpdateError
-    """
+    """Test UpdateError."""
     with pytest.raises(exceptions.UpdateError, match="test reason"):
         raise exceptions.UpdateError("test reason")
 
@@ -37,9 +33,7 @@ def test_update_error():
 
 
 def test_gitea_error():
-    """
-    Test GiteaError and its subclasses
-    """
+    """Test GiteaError and its subclasses."""
     from mtui.types import assignment
 
     with pytest.raises(exceptions.GiteaError):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -5,14 +5,14 @@ from mtui.colorlog import create_logger
 
 def test_formatter_name():
     formatter = create_logger("foo")
-    assert "foo" == formatter.name
+    assert formatter.name == "foo"
 
 
 def test_formatter_level():
     formatter = create_logger("foo")
-    assert 20 == formatter.level
+    assert formatter.level == 20
 
     formatter.setLevel(19)
-    assert 19 == formatter.level
+    assert formatter.level == 19
 
-    assert 19 == formatter.getEffectiveLevel()
+    assert formatter.getEffectiveLevel() == 19

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -85,7 +85,7 @@ class TestGiteaInit:
     def test_init_constructs_urls(self, mock_config):
         """Test init constructs API URLs correctly."""
         api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
-        gitea = Gitea(mock_config, api_url)
+        gitea = Gitea(mock_config, api_url)  # type: ignore[arg-type]
 
         assert gitea.pr == api_url
         assert "issues/comments" in gitea.issues
@@ -96,7 +96,7 @@ class TestGiteaInit:
     def test_init_custom_group(self, mock_config):
         """Test init with custom group."""
         api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
-        gitea = Gitea(mock_config, api_url, group="qam-kernel")
+        gitea = Gitea(mock_config, api_url, group="qam-kernel")  # type: ignore[arg-type]
 
         assert gitea.group == "qam-kernel"
 
@@ -110,7 +110,7 @@ class TestGiteaOperations:
     @pytest.fixture
     def gitea(self, mock_config):
         api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
-        return Gitea(mock_config, api_url)
+        return Gitea(mock_config, api_url)  # type: ignore[arg-type]
 
     def _make_comment(self, serial, body, date="2024-01-01T00:00:00+00:00"):
         return {"id": serial, "body": body, "updated_at": date}
@@ -211,7 +211,7 @@ class TestGiteaOperations:
         body = responses.calls[0].request.body
         if isinstance(body, bytes):
             body = body.decode("utf-8")
-        assert "test comment body" in body
+        assert body is not None and "test comment body" in body
 
     @responses.activate
     def test_get_hash(self, gitea):
@@ -255,7 +255,7 @@ class TestAssignmentStateMachine:
     @pytest.fixture
     def gitea(self, mock_config):
         api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
-        return Gitea(mock_config, api_url)
+        return Gitea(mock_config, api_url)  # type: ignore[arg-type]
 
     @responses.activate
     def test_check_assign_no_comments_returns_unassigned(self, gitea):

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -15,7 +15,6 @@ from mtui.exceptions import (
 )
 from mtui.types import assignment
 
-
 # --- Comment dataclass ---
 
 

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -1,7 +1,7 @@
 """Tests for the mtui connector gitea module."""
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import responses
@@ -13,7 +13,7 @@ from mtui.exceptions import (
     GiteaNoReview,
     MissingGiteaToken,
 )
-from mtui.types import assignment, method
+from mtui.types import assignment
 
 
 # --- Comment dataclass ---

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -8,10 +8,10 @@ import responses
 
 from mtui.connector.gitea import Comment, Gitea
 from mtui.exceptions import (
-    FailedGiteaCall,
-    GiteaAssignInvalid,
-    GiteaNoReview,
-    MissingGiteaToken,
+    FailedGiteaCallError,
+    GiteaAssignInvalidError,
+    GiteaNoReviewError,
+    MissingGiteaTokenError,
 )
 from mtui.types import assignment
 
@@ -75,11 +75,11 @@ class TestComment:
 
 class TestGiteaInit:
     def test_missing_token_raises(self):
-        """Test init raises MissingGiteaToken when token is empty."""
+        """Test init raises MissingGiteaTokenError when token is empty."""
         config = MagicMock()
         config.gitea_token = ""
 
-        with pytest.raises(MissingGiteaToken):
+        with pytest.raises(MissingGiteaTokenError):
             Gitea(config, "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1")
 
     def test_init_constructs_urls(self, mock_config):
@@ -158,7 +158,7 @@ class TestGiteaOperations:
 
     @responses.activate
     def test_assign_no_review_raises(self, gitea):
-        """Test assign raises GiteaNoReview when no review exists."""
+        """Test assign raises GiteaNoReviewError when no review exists."""
         responses.add(
             responses.GET,
             gitea.pr,
@@ -166,12 +166,12 @@ class TestGiteaOperations:
             status=200,
         )
 
-        with pytest.raises(GiteaNoReview):
+        with pytest.raises(GiteaNoReviewError):
             gitea.assign()
 
     @responses.activate
     def test_unassign_when_not_assigned_raises(self, gitea):
-        """Test unassign raises GiteaAssignInvalid when not assigned."""
+        """Test unassign raises GiteaAssignInvalidError when not assigned."""
         responses.add(
             responses.GET,
             gitea.prissues,
@@ -179,12 +179,12 @@ class TestGiteaOperations:
             status=200,
         )
 
-        with pytest.raises(GiteaAssignInvalid):
+        with pytest.raises(GiteaAssignInvalidError):
             gitea.unassign()
 
     @responses.activate
     def test_approve_when_not_assigned_raises(self, gitea):
-        """Test approve raises GiteaAssignInvalid when not assigned."""
+        """Test approve raises GiteaAssignInvalidError when not assigned."""
         responses.add(
             responses.GET,
             gitea.prissues,
@@ -192,7 +192,7 @@ class TestGiteaOperations:
             status=200,
         )
 
-        with pytest.raises(GiteaAssignInvalid):
+        with pytest.raises(GiteaAssignInvalidError):
             gitea.approve()
 
     @responses.activate
@@ -228,7 +228,7 @@ class TestGiteaOperations:
 
     @responses.activate
     def test_request_failure_raises_failed_gitea_call(self, gitea):
-        """Test API call failures raise FailedGiteaCall."""
+        """Test API call failures raise FailedGiteaCallError."""
         responses.add(
             responses.GET,
             gitea.pr,
@@ -236,7 +236,7 @@ class TestGiteaOperations:
             status=404,
         )
 
-        with pytest.raises(FailedGiteaCall):
+        with pytest.raises(FailedGiteaCallError):
             gitea.get_hash()
 
     def test_repr(self, gitea):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,7 +13,7 @@ def test_script_base():
     """Test Script base class."""
     tr = MockTestReport()
     path = Path("/tmp/pre_script.sh")
-    script = hooks.PreScript(tr, path)
+    script = hooks.PreScript(tr, path)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     assert "pre script" in str(script)
     assert "<MockTestReport>" in repr(script)
 
@@ -27,8 +27,8 @@ def test_pre_script(monkeypatch):
     targets = MagicMock()
 
     path = Path("/tmp/pre_script.sh")
-    script = hooks.PreScript(tr, path)
-    script._run(targets)
+    script = hooks.PreScript(tr, path)  # type: ignore[arg-type]
+    script._run(targets)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     targets.sftp_put.assert_any_call(path, "remote_path")
     targets.run.assert_called_once()
@@ -44,7 +44,7 @@ def test_compare_script(mock_run):
     target.hostname = "test_host"
 
     path = Path("/tmp/compare_script.sh")
-    script = hooks.CompareScript(tr, path)
-    script._run_single_target(target)
+    script = hooks.CompareScript(tr, path)  # type: ignore[arg-type]
+    script._run_single_target(target)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     mock_run.assert_called_once()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,9 +10,7 @@ class MockTestReport:
 
 
 def test_script_base():
-    """
-    Test Script base class
-    """
+    """Test Script base class."""
     tr = MockTestReport()
     path = Path("/tmp/pre_script.sh")
     script = hooks.PreScript(tr, path)
@@ -21,9 +19,7 @@ def test_script_base():
 
 
 def test_pre_script(monkeypatch):
-    """
-    Test PreScript
-    """
+    """Test PreScript."""
     tr = MagicMock()
     tr.target_wd.return_value = "remote_path"
     tr.report_wd.return_value = "local_path"
@@ -40,9 +36,7 @@ def test_pre_script(monkeypatch):
 
 @patch("subprocess.run")
 def test_compare_script(mock_run):
-    """
-    Test CompareScript
-    """
+    """Test CompareScript."""
     tr = MagicMock()
     tr.report_wd.side_effect = lambda *args, **kwargs: Path("/".join(args))
 

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -9,7 +9,6 @@ from mtui.messages import HostIsNotConnectedError
 from mtui.target.hostgroup import HostsGroup
 from mtui.target.locks import TargetLockedError
 
-
 # --- Initialization and selection ---
 
 

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -19,7 +19,7 @@ def test_hostgroup_init():
     t1.hostname = "host1.example.com"
     t2.hostname = "host2.example.com"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     assert len(hg) == 2
     assert "host1.example.com" in hg
@@ -38,7 +38,7 @@ def test_hostgroup_select_all():
     """Test select() with no args returns self."""
     t1 = MagicMock()
     t1.hostname = "h1"
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     selected = hg.select()
     assert selected is hg
@@ -53,7 +53,7 @@ def test_hostgroup_select_enabled_only():
     t1.state = "enabled"
     t2.state = "disabled"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     selected = hg.select(enabled=True)
 
     assert len(selected) == 1
@@ -68,7 +68,7 @@ def test_hostgroup_select_by_hostname():
     t1.hostname = "h1"
     t2.hostname = "h2"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     selected = hg.select(["h1"])
 
     assert len(selected) == 1
@@ -79,7 +79,7 @@ def test_hostgroup_select_nonexistent_host_raises():
     """Test select() with unknown hostname raises HostIsNotConnectedError."""
     t1 = MagicMock()
     t1.hostname = "h1"
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(HostIsNotConnectedError):
         hg.select(["unknown-host"])
@@ -94,7 +94,7 @@ def test_hostgroup_select_enabled_and_by_hostname():
     t1.state = "disabled"
     t2.state = "enabled"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     selected = hg.select(["h1", "h2"], enabled=True)
 
     assert len(selected) == 1
@@ -111,7 +111,7 @@ def test_hostgroup_unlock_delegates():
     t1.hostname = "h1"
     t2.hostname = "h2"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.unlock("test_comment")
 
     t1.unlock.assert_called_once_with("test_comment")
@@ -124,7 +124,7 @@ def test_hostgroup_unlock_suppresses_target_locked_error():
     t1.hostname = "h1"
     t1.unlock.side_effect = TargetLockedError("locked by someone")
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.unlock()  # should not raise
 
 
@@ -135,7 +135,7 @@ def test_hostgroup_lock_delegates():
     t1.hostname = "h1"
     t2.hostname = "h2"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.lock("comment")
 
     t1.lock.assert_called_once_with("comment")
@@ -148,7 +148,7 @@ def test_hostgroup_lock_suppresses_target_locked_error():
     t1.hostname = "h1"
     t1.lock.side_effect = TargetLockedError("locked")
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.lock()  # should not raise
 
 
@@ -164,7 +164,7 @@ def test_hostgroup_query_versions():
     t1.query_package_versions.return_value = {"pkg": "1.0"}
     t2.query_package_versions.return_value = {"pkg": "2.0"}
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     result = hg.query_versions(["pkg"])
 
     assert len(result) == 2
@@ -177,7 +177,7 @@ def test_hostgroup_add_history():
     t1 = MagicMock()
     t1.hostname = "h1"
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.add_history("data")
 
     t1.add_history.assert_called_once_with("data")
@@ -190,7 +190,7 @@ def test_hostgroup_names():
     t1.hostname = "alpha"
     t2.hostname = "beta"
 
-    hg = HostsGroup([t1, t2])
+    hg = HostsGroup([t1, t2])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     names = hg.names()
 
     assert set(names) == {"alpha", "beta"}
@@ -207,7 +207,7 @@ def test_update_lock_locks_unlocked_hosts(mock_queue, mock_thread_cls):
     t1.hostname = "h1"
     t1.is_locked.return_value = False
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.update_lock()
 
     t1.lock.assert_called_once()
@@ -229,7 +229,7 @@ def test_update_lock_raises_when_locked_by_other(mock_queue, mock_thread_cls):
     mock_lock.comment.return_value = ""
     type(t1)._lock = PropertyMock(return_value=mock_lock)
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(UpdateError, match="Hosts locked"):
         hg.update_lock()
@@ -253,7 +253,7 @@ def test_perform_install_runs_and_unlocks(mock_run, mock_queue, mock_thread):
     }
     t1.get_installer_check.return_value = MagicMock()
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.perform_install(["pkg"])
 
     # Verify unlock was called (cleanup always happens)
@@ -274,7 +274,7 @@ def test_perform_install_unlocks_on_error(mock_run, mock_queue, mock_thread):
         "reboot": MagicMock(substitute=MagicMock(return_value="")),
     }
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     # Make run raise
     mock_run.return_value.run.side_effect = RuntimeError("connection lost")
 
@@ -294,7 +294,7 @@ def test_report_self_delegates():
     t1.hostname = "h1"
     sink = MagicMock()
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_self(sink)
 
     t1.report_self.assert_called_once_with(sink)
@@ -306,7 +306,7 @@ def test_report_locks_delegates():
     t1.hostname = "h1"
     sink = MagicMock()
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_locks(sink)
 
     t1.report_locks.assert_called_once_with(sink)
@@ -318,7 +318,7 @@ def test_report_timeout_delegates():
     t1.hostname = "h1"
     sink = MagicMock()
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_timeout(sink)
 
     t1.report_timeout.assert_called_once_with(sink)
@@ -330,7 +330,7 @@ def test_report_products_delegates():
     t1.hostname = "h1"
     sink = MagicMock()
 
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_products(sink)
 
     t1.report_products.assert_called_once_with(sink)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,7 @@ from mtui.systemcheck import detect_system
 
 
 def test_systemcheck():
-    config = Config([])
+    config = Config([])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     config.distro, config.distro_ver, config.distro_kernel = detect_system()
     assert config.distro
     assert config.distro_ver

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -2,7 +2,7 @@
 
 import errno
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -279,8 +279,7 @@ class TestLockedTargets:
         """Test __exit__ unlocks targets even when exception occurs."""
         t1 = MagicMock()
 
-        with pytest.raises(ValueError):
-            with LockedTargets([t1]):
-                raise ValueError("test error")
+        with pytest.raises(ValueError), LockedTargets([t1]):
+            raise ValueError("test error")
 
         t1.unlock.assert_called_once()

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -8,7 +8,6 @@ import pytest
 
 from mtui.target.locks import LockedTargets, RemoteLock, TargetLock, TargetLockedError
 
-
 # --- RemoteLock ---
 
 
@@ -279,7 +278,7 @@ class TestLockedTargets:
         """Test __exit__ unlocks targets even when exception occurs."""
         t1 = MagicMock()
 
-        with pytest.raises(ValueError), LockedTargets([t1]):
+        with pytest.raises(ValueError, match="test error"), LockedTargets([t1]):
             raise ValueError("test error")
 
         t1.unlock.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import logging
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-from mtui.argparse import ArgsParseFailure
+from mtui.argparse import ArgsParseFailureError
 from mtui.main import main, run_mtui
 
 
@@ -13,12 +13,12 @@ def test_main_args_parse_failure(monkeypatch):
     monkeypatch.setattr("sys.argv", ["mtui", "--invalid"])
 
     with patch("mtui.main.get_parser") as mock_get_parser:
-        # Mock parse_args to raise ArgsParseFailure
+        # Mock parse_args to raise ArgsParseFailureError
         mock_parser = MagicMock()
         mock_get_parser.return_value = mock_parser
 
         # Setup the exception to be raised
-        mock_parser.parse_args.side_effect = ArgsParseFailure(status=2)
+        mock_parser.parse_args.side_effect = ArgsParseFailureError(status=2)
 
         # Call main and check result
         result = main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,7 +60,6 @@ def test_main_noninteractive_without_prerun(monkeypatch, caplog):
 
 def test_run_mtui_with_debug():
     """Test run_mtui with debug flag."""
-
     mock_config = MagicMock()
     mock_logger = MagicMock()
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -40,11 +40,11 @@ def test_messages():
         == "Starting compare script 'test_argv' failed: test_reason"
     )
     assert (
-        str(messages.CompareScriptFailed("test_argv", "stdout", "stderr", 1))
+        str(messages.CompareScriptFailedError("test_argv", "stdout", "stderr", 1))
         == "Compare script 'test_argv' failed: rc = 1 err:\nstderr"
     )
     assert (
-        str(messages.CompareScriptCrashed("test_argv", "stdout", "stderr", 1))
+        str(messages.CompareScriptCrashedError("test_argv", "stdout", "stderr", 1))
         == "Compare script 'test_argv' crashed:\nstderr"
     )
     assert (

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,9 +2,7 @@ from mtui import messages
 
 
 def test_messages():
-    """
-    Test all UserMessage subclasses
-    """
+    """Test all UserMessage subclasses."""
     # Test messages with arguments
     assert (
         str(messages.HostIsNotConnectedError("test_host"))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,7 +21,7 @@ def test_duplicate_found(caplog, log_install) -> None:
 
     export._writer(fn, data)
 
-    assert caplog.records[0].msg == f"Log {fn} exists and is same as export"
+    assert caplog.records[0].message == f"Log {fn} exists and is same as export"
 
 
 def test_diffeerent_files(caplog, log_install) -> None:
@@ -34,5 +34,5 @@ def test_diffeerent_files(caplog, log_install) -> None:
 
     export._writer(fn, data)
 
-    assert caplog.records[0].msg == f"file {fn} exists."
-    assert caplog.records[1].msg.startswith("exporting log to")
+    assert caplog.records[0].message == f"file {fn} exists."
+    assert caplog.records[1].message.startswith("exporting log to")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -17,7 +17,7 @@ def test_duplicate_found(caplog, log_install) -> None:
     fn = log_install
     data = fn.read_text().split("\n")
 
-    export = FakeExport("", "", [], False, "123", True)
+    export = FakeExport("", "", [], False, "123", True)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     export._writer(fn, data)
 
@@ -30,7 +30,7 @@ def test_diffeerent_files(caplog, log_install) -> None:
     fn = log_install
     data = ["Non duplicate text of install log", "fake log"]
 
-    export = FakeExport("", "", [], False, "123", False)
+    export = FakeExport("", "", [], False, "123", False)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     export._writer(fn, data)
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -5,9 +5,7 @@ from mtui import notification
 
 
 def test_display_success(monkeypatch):
-    """
-    Test display when pynotify is available and works.
-    """
+    """Test display when pynotify is available and works."""
     mock_pynotify = MagicMock()
     # Bypass the import/init logic by setting __impl directly
     monkeypatch.setattr(notification, "__impl", mock_pynotify)
@@ -21,9 +19,7 @@ def test_display_success(monkeypatch):
 
 
 def test_display_import_error(monkeypatch):
-    """
-    Test display when pynotify is not installed.
-    """
+    """Test display when pynotify is not installed."""
     # Reset state to ensure the import logic is triggered
     monkeypatch.setattr(notification, "__impl", None)
     # Make the import fail
@@ -34,9 +30,7 @@ def test_display_import_error(monkeypatch):
 
 
 def test_display_init_fails(monkeypatch):
-    """
-    Test display when pynotify is installed but fails to initialize.
-    """
+    """Test display when pynotify is installed but fails to initialize."""
     # Reset state to ensure the import logic is triggered
     monkeypatch.setattr(notification, "__impl", None)
 

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -1,6 +1,6 @@
 """Tests for the mtui connector oscqam module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_parsemeta.py
+++ b/tests/test_parsemeta.py
@@ -4,9 +4,7 @@ from mtui import parsemeta
 
 
 def test_reduced_metadata_parser_parse():
-    """
-    Test ReducedMetadataParser.parse
-    """
+    """Test ReducedMetadataParser.parse."""
     results = MagicMock()
     results.hostnames = set()
     results.jira = {}

--- a/tests/test_parsemetajson.py
+++ b/tests/test_parsemetajson.py
@@ -4,9 +4,7 @@ from mtui import parsemetajson
 
 
 def test_json_parser_parse():
-    """
-    Test JSONParser.parse
-    """
+    """Test JSONParser.parse."""
     results = MagicMock()
     results.jira = {}
     results.bugs = {}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -4,9 +4,7 @@ from mtui import prompt
 
 
 def test_command_prompt_init():
-    """
-    Test CommandPrompt initialization
-    """
+    """Test CommandPrompt initialization."""
     config = MagicMock()
     log = MagicMock()
     sys = MagicMock()
@@ -21,9 +19,7 @@ def test_command_prompt_init():
 
 
 def test_set_prompt():
-    """
-    Test set_prompt
-    """
+    """Test set_prompt."""
     config = MagicMock()
     config.auto = False
     config.kernel = False
@@ -38,9 +34,7 @@ def test_set_prompt():
 
 
 def test_cmd_queue():
-    """
-    Test CmdQueue
-    """
+    """Test CmdQueue."""
     term = MagicMock()
     queue = prompt.CmdQueue(["test_cmd"], "mtui> ", term)
 
@@ -51,9 +45,7 @@ def test_cmd_queue():
 
 
 def test_dispatching():
-    """
-    Test command, help, and completion dispatching
-    """
+    """Test command, help, and completion dispatching."""
     config = MagicMock()
     log = MagicMock()
     sys = MagicMock()
@@ -86,9 +78,7 @@ def test_dispatching():
 
 
 def test_cmdloop_keyboard_interrupt(monkeypatch):
-    """
-    Test that cmdloop handles KeyboardInterrupt
-    """
+    """Test that cmdloop handles KeyboardInterrupt."""
     config = MagicMock()
     log = MagicMock()
     sys = MagicMock()
@@ -109,9 +99,7 @@ def test_cmdloop_keyboard_interrupt(monkeypatch):
 
 
 def test_cmdloop_quit_loop(monkeypatch):
-    """
-    Test that cmdloop handles QuitLoopError
-    """
+    """Test that cmdloop handles QuitLoopError."""
     config = MagicMock()
     log = MagicMock()
     sys = MagicMock()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -96,9 +96,10 @@ def test_cmdloop_keyboard_interrupt(monkeypatch):
 
     p = prompt.CommandPrompt(config, log, sys, display_factory)
 
-    # Raise KeyboardInterrupt on the first call, then QuitLoop
+    # Raise KeyboardInterrupt on the first call, then QuitLoopError
     monkeypatch.setattr(
-        "cmd.Cmd.cmdloop", MagicMock(side_effect=[KeyboardInterrupt, prompt.QuitLoop])
+        "cmd.Cmd.cmdloop",
+        MagicMock(side_effect=[KeyboardInterrupt, prompt.QuitLoopError]),
     )
 
     p.cmdloop()
@@ -109,7 +110,7 @@ def test_cmdloop_keyboard_interrupt(monkeypatch):
 
 def test_cmdloop_quit_loop(monkeypatch):
     """
-    Test that cmdloop handles QuitLoop
+    Test that cmdloop handles QuitLoopError
     """
     config = MagicMock()
     log = MagicMock()
@@ -118,6 +119,6 @@ def test_cmdloop_quit_loop(monkeypatch):
 
     p = prompt.CommandPrompt(config, log, sys, display_factory)
 
-    monkeypatch.setattr("cmd.Cmd.cmdloop", MagicMock(side_effect=prompt.QuitLoop))
+    monkeypatch.setattr("cmd.Cmd.cmdloop", MagicMock(side_effect=prompt.QuitLoopError))
 
     p.cmdloop()  # Should exit cleanly

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -58,7 +58,7 @@ def test_dispatching():
     mock_argparser = MagicMock()
     mock_command.argparser.return_value = mock_argparser
 
-    p._add_subcommand(mock_command)
+    p._add_subcommand(mock_command)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Test do_
     do_method = p.do_test_command

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -3,7 +3,6 @@
 import re
 
 
-
 class TestArchListParsing:
     """Test that the refhost arch list parsing is safe (no eval)."""
 

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -2,7 +2,6 @@
 
 import re
 
-import pytest
 
 
 class TestArchListParsing:

--- a/tests/test_repoparse.py
+++ b/tests/test_repoparse.py
@@ -5,18 +5,14 @@ from mtui.types import Product
 
 
 def test_parse_product():
-    """
-    Test _parse_product
-    """
+    """Test _parse_product."""
     products = repoparse._parse_product("SLES 15 (x86_64, aarch64)")
     assert Product("SLES", "15", "x86_64") in products
     assert Product("SLES", "15", "aarch64") in products
 
 
 def test_slrepoparse():
-    """
-    Test slrepoparse
-    """
+    """Test slrepoparse."""
     repos = repoparse.slrepoparse("https://example.com", ["SLES 15 (x86_64)"])
     product = Product("SLES", "15", "x86_64")
     # we except repos has product key with exact value
@@ -24,9 +20,7 @@ def test_slrepoparse():
 
 
 def test_gitrepoparse():
-    """
-    Test gitrepoparse
-    """
+    """Test gitrepoparse."""
     repos = repoparse.gitrepoparse("https://example.com", ["SLES 15 (x86_64)"])
     product = Product("SLES", "15", "x86_64")
     # we except repos has product key with exact value
@@ -34,9 +28,7 @@ def test_gitrepoparse():
 
 
 def test_reporepoparse():
-    """
-    Test reporepoparse
-    """
+    """Test reporepoparse."""
     repos = repoparse.reporepoparse(
         frozenset(["https://example.com/SLES-15-x86_64/"]), ["SLES 15 (x86_64)"]
     )
@@ -46,9 +38,7 @@ def test_reporepoparse():
 
 
 def test_obsrepoparse(tmpdir):
-    """
-    Test obsrepoparse
-    """
+    """Test obsrepoparse."""
     project_xml = """
     <project>
       <repository name="SLE-15-x86_64">

--- a/tests/test_rpm_version.py
+++ b/tests/test_rpm_version.py
@@ -52,7 +52,7 @@ def test_version_ne():
 
 def test_version_none():
     with pytest.raises(ValueError):  # noqa: PT011
-        RPMVersion(None)
+        RPMVersion(None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rpm_version.py
+++ b/tests/test_rpm_version.py
@@ -4,7 +4,7 @@ from mtui.types.rpmver import RPMVersion
 
 
 @pytest.mark.parametrize(
-    "lower,higher",
+    ("lower", "higher"),
     [
         ("2014.104.0.0.2svn15878-21.19", "2015.104.0.0.2svn15878-21.12"),
         ("1.2.0-7.20", "1.2.0-7.30"),
@@ -16,7 +16,7 @@ def test_version_lt(lower, higher):
 
 
 @pytest.mark.parametrize(
-    "lower,higher",
+    ("lower", "higher"),
     [
         ("2014.104.0.0.2svn15878-21.19", "2015.104.0.0.2svn15878-21.12"),
         ("1.2.0-7.20", "1.2.0-7.30"),
@@ -33,14 +33,14 @@ def test_version_eq(version):
 
 
 @pytest.mark.parametrize(
-    "higher,lower", [("1.2-2", "1.2-2"), ("1.2.3-7.2", "1.2.3-7.2")]
+    ("higher", "lower"), [("1.2-2", "1.2-2"), ("1.2.3-7.2", "1.2.3-7.2")]
 )
 def test_version_le(higher, lower):
     assert RPMVersion(lower) <= RPMVersion(higher)
 
 
 @pytest.mark.parametrize(
-    "higher,lower", [("1.2-2", "1.2-2"), ("1.2.3-7.2", "1.2.3-7.2")]
+    ("higher", "lower"), [("1.2-2", "1.2-2"), ("1.2.3-7.2", "1.2.3-7.2")]
 )
 def test_version_ge(higher, lower):
     assert RPMVersion(higher) >= RPMVersion(lower)
@@ -51,12 +51,12 @@ def test_version_ne():
 
 
 def test_version_none():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         RPMVersion(None)
 
 
 @pytest.mark.parametrize(
-    "version,s", [("1.2.3-7.3", "1.2.3-7.3"), ("2.3", "2.3"), ("0.8+1-0", "0.8+1")]
+    ("version", "s"), [("1.2.3-7.3", "1.2.3-7.3"), ("2.3", "2.3"), ("0.8+1-0", "0.8+1")]
 )
 def test_version_str(version, s):
     assert str(RPMVersion(version)) == s

--- a/tests/test_systemcheck.py
+++ b/tests/test_systemcheck.py
@@ -4,9 +4,7 @@ from mtui import systemcheck
 
 
 def test_detect_system(monkeypatch):
-    """
-    Test detect_system
-    """
+    """Test detect_system."""
     mock_os_release = 'NAME="test_distro"\nVERSION_ID="test_verid"'
     mock_version = "Linux version test_kernel"
 

--- a/tests/test_systemcheck.py
+++ b/tests/test_systemcheck.py
@@ -13,10 +13,9 @@ def test_detect_system(monkeypatch):
     def mock_open_side_effect(path, mode="r", encoding="utf-8"):
         if path == "/etc/os-release":
             return mock_open(read_data=mock_os_release).return_value
-        elif path == "/proc/version":
+        if path == "/proc/version":
             return mock_open(read_data=mock_version).return_value
-        else:
-            raise FileNotFoundError
+        raise FileNotFoundError
 
     monkeypatch.setattr("builtins.open", mock_open_side_effect)
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -2,12 +2,10 @@
 
 from unittest.mock import MagicMock
 
-import pytest
 
 from mtui.target import Target
 from mtui.types import HostLog, Package
 from mtui.types.rpmver import RPMVersion
-from mtui.types.systems import System
 from mtui.types.product import Product
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -12,7 +12,7 @@ from mtui.types.rpmver import RPMVersion
 
 def test_target_init_defaults(mock_config):
     """Test Target initialization with default parameters."""
-    target = Target(mock_config, "test-host.example.com")
+    target = Target(mock_config, "test-host.example.com")  # type: ignore[arg-type]
 
     assert target.config is mock_config
     assert target.host == "test-host.example.com"
@@ -27,7 +27,7 @@ def test_target_init_defaults(mock_config):
 
 def test_target_init_with_port(mock_config):
     """Test Target initialization with port in hostname."""
-    target = Target(mock_config, "test-host.example.com:2222")
+    target = Target(mock_config, "test-host.example.com:2222")  # type: ignore[arg-type]
 
     assert target.host == "test-host.example.com"
     assert target.port == "2222"
@@ -37,7 +37,7 @@ def test_target_init_with_port(mock_config):
 def test_target_init_with_packages(mock_config):
     """Test Target initialization with packages dict."""
     packages = {"standard": {"bash": "5.1-1.2"}}
-    target = Target(mock_config, "host.example.com", packages)
+    target = Target(mock_config, "host.example.com", packages)  # type: ignore[arg-type]
 
     assert target._pkgs == packages
 
@@ -45,19 +45,19 @@ def test_target_init_with_packages(mock_config):
 def test_target_init_with_state(mock_config):
     """Test Target initialization with different states."""
     for state in ("enabled", "disabled", "serial", "parallel"):
-        target = Target(mock_config, "host.example.com", state=state)
+        target = Target(mock_config, "host.example.com", state=state)  # type: ignore[arg-type]
         assert target.state == state
 
 
 def test_target_init_with_timeout(mock_config):
     """Test Target initialization with custom timeout."""
-    target = Target(mock_config, "host.example.com", timeout=600)
+    target = Target(mock_config, "host.example.com", timeout=600)  # type: ignore[arg-type]
     assert target._timeout == 600
 
 
 def test_target_init_with_exclusive(mock_config):
     """Test Target initialization with exclusive mode."""
-    target = Target(mock_config, "host.example.com", exclusive=True)
+    target = Target(mock_config, "host.example.com", exclusive=True)  # type: ignore[arg-type]
     assert target.exclusive is True
 
 
@@ -66,11 +66,11 @@ def test_target_init_custom_classes(mock_config):
     mock_lock_class = MagicMock()
     mock_conn_class = MagicMock()
 
-    target = Target(
+    target = Target(  # type: ignore[arg-type]
         mock_config,
         "host.example.com",
-        lock=mock_lock_class,
-        connection=mock_conn_class,
+        lock=mock_lock_class,  # ty: ignore[invalid-argument-type]
+        connection=mock_conn_class,  # ty: ignore[invalid-argument-type]
     )
 
     assert target.TargetLock is mock_lock_class
@@ -82,14 +82,14 @@ def test_target_init_custom_classes(mock_config):
 
 def test_target_repr(mock_config):
     """Test Target __repr__."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     assert "Target" in repr(target)
     assert "host.example.com" in repr(target)
 
 
 def test_target_str(mock_config):
     """Test Target __str__ returns hostname."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     assert str(target) == "host.example.com"
 
 
@@ -98,7 +98,7 @@ def test_target_str(mock_config):
 
 def test_last_methods_empty(mock_config):
     """Test last* methods return empty strings when no output."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     assert target.lastin() == ""
     assert target.lastout() == ""
     assert target.lasterr() == ""
@@ -107,7 +107,7 @@ def test_last_methods_empty(mock_config):
 
 def test_last_methods_with_output(mock_config):
     """Test last* methods after appending output."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.out = HostLog()
     target.out.append(["ls -la", "file1\nfile2\n", "warning\n", 0, 5])
 
@@ -122,7 +122,7 @@ def test_last_methods_with_output(mock_config):
 
 def test_target_lock_delegates(mock_config):
     """Test lock() delegates to _lock."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target._lock = MagicMock()
 
     target.lock("test comment")
@@ -131,7 +131,7 @@ def test_target_lock_delegates(mock_config):
 
 def test_target_unlock_delegates(mock_config):
     """Test unlock() delegates to _lock."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target._lock = MagicMock()
 
     target.unlock()
@@ -140,7 +140,7 @@ def test_target_unlock_delegates(mock_config):
 
 def test_target_unlock_with_force(mock_config):
     """Test unlock(force=True) passes force flag."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target._lock = MagicMock()
 
     target.unlock(force=True)
@@ -152,7 +152,7 @@ def test_target_unlock_with_force(mock_config):
 
 def test_run_enabled_executes_command(mock_config):
     """Test run() in enabled state executes the command."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.run.return_value = 0
     target.connection.stdout = "output"
@@ -167,9 +167,9 @@ def test_run_enabled_executes_command(mock_config):
 
 def test_run_dryrun_does_not_execute(mock_config):
     """Test run() in dryrun state does not execute command."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
-    target.state = "dryrun"
+    target.state = "dryrun"  # ty: ignore[invalid-assignment]
 
     target.run("rm -rf /")
 
@@ -179,7 +179,7 @@ def test_run_dryrun_does_not_execute(mock_config):
 
 def test_run_disabled_does_not_execute(mock_config):
     """Test run() in disabled state does not execute command."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.state = "disabled"
 
@@ -192,7 +192,7 @@ def test_run_handles_command_timeout(mock_config):
     """Test run() catches CommandTimeoutError and sets exit code to -1."""
     from mtui.connection import CommandTimeoutError
 
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.run.side_effect = CommandTimeoutError("echo hello")
     target.state = "enabled"
@@ -205,7 +205,7 @@ def test_run_handles_command_timeout(mock_config):
 
 def test_run_handles_generic_exception(mock_config):
     """Test run() catches generic exceptions and sets exit code to -1."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.run.side_effect = OSError("connection lost")
     target.state = "enabled"
@@ -220,7 +220,7 @@ def test_run_handles_generic_exception(mock_config):
 
 def test_reconnect_delegates(mock_config):
     """Test reconnect() delegates to connection."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
 
     target.reconnect(3, True)
@@ -233,7 +233,7 @@ def test_reconnect_delegates(mock_config):
 
 def test_set_timeout(mock_config):
     """Test set_timeout updates both connection and internal timeout."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
 
     target.set_timeout(600)
@@ -247,7 +247,7 @@ def test_set_timeout(mock_config):
 
 def test_close_unlocks_and_closes(mock_config):
     """Test close() unlocks and closes the connection."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.is_active.return_value = True
     target._lock = MagicMock()
@@ -260,7 +260,7 @@ def test_close_unlocks_and_closes(mock_config):
 
 def test_close_with_reboot(mock_config):
     """Test close() with reboot action."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.is_active.return_value = True
     target.connection.run.return_value = 0
@@ -276,7 +276,7 @@ def test_close_with_reboot(mock_config):
 
 def test_close_handles_lost_connection(mock_config):
     """Test close() handles lost connections gracefully."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.is_active.side_effect = Exception("connection lost")
 
@@ -290,7 +290,7 @@ def test_close_handles_lost_connection(mock_config):
 
 def test_parse_packages_standard(mock_config):
     """Test _parse_packages with 'standard' key."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.system = MagicMock()
     target.system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
     target._pkgs = {"standard": {"bash": "5.1-1.2", "openssl": "3.0.8-1.2"}}
@@ -305,7 +305,7 @@ def test_parse_packages_standard(mock_config):
 
 def test_parse_packages_by_version(mock_config):
     """Test _parse_packages matches on base version."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.system = MagicMock()
     target.system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
     target._pkgs = {
@@ -321,7 +321,7 @@ def test_parse_packages_by_version(mock_config):
 
 def test_parse_packages_none(mock_config):
     """Test _parse_packages with no packages."""
-    target = Target(mock_config, "host.example.com")
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.system = MagicMock()
     target.system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
     target._pkgs = None

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -189,12 +189,12 @@ def test_run_disabled_does_not_execute(mock_config):
 
 
 def test_run_handles_command_timeout(mock_config):
-    """Test run() catches CommandTimeout and sets exit code to -1."""
-    from mtui.connection import CommandTimeout
+    """Test run() catches CommandTimeoutError and sets exit code to -1."""
+    from mtui.connection import CommandTimeoutError
 
     target = Target(mock_config, "host.example.com")
     target.connection = MagicMock()
-    target.connection.run.side_effect = CommandTimeout("echo hello")
+    target.connection.run.side_effect = CommandTimeoutError("echo hello")
     target.state = "enabled"
 
     target.run("echo hello")

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -2,12 +2,10 @@
 
 from unittest.mock import MagicMock
 
-
 from mtui.target import Target
 from mtui.types import HostLog, Package
-from mtui.types.rpmver import RPMVersion
 from mtui.types.product import Product
-
+from mtui.types.rpmver import RPMVersion
 
 # --- Initialization ---
 

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -1,12 +1,9 @@
 """Tests for the mtui target parsers modules."""
 
-import io
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from mtui.target.parsers.product import parse_os_release, parse_product
-from mtui.types import Product
 
 
 # --- parse_product ---

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -2,9 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from mtui.target.parsers.product import parse_os_release, parse_product
-
 
 # --- parse_product ---
 
@@ -134,8 +132,6 @@ class TestParseSystem:
         # Mock the SFTP file open as context manager
         base_file = MagicMock()
         addon_file = MagicMock()
-        transactional_check = MagicMock()
-
         # sftp_open calls sequence:
         # 1. base product file
         # 2. addon product file

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,12 +10,12 @@ from mtui.exceptions import (
 from mtui.types import RequestReviewID
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def r_review_id():
     return randint(0, 9999)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def m_review_id():
     return randint(0, 9999999)
 
@@ -45,7 +45,8 @@ def test_RRID_ok(r_review_id, m_review_id, rrid):
     if rr.kind != "SLFO":
         assert rr.maintenance_id == mid
     else:
-        assert isinstance(rr.maintenance_id, str) and rr.maintenance_id == "1.1"
+        assert isinstance(rr.maintenance_id, str)
+        assert rr.maintenance_id == "1.1"
 
 
 @pytest.mark.parametrize("missing", ["SUSE:Maintenance", "SUSE:M", "SUSE"])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -34,9 +34,7 @@ def m_review_id():
     ],
 )
 def test_RRID_ok(r_review_id, m_review_id, rrid):
-    """
-    Test correct RRID is parsed successfully
-    """
+    """Test correct RRID is parsed successfully."""
     rid = r_review_id
     mid = m_review_id
     rr = RequestReviewID(rrid.format(mid, rid))
@@ -51,9 +49,7 @@ def test_RRID_ok(r_review_id, m_review_id, rrid):
 
 @pytest.mark.parametrize("missing", ["SUSE:Maintenance", "SUSE:M", "SUSE"])
 def test_parse_rrid_mc(missing):
-    """
-    Test parse failure: missing component
-    """
+    """Test parse failure: missing component."""
     with pytest.raises(MissingComponentError):
         RequestReviewID(missing)
 
@@ -68,9 +64,7 @@ def test_parse_rrid_mc(missing):
     ],
 )
 def test_parse_rrid_cpe(cpe):
-    """
-    Test parse failure: componet parse errors
-    """
+    """Test parse failure: componet parse errors."""
     with pytest.raises(ComponentParseError):
         RequestReviewID(cpe)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,7 @@ import pytest
 
 from mtui.exceptions import (
     ComponentParseError,
-    MissingComponent,
+    MissingComponentError,
     TooManyComponentsError,
 )
 from mtui.types import RequestReviewID
@@ -54,7 +54,7 @@ def test_parse_rrid_mc(missing):
     """
     Test parse failure: missing component
     """
-    with pytest.raises(MissingComponent):
+    with pytest.raises(MissingComponentError):
         RequestReviewID(missing)
 
 

--- a/tests/test_types_expanded.py
+++ b/tests/test_types_expanded.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from mtui.types import CommandLog, HostLog, Package, Product
+from mtui.types import HostLog, Package, Product
 from mtui.types.enums import assignment, method
 from mtui.types.rpmver import RPMVersion
 from mtui.types.systems import System, UnknownSystemError

--- a/tests/test_types_expanded.py
+++ b/tests/test_types_expanded.py
@@ -8,7 +8,6 @@ from mtui.types.rpmver import RPMVersion
 from mtui.types.systems import System, UnknownSystemError
 from mtui.types.urls import URLs
 
-
 # --- Product ---
 
 
@@ -87,7 +86,7 @@ class TestSystem:
         assert len(flat) == 2
 
     @pytest.mark.parametrize(
-        "name,expected",
+        ("name", "expected"),
         [
             ("SLES", "15"),
             ("SLED", "15"),
@@ -203,7 +202,7 @@ class TestHostLog:
     def test_append_wrong_count_raises(self):
         """Test appending with wrong number of items raises."""
         hl = HostLog()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="it need 5 args"):
             hl.append(["too", "few"])
 
     def test_append_bytes_conversion(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from tempfile import mkdtemp
+from typing import ClassVar
 
 import pytest
 
@@ -15,7 +16,7 @@ def create_temp(tmpdir_factory):
 
 
 class TestEnsureDirExists:
-    _callback_paths = []
+    _callback_paths: ClassVar[list] = []
 
     def test_create(self, create_temp):
         d = self.mkpath(create_temp, "a")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,10 +4,11 @@ from tempfile import mkdtemp
 
 import pytest
 
+from mtui import utils
 from mtui.utils import atomic_write_file, chdir, ensure_dir_exists
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def create_temp(tmpdir_factory):
     """simple tmpdir_factory wrapper"""
     return tmpdir_factory.mktemp("utils")
@@ -41,10 +42,10 @@ class TestEnsureDirExists:
         try:
             ensure_dir_exists(Path(subdir) / "foo")
         except BaseException:
-            assert False
+            pytest.fail("ensure_dir_exists raised unexpectedly")
 
         os.chmod(subdir, 0)
-        with pytest.raises(OSError):
+        with pytest.raises(PermissionError):
             ensure_dir_exists(Path(subdir) / "bar")
 
     def test_on_create(self, create_temp):
@@ -74,9 +75,6 @@ def test_atomic_write(create_temp):
     data = "pokus"
     atomic_write_file(data, Path(path) / "string")
     atomic_write_file(data.encode(), Path(path) / "bytes")
-
-
-from mtui import utils
 
 
 def test_colors():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from mtui.utils import atomic_write_file, chdir, ensure_dir_exists
 
 @pytest.fixture
 def create_temp(tmpdir_factory):
-    """simple tmpdir_factory wrapper"""
+    """simple tmpdir_factory wrapper."""
     return tmpdir_factory.mktemp("utils")
 
 
@@ -23,8 +23,7 @@ class TestEnsureDirExists:
         ensure_dir_exists(d)
 
     def test_create_exists(self, create_temp):
-        """
-        ensure_dir_exists is obviously supposed to be convergent so second
+        """ensure_dir_exists is obviously supposed to be convergent so second
         call should result in the same state. This test asserts mainly that
         OSError(EEXIST) is not raised on second call.
         """
@@ -79,9 +78,7 @@ def test_atomic_write(create_temp):
 
 
 def test_colors():
-    """
-    Test ANSI color utils
-    """
+    """Test ANSI color utils."""
     text = "some text"
     assert utils.green(text) == f"\033[1;32m{text!s}\033[1;m\033[0m"
     assert utils.red(text) == f"\033[1;31m{text!s}\033[1;m\033[0m"
@@ -90,25 +87,19 @@ def test_colors():
 
 
 def test_filter_ansi():
-    """
-    Test ANSI filter
-    """
+    """Test ANSI filter."""
     text = "some text"
     ansi_text = utils.green(text)
     assert utils.filter_ansi(ansi_text) == text
 
 
 def test_timestamp():
-    """
-    Test timestamp
-    """
+    """Test timestamp."""
     assert isinstance(int(utils.timestamp()), int)
 
 
 def test_walk():
-    """
-    Test walk
-    """
+    """Test walk."""
     test_data = {
         "edges": [
             {

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -4,9 +4,7 @@ from mtui import xdg
 
 
 def test_save_cache_path(monkeypatch):
-    """
-    Test save_cache_path
-    """
+    """Test save_cache_path."""
     monkeypatch.setattr("mtui.xdg.x_save_cache_path", lambda _: "/tmp/cache")
     path = xdg.save_cache_path("test", "file")
     assert path == Path("/tmp/cache/test/file")


### PR DESCRIPTION
## Summary

- Enable 33 ruff lint rule groups/individual rules across 4 incremental phases
- Fix 803 violations across 119 files while keeping all 304 tests passing
- Fix a correctness bug in `System.__eq__` discovered during the process
- **Add ty type checking**: resolve all 116 type errors and add ty to CI pipeline

## Phase Breakdown

### Phase 1: Safe auto-fixable rules (458 violations, 90 files)
- `I` (isort), `UP` (pyupgrade), `FURB110`, `RET505/6/7`, `PLR5501`, `D202`, `D413`, `PTH201`
- Import sorting, modern Python syntax, code simplification, docstring spacing

### Phase 2: Code quality & bug prevention (112 violations, 48 files)
- `B` (bugbear), `G` (logging-format), `C4` (comprehensions), `PERF`, `T20` (print), `TRY400`, `PLW0127`, `PLW1510`
- Proper exception chaining (`raise from`), lazy logging (`%s` instead of f-strings), `logging.exception()` in except blocks, performance patterns

### Phase 3: Conventions & correctness (82 violations, 43 files)
- `N818`, `PGH003`, `RUF012`, `SLF001`, `PLW1641`
- Exception naming (`Error` suffix), removed 62 blanket `# type: ignore`, `ClassVar` for mutable defaults, `__hash__` for classes with `__eq__`
- **Bug fix:** `System.__eq__` was comparing `self.__addons == self.__addons` (always True) instead of `other.__addons`

### Phase 4: Docstring formatting & dead code (151 violations, 22 files)
- `ERA001`, `D200`, `D212`, `D400`, `D415`
- Single-line docstrings, summary on first line, trailing punctuation, no commented-out code

### Type checking: ty (116 errors → 0)
- Add class-level type annotations for `Config`, `TestReport`, `FileList`, `ManualExport`, `UserMessage`
- Fix `RPMVersion.__eq__`/`__ne__` for Liskov compliance (accept `object`, return `NotImplemented`)
- Narrow `walk()` from `Collection` to `dict | list`, `SMELT.data` from `Collection | None` to `dict | None`
- Fix method overrides (`argparse.exit` → `NoReturn`), `isinstance(*args)` bug in `hostlog.py`
- Add `isinstance(RPMVersion)` guards before `>=`/`<` comparisons in `hostgroup.py`
- Add type suppression comments for test files using MagicMock
- **CI: add `ty check` job** running in parallel with lint and test

## Rules Intentionally Skipped
- `ANN` (type annotations) — 1,084 violations, use `ty` for type checking instead
- `D401` (imperative mood) — 582 violations, too much churn
- `TRY003`/`EM101`/`EM102` — overly opinionated exception message style
- `FBT` (boolean args) — invasive signature changes
- `ARG` (unused args) — most are interface conformance
- `DTZ` (timezone) — needs careful analysis of upstream data formats
- `TID252` (relative imports) — 170 changes, valid Python style
- `TD`/`FIX` (TODO tracking) — informational only

## Testing
- `ruff check .` — All checks passed (0 violations)
- `ruff format .` — All files formatted
- `uv run ty check` — All checks passed (0 errors)
- `pytest` — 304 passed