### PR TITLE
Phase 2: latent bugs + test foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ docs/_build/
 
 # PyBuilder
 .pybuilder/
-target/
+/target/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/mtui/__main__.py
+++ b/mtui/__main__.py
@@ -1,0 +1,9 @@
+"""Module entrypoint enabling ``python -m mtui``.
+
+Mirrors the ``mtui`` console-script registered in ``pyproject.toml``.
+"""
+
+from .main import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mtui/commands/__init__.py
+++ b/mtui/commands/__init__.py
@@ -28,8 +28,8 @@ for pth in _rootdir.glob("*.py"):
     try:
         logger.debug("loading command module %s", modname)
         module = importlib.import_module("." + modname, "mtui.commands")
-    except BaseException:
-        logger.error("loading command module %s failed", modname)
+    except Exception:
+        logger.exception("loading command module %s failed", modname)
         continue
 
     # register classes

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -49,6 +49,7 @@ class Config:
     openqa_kernel_install_logs: str
     threshold: int
     gitea_token: str
+    ssh_strict_host_key_checking: str
 
     # -- Attributes set externally in main.py --
     kernel: bool
@@ -250,6 +251,12 @@ class Config:
             # RefhostsFactory which need access to parts of config.
             ("location", ("mtui", "location"), "default"),
             ("gitea_token", ("gitea", "token"), getenv("GITEA_TOKEN", "")),
+            (
+                "ssh_strict_host_key_checking",
+                ("connection", "ssh_strict_host_key_checking"),
+                "auto_add",
+                str,
+            ),
         ]
 
         def add_normalizer(x):

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -125,7 +125,10 @@ class Config:
 
             try:
                 val = self._get_option(inipath, getter)
-            except BaseException:
+            except Exception:
+                logger.debug(
+                    "config option %s not in INI; using default", attr, exc_info=True
+                )
                 val = default() if callable(default) else default
 
             setattr(self, str(attr), fixup(val))

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -83,6 +83,11 @@ class Connection:
         try:
             self.port = int(port)
         except ValueError:
+            logger.warning(
+                "invalid SSH port %r for %s; falling back to 22",
+                port,
+                hostname,
+            )
             self.port = 22
 
         self.timeout = timeout

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -236,13 +236,22 @@ class Connection:
                 sshlog = logging.getLogger(transport.get_log_channel())
                 sshlog.addHandler(logging.NullHandler())
             except Exception:
-                pass
+                logger.debug(
+                    "failed to attach NullHandler to paramiko log channel",
+                    exc_info=True,
+                )
             session = transport.open_session()
 
             # disable blocking and timeout to use the session in async mode
             session.setblocking(0)
             session.settimeout(0)
         except Exception:
+            logger.debug(
+                "failed to open new session on %s:%s",
+                self.hostname,
+                self.port,
+                exc_info=True,
+            )
             session = None
 
         return session
@@ -260,8 +269,12 @@ class Connection:
                 session.shutdown(2)
                 session.close()
             except Exception:
-                # pass all exceptions since the session is already closed or broken
-                pass
+                # session is already closed or broken; nothing to do beyond
+                # leaving a debug breadcrumb for diagnosis.
+                logger.debug(
+                    "ignoring error while closing already-broken session",
+                    exc_info=True,
+                )
 
     def __run_command(self, command: str) -> Channel | None:
         """Opens a new session and runs a command in it.
@@ -496,6 +509,12 @@ class Connection:
                     created = False
                     sftp = self.__sftp_reconnect()
                 except Exception:
+                    # Most commonly: directory already exists (sftp.mkdir
+                    # raises OSError on EEXIST). Treat as success but leave
+                    # a breadcrumb so unexpected failures are diagnosable.
+                    logger.debug(
+                        "sftp mkdir %s treated as success", path, exc_info=True
+                    )
                     created = True
 
         logger.debug(

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -52,10 +52,34 @@ class CommandTimeoutError(Exception):
         return repr(self.command)
 
 
+_HOST_KEY_POLICIES: dict[str, type[paramiko.MissingHostKeyPolicy]] = {
+    "auto_add": paramiko.AutoAddPolicy,
+    "warn": paramiko.WarningPolicy,
+    "reject": paramiko.RejectPolicy,
+}
+
+
+def policy_from_config(name: str) -> paramiko.MissingHostKeyPolicy:
+    """Map an ``ssh_strict_host_key_checking`` config value to a paramiko policy.
+
+    Unknown values fall back to ``AutoAddPolicy`` (preserving the legacy
+    behaviour) and emit a warning so misconfigurations are visible.
+    """
+    cls = _HOST_KEY_POLICIES.get(name)
+    if cls is None:
+        logger.warning(
+            "unknown ssh_strict_host_key_checking=%r; falling back to auto_add",
+            name,
+        )
+        cls = paramiko.AutoAddPolicy
+    return cls()
+
+
 class Connection:
     """Manages SSH and SFTP connections to a remote host."""
 
     __slots__ = [
+        "_policy",
         "client",
         "command",
         "hostname",
@@ -66,7 +90,13 @@ class Connection:
         "timeout",
     ]
 
-    def __init__(self, hostname: str, port: int | str, timeout: int) -> None:
+    def __init__(
+        self,
+        hostname: str,
+        port: int | str,
+        timeout: int,
+        missing_host_key_policy: paramiko.MissingHostKeyPolicy | None = None,
+    ) -> None:
         """Opens an SSH channel to the specified host.
 
         This method tries to authenticate using SSH keys and falls back to
