### PR TITLE
Public-API test coverage for config, prompt, refhost, target, hostgroup and connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   for adding a new command.
 - `Documentation/cfg.rst` documents the `ssh_strict_host_key_checking`
   option introduced in the Phase 2 release.
+- Project test coverage rose from 58 % to 67 % after a public-API safety
+  net was added for `mtui/config.py`, `mtui/prompt.py`, `mtui/refhost.py`,
+  `mtui/target/target.py`, `mtui/target/hostgroup.py` and
+  `mtui/connection.py`. The Codecov project floor is bumped from 56 % to
+  66 % (current − 1, ratchets upward); patch target stays at 80 %.
+
+### Known issues
+- A non-numeric value for `connection_timeout` (e.g.
+  `connection_timeout = abc` under `[mtui]`) crashes `Config.__init__`
+  with `ValueError` instead of falling back to the documented default of
+  300 seconds. Workaround: ensure the option is unset or numeric.
+- A bad value for the typed config options handled by
+  `configparser.getint` / `getboolean` (`refhosts.https_expiration`,
+  `template.smelt_threshold`, `mtui.chdir_to_template_dir`,
+  `mtui.use_keyring`) is silently replaced by the default with no log
+  message, due to a malformed format string in the error path. The
+  default behaviour is correct but the diagnostic is missing.
 
 ## [Phase 3] — CI / tooling
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,14 +4,14 @@ comment:
   behavior: default
   require_changes: true
 coverage:
-  range: 56..95
+  range: 66..95
   round: down
   precision: 2
   status:
     changes: false
     project:
       default:
-        target: 56.0
+        target: 66.0
         threshold: 0.5
     patch:
       default:

--- a/tests/fixtures/refhosts.yml
+++ b/tests/fixtures/refhosts.yml
@@ -1,0 +1,42 @@
+default:
+  - name: host-default-x86
+    arch: x86_64
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 5
+    addons:
+      - name: sdk
+        version:
+          major: 15
+          minor: 5
+  - name: host-default-aarch64
+    arch: aarch64
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 5
+  - name: host-default-noaddon
+    arch: x86_64
+    product:
+      name: sles
+      version:
+        major: 12
+        minor: sp4
+nuremberg:
+  - name: host-nbg-x86
+    arch: x86_64
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 5
+  - name: host-nbg-only-here
+    arch: ppc64le
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,11 @@
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from mtui import config
+from mtui.messages import InvalidLocationError
+from mtui.refhost import RefhostsResolveFailedError
 
 
 class MockRefhosts:
@@ -10,6 +14,22 @@ class MockRefhosts:
 
     def check_location_sanity(self, location):
         pass
+
+    def __call__(self, config):
+        return self
+
+
+class RaisingRefhosts:
+    """Refhosts double whose ``check_location_sanity`` raises on demand."""
+
+    exc: Exception | None = None
+
+    def __init__(self, config):
+        pass
+
+    def check_location_sanity(self, location):
+        if self.exc is not None:
+            raise self.exc
 
     def __call__(self, config):
         return self
@@ -68,3 +88,123 @@ def test_ssh_strict_host_key_checking_override(tmpdir):
     config_file.write_text("[connection]\nssh_strict_host_key_checking = reject\n")
     cfg = config.Config(config_file, refhosts=MockRefhosts)
     assert cfg.ssh_strict_host_key_checking == "reject"
