### PR TITLE
refactor: remove dead code surfaced by vulture and ruff

### DIFF
--- a/mtui/__init__.py
+++ b/mtui/__init__.py
@@ -4,12 +4,4 @@ This package provides a command-line tool for running shell commands on
 multiple hosts in parallel, with a focus on maintenance update testing.
 """
 
-__version__ = "16.1.0"
-
-
-def __getattr__(name):
-    if name == "loose_version":
-        from looseversion import LooseVersion
-
-        return LooseVersion(__version__)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__version__ = "16.2.0"

--- a/mtui/colorlog.py
+++ b/mtui/colorlog.py
@@ -3,7 +3,10 @@
 import inspect
 import logging
 
-(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE) = list(range(8))
+# ANSI color offsets (added to 30 to form the foreground color escape code).
+# Positions matter: only RED..BLUE are referenced, but the indexes determine
+# the resulting ANSI code (e.g. 30 + 1 = 31 = red).
+(_, RED, GREEN, YELLOW, BLUE, *_) = list(range(8))
 
 RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[1;{}m"

--- a/mtui/commands/showrepos.py
+++ b/mtui/commands/showrepos.py
@@ -12,4 +12,4 @@ class Showrepos(Command):
     @requires_update
     def __call__(self) -> None:
         """Executes the `show_update_repos` command."""
-        self.display.list_update_repos(self.metadata.update_repos, self.metadata.id)
+        self.display.list_update_repos(self.metadata.update_repos)

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -20,10 +20,6 @@ from .refhost import RefhostsFactory, RefhostsResolveFailedError
 logger = getLogger("mtui.config")
 
 
-class InvalidOptionNameError(RuntimeError):
-    """Exception raised when an invalid configuration option name is used."""
-
-
 class Config:
     """Read and store the variables from mtui config files."""
 
@@ -266,39 +262,6 @@ class Config:
         self.data: list[tuple[str, tuple[str, ...], Any, Callable, Callable]] = [
             add_getter(x) for x in n_data
         ]
-
-    def _has_option(self, opt: str) -> bool:
-        """Checks if a given option name is valid.
-
-        Args:
-            opt: The option name to check.
-
-        Returns:
-            True if the option name is valid, False otherwise.
-
-        """
-        return opt in (x[0] for x in self.data)
-
-    def set_option(self, opt: str, val: Any) -> None:
-        """Sets a configuration option to a new value.
-
-        Warning:
-            This method is not type safe. You need to take care to
-            pass proper type as the value.
-
-        Args:
-            opt: The name of the option to set.
-            val: The new value for the option.
-
-        Raises:
-            InvalidOptionNameError: If opt is not a valid option name.
-
-        """
-        # FIXME: ^ remove warning (add type safety)
-        if not self._has_option(opt):
-            raise InvalidOptionNameError()
-
-        setattr(self, opt, val)
 
     def _list_terms(self) -> None:
         """Finds available terminal scripts."""

--- a/mtui/connector/gitea.py
+++ b/mtui/connector/gitea.py
@@ -110,7 +110,6 @@ class Gitea:
 
         # Construct the necessary API endpoints from the base PR URL.
         self.pr = giteaprapi
-        self.issues = "/".join(giteaprapi.split("/")[:-2]) + "/issues/comments"
         self.prissues = giteaprapi.replace("pulls", "issues") + "/comments"
 
     def __request(

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -73,20 +73,6 @@ class QEMIncident:
             return None
         return str(sorted(packages, key=len)[0])
 
-    def get_version(self) -> str | None:
-        """Best-effort version derived from the first dashboard channel."""
-        if not self.data:
-            return None
-        channels = self.data.get("channels") or []
-        if not channels:
-            return None
-        parts = str(channels[0]).split(":")[-2].split("-")
-        if len(parts) < 2:
-            return None
-        if parts[0] in ("SLE", "SLES") and len(parts) > 2:
-            return f"{parts[1]}-{parts[2]}"
-        return f"{parts[0]}-{parts[1]}"
-
     def __bool__(self) -> bool:
         return bool(self.data)
 

--- a/mtui/datafiles.py
+++ b/mtui/datafiles.py
@@ -1,7 +1,7 @@
 """Locate package data files bundled with mtui.
 
