### PR TITLE
fix(connection): make SSH port parameter optional with default 22

### DIFF
--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -114,7 +114,7 @@ class Connection:
         self.hostname = hostname
 
         try:
-            self.port = int(port)
+            self.port = int(port) if port else 22
         except ValueError:
             logger.warning(
                 "invalid SSH port %r for %s; falling back to 22",


### PR DESCRIPTION
## Summary
- Makes the SSH port parameter optional in the Connection API, defaulting to port 22 when not specified

## Changes
- Updated port assignment in `mtui/connection.py` to handle `None` by defaulting to 22
- Existing ValueError handling for invalid port strings remains unchanged
- Port parsing logic now checks for None before attempting int conversion

## Problem Solved
Users can now omit the port parameter when creating SSH connections, and it will automatically default to port 22 (the standard SSH port). This makes the API more ergonomic for the common case while maintaining backward compatibility with explicit port specifications.