### PR TITLE
ci: pass matrix python version to setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
+           python-version: ${{ matrix.python-version }}
            cache: 'pip'
            cache-dependency-path: 'requirements_ci.txt'
       - run: pip3 install -r requirements_ci.txt


### PR DESCRIPTION
## Summary

The `test` job declares a matrix of `python-version: ['3.11', '3.13']`, but the `actions/setup-python@v6` step is missing the `python-version` input. Without it, the action does not provision the requested interpreter and both matrix legs end up running on the runner's default Python (currently 3.12 on `ubuntu-latest`). Only the job/step name reflected the matrix value; the actual interpreter did not.

This PR wires `matrix.python-version` into the `setup-python` step so each leg genuinely exercises its target Python.

## Change

```diff
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
+           python-version: ${{ matrix.python-version }}
            cache: 'pip'
            cache-dependency-path: 'requirements_ci.txt'
```

## Verification

After merge, the `test` job's "Set up python" step logs should show `3.11.x` for the 3.11 leg and `3.13.x` for the 3.13 leg (previously both showed 3.12.x).

## Notes / out of scope

- The `pyproject.toml` classifiers advertise 3.11–3.14; expanding the matrix to add 3.12 / 3.14 is intentionally left for a follow-up.
- The Codecov coverage upload remains pinned to the `3.13` leg; with this fix it now genuinely uploads from a 3.13 run.