@@ -76,6 +106,9 @@ class Connection:
             hostname: The hostname or IP address of the remote host.
             port: The port number to connect to.
             timeout: The timeout for remote commands.
+            missing_host_key_policy: paramiko policy applied to unknown
+                host keys. ``None`` (the default) preserves the legacy
+                behaviour of ``AutoAddPolicy``.
 
         """
         self.hostname = hostname
@@ -93,6 +126,7 @@ class Connection:
         self.timeout = timeout
 
         self.client = SSHClient()
+        self._policy = missing_host_key_policy
 
         self.load_keys()
 
@@ -102,9 +136,10 @@ class Connection:
         return f"<{self.__class__.__name__} object hostname={self.hostname} port={self.port}>"
 
     def load_keys(self) -> None:
-        """Loads system host keys."""
+        """Loads system host keys and applies the missing-key policy."""
         self.client.load_system_host_keys()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        policy = self._policy if self._policy is not None else paramiko.AutoAddPolicy()
+        self.client.set_missing_host_key_policy(policy)
 
     def connect(self) -> None:
         """Connects to the remote host using paramiko."""

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -382,7 +382,7 @@ class _RefhostsFactory:
         for resolver in [x.strip() for x in config.refhosts_resolvers.split(",")]:
             try:
                 return self._resolve_one(resolver, config)
-            except BaseException:
+            except Exception:
                 logger.warning("Refhosts: resolver %s failed", resolver)
                 logger.debug(format_exc())
 

--- a/mtui/target/actions.py
+++ b/mtui/target/actions.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, ValuesView
 from contextlib import suppress
 from pathlib import Path
-from queue import Queue
+from queue import Empty, Queue
 from threading import Lock
 from typing import Any
 
@@ -37,13 +37,11 @@ class ThreadedMethod(threading.Thread):
         while True:
             try:
                 (method, parameter) = self.queue.get(timeout=10)
-            except BaseException:
+            except Empty:
                 return
 
             try:
                 method(*parameter)
-            except BaseException:
-                raise
             finally:
                 with suppress(ValueError):
                     self.queue.task_done()

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -259,7 +259,13 @@ class TargetLock:
             self.connection.sftp_remove(self.filename)
         except OSError as e:
             if e.errno == errno.ENOENT:
-                pass
+                logger.debug("lockfile %s already gone", self.filename)
+            else:
+                logger.debug(
+                    "ignoring OSError while removing lockfile %s",
+                    self.filename,
+                    exc_info=True,
+                )
         except Exception:
             logger.error("failed to remove lockfile")
             raise

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -134,17 +134,27 @@ class Target:
         """Reloads the system information for the target host."""
         self.system, self.transactional = parse_system(self.connection)
 
-    def __eq__(self, other) -> bool:
-        """Checks if two `Target` objects are equal."""
-        return self.system == other.system
+    def __eq__(self, other: object) -> bool:
+        """Checks if two `Target` objects are equal.
+
+        Equality is keyed on ``hostname`` so the contract matches
+        ``__hash__``. Comparing against a non-``Target`` returns
+        ``NotImplemented`` per the Python data model.
+        """
+        if not isinstance(other, Target):
+            return NotImplemented
+        return self.hostname == other.hostname
 
     def __hash__(self) -> int:
         """Hashes the target by hostname."""
         return hash(self.hostname)
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: object) -> bool:
         """Checks if two `Target` objects are not equal."""
-        return self.system != other.system
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented  # type: ignore[return-value]
+        return not result
 
     def query_versions(self, packages=None) -> None:
         """Queries the package versions for the target host.

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -378,7 +378,7 @@ class Target:
         """
         try:
             return self.out[-1][0]
-        except BaseException:
+        except IndexError:
             return ""
 
     def lastout(self) -> str:
@@ -390,7 +390,7 @@ class Target:
         """
         try:
             return self.out[-1][1]