-Uses importlib.resources to find scripts, helper files, and terminal
-launcher scripts that are shipped inside the mtui package.
+Uses importlib.resources to find scripts and terminal launcher scripts
+that are shipped inside the mtui package.
 """
 
 from __future__ import annotations
@@ -13,8 +13,8 @@ from pathlib import Path
 def _package_data_path() -> Path:
     """Return the filesystem path to the mtui package directory.
 
-    This is the root from which ``scripts/``, ``helper/``, and
-    ``terms/`` subdirectories can be reached.
+    This is the root from which ``scripts/`` and ``terms/`` subdirectories
+    can be reached.
     """
     pkg = files("mtui")
 
@@ -28,11 +28,6 @@ def _package_data_path() -> Path:
 def scripts_path() -> Path:
     """Return the path to the ``scripts/`` data directory."""
     return _package_data_path() / "scripts"
-
-
-def helper_path() -> Path:
-    """Return the path to the ``helper/`` data directory."""
-    return _package_data_path() / "helper"
 
 
 def terms_path() -> Path:

--- a/mtui/display.py
+++ b/mtui/display.py
@@ -207,12 +207,11 @@ class CommandPromptDisplay:
             self.println(x)
         self.println()
 
-    def list_update_repos(self, repos, update_id) -> None:
+    def list_update_repos(self, repos) -> None:
         """Displays the update repositories.
 
         Args:
             repos: A dictionary of repositories.
-            update_id: The ID of the update.
 
         """
         for p, r in repos.items():

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -99,13 +99,6 @@ class SvnCheckoutFailed(ErrorMessage):
         self.message = self._msg.format(uri, f_url)
 
 
-class QadbReportCommentLengthWarning(UserMessage):
-    """A warning about comment length limitations."""
-
-    def __str__(self) -> str:
-        return "comment strings > 100 chars are truncated by remote_qa_db_report.pl"
-
-
 class ConnectingTargetFailedMessage(UserMessage):
     """A message for when connecting to a target fails."""
 
@@ -118,16 +111,6 @@ class ConnectingTargetFailedMessage(UserMessage):
 
     def __repr__(self) -> str:
         return f"<{self.__class__} {self.hostname!r}:{self.reason!r}>"
-
-
-class ConnectingToMessage(UserMessage):
-    """A message for when connecting to a target."""
-
-    def __init__(self, hostname) -> None:
-        self.hostname = hostname
-
-    def __str__(self) -> str:
-        return f"connecting to {self.hostname}"
 
 
 class MissingPackagesError(UserError):
@@ -215,18 +198,6 @@ class LocationChangedMessage(UserMessage):
         return f"changed location from {self.old!r} to {self.new!r}"
 
 
-class PackageRevisionHasntChangedWarning(UserMessage):
-    """A warning for when a package revision has not changed."""
-
-    _msg = (
-        "Revision of package {0!r} hasn't changed, "
-        + "it's most likely already updated. skipping."
-    )
-
-    def __init__(self, package) -> None:
-        self.message = self._msg.format(package)
-
-
 class MissingDoerError(ErrorMessage):
     """Base class for missing "doer" errors."""
 
@@ -292,21 +263,6 @@ class ReConnectFailed(ErrorMessage):
         self.message = self._msg.format(host)
 
 
-class RepositoryError(ErrorMessage):
-    """failed to read IBS Repository."""
-
-    def __init__(self, repo) -> None:
-        self.repo = repo
-        self.message = f"Repository empty {repo}"
-
-
-class openQAError(ErrorMessage):
-    """openQA related Errors."""
-
-    def __init__(self) -> None:
-        self.message = "Something wrong with openQA connection"
-
-
 class ResultsMissingError(ErrorMessage):
     """missing results json file."""
 
@@ -314,11 +270,3 @@ class ResultsMissingError(ErrorMessage):
         self.test = test
         self.arch = arch
         self.message = f"Test: {test} on arch: {arch} missing results.json file. Please restart it."
-
-
-class SVNError(ErrorMessage):
-    """SVN related Errors."""
-
-    def __init__(self, cmd) -> None:
-        self.cmd = cmd
-        self.message: str = f"SVN {cmd} command failed"

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -32,10 +32,6 @@ class UserError(UserMessage, RuntimeError):
     """An error caused by improper usage of the program."""
 
 
-class DeprecationMessage(UserMessage):
-    """A message for deprecated features."""
-
-
 class NoRefhostsDefinedError(UserError, ValueError):
     """Raised when an operation is requested without defined refhosts."""
 

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -307,18 +307,6 @@ class Refhosts:
                 return False
         return True
 
-    def _location_hosts(self, location: str):
-        """Returns the hosts for a given location.
-
-        Args:
-            location: The location to get hosts for.
-
-        Returns:
-            A list of host elements for the given location.
-
-        """
-        return self.data[location]
-
     def check_location_sanity(self, location) -> None:
         """Checks if a location is valid.
 

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -206,26 +206,6 @@ class Target:
                 pkgs[p] = new_ver
         return pkgs
 