+
+
+def test_mtui_conf_env_var_selects_configfile(tmpdir, monkeypatch):
+    """When ``path`` is ``None`` and ``MTUI_CONF`` is set, that file is read."""
+    cfg_file = Path(tmpdir.join("via_env.cfg"))
+    cfg_file.write_text("[mtui]\nconnection_timeout = 777\n")
+    monkeypatch.setenv("MTUI_CONF", str(cfg_file))
+    cfg = config.Config(None, refhosts=MockRefhosts)
+    assert cfg.configfiles == [cfg_file]
+    assert cfg.connection_timeout == 777
+
+
+def test_default_configfiles_when_no_path_no_env(monkeypatch):
+    """No ``path`` and no ``MTUI_CONF`` falls back to the canonical pair."""
+    monkeypatch.delenv("MTUI_CONF", raising=False)
+    cfg = config.Config(None, refhosts=MockRefhosts)
+    assert cfg.configfiles == [
+        Path("/etc/mtui.cfg"),
+        Path("~/.mtuirc").expanduser(),
+    ]
+
+
+def test_read_logs_and_swallows_configparser_error(tmpdir, caplog):
+    """A malformed INI is logged at error and does not crash construction."""
+    cfg_file = Path(tmpdir.join("broken.cfg"))
+    # MissingSectionHeaderError: option line before any [section].
+    cfg_file.write_text("connection_timeout = 42\n")
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+    assert any(
+        "MissingSectionHeader" in r.message or "section" in r.message.lower()
+        for r in caplog.records
+    )
+    # Defaults still applied; broken file did not poison subsequent steps.
+    assert cfg.connection_timeout == 300
+
+
+def test_location_setter_invalid_location_keeps_previous(tmpdir, caplog):
+    """``InvalidLocationError`` is logged and the location is unchanged."""
+    cfg_file = Path(tmpdir.join("loc.cfg"))
+    cfg_file.write_text("")
+    refhosts = RaisingRefhosts
+    cfg = config.Config(cfg_file, refhosts=refhosts)
+    assert cfg.location == "default"
+    refhosts.exc = InvalidLocationError("nowhere", ["here", "there"])
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg.location = "nowhere"
+    assert cfg.location == "default"
+    assert any("nowhere" in r.message for r in caplog.records)
+    refhosts.exc = None  # reset shared class state
+
+
+def test_location_setter_resolve_failed_keeps_previous(tmpdir, caplog):
+    """``RefhostsResolveFailedError`` is logged and the location is unchanged."""
+    cfg_file = Path(tmpdir.join("loc.cfg"))
+    cfg_file.write_text("")
+    refhosts = RaisingRefhosts
+    cfg = config.Config(cfg_file, refhosts=refhosts)
+    refhosts.exc = RefhostsResolveFailedError()
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg.location = "anywhere"
+    assert cfg.location == "default"
+    assert any("refhosts.yml" in r.message for r in caplog.records)
+    refhosts.exc = None
+
+
+@pytest.mark.parametrize(
+    ("ini_section", "ini_key", "ini_value"),
+    [
+        # ``connection_timeout`` reads via ``config.get`` then ``int`` as fixup.
+        # The ``ValueError`` from ``int("abc")`` escapes ``_parse_config`` and
+        # crashes ``Config.__init__``.
+        ("mtui", "connection_timeout", "abc"),
+    ],
+)
+def test_fixup_failure_propagates_and_aborts_construction(
+    tmpdir, ini_section, ini_key, ini_value
+):
+    """Captures current behaviour: a bad ``int`` fixup crashes ``Config()``.
+
+    FIXME (Phase 5b/C10): ``_parse_config`` only handles failures that
+    originate inside ``_get_option``; ``fixup(val)`` is invoked outside the
+    ``try`` so its exceptions are not converted into the documented
+    "use default" behaviour. Replace with explicit per-option parse handling.
+    """
+    cfg_file = Path(tmpdir.join("typed.cfg"))
+    cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
+    with pytest.raises(ValueError, match="invalid literal for int"):
+        config.Config(cfg_file, refhosts=MockRefhosts)
+
+
+@pytest.mark.parametrize(
+    ("ini_section", "ini_key", "ini_value", "attr", "expected_default"),
+    [
+        # ``getint`` raises inside ``_get_option`` → caught by outer
+        # ``except Exception`` → default applied.
+        ("refhosts", "https_expiration", "xyz", "refhosts_https_expiration", 3600 * 12),
+        ("template", "smelt_threshold", "nope", "threshold", 10),
+        # ``getboolean`` raises inside ``_get_option`` → same path.
+        ("mtui", "chdir_to_template_dir", "maybe", "chdir_to_template_dir", False),
+        ("mtui", "use_keyring", "perhaps", "use_keyring", False),
+    ],
+)
+def test_typed_getter_failure_falls_back_to_default(
+    tmpdir, ini_section, ini_key, ini_value, attr, expected_default
+):
+    """Captures current behaviour: typed-getter failures silently use the default.
+
+    FIXME (Phase 5b/C10): ``_get_option`` lines 298-301 are intended to log an
+    error before re-raising, but the format-string call
+    ``msg.format((*secopt, self.configfiles))`` passes a single tuple to a
+    template that expects three positional args, so the ``logger.error`` call
+    itself raises and the user gets no diagnostic. Either way, the outer
+    ``except Exception`` in ``_parse_config`` swallows everything and applies
+    the default. The "log on failure" intent should be restored.
+    """
+    cfg_file = Path(tmpdir.join("typed.cfg"))
+    cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
+    cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+    assert getattr(cfg, attr) == expected_default

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -183,3 +183,389 @@ def test_connection_uses_provided_policy(mock_ssh_client, mock_ssh_config, mock_
 
     args, _ = mock_ssh_client.set_missing_host_key_policy.call_args
     assert args[0] is policy
+
+
+# ---------------------------------------------------------------------------
+# misc helpers
+# ---------------------------------------------------------------------------
+
+
+def test_command_timeout_str_formats_command():
+    """``CommandTimeoutError.__str__`` returns ``repr(self.command)``."""
+    assert str(CommandTimeoutError("ls -l")) == "'ls -l'"
+
+
+def test_connection_repr(mock_ssh_client, mock_ssh_config, mock_path):
+    conn = Connection("h", 22, 300)
+    text = repr(conn)
+    assert "Connection" in text
+    assert "h" in text
+    assert "22" in text
+
+
+# ---------------------------------------------------------------------------
+# connect() — config error and additional auth/exception branches
+# ---------------------------------------------------------------------------
+
+
+def test_connect_logs_non_enoent_ssh_config_error(
+    mock_ssh_client, mock_ssh_config, monkeypatch, caplog
+):
+    """An OSError other than ENOENT when reading ~/.ssh/config is logged."""
+    import errno as _errno
+
+    fake_path = MagicMock()
+    fake_path.expanduser.return_value.open.side_effect = OSError(
+        _errno.EACCES, "denied"
+    )
+    monkeypatch.setattr("mtui.connection.Path", lambda _path: fake_path)
+    with caplog.at_level("WARNING", logger="mtui.connection"):
+        Connection("test_host", 22, 300)
+    assert any("denied" in r.message for r in caplog.records)
+
+
+def test_connect_wrong_password_reraises(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Failing both key and password auth re-raises the second exception."""
+    mock_ssh_client.connect.side_effect = [
+        paramiko.AuthenticationException,
+        paramiko.AuthenticationException,
+    ]
+    with (
+        patch("getpass.getpass", return_value="wrong"),
+        pytest.raises(paramiko.AuthenticationException),
+        caplog.at_level("ERROR", logger="mtui.connection"),
+    ):
+        Connection("test_host", 22, 300)
+
+
+def test_connect_sshexception_propagates(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Generic SSHException is logged and re-raised."""
+    mock_ssh_client.connect.side_effect = paramiko.SSHException("boom")
+    with (
+        caplog.at_level("ERROR", logger="mtui.connection"),
+        pytest.raises(paramiko.SSHException),
+    ):
+        Connection("test_host", 22, 300)
+
+
+def test_connect_oserror_is_logged_not_raised(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Network-level OSError on connect is logged but not re-raised."""
+    mock_ssh_client.connect.side_effect = OSError("network")
+    with caplog.at_level("ERROR", logger="mtui.connection"):
+        Connection("test_host", 22, 300)
+    assert any("No valid connection" in r.message for r in caplog.records)
+
+
+def test_connect_unknown_exception_propagates(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Truly unexpected exceptions are logged at debug and re-raised."""
+    mock_ssh_client.connect.side_effect = RuntimeError("weird")
+    with (
+        caplog.at_level("DEBUG", logger="mtui.connection"),
+        pytest.raises(RuntimeError, match="weird"),
+    ):
+        Connection("test_host", 22, 300)
+
+
+# ---------------------------------------------------------------------------
+# reconnect  # noqa: ERA001
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_no_op_when_already_active(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport.is_active.return_value = True
+    # Reset the connect counter so we observe just the reconnect.
+    mock_ssh_client.connect.reset_mock()
+    conn.reconnect(retry=3)
+    mock_ssh_client.connect.assert_not_called()
+
+
+def test_reconnect_raises_after_exhausting_retries(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
+):
+    """If reconnects don't restore activity, ``ConnectionError`` is raised."""
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport.is_active.return_value = False
+    monkeypatch.setattr(
+        "mtui.connection.select.select", lambda *_a, **_kw: ([], [], [])
+    )
+    with pytest.raises(ConnectionError, match="Failed to reconnect"):
+        conn.reconnect(retry=2, timeout=0)
+
+
+def test_reconnect_backoff_grows_timeout(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
+):
+    """The backoff branch widens the select timeout per attempt."""
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport.is_active.return_value = False
+    sel_mock = MagicMock(return_value=([], [], []))
+    monkeypatch.setattr("mtui.connection.select.select", sel_mock)
+    with pytest.raises(ConnectionError):
+        conn.reconnect(retry=2, timeout=1, backoff=True)
+    # First attempt uses raw timeout, then 2*(1 + 5*1) = 12, then 2*(1 + 5*2) = 22.
+    timeouts = [c.args[3] for c in sel_mock.call_args_list]
+    assert timeouts[0] == 1
+    assert timeouts[1] == 12
+
+
+# ---------------------------------------------------------------------------
+# new_session / close_session / __run_command branches
+# ---------------------------------------------------------------------------
+
+
+def test_new_session_returns_none_when_no_transport(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    conn = Connection("h", 22, 300)
+    mock_ssh_client.get_transport.return_value = None
+    assert conn.new_session() is None
+
+
+def test_new_session_swallows_logger_attach_failure(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """Failing to attach the NullHandler logs at debug but doesn't crash."""
+    conn = Connection("h", 22, 300)
+    transport = mock_ssh_client.get_transport.return_value
+    transport.get_log_channel.side_effect = RuntimeError("no log")
+    # ``open_session`` still works.
+    transport.open_session.return_value = MagicMock()
+    with caplog.at_level("DEBUG", logger="mtui.connection"):
+        sess = conn.new_session()
+    assert sess is transport.open_session.return_value
+
+
+def test_new_session_logs_when_open_session_fails(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    conn = Connection("h", 22, 300)
+    transport = mock_ssh_client.get_transport.return_value
+    transport.open_session.side_effect = paramiko.SSHException("kaboom")
+    with caplog.at_level("DEBUG", logger="mtui.connection"):
+        assert conn.new_session() is None
+    assert any("failed to open new session" in r.message for r in caplog.records)
+
+
+def test_close_session_swallows_errors(caplog):
+    sess = MagicMock()
+    sess.shutdown.side_effect = OSError("already closed")
+    with caplog.at_level("DEBUG", logger="mtui.connection"):
+        Connection.close_session(sess)
+    assert any("ignoring error" in r.message for r in caplog.records)
+
+
+def test_close_session_none_is_noop():
+    Connection.close_session(None)  # must not raise
+
+
+def test_run_command_retries_then_raises_reconnect_failed(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
+):
+    """If ``__run_command`` keeps failing, ``ReConnectFailed`` is raised."""
+    from mtui.messages import ReConnectFailed
+
+    conn = Connection("h", 22, 300)
+    # Force ``new_session`` to always return None so __run_command yields None.
+    mock_ssh_client.get_transport.return_value = None
+    # ``Connection`` uses ``__slots__``; patch on the class instead of the instance.
+    monkeypatch.setattr(Connection, "reconnect", lambda *_args, **_kw: None)
+    with pytest.raises(ReConnectFailed):
+        conn.run("cmd")
+
+
+# ---------------------------------------------------------------------------
+# run() — recv TimeoutError branch
+# ---------------------------------------------------------------------------
+
+
+def test_run_recv_timeout_is_swallowed(mock_ssh_client, mock_ssh_config, mock_path):
+    """A TimeoutError during recv is caught; the loop sleeps and continues."""
+    conn = Connection("h", 22, 300)
+    sess = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = sess
+    sess.recv_exit_status.return_value = 0
+    # First iteration: recv_ready True but recv raises TimeoutError; second: clean.
+    sess.recv_ready.side_effect = [True, True, False]
+    sess.recv.side_effect = [TimeoutError("boom"), b"data", b""]
+    sess.recv_stderr_ready.return_value = False
+    with patch("mtui.connection.select.select", return_value=([sess], [], [])):
+        rc = conn.run("cmd")
+    assert rc == 0
+    assert "data" in conn.stdout
+
+
+# ---------------------------------------------------------------------------
+# is_active / close
+# ---------------------------------------------------------------------------
+
+
+def test_is_active_no_transport_returns_false(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport = None
+    assert conn.is_active() is False
+
+
+def test_is_active_delegates_to_transport(mock_ssh_client, mock_ssh_config, mock_path):
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport.is_active.return_value = False
+    assert conn.is_active() is False
+
+
+def test_close_delegates_to_client(mock_ssh_client, mock_ssh_config, mock_path):
+    conn = Connection("h", 22, 300)
+    conn.close()
+    mock_ssh_client.close.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# SFTP family
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sftp_client():
+    """A bare SFTPClient mock."""
+    return MagicMock()
+
+
+@pytest.fixture
+def conn_with_sftp(mock_ssh_client, mock_ssh_config, mock_path, sftp_client):
+    """A ``Connection`` whose ``open_sftp`` returns the supplied SFTP mock."""
+    mock_ssh_client.open_sftp.return_value = sftp_client
+    return Connection("h", 22, 300)
+
+
+def test_sftp_open_failure_returns_none(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
+):
+    mock_ssh_client.open_sftp.side_effect = paramiko.SSHException("nope")
+    conn = Connection("h", 22, 300)
+    # Force is_active False so reconnect loop runs once and fails.
+    mock_ssh_client._transport.is_active.return_value = False
+    from mtui.messages import ReConnectFailed
+
+    monkeypatch.setattr(Connection, "reconnect", lambda *_args, **_kw: None)
+    with pytest.raises(ReConnectFailed):
+        conn.sftp_listdir()
+
+
+def test_sftp_put_creates_subdirs_and_chmods(conn_with_sftp, sftp_client):
+    """``sftp_put`` walks the parent path, mkdirs each segment, then chmods."""
+    from pathlib import Path as _Path
+
+    conn_with_sftp.sftp_put(_Path("/local/file"), _Path("/srv/sub/file.txt"))
+    # mkdir called for /, srv/, sub/  (the loop creates the parent path).
+    assert sftp_client.mkdir.call_count >= 1
+    sftp_client.put.assert_called_once_with("/local/file", "/srv/sub/file.txt")
+    sftp_client.chmod.assert_called_once()
+    sftp_client.close.assert_called()
+
+
+def test_sftp_put_treats_existing_dir_as_success(conn_with_sftp, sftp_client, caplog):
+    """An ``OSError`` on ``mkdir`` (e.g. EEXIST) is debug-logged and skipped."""
+    from pathlib import Path as _Path
+
+    sftp_client.mkdir.side_effect = OSError("File exists")
+    with caplog.at_level("DEBUG", logger="mtui.connection"):
+        conn_with_sftp.sftp_put(_Path("/local"), _Path("/srv/x"))
+    sftp_client.put.assert_called_once()
+
+
+def test_sftp_get_calls_paramiko_get(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    conn_with_sftp.sftp_get(_Path("/remote"), _Path("/local"))
+    sftp_client.get.assert_called_once_with("/remote", _Path("/local"))
+    sftp_client.close.assert_called()
+
+
+def test_sftp_get_folder_iterates_listdir(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    sftp_client.listdir.return_value = ["a", "b"]
+    conn_with_sftp.sftp_get_folder(_Path("/remote"), _Path("/local/"))
+    # 2 files → 2 ``get`` calls.
+    assert sftp_client.get.call_count == 2
+
+
+def test_sftp_listdir_returns_paramiko_listdir(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    sftp_client.listdir.return_value = ["a", "b"]
+    assert conn_with_sftp.sftp_listdir(_Path("/x")) == ["a", "b"]
+    sftp_client.close.assert_called()
+
+
+def test_sftp_open_returns_handle(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    file_handle = MagicMock()
+    sftp_client.open.return_value = file_handle
+    assert conn_with_sftp.sftp_open(_Path("/x"), "r") is file_handle
+
+
+def test_sftp_open_logs_and_reraises_on_failure(conn_with_sftp, sftp_client, caplog):
+    """``sftp_open`` debug-logs the traceback and re-raises any error.
+
+    NB: the source path also tries to ``sftp.close()`` when the local
+    ``sftp`` happens to be a real ``paramiko.SFTPClient``. With a MagicMock
+    that ``isinstance`` check is False, so ``close`` isn't called. This
+    test just locks in the "log + re-raise" public contract.
+    """
+    from pathlib import Path as _Path
+
+    sftp_client.open.side_effect = OSError("perm")
+    with (
+        caplog.at_level("DEBUG", logger="mtui.connection"),
+        pytest.raises(OSError, match="perm"),
+    ):
+        conn_with_sftp.sftp_open(_Path("/x"), "r")
+    assert any("Traceback" in r.message for r in caplog.records)
+
+
+def test_sftp_remove_calls_paramiko_remove(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    conn_with_sftp.sftp_remove(_Path("/x"))
+    sftp_client.remove.assert_called_once_with("/x")
+    sftp_client.close.assert_called()
+
+
+def test_sftp_remove_logs_oserror(conn_with_sftp, sftp_client, caplog):
+    from pathlib import Path as _Path
+
+    sftp_client.remove.side_effect = OSError("perm")
+    with caplog.at_level("ERROR", logger="mtui.connection"):
+        conn_with_sftp.sftp_remove(_Path("/x"))
+    assert any("Can't remove" in r.message for r in caplog.records)
+
+
+def test_sftp_rmdir_recursively_removes(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    sftp_client.listdir.return_value = ["a", "b"]
+    conn_with_sftp.sftp_rmdir(_Path("/some/dir"))
+    # Each child file is removed, then the directory itself.
+    assert sftp_client.remove.call_count == 2
+    sftp_client.rmdir.assert_called_once_with("/some/dir")
+
+
+def test_sftp_readlink_returns_target(conn_with_sftp, sftp_client):
+    from pathlib import Path as _Path
+
+    sftp_client.readlink.return_value = "/real/path"
+    assert conn_with_sftp.sftp_readlink(_Path("/link")) == "/real/path"
+    sftp_client.close.assert_called()

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -1,5 +1,6 @@
 """Tests for the mtui hostgroup module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -8,6 +9,36 @@ from mtui.exceptions import UpdateError
 from mtui.messages import HostIsNotConnectedError
 from mtui.target.hostgroup import HostsGroup
 from mtui.target.locks import TargetLockedError
+
+
+def _stub_target(
+    hostname: str,
+    *,
+    transactional: bool = False,
+    is_locked: bool = False,
+    is_mine: bool = True,
+):
+    """A bare MagicMock-backed target with the attributes HostsGroup reads."""
+    t = MagicMock()
+    t.hostname = hostname
+    t.transactional = transactional
+    t.is_locked.return_value = is_locked
+    lock = MagicMock()
+    lock.is_mine.return_value = is_mine
+    type(t)._lock = PropertyMock(return_value=lock)
+    return t
+
+
+def _doer_dict(**templates: str):
+    """Build a ``{name: Template-like}`` mapping for get_*er return values."""
+    out = {}
+    for name, value in templates.items():
+        tpl = MagicMock()
+        tpl.substitute.return_value = value
+        tpl.safe_substitute.return_value = value
+        out[name] = tpl
+    return out
+
 
 # --- Initialization and selection ---
 
@@ -334,3 +365,398 @@ def test_report_products_delegates():
     hg.report_products(sink)
 
     t1.report_products.assert_called_once_with(sink)
+
+
+# ---------------------------------------------------------------------------
+# Group-level sftp wrappers
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.FileDownload")
+def test_sftp_get_delegates_to_filedownload(mock_dl):
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg.sftp_get(Path("/remote/x"), Path("/local/x"))
+    mock_dl.assert_called_once()
+    mock_dl.return_value.run.assert_called_once()
+
+
+@patch("mtui.target.hostgroup.FileUpload")
+def test_sftp_put_delegates_to_fileupload(mock_ul):
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg.sftp_put(Path("/local/x"), Path("/remote/x"))
+    mock_ul.assert_called_once()
+    mock_ul.return_value.run.assert_called_once()
+
+
+@patch("mtui.target.hostgroup.FileDelete")
+def test_sftp_remove_delegates_to_filedelete(mock_rm):
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg.sftp_remove(Path("/remote/x"))
+    mock_rm.assert_called_once()
+    mock_rm.return_value.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _reboot
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.RunCommand")
+def test_reboot_runs_commands_and_reconnects(mock_run):
+    """Non-empty reboot dict triggers run + per-host reconnect."""
+    t1 = _stub_target("h1", transactional=True)
+    hg = HostsGroup([t1])
+    hg._reboot({"h1": "systemctl reboot"})
+    mock_run.return_value.run.assert_called_once()
+    t1.reconnect.assert_called_once_with(retry=10, backoff=True)
+
+
+def test_reboot_empty_dict_is_noop():
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg._reboot({})
+    t1.reconnect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_lock — comment-logging branch
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+def test_update_lock_logs_other_user_comment(mock_queue, mock_thread, caplog):
+    """When the locking user left a comment, it is logged at info level."""
+    t1 = _stub_target("h1", is_locked=True, is_mine=False)
+    t1._lock.time.return_value = "Mon 01.01.2024"
+    t1._lock.locked_by.return_value = "carol"
+    t1._lock.comment.return_value = "investigating bug"
+    hg = HostsGroup([t1])
+    with (
+        caplog.at_level("INFO", logger="mtui.target.hostgroup"),
+        pytest.raises(UpdateError),
+    ):
+        hg.update_lock()
+    assert any("investigating bug" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# perform_uninstall
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_uninstall_runs_and_unlocks(mock_run, mock_queue, mock_thread):
+    t1 = _stub_target("h1")
+    t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
+    t1.get_uninstaller_check.return_value = MagicMock()
+    hg = HostsGroup([t1])
+    hg.perform_uninstall(["pkg"])
+    mock_run.assert_called()
+    t1.unlock.assert_called()
+
+
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_uninstall_unlocks_on_error(mock_run, mock_queue, mock_thread):
+    t1 = _stub_target("h1")
+    t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
+    hg = HostsGroup([t1])
+    mock_run.return_value.run.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        hg.perform_uninstall(["pkg"])
+    t1.unlock.assert_called()
+
+
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_uninstall_transactional_triggers_reboot(
+    mock_run, mock_queue, mock_thread
+):
+    t1 = _stub_target("h1", transactional=True)
+    t1.get_uninstaller.return_value = _doer_dict(
+        command="transactional-update -n pkg remove pkg",
+        reboot="systemctl reboot",
+    )
+    t1.get_uninstaller_check.return_value = MagicMock()
+    hg = HostsGroup([t1])
+    hg.perform_uninstall(["pkg"])
+    # _reboot eventually triggers reconnect.
+    t1.reconnect.assert_called_once_with(retry=10, backoff=True)
+
+
+# ---------------------------------------------------------------------------
+# perform_prepare
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_prepare_runs_per_package_command(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """``perform_prepare`` runs the command-template once per package."""
+    t1 = _stub_target("h1")
+    t1.lasterr.return_value = ""
+    t1.get_preparer.return_value = _doer_dict(
+        command="zypper in $package", reboot="", start_command=""
+    )
+    t1.get_preparer_check.return_value = MagicMock()
+    # ``queue.unfinished_tasks`` is used as a loop sentinel; force it to 0.
+    mock_queue.unfinished_tasks = 0
+    hg = HostsGroup([t1])
+    hg.perform_prepare(["pkg-a", "pkg-b"], MagicMock())
+    # 2 packages → 2 RunCommand invocations beyond the lock cleanup.
+    assert mock_run.call_count >= 2
+    t1.unlock.assert_called()
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_prepare_filters_branding_upstream(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """The hard-coded ``branding-upstream`` name is excluded from per-pkg cmds."""
+    t1 = _stub_target("h1")
+    t1.lasterr.return_value = ""
+    t1.get_preparer.return_value = _doer_dict(
+        command="zypper in $package", reboot="", start_command=""
+    )
+    t1.get_preparer_check.return_value = MagicMock()
+    mock_queue.unfinished_tasks = 0
+    hg = HostsGroup([t1])
+    hg.perform_prepare(["pkg-a", "branding-upstream", "pkg-b"], MagicMock())
+    # 2 surviving packages.
+    per_pkg_calls = [
+        c
+        for c in mock_run.call_args_list
+        if isinstance(c.args[1], dict) and "h1" in c.args[1]
+    ]
+    assert len(per_pkg_calls) == 2
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_prepare_aborts_on_set_repo_error(
+    mock_run, mock_queue, mock_thread, mock_spinner, caplog
+):
+    """``set_repo`` failure (non-empty ``lasterr``) logs critical and returns early."""
+    t1 = _stub_target("h1")
+    t1.lasterr.return_value = "repo failure"
+    t1.lastin.return_value = "zypper ar"
+    t1.lastout.return_value = ""
+    t1.get_preparer.return_value = _doer_dict(
+        command="zypper in $package", reboot="", start_command=""
+    )
+    mock_queue.unfinished_tasks = 0
+    hg = HostsGroup([t1])
+    with caplog.at_level("CRITICAL", logger="mtui.target.hostgroup"):
+        hg.perform_prepare(["pkg-a"], MagicMock())
+    assert any("Failed to prepare host" in r.message for r in caplog.records)
+    # No per-package command should have been issued.
+    per_pkg_calls = [
+        c
+        for c in mock_run.call_args_list
+        if isinstance(c.args[1], dict) and "h1" in c.args[1]
+    ]
+    assert len(per_pkg_calls) == 0
+    t1.unlock.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# perform_downgrade
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_downgrade_picks_highest_version_then_runs(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """The list_command output is parsed and the newest version is chosen."""
+    t1 = _stub_target("h1")
+    # Pretend list_command output is parsed: ``pkg-a = 1.0`` and ``pkg-a = 1.5``.
+    t1.lastout.return_value = "pkg-a = 1.0-1\npkg-a = 1.5-1\n"
+    t1.get_downgrader.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
+        "command": MagicMock(
+            safe_substitute=MagicMock(return_value="zypper in pkg-a-1.5-1")
+        ),
+    }
+    t1.get_downgrader_check.return_value = MagicMock()
+    mock_queue.unfinished_tasks = 0
+    hg = HostsGroup([t1])
+    hg.perform_downgrade(["pkg-a"], MagicMock())
+    # Confirm the per-package command was substituted with the higher version.
+    cmd_tpl = t1.get_downgrader.return_value["command"]
+    cmd_tpl.safe_substitute.assert_any_call(package="pkg-a", version="1.5-1")
+    t1.unlock.assert_called()
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_downgrade_unlocks_on_error(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    t1 = _stub_target("h1")
+    t1.lastout.return_value = ""
+    t1.get_downgrader.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="x")),
+    }
+    mock_queue.unfinished_tasks = 0
+    hg = HostsGroup([t1])
+    mock_run.return_value.run.side_effect = RuntimeError("downgrade boom")
+    with pytest.raises(RuntimeError, match="downgrade boom"):
+        hg.perform_downgrade(["pkg-a"], MagicMock())
+    t1.unlock.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# perform_update
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_update_runs_full_flow_with_noprepare_and_noscript(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """``noprepare`` skips prepare; ``noscript`` skips Pre/Post/Compare scripts."""
+    t1 = _stub_target("h1")
+    t1.packages = {}  # short-circuit package_check
+    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.get_updater_check.return_value = MagicMock()
+    mock_queue.unfinished_tasks = 0
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1])
+    hg.perform_update(testreport, ["noprepare", "noscript"])
+    # Pre/Post/Compare scripts must not have been run.
+    testreport.run_scripts.assert_not_called()
+    t1.unlock.assert_called()
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_update_runs_pre_post_and_compare_scripts(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """Default flow runs Pre, Post and Compare scripts when not in auto mode."""
+    from mtui.hooks import CompareScript, PostScript, PreScript
+
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.get_updater_check.return_value = MagicMock()
+    t1.get_preparer.return_value = _doer_dict(
+        command="zypper in $package", reboot="", start_command=""
+    )
+    t1.get_preparer_check.return_value = MagicMock()
+    t1.lasterr.return_value = ""
+    mock_queue.unfinished_tasks = 0
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1])
+    hg.perform_update(testreport, [])
+    # PreScript before update, Post + Compare after.
+    script_classes_called = [c.args[0] for c in testreport.run_scripts.call_args_list]
+    assert PreScript in script_classes_called
+    assert PostScript in script_classes_called
+    assert CompareScript in script_classes_called
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_update_unlocks_when_run_fails(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    mock_queue.unfinished_tasks = 0
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1])
+    mock_run.return_value.run.side_effect = RuntimeError("update boom")
+    with pytest.raises(RuntimeError, match="update boom"):
+        hg.perform_update(testreport, ["noprepare", "noscript"])
+    t1.unlock.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# remaining group report methods
+# ---------------------------------------------------------------------------
+
+
+@patch("mtui.target.hostgroup.RunCommand")
+def test_report_history_with_events_uses_grep(mock_run):
+    t1 = _stub_target("h1")
+    sink = MagicMock()
+    hg = HostsGroup([t1])
+    hg.report_history(sink, count=5, events=["state", "comment"])
+    cmd = mock_run.call_args[0][1]
+    assert "grep" in cmd
+    assert "-m 5" in cmd
+    t1.report_history.assert_called_once_with(sink)
+
+
+@patch("mtui.target.hostgroup.RunCommand")
+def test_report_history_without_events_uses_tail(mock_run):
+    t1 = _stub_target("h1")
+    sink = MagicMock()
+    hg = HostsGroup([t1])
+    hg.report_history(sink, count=10, events=[])
+    cmd = mock_run.call_args[0][1]
+    assert "tail -n 10" in cmd
+    t1.report_history.assert_called_once_with(sink)
+
+
+def test_report_sessions_delegates():
+    t1 = _stub_target("h1")
+    sink = MagicMock()
+    hg = HostsGroup([t1])
+    hg.report_sessions(sink)
+    t1.report_sessions.assert_called_once_with(sink)
+
+
+def test_report_log_delegates():
+    t1 = _stub_target("h1")
+    sink = MagicMock()
+    hg = HostsGroup([t1])
+    hg.report_log(sink, "arg")
+    t1.report_log.assert_called_once_with(sink, "arg")

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,6 +1,22 @@
+import subprocess
 from unittest.mock import MagicMock
 
-from mtui import prompt
+import pytest
+
+from mtui import messages, prompt
+from mtui.argparse import ArgsParseFailureError
+from mtui.template.nulltestreport import NullTestReport
+
+
+def _make_prompt(*, auto: bool = False, kernel: bool = False) -> prompt.CommandPrompt:
+    """Build a ``CommandPrompt`` with stock magic-mocked collaborators."""
+    config = MagicMock()
+    config.auto = auto
+    config.kernel = kernel
+    log = MagicMock()
+    sys = MagicMock()
+    display_factory = MagicMock()
+    return prompt.CommandPrompt(config, log, sys, display_factory)
 
 
 def test_command_prompt_init():
@@ -110,3 +126,229 @@ def test_cmdloop_quit_loop(monkeypatch):
     monkeypatch.setattr("cmd.Cmd.cmdloop", MagicMock(side_effect=prompt.QuitLoopError))
 
     p.cmdloop()  # Should exit cleanly
+
+
+def test_notify_user_calls_notification_display(monkeypatch):
+    """``notify_user`` is a thin wrapper around ``notification.display``."""
+    p = _make_prompt()
+    display = MagicMock()
+    monkeypatch.setattr(prompt.notification, "display", display)
+    p.notify_user("hello", class_="info")
+    display.assert_called_once_with("MTUI", "hello", "info")
+
+
+def test_read_history_swallows_oserror(monkeypatch, caplog):
+    """A missing/unreadable history file is logged at debug and ignored."""
+    monkeypatch.setattr(
+        prompt.readline,
+        "read_history_file",
+        MagicMock(side_effect=OSError("no such file")),
+    )
+    with caplog.at_level("DEBUG", logger="mtui.prompt"):
+        # Construction calls ``_read_history``; must not raise.
+        _make_prompt()
+    assert any("history file" in r.message for r in caplog.records)
+
+
+def test_add_subcommand_duplicate_raises():
+    """Re-registering a command name is a hard error."""
+    p = _make_prompt()
+    cmd_a = MagicMock()
+    cmd_a.command = "dup"
+    cmd_b = MagicMock()
+    cmd_b.command = "dup"
+    p._add_subcommand(cmd_a)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    with pytest.raises(prompt.CommandAlreadyBoundError, match="dup"):
+        p._add_subcommand(cmd_b)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+def test_set_cmdqueue_interactive_keeps_queue_as_is():
+    """Interactive sessions must not get an auto-appended ``quit``."""
+    p = _make_prompt()
+    p.interactive = True
+    p.set_cmdqueue(["a", "b"])
+    assert list(p.cmdqueue) == ["a", "b"]
+    assert isinstance(p.cmdqueue, prompt.CmdQueue)
+
+
+def test_set_cmdqueue_non_interactive_appends_quit():
+    """Non-interactive sessions terminate by appending ``quit``."""
+    p = _make_prompt()
+    p.interactive = False
+    p.set_cmdqueue(["a", "b"])
+    assert list(p.cmdqueue) == ["a", "b", "quit"]
+
+
+def test_cmdloop_user_message_logs_error_then_quits(monkeypatch, caplog):
+    """``UserMessage`` is logged at error level (non-debug path) and the loop continues."""
+    p = _make_prompt()
+    err = messages.NoRefhostsDefinedError()
+    monkeypatch.setattr(
+        "cmd.Cmd.cmdloop",
+        MagicMock(side_effect=[err, prompt.QuitLoopError]),
+    )
+    with caplog.at_level("ERROR", logger="mtui.prompt"):
+        p.cmdloop()
+    assert any("No refhosts defined" in r.message for r in caplog.records)
+
+
+def test_cmdloop_user_message_logs_traceback_in_debug(monkeypatch, caplog):
+    """When debug is enabled, ``UserMessage`` is logged with a traceback."""
+    p = _make_prompt()
+    monkeypatch.setattr(
+        "cmd.Cmd.cmdloop",
+        MagicMock(
+            side_effect=[messages.NoRefhostsDefinedError(), prompt.QuitLoopError]
+        ),
+    )
+    with caplog.at_level("DEBUG", logger="mtui.prompt"):
+        p.cmdloop()
+    assert any(r.exc_info is not None for r in caplog.records)
+
+
+def test_cmdloop_called_process_error_logs_and_continues(monkeypatch, caplog):
+    """``subprocess.CalledProcessError`` follows the same path as ``UserMessage``."""
+    p = _make_prompt()
+    err = subprocess.CalledProcessError(1, ["false"])
+    monkeypatch.setattr(
+        "cmd.Cmd.cmdloop",
+        MagicMock(side_effect=[err, prompt.QuitLoopError]),
+    )
+    with caplog.at_level("ERROR", logger="mtui.prompt"):
+        p.cmdloop()
+    assert any("false" in r.message or "1" in r.message for r in caplog.records)
+
+
+def test_cmdloop_unexpected_error_logs_and_continues(monkeypatch, caplog):
+    """Generic ``Exception`` is logged as 'Unexpected error' and the loop continues."""
+    p = _make_prompt()
+    monkeypatch.setattr(
+        "cmd.Cmd.cmdloop",
+        MagicMock(side_effect=[RuntimeError("kaboom"), prompt.QuitLoopError]),
+    )
+    with caplog.at_level("ERROR", logger="mtui.prompt"):
+        p.cmdloop()
+    assert any(
+        "Unexpected error" in r.message and "kaboom" in r.message
+        for r in caplog.records
+    )
+
+
+def test_cmdloop_unexpected_error_logs_traceback_in_debug(monkeypatch, caplog):
+    """In debug mode the unexpected-error path uses ``logger.exception``."""
+    p = _make_prompt()
+    monkeypatch.setattr(
+        "cmd.Cmd.cmdloop",
+        MagicMock(side_effect=[RuntimeError("kaboom"), prompt.QuitLoopError]),
+    )
+    with caplog.at_level("DEBUG", logger="mtui.prompt"):
+        p.cmdloop()
+    assert any(
+        r.exc_info is not None and "Unexpected error" in r.message
+        for r in caplog.records
+    )
+
+
+def test_postcmd_short_circuits_for_null_test_report():
+    """Until a real test report is loaded, ``postcmd`` must not touch the prompt."""
+    p = _make_prompt()
+    assert isinstance(p.metadata, NullTestReport)
+    original_prompt = p.prompt
+    assert p.postcmd(False, "noop") is False
+    assert p.prompt == original_prompt
+
+
+def test_postcmd_updates_prompt_when_metadata_loaded():
+    """With a real test report, ``postcmd`` refreshes the prompt with the session."""
+    p = _make_prompt()
+    p.metadata = MagicMock()  # not a NullTestReport
+    p.session = "sess1"
+    p.postcmd(False, "noop")
+    assert p.prompt == "mtui:sess1> "
+
+
+def test_get_names_includes_registered_commands():
+    """``get_names`` must surface ``do_X`` and ``help_X`` for every registered command."""
+    p = _make_prompt()
+    cmd = MagicMock()
+    cmd.command = "alpha"
+    p._add_subcommand(cmd)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    names = p.get_names()
+    assert "do_alpha" in names
+    assert "help_alpha" in names
+
+
+def test_do_handles_argsparse_failure(caplog):
+    """``do_*`` swallows ``ArgsParseFailureError`` and does not invoke the command."""
+    p = _make_prompt()
+    cmd = MagicMock()
+    cmd.command = "boom"
+    cmd.parse_args.side_effect = ArgsParseFailureError()
+    p._add_subcommand(cmd)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    p.do_boom("--bad")
+    cmd.assert_not_called()  # the command class itself must not be instantiated
+
+
+def test_complete_logs_and_reraises(caplog):
+    """``complete_*`` logs the exception then re-raises so readline sees it."""
+    p = _make_prompt()
+    cmd = MagicMock()
+    cmd.command = "alpha"
+    cmd.complete.side_effect = RuntimeError("comp-fail")
+    p._add_subcommand(cmd)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    with (
+        caplog.at_level("ERROR", logger="mtui.prompt"),
+        pytest.raises(RuntimeError, match="comp-fail"),
+    ):
+        p.complete_alpha("text", "line", 0, 1)
+    assert any(r.exc_info is not None for r in caplog.records)
+
+
+def test_getattr_unknown_attr_raises():
+    """Unknown attributes that don't match the do_/help_/complete_ prefixes raise."""
+    p = _make_prompt()
+    with pytest.raises(AttributeError, match="no_such_thing"):
+        p.no_such_thing  # noqa: B018  -- attribute access is the side effect under test
+
+
+def test_getattr_unknown_command_raises():
+    """do_/help_/complete_ for an unregistered command also raises ``AttributeError``."""
+    p = _make_prompt()
+    with pytest.raises(AttributeError):
+        p.do_nonexistent  # noqa: B018
+
+
+def test_emptyline_returns_false():
+    """An empty input line must not stop the loop and must not repeat the last command."""
+    p = _make_prompt()
+    assert p.emptyline() is False
+
+
+def test_set_prompt_auto_mode():
+    """``config.auto`` (and not kernel) renders the ``mtui-auto`` prefix."""
+    p = _make_prompt(auto=True, kernel=False)
+    p.set_prompt("s1")
+    assert p.prompt == "mtui-auto:s1> "
+
+
+def test_set_prompt_kernel_mode():
+    """``config.kernel`` overrides auto-mode and renders ``mtui-kernel``."""
+    p = _make_prompt(auto=True, kernel=True)
+    p.set_prompt(None)
+    assert p.prompt == "mtui-kernel> "
+
+
+def test_load_update_swaps_metadata_and_targets():
+    """``load_update`` installs the new test report and resets the prompt."""
+    p = _make_prompt()
+    new_targets = MagicMock()
+    new_tr = MagicMock(targets=new_targets)
+    update = MagicMock()
+    update.make_testreport.return_value = new_tr
+    p.load_update(update, autoconnect=False)
+    update.make_testreport.assert_called_once_with(p.config, False, p.interactive)
+    assert p.metadata is new_tr
+    assert p.targets is new_targets
+    # ``set_prompt(None)`` resets the session marker to empty.
+    assert p.prompt.endswith("> ")
+    assert ":" not in p.prompt

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -1,6 +1,17 @@
 """Tests for the mtui refhost module - specifically the eval() fix."""
 
+import errno
 import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui import refhost
+from mtui.messages import InvalidLocationError
+
+REFHOSTS_FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
 
 
 class TestArchListParsing:
@@ -59,3 +70,407 @@ class TestArchListParsing:
         content = "x86_64"
         capture = re.match(r"\[(.*)\]", content)
         assert capture is None
+
+
+# ---------------------------------------------------------------------------
+# Attributes
+# ---------------------------------------------------------------------------
+
+
+class TestAttributes:
+    """Public-API behaviour of ``Attributes``."""
+
+    def test_empty_attributes_is_falsy(self):
+        attr = refhost.Attributes()
+        assert not attr
+        assert str(attr) == ""
+
+    def test_str_with_product_major_only(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 12}}
+        assert str(attr) == "sles 12"
+
+    def test_str_with_product_int_minor_uses_dot(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 15, "minor": 5}}
+        assert str(attr) == "sles 15.5"
+
+    def test_str_with_product_string_minor_concatenated(self):
+        """SP-style minor versions render without a dot separator."""
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 12, "minor": "sp4"}}
+        assert str(attr) == "sles 12sp4"
+
+    def test_str_with_arch(self):
+        attr = refhost.Attributes()
+        attr.arch = "x86_64"
+        assert str(attr) == "x86_64"
+
+    def test_str_with_addons_sorted(self):
+        attr = refhost.Attributes()
+        attr.addons = [
+            {"name": "sdk", "version": {"major": 15, "minor": 5}},
+            {"name": "ha", "version": {"major": 15}},
+        ]
+        # Addons are sorted alphabetically.
+        assert str(attr) == "ha 15. sdk 15.5"
+
+    def test_repr_wraps_str(self):
+        attr = refhost.Attributes()
+        attr.arch = "x86_64"
+        assert repr(attr) == "<Attributes: x86_64>"
+
+
+class TestFromTestplatform:
+    """``Attributes.from_testplatform`` covers the documented testplatform DSL."""
+
+    def test_base_arch_addon_with_int_minor(self):
+        tp = (
+            "base=sles(major=11,minor=4);"
+            "arch=[i386,s390x,x86_64];"
+            "addon=sdk(major=11,minor=4)"
+        )
+        attrs = refhost.Attributes.from_testplatform(tp)
+        # One Attributes per arch.
+        assert [a.arch for a in attrs] == ["i386", "s390x", "x86_64"]
+        for a in attrs:
+            assert a.product == {
+                "name": "sles",
+                "version": {"major": 11, "minor": 4},
+            }
+            assert a.addons == [{"name": "sdk", "version": {"major": 11, "minor": 4}}]
+
+    def test_addon_with_string_minor_kept_as_string(self):
+        tp = "base=sles(major=12,minor=sp4);arch=[x86_64];addon=ha(major=12,minor=sp4)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        assert len(attrs) == 1
+        assert attrs[0].product["version"]["minor"] == "sp4"
+        assert attrs[0].addons[0]["version"]["minor"] == "sp4"
+
+    def test_addon_with_empty_minor(self):
+        """``minor=`` with no value sentinels a search-for-unset query."""
+        tp = "base=sles(major=11);arch=[x86_64];addon=sdk(major=11,minor=)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        assert attrs[0].addons[0]["version"] == {"major": 11, "minor": ""}
+
+    def test_addon_major_only(self):
+        tp = "base=sles(major=11);arch=[x86_64];addon=sdk(major=11)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        assert attrs[0].addons[0]["version"] == {"major": 11}
+
+    def test_tags_sets_named_attribute(self):
+        tp = "base=sles(major=15,minor=5);arch=[x86_64];tags=(kernel)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        # ``tags=(name)`` sets ``name`` as a dynamic attribute on Attributes.
+        assert getattr(attrs[0], "kernel") == {"enabled": True}  # noqa: B009
+
+    def test_malformed_segment_logged_and_skipped(self, caplog):
+        """A segment without ``=`` is logged at error and the rest still parses."""
+        tp = "garbage_no_equals;base=sles(major=15,minor=5);arch=[x86_64]"
+        with caplog.at_level("ERROR", logger="mtui.refhost"):
+            attrs = refhost.Attributes.from_testplatform(tp)
+        assert len(attrs) == 1
+        assert attrs[0].product["name"] == "sles"
+        assert any(
+            "garbage_no_equals" in r.message or "parsing" in r.message
+            for r in caplog.records
+        )
+
+    def test_no_arch_yields_empty_attribute_list(self):
+        """Without an ``arch=[…]`` segment, no Attributes are emitted at all."""
+        tp = "base=sles(major=15,minor=5)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        assert attrs == []
+
+    def test_unknown_property_setattr_branch(self):
+        """A non-base/non-addon complex property is set as a named attribute."""
+        tp = "base=sles(major=15);arch=[x86_64];other=thing(major=1)"
+        attrs = refhost.Attributes.from_testplatform(tp)
+        assert getattr(attrs[0], "other") == {  # noqa: B009
+            "name": "thing",
+            "version": {"major": 1},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Refhosts
+# ---------------------------------------------------------------------------
+
+
+class TestRefhosts:
+    """Public-API behaviour of ``Refhosts``."""
+
+    def test_init_defaults_to_default_location(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        assert rh.location == "default"
+
+    def test_init_with_explicit_location(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+        assert rh.location == "nuremberg"
+
+    def test_parse_refhosts_propagates_load_failure(self, tmp_path, caplog):
+        """A broken yml file is logged at error and re-raised."""
+        from ruamel.yaml import YAMLError
+
+        broken = tmp_path / "broken.yml"
+        broken.write_text("not: valid: yaml: at all: [")
+        with (
+            caplog.at_level("ERROR", logger="mtui.refhost"),
+            pytest.raises(YAMLError),
+        ):
+            refhost.Refhosts(broken)
+        assert any("failed to parse refhosts.yml" in r.message for r in caplog.records)
+
+    def test_get_locations(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        assert rh.get_locations() == {"default", "nuremberg"}
+
+    def test_check_location_sanity_known_location_returns_none(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        assert rh.check_location_sanity("nuremberg") is None
+
+    def test_check_location_sanity_unknown_location_raises(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        with pytest.raises(InvalidLocationError):
+            rh.check_location_sanity("atlantis")
+
+    def test_search_finds_host_in_current_location(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+        attrs = refhost.Attributes.from_testplatform(
+            "base=sles(major=15,minor=5);arch=[x86_64]"
+        )
+        assert rh.search(attrs) == ["host-nbg-x86"]
+
+    def test_search_falls_back_to_default_when_location_misses(self):
+        """When the configured location has no match, default location is checked."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+        attrs = refhost.Attributes.from_testplatform(
+            "base=sles(major=12,minor=sp4);arch=[x86_64]"
+        )
+        # Only present under ``default``.
+        assert rh.search(attrs) == ["host-default-noaddon"]
+
+    def test_search_returns_empty_when_no_match_anywhere(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attrs = refhost.Attributes.from_testplatform(
+            "base=sles(major=99,minor=99);arch=[mips]"
+        )
+        assert rh.search(attrs) == []
+
+    def test_search_addon_filter_excludes_hosts_missing_addon(self):
+        """Searching for sdk excludes hosts that don't list it."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attrs = refhost.Attributes.from_testplatform(
+            "base=sles(major=15,minor=5);arch=[x86_64];addon=sdk(major=15,minor=5)"
+        )
+        assert rh.search(attrs) == ["host-default-x86"]
+
+    def test_search_default_location_no_fallback(self):
+        """The fallback branch is skipped when already searching the default."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)  # default location
+        attrs = refhost.Attributes.from_testplatform(
+            "base=sles(major=99,minor=99);arch=[mips]"
+        )
+        assert rh.search(attrs) == []
+
+
+class TestIsCandidateMatch:
+    """Direct tests of the matcher to cover its branches."""
+
+    def setup_method(self):
+        self.rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+
+    def test_attribute_key_missing_in_candidate_returns_false(self):
+        attr = refhost.Attributes()
+        attr.arch = "x86_64"
+        candidate = {"name": "h", "product": {"name": "sles"}}  # no arch
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_scalar_mismatch_returns_false(self):
+        attr = refhost.Attributes()
+        attr.arch = "aarch64"
+        candidate = {"arch": "x86_64"}
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_scalar_match_returns_true(self):
+        attr = refhost.Attributes()
+        attr.arch = "x86_64"
+        candidate = {"arch": "x86_64"}
+        assert self.rh.is_candidate_match(candidate, attr) is True
+
+    def test_includes_version_empty_minor_excludes_when_candidate_has_minor(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 15, "minor": ""}}
+        candidate = {"product": {"name": "sles", "version": {"major": 15, "minor": 5}}}
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_includes_version_empty_minor_matches_when_candidate_has_no_minor(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 15, "minor": ""}}
+        candidate = {"product": {"name": "sles", "version": {"major": 15}}}
+        assert self.rh.is_candidate_match(candidate, attr) is True
+
+    def test_includes_version_minor_mismatch_returns_false(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 15, "minor": 5}}
+        candidate = {"product": {"name": "sles", "version": {"major": 15, "minor": 4}}}
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_includes_version_major_mismatch_returns_false(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "version": {"major": 15}}
+        candidate = {"product": {"name": "sles", "version": {"major": 12}}}
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_includes_simple_attributes_missing_key_returns_false(self):
+        attr = refhost.Attributes()
+        attr.product = {"name": "sles", "extra_key": "x"}
+        candidate = {"product": {"name": "sles"}}  # no extra_key
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+
+# ---------------------------------------------------------------------------
+# _RefhostsFactory
+# ---------------------------------------------------------------------------
+
+
+def _make_factory(**overrides):
+    """Build a ``_RefhostsFactory`` with all collaborators mocked."""
+    defaults: dict[str, object] = {
+        "time_now_getter": MagicMock(return_value=1_000_000),
+        "statter": MagicMock(),
+        "urlopener": MagicMock(),
+        "file_writer": MagicMock(),
+        "cache_path": Path("/tmp/refhosts.yml"),
+        "refhosts_factory": MagicMock(),
+    }
+    defaults.update(overrides)
+    return refhost._RefhostsFactory(**defaults)  # ty: ignore[invalid-argument-type]
+
+
+def _make_config(**overrides):
+    base: dict[str, object] = {
+        "refhosts_resolvers": "path",
+        "refhosts_path": REFHOSTS_FIXTURE,
+        "refhosts_https_uri": "https://example.invalid/refhosts.yml",
+        "refhosts_https_expiration": 3600,
+        "location": "default",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestRefhostsFactory:
+    def test_call_returns_first_successful_resolver(self):
+        factory = _make_factory()
+        cfg = _make_config(refhosts_resolvers="path")
+        rh = factory(cfg)
+        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "default")
+        assert rh is factory.refhosts_factory.return_value
+
+    def test_call_falls_back_to_next_resolver_on_failure(self, caplog):
+        """A failing first resolver is logged and the second one is tried."""
+        factory = _make_factory()
+        # First resolver name is invalid (no resolve_invalid method).
+        cfg = _make_config(refhosts_resolvers="invalid,path")
+        with caplog.at_level("DEBUG", logger="mtui.refhost"):
+            factory(cfg)
+        assert any("invalid" in r.message for r in caplog.records)
+        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "default")
+
+    def test_call_raises_when_all_resolvers_fail(self):
+        factory = _make_factory()
+        cfg = _make_config(refhosts_resolvers="invalid_a,invalid_b")
+        with pytest.raises(refhost.RefhostsResolveFailedError):
+            factory(cfg)
+
+    def test_resolve_one_unknown_resolver_logs_and_raises(self, caplog):
+        factory = _make_factory()
+        cfg = _make_config()
+        with (
+            caplog.at_level("WARNING", logger="mtui.refhost"),
+            pytest.raises(AttributeError),
+        ):
+            factory._resolve_one("nonexistent", cfg)
+        assert any("invalid resolver" in r.message for r in caplog.records)
+
+    def test_is_https_cache_refresh_needed_missing_file(self):
+        statter = MagicMock(side_effect=OSError(errno.ENOENT, "missing"))
+        factory = _make_factory(statter=statter)
+        assert factory._is_https_cache_refresh_needed(Path("/nope"), 3600) is True
+
+    def test_is_https_cache_refresh_needed_other_oserror_raises(self):
+        statter = MagicMock(side_effect=OSError(errno.EACCES, "denied"))
+        factory = _make_factory(statter=statter)
+        with pytest.raises(OSError, match="denied"):
+            factory._is_https_cache_refresh_needed(Path("/denied"), 3600)
+
+    def test_is_https_cache_refresh_needed_fresh_cache(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
+        factory = _make_factory(
+            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
+        )
+        # delta = 1; expiration = 3600 → no refresh.
+        assert factory._is_https_cache_refresh_needed(Path("/x"), 3600) is False
+
+    def test_is_https_cache_refresh_needed_stale_cache(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=0))
+        factory = _make_factory(
+            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
+        )
+        assert factory._is_https_cache_refresh_needed(Path("/x"), 3600) is True
+
+    def test_refresh_https_cache_writes_url_payload(self):
+        url_resp = MagicMock()
+        url_resp.read.return_value = b"yaml-bytes"
+        urlopener = MagicMock(return_value=url_resp)
+        file_writer = MagicMock()
+        factory = _make_factory(urlopener=urlopener, file_writer=file_writer)
+        factory.refresh_https_cache(Path("/dst"), "https://x/refhosts.yml")
+        urlopener.assert_called_once_with("https://x/refhosts.yml")
+        file_writer.assert_called_once_with(b"yaml-bytes", Path("/dst"))
+
+    def test_refresh_https_cache_if_needed_skips_when_fresh(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
+        factory = _make_factory(
+            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
+        )
+        # urlopener untouched.
+        factory.refresh_https_cache_if_needed(Path("/x"), _make_config())
+        factory._urlopen.assert_not_called()
+
+    def test_refresh_https_cache_if_needed_refreshes_when_stale(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=0))
+        url_resp = MagicMock()
+        url_resp.read.return_value = b"payload"
+        urlopener = MagicMock(return_value=url_resp)
+        file_writer = MagicMock()
+        factory = _make_factory(
+            statter=statter,
+            time_now_getter=MagicMock(return_value=1_000_000),
+            urlopener=urlopener,
+            file_writer=file_writer,
+        )
+        factory.refresh_https_cache_if_needed(Path("/x"), _make_config())
+        urlopener.assert_called_once()
+        file_writer.assert_called_once_with(b"payload", Path("/x"))
+
+    def test_resolve_https_uses_cache_path(self):
+        """``resolve_https`` runs the cache-refresh check then builds via the factory."""
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
+        factory = _make_factory(
+            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
+        )
+        cfg = _make_config(location="nuremberg")
+        rh = factory.resolve_https(cfg)
+        factory.refhosts_factory.assert_called_once_with(
+            factory.refhosts_cache_path, "nuremberg"
+        )
+        assert rh is factory.refhosts_factory.return_value
+
+    def test_resolve_path_uses_configured_path(self):
+        factory = _make_factory()
+        cfg = _make_config(location="nuremberg")
+        rh = factory.resolve_path(cfg)
+        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "nuremberg")
+        assert rh is factory.refhosts_factory.return_value

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,8 +1,13 @@
 """Tests for the mtui target module."""
 
+import errno
+from pathlib import Path
+from string import Template
 from unittest.mock import MagicMock
 
-from mtui.target import Target
+import pytest
+
+from mtui.target import Target, TargetLockedError
 from mtui.types import HostLog, Package
 from mtui.types.product import Product
 from mtui.types.rpmver import RPMVersion
@@ -437,3 +442,508 @@ def test_target_set_dedup_by_hostname(mock_config):
     t2 = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
 
     assert len({t1, t2}) == 1
+
+
+# ---------------------------------------------------------------------------
+# connect  # noqa: ERA001
+# ---------------------------------------------------------------------------
+
+
+def test_connect_success_wires_up_lock_and_system(mock_config, monkeypatch):
+    """Successful connect builds a connection, lock, parses system + packages."""
+    conn_class = MagicMock()
+    lock_class = MagicMock()
+    lock_class.return_value.is_locked.return_value = False
+    fake_system = MagicMock()
+    fake_system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
+    monkeypatch.setattr(
+        "mtui.target.target.parse_system", lambda _conn: (fake_system, False)
+    )
+    target = Target(  # type: ignore[arg-type]
+        mock_config,
+        "host.example.com",
+        connection=conn_class,  # ty: ignore[invalid-argument-type]
+        lock=lock_class,  # ty: ignore[invalid-argument-type]
+    )
+    target.connect()
+    conn_class.assert_called_once()
+    assert target.connection is conn_class.return_value
+    assert target.system is fake_system
+    assert target.transactional is False
+
+
+def test_connect_warns_when_already_locked(mock_config, monkeypatch, caplog):
+    """A pre-existing lock is logged at warning but does not abort connect."""
+    conn_class = MagicMock()
+    lock_class = MagicMock()
+    lock_class.return_value.is_locked.return_value = True
+    lock_class.return_value.locked_by_msg.return_value = "locked by alice"
+    fake_system = MagicMock()
+    fake_system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
+    monkeypatch.setattr(
+        "mtui.target.target.parse_system", lambda _conn: (fake_system, False)
+    )
+    target = Target(  # type: ignore[arg-type]
+        mock_config,
+        "host.example.com",
+        connection=conn_class,  # ty: ignore[invalid-argument-type]
+        lock=lock_class,  # ty: ignore[invalid-argument-type]
+    )
+    with caplog.at_level("WARNING", logger="mtui.target"):
+        target.connect()
+    assert any("locked by alice" in r.message for r in caplog.records)
+
+
+def test_connect_failure_logs_critical_and_reraises(mock_config, caplog):
+    """A connection-time exception is logged at critical and propagated."""
+    conn_class = MagicMock(side_effect=OSError("network down"))
+    target = Target(  # type: ignore[arg-type]
+        mock_config,
+        "host.example.com",
+        connection=conn_class,  # ty: ignore[invalid-argument-type]
+    )
+    with (
+        caplog.at_level("CRITICAL", logger="mtui.target"),
+        pytest.raises(OSError, match="network down"),
+    ):
+        target.connect()
+    assert any("host.example.com" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# reload_system / set_repo
+# ---------------------------------------------------------------------------
+
+
+def test_reload_system_replaces_system_and_transactional(mock_config, monkeypatch):
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.connection = MagicMock()
+    new_system = MagicMock()
+    monkeypatch.setattr(
+        "mtui.target.target.parse_system", lambda _conn: (new_system, True)
+    )
+    target.reload_system()
+    assert target.system is new_system
+    assert target.transactional is True
+
+
+def test_set_repo_delegates_to_testreport(mock_config):
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    tr = MagicMock()
+    target.set_repo("add", tr)
+    tr.set_repo.assert_called_once_with(target, "add")
+
+
+# ---------------------------------------------------------------------------
+# query_versions / query_package_versions
+# ---------------------------------------------------------------------------
+
+
+def test_query_versions_enabled_updates_packages(mock_target, monkeypatch):
+    """``enabled`` calls ``query_package_versions`` and updates ``Package.current``."""
+    mock_target.state = "enabled"
+    new_versions = {"bash": RPMVersion("5.2-1"), "openssl": RPMVersion("3.0.9-1")}
+    monkeypatch.setattr(
+        Target, "query_package_versions", lambda self, pkgs: new_versions
+    )
+    mock_target.query_versions()
+    assert mock_target.packages["bash"].current == RPMVersion("5.2-1")
+    assert mock_target.packages["openssl"].current == RPMVersion("3.0.9-1")
+
+
+def test_query_versions_dryrun_logs_and_appends(mock_config):
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.state = "dryrun"  # ty: ignore[invalid-assignment]
+    target.packages = {"bash": Package("bash")}
+    target.query_versions()
+    assert target.lastout() == "dryrun\n"
+
+
+def test_query_versions_disabled_appends_empty(mock_config):
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.state = "disabled"
+    target.packages = {"bash": Package("bash")}
+    target.query_versions()
+    assert target.lastout() == ""
+    assert target.lastexit() == 0
+
+
+def test_query_package_versions_rpm_path(mock_target):
+    """Non-ubuntu systems use ``rpm -q``."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = "bash 5.1-1\nopenssl 3.0-1\n"
+    mock_target.connection.stderr = ""
+    out = mock_target.query_package_versions(["bash", "openssl"])
+    cmd = mock_target.connection.run.call_args[0][0]
+    assert cmd.startswith("rpm -q")
+    assert out["bash"] == RPMVersion("5.1-1")
+    assert out["openssl"] == RPMVersion("3.0-1")
+
+
+def test_query_package_versions_ubuntu_path(mock_target):
+    """Ubuntu systems use ``dpkg-query``."""
+    mock_target.system = MagicMock()
+    mock_target.system.get_base.return_value = Product("ubuntu", "22.04", "x86_64")
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = "bash 5.1-1\n"
+    mock_target.connection.stderr = ""
+    mock_target.query_package_versions(["bash"])
+    cmd = mock_target.connection.run.call_args[0][0]
+    assert cmd.startswith("dpkg-query")
+
+
+def test_query_package_versions_not_installed_returns_none(mock_target):
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = "package missing-pkg is not installed\n"
+    mock_target.connection.stderr = ""
+    out = mock_target.query_package_versions(["missing-pkg"])
+    assert out == {"missing-pkg": None}
+
+
+def test_query_package_versions_keeps_max_on_duplicate(mock_target):
+    """Duplicate package lines collapse to the highest version."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = "bash 5.0-1\nbash 5.2-1\nbash 5.1-1\n"
+    mock_target.connection.stderr = ""
+    out = mock_target.query_package_versions(["bash"])
+    assert out["bash"] == RPMVersion("5.2-1")
+
+
+# ---------------------------------------------------------------------------
+# run_zypper
+# ---------------------------------------------------------------------------
+
+
+def test_run_zypper_ar_emits_add_command(mock_target, mock_rrid):
+    """``ar`` (add-repo) builds an issue-* alias and runs zypper ar."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    mock_target.run_zypper("ar", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert any("zypper ar" in c and "issue-SLES" in c for c in commands)
+    assert commands[-1] == "zypper -n ref"
+
+
+def test_run_zypper_rr_emits_remove_command(mock_target, mock_rrid):
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    mock_target.run_zypper("rr", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert any("zypper rr https://example/repo" in c for c in commands)
+
+
+def test_run_zypper_unknown_command_unlocks_and_raises(mock_target, mock_rrid):
+    mock_target.state = "enabled"
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    with pytest.raises(ValueError):  # noqa: PT011  -- bare ValueError raised by run_zypper
+        mock_target.run_zypper("nosuch", repos, mock_rrid)
+    mock_target._lock.unlock.assert_called_with(True)
+
+
+# ---------------------------------------------------------------------------
+# run() additional branches
+# ---------------------------------------------------------------------------
+
+
+def test_run_assertion_error_swallowed_with_debug_log(mock_config, caplog):
+    """A zombie ``AssertionError`` from the connection is swallowed at debug level."""
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.connection = MagicMock()
+    target.connection.run.side_effect = AssertionError("zombie")
+    target.state = "enabled"
+    with caplog.at_level("DEBUG", logger="mtui.target"):
+        target.run("noop")
+    assert target.out == []  # nothing appended on this branch
+    assert any("zombie" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# shell  # noqa: ERA001
+# ---------------------------------------------------------------------------
+
+
+def test_shell_delegates_to_connection(mock_target):
+    mock_target.shell()
+    mock_target.connection.shell.assert_called_once()
+
+
+def test_shell_logs_on_failure(mock_target, caplog):
+    mock_target.connection.shell.side_effect = RuntimeError("no tty")
+    with caplog.at_level("ERROR", logger="mtui.target"):
+        mock_target.shell()
+    assert any("failed to spawn shell" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# sftp_put / sftp_get
+# ---------------------------------------------------------------------------
+
+
+def test_sftp_put_oserror_logged(mock_target, caplog):
+    mock_target.state = "enabled"
+    mock_target.connection.sftp_put.side_effect = OSError("disk full")
+    with caplog.at_level("ERROR", logger="mtui.target"):
+        mock_target.sftp_put(Path("/local"), Path("/remote"))
+    assert any("failed to send" in r.message for r in caplog.records)
+
+
+def test_sftp_get_file_enabled(mock_target):
+    mock_target.state = "enabled"
+    mock_target.sftp_get(Path("/remote/file"), Path("/local/file"))
+    mock_target.connection.sftp_get.assert_called_once()
+    mock_target.connection.sftp_get_folder.assert_not_called()
+
+
+def test_sftp_get_folder_enabled(mock_target):
+    """Trailing-slash remote uses ``sftp_get_folder``.
+
+    NB: the parameter is typed ``Path`` but ``Path('/x/') == Path('/x')`` so
+    the trailing-slash branch is only reachable when callers pass a raw
+    string (or a string-coerced ``Path``). This locks in that behaviour.
+    """
+    mock_target.state = "enabled"
+    mock_target.sftp_get("/remote/dir/", Path("/local"))
+    mock_target.connection.sftp_get_folder.assert_called_once()
+    mock_target.connection.sftp_get.assert_not_called()
+
+
+def test_sftp_get_dryrun_does_nothing(mock_target):
+    mock_target.state = "dryrun"
+    mock_target.sftp_get(Path("/remote/file"), Path("/local"))
+    mock_target.connection.sftp_get.assert_not_called()
+    mock_target.connection.sftp_get_folder.assert_not_called()
+
+
+def test_sftp_get_oserror_logged(mock_target, caplog):
+    mock_target.state = "enabled"
+    mock_target.connection.sftp_get.side_effect = OSError("perm denied")
+    with caplog.at_level("ERROR", logger="mtui.target"):
+        mock_target.sftp_get(Path("/remote/file"), Path("/local"))
+    assert any("failed to get" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# is_locked / unlock
+# ---------------------------------------------------------------------------
+
+
+def test_is_locked_delegates(mock_target):
+    mock_target._lock.is_locked.return_value = True
+    assert mock_target.is_locked() is True
+
+
+def test_unlock_target_locked_reraises(mock_target, caplog):
+    mock_target._lock.unlock.side_effect = TargetLockedError(
+        {"user": "bob", "timestamp": "now", "comment": ""}
+    )
+    with (
+        caplog.at_level("WARNING", logger="mtui.target"),
+        pytest.raises(TargetLockedError),
+    ):
+        mock_target.unlock()
+
+
+# ---------------------------------------------------------------------------
+# add_history
+# ---------------------------------------------------------------------------
+
+
+def test_add_history_writes_entry(mock_target):
+    mock_target.state = "enabled"
+    fh = MagicMock()
+    mock_target.connection.sftp_open.return_value = fh
+    mock_target.add_history(["update", "msg"])
+    fh.write.assert_called_once()
+    fh.close.assert_called_once()
+
+
+def test_add_history_logs_when_open_fails(mock_target, caplog):
+    mock_target.state = "enabled"
+    mock_target.connection.sftp_open.side_effect = OSError("perm")
+    with caplog.at_level("ERROR", logger="mtui.target"):
+        mock_target.add_history(["update", "msg"])
+    assert any("failed to open history file" in r.message for r in caplog.records)
+
+
+def test_add_history_swallows_write_failure(mock_target):
+    """Write/close failures are silently swallowed (current behaviour)."""
+    mock_target.state = "enabled"
+    fh = MagicMock()
+    fh.write.side_effect = OSError("write failed")
+    mock_target.connection.sftp_open.return_value = fh
+    # Must not raise.
+    mock_target.add_history(["update", "msg"])
+
+
+# ---------------------------------------------------------------------------
+# sftp_listdir / sftp_remove
+# ---------------------------------------------------------------------------
+
+
+def test_sftp_listdir_returns_connection_result(mock_target):
+    mock_target.connection.sftp_listdir.return_value = ["a", "b"]
+    assert mock_target.sftp_listdir(Path("/")) == ["a", "b"]
+
+
+def test_sftp_listdir_enoent_returns_empty(mock_target, caplog):
+    err = OSError(errno.ENOENT, "missing")
+    mock_target.connection.sftp_listdir.side_effect = err
+    with caplog.at_level("DEBUG", logger="mtui.target"):
+        assert mock_target.sftp_listdir(Path("/nope")) == []
+
+
+def test_sftp_remove_file_success(mock_target):
+    mock_target.sftp_remove(Path("/some/file"))
+    mock_target.connection.sftp_remove.assert_called_once()
+    mock_target.connection.sftp_rmdir.assert_not_called()
+
+
+def test_sftp_remove_enoent_logged_silently(mock_target, caplog):
+    mock_target.connection.sftp_remove.side_effect = OSError(errno.ENOENT, "missing")
+    with caplog.at_level("DEBUG", logger="mtui.target"):
+        mock_target.sftp_remove(Path("/missing"))
+    mock_target.connection.sftp_rmdir.assert_not_called()
+
+
+def test_sftp_remove_other_oserror_falls_back_to_rmdir(mock_target):
+    """Non-ENOENT OSError on remove is treated as 'might be a directory'."""
+    mock_target.connection.sftp_remove.side_effect = OSError(errno.EISDIR, "is dir")
+    mock_target.sftp_remove(Path("/some/dir"))
+    mock_target.connection.sftp_rmdir.assert_called_once()
+
+
+def test_sftp_remove_rmdir_failure_warns(mock_target, caplog):
+    mock_target.connection.sftp_remove.side_effect = OSError(errno.EISDIR, "is dir")
+    mock_target.connection.sftp_rmdir.side_effect = OSError("nonempty")
+    with caplog.at_level("WARNING", logger="mtui.target"):
+        mock_target.sftp_remove(Path("/some/dir"))
+    assert any("unable to remove" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# close additional branches
+# ---------------------------------------------------------------------------
+
+
+def test_close_poweroff(mock_target):
+    mock_target.connection.is_active.return_value = True
+    mock_target.state = "enabled"
+    mock_target.close(action="poweroff")
+    halt_calls = [
+        c for c in mock_target.connection.run.call_args_list if "halt" in str(c)
+    ]
+    assert halt_calls
+    mock_target.connection.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# remaining report_* sinks
+# ---------------------------------------------------------------------------
+
+
+def test_report_locks_calls_sink(mock_target):
+    sink = MagicMock()
+    mock_target.report_locks(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname, mock_target.system, mock_target._lock
+    )
+
+
+def test_report_sessions_calls_sink(mock_target):
+    sink = MagicMock()
+    mock_target.out = HostLog()
+    mock_target.out.append(["who", "alice tty1\n", "", 0, 0])
+    mock_target.report_sessions(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname, mock_target.system, "alice tty1\n"
+    )
+
+
+def test_report_log_calls_sink_with_full_outlog(mock_target):
+    sink = MagicMock()
+    mock_target.out = HostLog()
+    mock_target.report_log(sink, "some-arg")
+    sink.assert_called_once_with(mock_target.hostname, mock_target.out, "some-arg")
+
+
+def test_report_products_calls_sink(mock_target):
+    sink = MagicMock()
+    mock_target.report_products(sink)
+    sink.assert_called_once_with(mock_target.hostname, mock_target.system)
+
+
+# ---------------------------------------------------------------------------
+# Doer / check getters
+# ---------------------------------------------------------------------------
+
+
+def _target_with_release(mock_config, release: str = "15", transactional: bool = False):
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.system = MagicMock()
+    target.system.get_release.return_value = release
+    target.transactional = transactional
+    return target
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get_installer",
+        "get_uninstaller",
+        "get_downgrader",
+        "get_updater",
+    ],
+)
+def test_doer_getters_return_command_template_dict(mock_config, method):
+    """All non-preparer doer getters yield a ``{name: Template}`` mapping for SLES 15."""
+    target = _target_with_release(mock_config)
+    result = getattr(target, method)()
+    assert isinstance(result, dict)
+    assert all(isinstance(v, Template) for v in result.values())
+
+
+def test_get_preparer_invokes_factory_with_force_and_testing(mock_config):
+    """``preparer`` is ``Callable``; the getter forwards force/testing flags."""
+    target = _target_with_release(mock_config)
+    result = target.get_preparer(force=True, testing=True)
+    assert isinstance(result, dict)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get_installer_check",
+        "get_uninstaller_check",
+        "get_downgrader_check",
+        "get_updater_check",
+        "get_preparer_check",
+    ],
+)
+def test_check_getters_return_callable(mock_config, method):
+    target = _target_with_release(mock_config)
+    fn = getattr(target, method)()
+    assert callable(fn)
+
+
+def test_check_getter_returns_no_checks_for_unknown_release(mock_config):
+    """Unknown ``(release, transactional)`` combinations fall back to the no-op."""
+    from mtui.target.target import _no_checks
+
+    target = _target_with_release(mock_config, release="9999", transactional=False)
+    assert target.get_installer_check() is _no_checks


### PR DESCRIPTION
## Summary

Adds public-API regression tests covering the previously undertested
modules in `mtui/`. Project test coverage rises from 58 % to 67 %; per
the standing 'current minus one' policy the Codecov project floor is
moved from 56 to 66 (patch target unchanged at 80).

## Per-module coverage

| Module                       | Before | After | Tests added |
| ---------------------------- | ------ | ----- | ----------- |
| `mtui/config.py`             | 88 %   | 99 %  | +10 |
| `mtui/prompt.py`             | 73 %   | 100 % | +21 |
| `mtui/refhost.py`            | 26 %   | 98 %  | +47 |
| `mtui/target/target.py`      | 56 %   | 99 %  | +50 |
| `mtui/target/hostgroup.py`   | 42 %   | 89 %  | +22 |
| `mtui/connection.py`         | 44 %   | 85 %  | +32 |

Total suite: 351 → 532 passing tests. No production code was
modified; this PR is tests + one CHANGELOG entry + one `codecov.yml`
floor bump.

## Behaviour locked in (worth a closer review)

While writing characterization tests for `mtui/config.py` two
pre-existing bugs surfaced. Both are now under regression tests with
inline `FIXME` comments so they are visible to the next person who
touches `Config`:

1. `_parse_config` runs `fixup(val)` outside its `try/except`, so a
   non-numeric value for `connection_timeout` (e.g.
   `connection_timeout = abc` under `[mtui]`) crashes
   `Config.__init__` with `ValueError` instead of falling back to the
   documented default of 300 seconds.
2. `_get_option`'s error-logging path (lines 298–301) calls
   `msg.format((*secopt, self.configfiles))`, which passes a single
   tuple to a format string expecting three positional args. The
   `format()` call itself raises before `logger.error` can run, so a
   bad value for any `getint`/`getboolean` option
   (`refhosts.https_expiration`, `template.smelt_threshold`,
   `mtui.chdir_to_template_dir`, `mtui.use_keyring`) is silently
   replaced by the default with no diagnostic in the logs. The
   default is correct; only the error message is missing.

Both are also documented under `### Known issues` in `CHANGELOG.md`.

A handful of smaller findings are noted inline (no FIXME, just locked
in):

- `Target.sftp_get`'s "trailing slash → folder mode" branch is
  unreachable when callers pass a real `Path` because
  `Path('/x/') == Path('/x')`. Only string callers exercise it.
- `Connection.sftp_open`'s `isinstance(sftp, SFTPClient)` guard makes
  the close-on-failure branch unreachable in any test that mocks the
  SFTP collaborator. The public `log + re-raise` contract is what's
  asserted.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (532 passed)
- `uv run --group doc sphinx-build -W -b html Documentation /tmp/x`
- `uv run python -m mtui --help` and `-V`