-        except BaseException:
+        except IndexError:
             return ""
 
     def lasterr(self) -> str:
@@ -402,7 +402,7 @@ class Target:
         """
         try:
             return self.out[-1][2]
-        except BaseException:
+        except IndexError:
             return ""
 
     def lastexit(self) -> str:
@@ -414,7 +414,7 @@ class Target:
         """
         try:
             return self.out[-1][3]
-        except BaseException:
+        except IndexError:
             return ""
 
     def is_locked(self) -> bool:

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -13,7 +13,7 @@ from .. import messages
 from ..actions import downgrader, installer, preparer, uninstaller, updater
 from ..checks import downgrade_checks, install_checks, prepare_checks, update_checks
 from ..config import Config
-from ..connection import CommandTimeoutError, Connection
+from ..connection import CommandTimeoutError, Connection, policy_from_config
 from ..target.parsers import parse_system
 from ..types import HostLog, Package, System
 from ..types.rpmver import RPMVersion
@@ -104,7 +104,15 @@ class Target:
         """Connects to the target host."""
         try:
             logger.info("connecting to %s", self.hostname)
-            self.connection = self.Connection(self.host, self.port, self._timeout)
+            policy_name = getattr(
+                self.config, "ssh_strict_host_key_checking", "auto_add"
+            )
+            self.connection = self.Connection(
+                self.host,
+                self.port,
+                self._timeout,
+                missing_host_key_policy=policy_from_config(policy_name),
+            )
         except Exception as e:
             logger.critical(messages.ConnectingTargetFailedMessage(self.hostname, e))
             raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ doc = [
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+testpaths = ["tests"]
+markers = [
+  "slow: tests that take noticeably longer to run",
+  "integration: tests that exercise multiple components together",
+  "network: tests that perform real network I/O",
+]
+
 [tool.ruff]
 target-version = "py311"
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,68 @@
+"""Smoke tests for the mtui command-line entrypoint.
+
+Exercises ``mtui --help`` and ``mtui -V`` end-to-end via subprocess
+to catch import-time, argparse, and entrypoint regressions that unit
+tests typically miss. Runs first under ``python -m mtui``; falls back
+to the ``mtui`` console script on PATH; skips when neither is usable
+(e.g. uninstalled checkout in some CI environments).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+def _invoke_args() -> list[str] | None:
+    """Return argv prefix for invoking mtui, or ``None`` if not runnable."""
+    probe = subprocess.run(
+        [sys.executable, "-m", "mtui", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if probe.returncode == 0:
+        return [sys.executable, "-m", "mtui"]
+
+    on_path = shutil.which("mtui")
+    if on_path:
+        return [on_path]
+
+    return None
+
+
+@pytest.fixture(scope="module")
+def mtui_argv() -> list[str]:
+    argv = _invoke_args()
+    if argv is None:
+        pytest.skip("mtui is not invokable in this environment")
+    return argv
+
+
+@pytest.mark.integration
+def test_cli_help_exits_zero(mtui_argv):
+    """``mtui --help`` exits 0 and prints argparse usage."""
+    result = subprocess.run(
+        [*mtui_argv, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_cli_version_exits_zero(mtui_argv):
+    """``mtui -V`` exits 0 and prints a non-empty version string."""
+    result = subprocess.run(
+        [*mtui_argv, "-V"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip(), "version output should be non-empty"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,3 +52,19 @@ def test_merge_args(tmpdir):
     assert cfg.connection_timeout == 1200
     assert cfg.qem_dashboard_api == "http://dashboard.qam.suse.de/api"
     assert cfg.gitea_token == "cmd_gitea_token"
+
+
+def test_ssh_strict_host_key_checking_default(tmpdir):
+    """Default value preserves backward-compatible auto-add behaviour."""
+    config_file = Path(tmpdir.join("test.cfg"))
+    config_file.write_text("")
+    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    assert cfg.ssh_strict_host_key_checking == "auto_add"
+
+
+def test_ssh_strict_host_key_checking_override(tmpdir):
+    """[connection] section in INI overrides the default."""
+    config_file = Path(tmpdir.join("test.cfg"))
+    config_file.write_text("[connection]\nssh_strict_host_key_checking = reject\n")
+    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    assert cfg.ssh_strict_host_key_checking == "reject"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -116,3 +116,19 @@ def test_run_command_timeout(mock_ssh_client, mock_ssh_config, mock_path):
         pytest.raises(CommandTimeoutError),
     ):
         conn.run("sleep 10")
+
+
+def test_connection_invalid_port_warns_and_falls_back(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Invalid SSH port string should log a warning and fall back to 22."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="mtui.connection"):
+        conn = Connection("test_host", "not-a-number", 300)
+
+    assert conn.port == 22
+    assert any(
+        "invalid SSH port" in rec.message and "not-a-number" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import paramiko
 import pytest
 
-from mtui.connection import CommandTimeoutError, Connection
+from mtui.connection import CommandTimeoutError, Connection, policy_from_config
 
 
 @pytest.fixture
@@ -132,3 +132,54 @@ def test_connection_invalid_port_warns_and_falls_back(
         "invalid SSH port" in rec.message and "not-a-number" in rec.message
         for rec in caplog.records
     )
+
+
+# --- ssh_strict_host_key_checking host-key policy mapping ---
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_cls"),
+    [
+        ("auto_add", paramiko.AutoAddPolicy),
+        ("warn", paramiko.WarningPolicy),
+        ("reject", paramiko.RejectPolicy),
+    ],
+)
+def test_policy_from_config_known(name, expected_cls):
+    """Known config values map to the matching paramiko policy class."""
+    policy = policy_from_config(name)
+    assert isinstance(policy, expected_cls)
+
+
+def test_policy_from_config_unknown_falls_back_with_warning(caplog):
+    """Unknown config values warn and fall back to AutoAddPolicy."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="mtui.connection"):
+        policy = policy_from_config("garbage")
+
+    assert isinstance(policy, paramiko.AutoAddPolicy)
+    assert any(
+        "unknown ssh_strict_host_key_checking" in rec.message
+        and "garbage" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_connection_default_policy_is_auto_add(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """No explicit policy passed -> Connection still uses AutoAddPolicy."""
+    Connection("test_host", 22, 300)
+
+    args, _ = mock_ssh_client.set_missing_host_key_policy.call_args
+    assert isinstance(args[0], paramiko.AutoAddPolicy)
+
+
+def test_connection_uses_provided_policy(mock_ssh_client, mock_ssh_config, mock_path):
+    """Explicit policy is forwarded to the paramiko client."""
+    policy = paramiko.RejectPolicy()
+    Connection("test_host", 22, 300, missing_host_key_policy=policy)
+
+    args, _ = mock_ssh_client.set_missing_host_key_policy.call_args
+    assert args[0] is policy

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -392,3 +392,48 @@ def test_sftp_put_dryrun(mock_target):
     mock_target.sftp_put(Path("/local/file"), Path("/remote/file"))
 
     mock_target.connection.sftp_put.assert_not_called()
+
+
+# --- __eq__ / __hash__ contract (regression for hostname/system mismatch) ---
+
+
+def test_target_eq_same_hostname_different_system(mock_config):
+    """Targets with the same hostname must be equal regardless of system.
+
+    Regression: previously __eq__ compared self.system while __hash__
+    used hostname, breaking the data-model contract.
+    """
+    t1 = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    t2 = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    t1.system = MagicMock()
+    t2.system = MagicMock()  # different system instance
+
+    assert t1 == t2
+    assert hash(t1) == hash(t2)
+
+
+def test_target_eq_different_hostname(mock_config):
+    """Targets with different hostnames must be unequal."""
+    t1 = Target(mock_config, "host1.example.com")  # type: ignore[arg-type]
+    t2 = Target(mock_config, "host2.example.com")  # type: ignore[arg-type]
+
+    assert t1 != t2
+    assert hash(t1) != hash(t2)
+
+
+def test_target_eq_non_target_returns_notimplemented(mock_config):
+    """Comparing Target to a non-Target must defer to the other side."""
+    t = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+
+    # __eq__ should return NotImplemented; the public `==` falls back to
+    # identity comparison and yields False.
+    assert t.__eq__("host.example.com") is NotImplemented
+    assert (t == "host.example.com") is False
+
+
+def test_target_set_dedup_by_hostname(mock_config):
+    """Two Target objects with the same hostname collapse in a set."""
+    t1 = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    t2 = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+
+    assert len({t1, t2}) == 1


### PR DESCRIPTION
## Summary

Eight focused commits fixing latent correctness bugs, adding the first user-facing SSH config knob, and laying test infrastructure. All changes are individually small, tested, and (apart from the new opt-in config option) preserve byte-identical default behaviour.

## Commits

1. **`feat(test): register pytest config and markers`** — `[tool.pytest.ini_options]` in `pyproject.toml` with `-ra --strict-markers`, `testpaths = ["tests"]`, and registered `slow`/`integration`/`network` markers.

2. **`fix(repo): scope /target/ gitignore rule to repo root`** — anchor the unanchored `target/` rule to `/target/` so `mtui/target/` is no longer hidden from git and ruff. Surfaces 8 additional `mtui/target/*.py` files to `ruff check` (all pass).

3. **`fix(target): align Target __eq__ with __hash__ on hostname`** — `Target.__hash__` used `hostname` while `__eq__`/`__ne__` used `system`, breaking the data-model contract. Switch all three to `hostname` and return `NotImplemented` for non-`Target` operands. +4 regression tests.

4. **`refactor(errors): replace silent excepts with debug logs`** — five `except Exception: pass` sites in SSH/SFTP and lockfile paths now `logger.debug(..., exc_info=True)`. Behaviour unchanged on the happy path; partial failures are now diagnosable when DEBUG is enabled.

5. **`refactor(errors): narrow BaseException to Exception`** — six sites narrowed so `KeyboardInterrupt` and `SystemExit` propagate. Includes special-case fixes (`Queue.Empty` in the worker thread, removal of a no-op `except BaseException: raise` wrapper, `IndexError` for the four `last*` getters, upgrade `logger.error` → `logger.exception` in the plugin loader).

6. **`fix(connection): warn on invalid SSH port fallback`** — `Connection.__init__` no longer silently rewrites unparseable ports to 22; emits a WARNING first. +1 regression test.

7. **`feat(connection): add ssh_strict_host_key_checking knob`** — opt-in config option with three values: `auto_add` (default, legacy behaviour), `warn` (`paramiko.WarningPolicy`), `reject` (`paramiko.RejectPolicy`). Plumbed via a new `missing_host_key_policy` parameter on `Connection.__init__`; `Target.connect` reads the option through `getattr` so existing test mocks keep working. Unknown values warn and fall back to `auto_add`. +8 tests.

8. **`test(cli): add smoke tests for --help and -V`** — subprocess-based end-to-end CLI tests, tagged `@pytest.mark.integration`. Adds a one-line `mtui/__main__.py` so `python -m mtui` works in editable installs. The fixture probes `python -m mtui` first, falls back to the `mtui` console script via `shutil.which`, and skips cleanly when neither is usable.

## Verification

- `ruff format --check` — 159 files clean (up from 149; the gitignore fix surfaced previously-hidden files to the formatter)
- `ruff check mtui` — clean
- `pytest` — **331 passed** (baseline 316 + 15 new tests)
- `ty check mtui` — only the pre-existing `mtui/types/rpmver.py:9` unused-`ty: ignore` warning; no new diagnostics
- Manual: `python -m mtui --help` and `python -m mtui -V` exit 0

## Notes on backward compatibility

- The new `ssh_strict_host_key_checking` config option defaults to `auto_add`, byte-identically preserving today's behaviour.
- `Connection.__init__`'s new `missing_host_key_policy` parameter defaults to `None` → falls back to `AutoAddPolicy`, so direct callers (including tests that don't go through `Target`) need no changes.
- All other commits are bug fixes or pure-additive (markers, tests, `__main__.py`).