-    def disable_repo(self, repo: str) -> None:
-        """Disables a repository on the target host.
-
-        Args:
-            repo: The name of the repository to disable.
-
-        """
-        logger.debug("%s: disabling repo %s", self.hostname, repo)
-        self.run(f"zypper mr -d {repo}")
-
-    def enable_repo(self, repo: str) -> None:
-        """Enables a repository on the target host.
-
-        Args:
-            repo: The name of the repository to enable.
-
-        """
-        logger.debug("%s: enabling repo %s", self.hostname, repo)
-        self.run(f"zypper mr -e {repo}")
-
     def set_timeout(self, value: int) -> None:
         """Sets the command timeout for the target host.
 

--- a/mtui/template/nulltestreport.py
+++ b/mtui/template/nulltestreport.py
@@ -15,11 +15,6 @@ class NullTestReport(TestReport):
     This class is used when no test report is loaded.
     """
 
-    @property
-    def _type(self) -> str:
-        """Returns the type of the test report."""
-        return "No"
-
     def __init__(self, *a, **kw) -> None:
         """Initializes the `NullTestReport` object."""
         super().__init__(*a, **kw)

--- a/mtui/template/obstestreport.py
+++ b/mtui/template/obstestreport.py
@@ -26,11 +26,6 @@ class OBSTestReport(TestReport):
         self._attrs += ["rrid", "rating", "realid"]
 
     @property
-    def _type(self) -> str:
-        """Returns the type of the test report."""
-        return "OBS"
-
-    @property
     def id(self) -> str:
         """Returns the ID of the test report."""
         return str(self.rrid)

--- a/mtui/template/pitestreport.py
+++ b/mtui/template/pitestreport.py
@@ -26,11 +26,6 @@ class PITestReport(TestReport):
         self._attrs += ["rrid", "rating", "realid"]
 
     @property
-    def _type(self) -> str:
-        """Returns the type of the test report."""
-        return "PI"
-
-    @property
     def id(self) -> str:
         """Returns the ID of the test report."""
         return str(self.rrid)

--- a/mtui/template/sltestreport.py
+++ b/mtui/template/sltestreport.py
@@ -33,11 +33,6 @@ class SLTestReport(TestReport):
         self._attrs += ["rrid", "rating", "realid"]
 
     @property
-    def _type(self) -> str:
-        """Returns the type of the test report."""
-        return "SLFO"
-
-    @property
     def id(self) -> str:
         """Returns the ID of the test report."""
         return str(self.rrid)

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -15,7 +15,6 @@ from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
 from typing import Any, Literal
