### PR TITLE
docs: refresh README and documentation build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+# dev env artifacts
+default.profraw

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -336,6 +336,8 @@ command output.
   | **default**
   |     `os.getenv('GITEA_TOKEN','')`__
 
+.. __: https://docs.python.org/3/library/os.html#os.getenv
+
 Gitea API access token, this config has higher prio than environment
 variable. Token must have full access to the issue API.
 

--- a/Documentation/cli.rst
+++ b/Documentation/cli.rst
@@ -127,7 +127,7 @@ Overrides the ``mtui.connection_timeout`` configuration.
 
 
 ``-g string,  --gitea_token string``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Overrides the ``gitea.token`` configuration.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+[![CI](https://github.com/openSUSE/mtui/actions/workflows/ci.yml/badge.svg)](https://github.com/openSUSE/mtui/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/github/openSUSE/mtui/branch/main/graph/badge.svg?token=60D3XUROAF)](https://codecov.io/github/openSUSE/mtui)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/openSUSE/mtui)
+
+# MTUI
+
+The Maintenance Test Update Installer (MTUI) allows you to run shell commands on multiple hosts in parallel.
+
+In addition, MTUI provides convenience commands to help with maintenance update testing and integrating with other systems like Bugzilla and test report templates.
+
+## License
+
+This project is licensed under the GPLv2 license, see the COPYING file for details.
+
+## Contents
+
+- [Installation](Documentation/installation.rst)
+- [User Guide](Documentation/user.rst)
+- [Developer Guide](Documentation/developer.rst)
+- [Support](Documentation/support.rst)
+- [FAQ](Documentation/faq.rst)
+
+## Authors
+
+MTUI was originally written by:
+
+- Christian Kornacker
+- Heiko Rommel <rommel@suse.de>
+- Jan Matějka
+- Roman Neuhauser
+- David Santiago
+
+The project is currently maintained mainly by:
+
+- Ondřej Súkup <osukup@suse.cz>
+- Jan Baier <jbaier@suse.cz>
+
+Besides that, numerous other contributors have committed to MTUI. Thanks everyone for their contributions!

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,12 @@
-.. MTUI documentation master file, created by
-   sphinx-quickstart on Wed Nov 26 18:12:29 2014.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 .. image:: https://github.com/openSUSE/mtui/actions/workflows/ci.yml/badge.svg
  :target: https://github.com/openSUSE/mtui/actions/workflows/ci.yml
 
 .. image:: https://codecov.io/github/openSUSE/mtui/branch/main/graph/badge.svg?token=60D3XUROAF
  :target: https://codecov.io/github/openSUSE/mtui
 
-################################
-Welcome to MTUI's documentation!
-################################
+####
+MTUI
+####
 
 The Maintenance Test Update Installer (MTUI) allows you to run shell
 commands on multiple hosts in parallel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,68 @@ notify = ["notify"]
 rpm = ["rpm"]
 
 [dependency-groups]
-dev = ["coverage", "pytest", "pytest-cov", "responses", "ruff", "ty"]
+dev = [
+  "coverage",
+  "pytest",
+  "pytest-cov",
+  "responses",
+  "ruff",
+  "ty",
+]
+doc = [
+  "sphinx>=9.0.4",
+]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "E",  # pycodestyle errors
+  "F",  # pyflakes
+  "I",  # isort (import sorting)
+  "B",  # flake8-bugbear (bug detection)
+  "G",  # flake8-logging-format
+  "N818",  # exception names should end in Error
+  "PGH003",  # blanket type: ignore (require specific codes)
+  "PT",  # flake8-pytest-style
+  "C4",  # flake8-comprehensions
+  "PERF",  # perflint (performance)
+  "T20",  # flake8-print (no print statements)
+  "RUF005",  # use iterable unpacking instead of concatenation
+  "RUF012",  # mutable class defaults need ClassVar
+  "SLF001",  # private member access
+  "SIM",  # flake8-simplify
+  "UP",  # pyupgrade (modernize syntax for py311+)
+  "FURB110",  # if-exp instead of or-operator
+  "RET505",  # superfluous else after return
+  "RET506",  # superfluous else after raise
+  "RET507",  # superfluous else after continue
+  "PLR5501",  # collapsible else-if
+  "PLW0127",  # self-assigning variable
+  "PLW1510",  # subprocess.run without check
+  "PLW1641",  # __eq__ without __hash__
+
+  "D200",  # single-line docstrings should fit on one line
+  "D202",  # no blank lines after function docstring
+  "D212",  # multi-line summary should start on first line
+  "D400",  # first line should end with a period
+  "D413",  # missing blank line after last docstring section
+  "D415",  # first line should end with punctuation
+  "ERA001",  # no commented-out code
+  "PTH201",  # Path(".") -> Path()
+]
+ignore = [
+  "E501",  # line-too-long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S108", "ARG", "SLF001"]
+"Documentation/conf.py" = ["INP001", "ERA001", "A001", "D"]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -54,50 +111,3 @@ mtui = [
 
 [tool.setuptools.dynamic]
 version = { attr = "mtui.__version__" }
-
-[tool.ruff]
-target-version = "py311"
-
-[tool.ruff.lint]
-select = [
-    "E",      # pycodestyle errors
-    "F",      # pyflakes
-    "I",      # isort (import sorting)
-    "B",      # flake8-bugbear (bug detection)
-    "G",      # flake8-logging-format
-    "N818",   # exception names should end in Error
-    "PGH003", # blanket type: ignore (require specific codes)
-    "PT",     # flake8-pytest-style
-    "C4",     # flake8-comprehensions
-    "PERF",   # perflint (performance)
-    "T20",    # flake8-print (no print statements)
-    "RUF005", # use iterable unpacking instead of concatenation
-    "RUF012", # mutable class defaults need ClassVar
-    "SLF001", # private member access
-    "SIM",    # flake8-simplify
-    "UP",     # pyupgrade (modernize syntax for py311+)
-    "FURB110",# if-exp instead of or-operator
-    "RET505", # superfluous else after return
-    "RET506", # superfluous else after raise
-    "RET507", # superfluous else after continue
-    "PLR5501",# collapsible else-if
-    "PLW0127",# self-assigning variable
-    "PLW1510",# subprocess.run without check
-    "PLW1641",# __eq__ without __hash__
-
-    "D200",   # single-line docstrings should fit on one line
-    "D202",   # no blank lines after function docstring
-    "D212",   # multi-line summary should start on first line
-    "D400",   # first line should end with a period
-    "D413",   # missing blank line after last docstring section
-    "D415",   # first line should end with punctuation
-    "ERA001", # no commented-out code
-    "PTH201", # Path(".") -> Path()
-]
-ignore = [
-    "E501",   # line-too-long (handled by formatter)
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S108", "ARG", "SLF001"]
-"Documentation/conf.py" = ["INP001", "ERA001", "A001", "D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mtui"
 description = "Maintenance Test Update Installer"
-readme = "README.rst"
+readme = "README.md"
 license = "GPL-2.0-only"
 authors = [{ name = "Christian Kornacker", email = "ckornacker@suse.de" }]
 maintainers = [


### PR DESCRIPTION
## Summary
- Add a Markdown README for package and GitHub rendering, and point package metadata at it.
- Add Sphinx doc tooling and fix small reStructuredText issues that affect documentation builds.
- Ignore local profiling artifacts generated during development.

## Testing
- Not run; documentation/package metadata only.