### PR TITLE
fix(prompt,commands): surface bad shlex input cleanly and gate tracebacks on debug

### DIFF
--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -67,8 +67,11 @@ class Command(ABC):
             A namespace containing the parsed arguments.
 
         """
-        arg = shlex.split(args)
         p = cls.argparser(sys)
+        try:
+            arg = shlex.split(args)
+        except ValueError as e:
+            p.error(f"invalid syntax: {e}")
         pa = p.parse_args(arg)
 
         if cls._check_subparser and not hasattr(pa, cls._check_subparser):

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -9,7 +9,7 @@ import cmd
 import readline
 import subprocess
 from collections.abc import Callable
-from logging import getLogger
+from logging import DEBUG, getLogger
 from pathlib import Path
 from typing import Any
 
@@ -208,9 +208,15 @@ class CommandPrompt(cmd.Cmd):
             except QuitLoopError:
                 return
             except (messages.UserMessage, subprocess.CalledProcessError) as e:
-                logger.exception(e)
-            except Exception:
-                logger.exception("Unexpected error")
+                if logger.isEnabledFor(DEBUG):
+                    logger.exception(e)
+                else:
+                    logger.error(e)
+            except Exception as e:
+                if logger.isEnabledFor(DEBUG):
+                    logger.exception("Unexpected error")
+                else:
+                    logger.error("Unexpected error: %s", e)
 
     def postcmd(self, stop: bool, line: str) -> bool:
         """A hook that is called after a command is executed.

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from mtui.argparse import ArgsParseFailureError
 from mtui.commands._command import Command
 from mtui.messages import HostIsNotConnectedError
 from mtui.target.hostgroup import HostsGroup
@@ -63,6 +64,24 @@ class TestParseArgs:
         sys = MagicMock()
         result = ConcreteCommandWithHosts.parse_args("", sys)
         assert result.hosts is None
+
+    def test_invalid_shlex_raises_argsparsefailure(self):
+        """Stray backslash must surface as ArgsParseFailureError, not ValueError."""
+        sys = MagicMock()
+        with pytest.raises(ArgsParseFailureError):
+            ConcreteCommand.parse_args("foo\\", sys)
+
+    def test_invalid_shlex_unbalanced_quote(self):
+        """Unbalanced quote must surface as ArgsParseFailureError."""
+        sys = MagicMock()
+        with pytest.raises(ArgsParseFailureError):
+            ConcreteCommand.parse_args('foo "bar', sys)
+
+    def test_quoted_args_preserved(self):
+        """Quoted arguments containing whitespace stay together (the original commit's intent)."""
+        sys = MagicMock()
+        result = ConcreteCommand.parse_args('"my name"', sys)
+        assert result.name == "my name"
 
 
 # --- argparser ---


### PR DESCRIPTION
## Summary

Two follow-ups to 7131d8c (`fix(commands): parse args with shlex.split`) that surfaced as user-reported issues:

- **`shlex.split` `ValueError` is now caught.** Inputs like `list_packages\` (trailing backslash) or unbalanced quotes raised `ValueError("No escaped character")`, which fell through to `cmdloop`'s generic handler and produced a noisy *"Unexpected error"* with full traceback for what is really a typo. The call now goes through `ArgumentParser.error()`, which raises the existing `ArgsParseFailureError` already swallowed cleanly in `prompt.py:258`.

- **Tracebacks are now gated on `--debug`.** `cmdloop` used `logger.exception`, which always includes a stack trace regardless of log level. So polite `UserError`s like *"Missing packages: TestReport not loaded and no -p given."* were followed by an irrelevant traceback. The handlers now check `logger.isEnabledFor(DEBUG)` and fall back to plain `logger.error` otherwise. Tracebacks remain available with `--debug`.

## Why

Reported by a user after upgrading to a build containing 7131d8c:

```
mtui> list_packages\
error: Unexpected error
Traceback (most recent call last):
  ...
ValueError: No escaped character
```

and

```
mtui> list_packages
error: Missing packages: TestReport not loaded and no -p given.
Traceback (most recent call last):
  ...
mtui.messages.MissingPackagesError: Missing packages: TestReport not loaded and no -p given.
```

Both should be one-line errors in normal mode.

## Out of scope

The completer handler at `prompt.py:281` is intentionally left as-is. Readline discards completer exceptions silently, so the logged traceback is the only signal a developer ever gets — gating it on debug would mask real completer bugs.

## Tests

Three new regression tests in `tests/test_command_base.py`:
- `test_invalid_shlex_raises_argsparsefailure` — stray backslash
- `test_invalid_shlex_unbalanced_quote` — unbalanced `"`
- `test_quoted_args_preserved` — happy-path quoted argument with whitespace (the original 7131d8c intent)

Full suite: 319 passed.