-from urllib.request import urlopen
 
 from ..config import Config
 from ..datafiles import scripts_path
@@ -46,13 +45,6 @@ class TestReport(ABC):
 
     # -- Attributes set dynamically by UpdateID subclasses --
     incident: Any
-    updateid: Any
-
-    @property
-    @abstractmethod
-    def _type(self) -> str:
-        """Returns the type of the test report."""
-        ...
 
     def __init__(self, config: Config, scripts_src_dir: Path | None = None) -> None:
         """Initializes the `TestReport` object.
@@ -556,18 +548,6 @@ class TestReport(ABC):
         """Returns the URL for the fancy test report."""
         return "/".join([self.config.fancy_reports_url, str(self.id), "log"])
 
-    def local_wd(self, *paths) -> Path:
-        """Returns the local working directory.
-
-        Args:
-            *paths: The path components to join to the working directory.
-
-        Returns:
-            The path to the local working directory.
-
-        """
-        return self._wd(self.config.local_tempdir, str(self.id), *paths)
-
     def report_wd(self, *paths, **kw) -> Path:
         """Returns the working directory relative to the test report checkout.
 
@@ -641,20 +621,6 @@ class TestReport(ABC):
                 for f in filelist:
                     x = s(self, d / f)
                     x.run(targets)
-
-    def download_file(self, from_, into) -> None:
-        """Downloads a file.
-
-        Args:
-            from_: The URL to download the file from.
-            into: The path to save the downloaded file to.
-
-        """
-        logger.info("Downloading %s", from_)
-        from contextlib import closing
-
-        with open(into, "wb") as dst, closing(urlopen(from_)) as src:
-            dst.writelines(src)
 
     def list_versions(self, sink, targets: HostsGroup, packages):
         """Lists the available versions of packages.

--- a/mtui/types/enums.py
+++ b/mtui/types/enums.py
@@ -8,8 +8,6 @@ class method(StrEnum):
 
     POST = auto()
     GET = auto()
-    PATCH = auto()
-    DELETE = auto()
 
 
 class assignment(Enum):

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -204,7 +204,6 @@ class AutoOBSUpdateID(UpdateID):
                 logger.info("Connect refhosts from TestPlatform")
                 tr.connect_targets()
 
-        tr.updateid = self
         return tr
 
 
@@ -257,7 +256,6 @@ class KernelOBSUpdateID(UpdateID):
         self._create_installogs_dir(config)
         self.create_results_dir(config)
         tr.incident = QEMIncident(self.id, config.qem_dashboard_api)
-        tr.updateid = self
         tr.openqa.auto = DashboardAutoOpenQA(
             config,
             config.openqa_instance,

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -7,7 +7,6 @@ import termios
 import time
 from collections.abc import Callable, Collection, Sequence
 from contextlib import contextmanager
-from copy import deepcopy
 from functools import wraps
 from itertools import chain
 from pathlib import Path
@@ -421,35 +420,3 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
         f.write(data)
 
     move(fname, path)
-
-
-def walk(inc: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
-    """Recursively walks through a nested data structure.
-
-    This function is designed to simplify nested data structures,
-    particularly those that resemble GraphQL responses with 'edges'
-    and 'node' keys.
-
-    Args:
-        inc: The collection (list or dict) to walk through.
-
-    Returns:
-        The modified collection.
-
-    """
-    if isinstance(inc, list):
-        for i, j in enumerate(inc):
-            if isinstance(j, list | dict):
-                inc[i] = walk(j)
-    if isinstance(inc, dict):
-        if len(inc) == 1:
-            if "edges" in inc:
-                return walk(inc["edges"])
-            if "node" in inc:
-                tmp = deepcopy(inc["node"])
-                del inc["node"]
-                inc.update(tmp)
-        for key in inc:
-            if isinstance(inc[key], list | dict):
-                inc[key] = walk(inc[key])
-    return inc

--- a/mtui/utils.py
+++ b/mtui/utils.py
@@ -3,8 +3,6 @@ import os
 import re
 import readline
 import struct
-import subprocess
-import tempfile
 import termios
 import time
 from collections.abc import Callable, Collection, Sequence
@@ -18,34 +16,6 @@ from tempfile import mkstemp
 from typing import Any
 
 from .messages import TestReportNotLoadedError
-
-
-def edit_text(text: str) -> str:
-    """Opens the user's default editor to edit the given text.
-
-    Args:
-        text: The initial text to be edited.
-
-    Returns:
-        The edited text.
-
-    """
-    editor = os.getenv("EDITOR", "vim")
-    tmpfile = tempfile.NamedTemporaryFile()  # noqa: SIM115
-
-    with open(tmpfile.name, "w") as tmp:
-        tmp.write(text)
-
-    subprocess.check_call((editor, tmpfile.name))
-
-    with open(tmpfile.name) as tmp:
-        text = tmp.read().strip("\n")
-        text = text.replace("'", '"')
-
-    del tmpfile
-
-    return text
-
 
 if os.getenv("COLOR", "always") == "always":
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Programming Language :: Python :: 3.14"
 ]
 dependencies = [
-  "looseversion",
   "openqa-client",
   "paramiko",
   "pyxdg",

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -4,7 +4,6 @@ pyxdg
 requests
 ruamel.yaml
 osc
-looseversion
 openqa-client
 
 pytest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ pyxdg
 requests
 ruamel.yaml
 osc
-looseversion
 openqa-client
 
 pytest

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -88,7 +88,6 @@ class TestGiteaInit:
         gitea = Gitea(mock_config, api_url)  # type: ignore[arg-type]
 
         assert gitea.pr == api_url
-        assert "issues/comments" in gitea.issues
         assert "issues" in gitea.prissues
         assert gitea.user == "testuser"
         assert gitea.group == "qam-sle"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -28,7 +28,6 @@ def test_messages():
         str(messages.ConnectingTargetFailedMessage("test_host", "test_reason"))
         == "connecting to test_host failed: test_reason"
     )
-    assert str(messages.ConnectingToMessage("test_host")) == "connecting to test_host"
     assert (
         str(messages.FailedToWriteScriptResult("test_path", "test_reason"))
         == "failed to write script output to test_path: test_reason"
@@ -48,10 +47,6 @@ def test_messages():
     assert (
         str(messages.LocationChangedMessage("old", "new"))
         == "changed location from 'old' to 'new'"
-    )
-    assert (
-        str(messages.PackageRevisionHasntChangedWarning("test_pkg"))
-        == "Revision of package 'test_pkg' hasn't changed, it's most likely already updated. skipping."
     )
     assert (
         str(messages.MissingPreparerError("test_release"))
@@ -81,12 +76,10 @@ def test_messages():
         str(messages.ReConnectFailed("test_host"))
         == "Failed to re-connect to test_host"
     )
-    assert str(messages.RepositoryError("test_repo")) == "Repository empty test_repo"
     assert (
         str(messages.ResultsMissingError("test_test", "test_arch"))
         == "Test: test_test on arch: test_arch missing results.json file. Please restart it."
     )
-    assert str(messages.SVNError("test_cmd")) == "SVN test_cmd command failed"
 
     # Test messages with no arguments
     assert str(messages.NoRefhostsDefinedError()) == "No refhosts defined"
@@ -95,13 +88,8 @@ def test_messages():
         == "xdg-open finished successfully but suspiciously too fast"
     )
     assert (
-        str(messages.QadbReportCommentLengthWarning())
-        == "comment strings > 100 chars are truncated by remote_qa_db_report.pl"
-    )
-    assert (
         str(messages.MissingPackagesError())
         == "Missing packages: TestReport not loaded and no -p given."
     )
     assert str(messages.TestReportNotLoadedError()) == "TestReport not loaded"
     assert str(messages.MetadataNotLoadedError()) == "Metadata not found"
-    assert str(messages.openQAError()) == "Something wrong with openQA connection"

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -23,7 +23,6 @@ def test_qem_incident_metadata():
 
     assert incident
     assert incident.get_incident_name() == "kernel-ec2"
-    assert incident.get_version() == "12-SP2"
 
 
 @responses.activate

--- a/tests/test_types_expanded.py
+++ b/tests/test_types_expanded.py
@@ -221,8 +221,6 @@ class TestEnums:
         """Test method enum values."""
         assert method.GET == "get"
         assert method.POST == "post"
-        assert method.PATCH == "patch"
-        assert method.DELETE == "delete"
 
     def test_assignment_enum(self):
         """Test assignment enum has expected members."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,22 +98,6 @@ def test_timestamp():
     assert isinstance(int(utils.timestamp()), int)
 
 
-def test_walk():
-    """Test walk."""
-    test_data = {
-        "edges": [
-            {
-                "node": {
-                    "a": 1,
-                    "b": 2,
-                }
-            }
-        ]
-    }
-    expected_data = [{"a": 1, "b": 2}]
-    assert utils.walk(test_data) == expected_data
-
-
 def test_sutparse():
     sut = utils.SUTParse("a,b,c")
     assert sut.print_args() == "-t a -t b -t c"


### PR DESCRIPTION
## What

Removes 23 pieces of unused code across 17 source files plus matching test
assertions. Net diff: **+11 / -317** lines across 27 files. No behaviour
changes.

## Why it's safe to merge

Each removal was verified independently before deletion:

- **Zero src callers** — confirmed via `rg` across the whole repo (not just
  `mtui/**`), including the dynamic command loader at
  `mtui/commands/__init__.py` and any `getattr`-based dispatch sites.
- **Tests pass** — `pytest`: 316 passed (was 317; one test removed because
  it exercised a since-deleted helper).
- **Linter clean** — `ruff check mtui/` passes with no new findings. The
  one pre-existing PT018 warning in `tests/test_gitea.py:213` is untouched
  and out of scope.
- **Vulture clean** — `vulture mtui/ --min-confidence 60` no longer reports
  any of the removed items; remaining warnings are documented framework
  hooks (`cmd.Cmd`, context-manager protocol), reflection-driven config
  attributes, and decorator-driven dispatch (`@functools.total_ordering`).

## What was *not* removed (false positives surfaced during review)

A handful of items vulture flagged turned out to be live code reachable via
indirect dispatch. They are kept and documented in commit messages:

- `_RefhostsFactory.resolve_https()` / `resolve_path()` — dispatched via
  `getattr(self, f"resolve_{name}")` from the `config.refhosts_resolvers`
  setting.
- `Comment.__gt__()` — required by `@functools.total_ordering` to derive
  `__lt__` for `sorted(comments)` in the gitea connector.
- `System.get_addons()` — kept for public API symmetry with the
  actively-used `get_base()`.

## Notable cascaded cleanups

A few removals had transitively-dead consequences that were also cleaned up:

- `mtui/utils.py`: dropped now-unused `subprocess`, `tempfile`, `deepcopy`
  imports.
- `mtui/template/testreport.py`: dropped now-unused `urlopen` import.
- `mtui/config.py`: removed `_has_option()` and the `InvalidOptionNameError`
  exception class along with their sole consumer `set_option()`.
- `pyproject.toml` + `requirements_*.txt`: dropped `looseversion` after
  removing the `loose_version` `__getattr__` shim that was its only
  consumer.

## How the commits are organised

Each commit is scoped to a single subsystem (template, target, refhost,
config, utils, datafiles, messages, display, colorlog, deps, gitea, enums,
walk-helper, qem-dashboard) so reviewers can read or revert one at a time.
Every commit message explains the *why*, not just the *what*, and notes any
false positives ruled out during that change.

## Verification commands

```sh
pytest                                 # 316 passed
ruff check mtui/                       # All checks passed!
vulture mtui/ --min-confidence 60      # only documented false positives remain
```