### PR TITLE
refactor(types): introduce TargetState, ExecutionMode, RequestKind enums (Phase 5b / C9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   message, due to a malformed format string in the error path. The
   default behaviour is correct but the diagnostic is missing.
 
+### Fixed
+- `Target.state` is now validated at construction; previously the
+  Literal type annotation listed `serial`/`parallel` (which are not
+  valid states, only execution modes) and omitted `dryrun` (which is).
+  The C9 refactor introduces a `TargetState` enum that rejects invalid
+  values with a clear `ValueError` instead of letting them sit in the
+  field and silently misroute downstream branches.
+
 ## [Phase 3] — CI / tooling
 
 ### Added

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -16,6 +16,7 @@ from ..argparse import ArgumentParser
 from ..commands import Command
 from ..connector import OSC, Gitea
 from ..exceptions import GiteaError, InvalidGiteaHashError
+from ..types import RequestKind
 from ..utils import complete_choices, prompt_user, requires_update
 
 logger = getLogger("mtui.command.apicalls")
@@ -46,7 +47,7 @@ class BaseApiCall(Command, ABC):
     def _is_gitea_workflow(self) -> bool:
         """Determines if the request should be handled by the Gitea API."""
         rrid = self.metadata.rrid
-        return rrid.kind == "SLFO" and rrid.maintenance_id != "1.1"
+        return rrid.kind is RequestKind.SLFO and rrid.maintenance_id != "1.1"
 
     @requires_update
     def __call__(self) -> None:

--- a/mtui/commands/hoststate.py
+++ b/mtui/commands/hoststate.py
@@ -3,6 +3,7 @@
 from logging import getLogger
 
 from mtui.commands import Command
+from mtui.types import ExecutionMode
 from mtui.utils import complete_choices
 
 logger = getLogger("mtui.command.hoststate")
@@ -35,18 +36,16 @@ class HostState(Command):
         """Executes the `set_host_state` command."""
         targets = self.parse_hosts(enabled=False)
         state = self.args.state[0]
-        if state in ["serial", "parallel"]:
-            if state == "serial":
-                exclusive = True
-            elif state == "parallel":
-                exclusive = False
-            for target in targets:
-                logger.info("Setting host %s mode to %s", target, state)
-                targets[target].exclusive = exclusive
-        else:
-            for target in targets:
-                logger.info("Setting host %s state to %s", target, state)
-                targets[target].state = state
+        match state:
+            case "serial" | "parallel":
+                mode = ExecutionMode(state)
+                for target in targets:
+                    logger.info("Setting host %s mode to %s", target, state)
+                    targets[target].mode = mode
+            case _:
+                for target in targets:
+                    logger.info("Setting host %s state to %s", target, state)
+                    targets[target].state = state
 
     @staticmethod
     def complete(state, text, line, begidx, endidx):

--- a/mtui/connector/openqa/base.py
+++ b/mtui/connector/openqa/base.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Self
 import openqa_client.exceptions
 from openqa_client.client import OpenQA_Client as oqa
 
-from ...types import RequestReviewID, Test, URLs
+from ...types import RequestKind, RequestReviewID, Test, URLs
 
 logger = getLogger("mtui.connector.openqa")
 
@@ -36,7 +36,7 @@ class OpenQA(ABC):
         self.params["scope"] = "relevant"
         self.params["latest"] = 1
         # New format of build
-        prefix = "git" if rrid.kind == "SLFO" else "smelt"
+        prefix = "git" if rrid.kind is RequestKind.SLFO else "smelt"
         self.params["build"] = (
             f":{prefix}:{rrid.maintenance_id}:{incident.get_incident_name()}"
         )

--- a/mtui/connector/oscqam.py
+++ b/mtui/connector/oscqam.py
@@ -6,6 +6,7 @@ from shlex import quote
 from subprocess import CalledProcessError, check_call
 
 from ..config import Config
+from ..types.enums import RequestKind
 from ..types.rrid import RequestReviewID
 
 logger = getLogger("mtui.connector.oscqam")
@@ -66,7 +67,7 @@ class OSC:
         skip_args = (
             ["--skip-template"]
             if (
-                self.rrid.kind in ("PI", "SLFO")
+                self.rrid.kind in (RequestKind.PI, RequestKind.SLFO)
                 and operation in ("assign", "approve", "reject")
             )
             else []

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -6,7 +6,7 @@ from typing import Any, Self
 
 import requests
 
-from ..types import RequestReviewID, URLs
+from ..types import RequestKind, RequestReviewID, URLs
 
 logger = getLogger("mtui.connector.qem_dashboard")
 
@@ -60,7 +60,7 @@ class QEMIncident:
 
     @staticmethod
     def _incident_number(rrid: RequestReviewID) -> str | int:
-        if rrid.kind == "SLFO" and rrid.maintenance_id == "1.2":
+        if rrid.kind is RequestKind.SLFO and rrid.maintenance_id == "1.2":
             return rrid.review_id
         return rrid.maintenance_id
 

--- a/mtui/display.py
+++ b/mtui/display.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import IO, Any
 
 from .target.hostgroup import HostsGroup
-from .types import RPMVersion, System
+from .types import RPMVersion, System, TargetState
 from .utils import green, red, yellow
 
 
@@ -90,7 +90,7 @@ class CommandPromptDisplay:
         hostname: str,
         system: System,
         transactional: bool,
-        state: str,
+        state: TargetState | str,
         exclusive: str,
     ) -> None:
         """Displays the status of a host.
@@ -105,12 +105,13 @@ class CommandPromptDisplay:
         """
         mode = "serial" if exclusive else "parallel"
 
-        if state == "enabled":
-            state = green("Enabled")
-        elif state == "dryrun":
-            state = yellow("Dryrun")
-        else:
-            state = red("Disabled")
+        match state:
+            case TargetState.ENABLED:
+                state = green("Enabled")
+            case TargetState.DRYRUN:
+                state = yellow("Dryrun")
+            case _:
+                state = red("Disabled")
 
         trn = red("transactional") if transactional else green("standard     ")
 

--- a/mtui/display.py
+++ b/mtui/display.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import IO, Any
 
 from .target.hostgroup import HostsGroup
-from .types import RPMVersion, System, TargetState
+from .types import ExecutionMode, RPMVersion, System, TargetState
 from .utils import green, red, yellow
 
 
@@ -91,7 +91,7 @@ class CommandPromptDisplay:
         system: System,
         transactional: bool,
         state: TargetState | str,
-        exclusive: str,
+        mode: ExecutionMode,
     ) -> None:
         """Displays the status of a host.
 
@@ -100,10 +100,10 @@ class CommandPromptDisplay:
             system: The system information for the host.
             transactional: Whether the host is transactional.
             state: The state of the host (enabled, disabled, or dryrun).
-            exclusive: Whether the host is in exclusive mode.
+            mode: Whether the host runs in parallel or serial mode.
 
         """
-        mode = "serial" if exclusive else "parallel"
+        mode_label = mode.value
 
         match state:
             case TargetState.ENABLED:
@@ -116,7 +116,7 @@ class CommandPromptDisplay:
         trn = red("transactional") if transactional else green("standard     ")
 
         self.println(
-            f"{hostname:<20} ({system!s:<28}): {state:<8} - {trn:<15} - ({mode})"
+            f"{hostname:<20} ({system!s:<28}): {state:<8} - {trn:<15} - ({mode_label})"
         )
 
     def list_locks(self, hostname: str, system: System, lock) -> None:

--- a/mtui/target/actions.py
+++ b/mtui/target/actions.py
@@ -13,6 +13,7 @@ from queue import Empty, Queue
 from threading import Lock
 from typing import Any
 
+from ..types import ExecutionMode
 from ..utils import prompt_user
 from . import Target
 
@@ -203,7 +204,7 @@ class RunCommand:
         lock = Lock()
 
         for target in self.targets:
-            if self.targets[target].exclusive:
+            if self.targets[target].mode is ExecutionMode.SERIAL:
                 serial[target] = self.targets[target]
             else:
                 parallel[target] = self.targets[target]

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -15,7 +15,7 @@ from ..checks import downgrade_checks, install_checks, prepare_checks, update_ch
 from ..config import Config
 from ..connection import CommandTimeoutError, Connection, policy_from_config
 from ..target.parsers import parse_system
-from ..types import HostLog, Package, System, TargetState
+from ..types import ExecutionMode, HostLog, Package, System, TargetState
 from ..types.rpmver import RPMVersion
 from ..utils import timestamp
 from . import TargetLock, TargetLockedError
@@ -42,7 +42,7 @@ class Target:
         packages: dict[str, dict[str, str]] | None = None,
         state: TargetState | str = TargetState.ENABLED,
         timeout: int = 300,
-        exclusive: bool = False,
+        mode: ExecutionMode = ExecutionMode.PARALLEL,
         lock: type[TargetLock] = TargetLock,
         connection: type[Connection] = Connection,
     ) -> None:
@@ -54,7 +54,8 @@ class Target:
             packages: A dictionary of packages for the target.
             state: The initial state of the target.
             timeout: The command timeout for the target.
-            exclusive: Whether the target is in exclusive mode.
+            mode: Whether the target runs commands in parallel with the
+                rest of its group or holds the group in a serial barrier.
             lock: The lock class to use for the target.
             connection: The connection class to use for the target.
 
@@ -71,7 +72,7 @@ class Target:
         self.state: TargetState | str = TargetState(state)
         # default timeout for target, used only on connecting/reconnecting Target
         self._timeout = timeout
-        self.exclusive = exclusive
+        self.mode = mode
         self.connection: Connection
         self.transactional = False
         # helper for packages before system analysis
@@ -551,14 +552,17 @@ class Target:
         if self.connection:
             self.connection.close()
 
-    def report_self(self, sink: Callable[[str, System, bool, str, bool], None]) -> None:
+    def report_self(
+        self,
+        sink: Callable[[str, System, bool, TargetState | str, ExecutionMode], None],
+    ) -> None:
         """Reports the status of the target.
 
         Args:
             sink: The function to use for reporting.
 
         """
-        sink(self.hostname, self.system, self.transactional, self.state, self.exclusive)
+        sink(self.hostname, self.system, self.transactional, self.state, self.mode)
 
     def report_history(self, sink: Callable[[str, System, list[str]], None]) -> None:
         """Reports the history of the target.

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from pathlib import Path
 from string import Template
 from traceback import format_exc
-from typing import Any, Literal, final
+from typing import Any, final
 
 from .. import messages
 from ..actions import downgrader, installer, preparer, uninstaller, updater
@@ -15,7 +15,7 @@ from ..checks import downgrade_checks, install_checks, prepare_checks, update_ch
 from ..config import Config
 from ..connection import CommandTimeoutError, Connection, policy_from_config
 from ..target.parsers import parse_system
-from ..types import HostLog, Package, System
+from ..types import HostLog, Package, System, TargetState
 from ..types.rpmver import RPMVersion
 from ..utils import timestamp
 from . import TargetLock, TargetLockedError
@@ -40,7 +40,7 @@ class Target:
         config: Config,
         hostname: str,
         packages: dict[str, dict[str, str]] | None = None,
-        state: Literal["enabled", "disabled", "serial", "parallel"] = "enabled",
+        state: TargetState | str = TargetState.ENABLED,
         timeout: int = 300,
         exclusive: bool = False,
         lock: type[TargetLock] = TargetLock,
@@ -68,7 +68,7 @@ class Target:
         self.TargetLock = lock
         self.Connection = connection
 
-        self.state = state
+        self.state: TargetState | str = TargetState(state)
         # default timeout for target, used only on connecting/reconnecting Target
         self._timeout = timeout
         self.exclusive = exclusive
@@ -174,15 +174,16 @@ class Target:
         """
         if packages is None:
             packages = list(self.packages.keys())
-        if self.state == "enabled":
-            pvs = self.query_package_versions(packages)
-            for p, v in pvs.items():
-                self.packages[p].current = v
-        elif self.state == "dryrun":
-            logger.info('dryrun: %s running "rpm -q %s"', self.hostname, packages)
-            self.out.append([f"rpm -q {packages}", "dryrun\n", "", 0, 0])
-        elif self.state == "disabled":
-            self.out.append(["", "", "", 0, 0])
+        match self.state:
+            case TargetState.ENABLED:
+                pvs = self.query_package_versions(packages)
+                for p, v in pvs.items():
+                    self.packages[p].current = v
+            case TargetState.DRYRUN:
+                logger.info('dryrun: %s running "rpm -q %s"', self.hostname, packages)
+                self.out.append([f"rpm -q {packages}", "dryrun\n", "", 0, 0])
+            case TargetState.DISABLED:
+                self.out.append(["", "", "", 0, 0])
 
     def query_package_versions(
         self, packages: list[str]
@@ -282,40 +283,45 @@ class Target:
             lock: An optional lock to use.
 
         """
-        if self.state == "enabled":
-            logger.debug('%s: running "%s"', self.hostname, command)
-            time_before = timestamp()
-            try:
-                exitcode = self.connection.run(command, lock)
-            except CommandTimeoutError:
-                logger.critical('%s: command "%s" timed out', self.hostname, command)
-                exitcode = -1
-            except AssertionError:
-                logger.debug("zombie command terminated")
-                logger.debug(format_exc())
-                return
-            except Exception:
-                # failed to run command
-                logger.error('%s: failed to run command "%s"', self.hostname, command)
-                exitcode = -1
+        match self.state:
+            case TargetState.ENABLED:
+                logger.debug('%s: running "%s"', self.hostname, command)
+                time_before = timestamp()
+                try:
+                    exitcode = self.connection.run(command, lock)
+                except CommandTimeoutError:
+                    logger.critical(
+                        '%s: command "%s" timed out', self.hostname, command
+                    )
+                    exitcode = -1
+                except AssertionError:
+                    logger.debug("zombie command terminated")
+                    logger.debug(format_exc())
+                    return
+                except Exception:
+                    # failed to run command
+                    logger.error(
+                        '%s: failed to run command "%s"', self.hostname, command
+                    )
+                    exitcode = -1
 
-            time_after = timestamp()
-            runtime = int(time_after) - int(time_before)
-            # this is wrong
-            self.out.append(
-                [
-                    command,
-                    self.connection.stdout,
-                    self.connection.stderr,
-                    exitcode,
-                    runtime,
-                ]
-            )
-        elif self.state == "dryrun":
-            logger.info('dryrun: %s running "%s"', self.hostname, command)
-            self.out.append([command, "dryrun\n", "", 0, 0])
-        elif self.state == "disabled":
-            self.out.append(["", "", "", 0, 0])
+                time_after = timestamp()
+                runtime = int(time_after) - int(time_before)
+                # this is wrong
+                self.out.append(
+                    [
+                        command,
+                        self.connection.stdout,
+                        self.connection.stderr,
+                        exitcode,
+                        runtime,
+                    ]
+                )
+            case TargetState.DRYRUN:
+                logger.info('dryrun: %s running "%s"', self.hostname, command)
+                self.out.append([command, "dryrun\n", "", 0, 0])
+            case TargetState.DISABLED:
+                self.out.append(["", "", "", 0, 0])
 
     def shell(self) -> None:
         """Spawns a shell on the target host."""

--- a/mtui/types/__init__.py
+++ b/mtui/types/__init__.py
@@ -5,7 +5,7 @@ throughout the application.
 """
 
 from .commandlog import CommandLog
-from .enums import assignment, method
+from .enums import ExecutionMode, RequestKind, TargetState, assignment, method
 from .filelist import FileList
 from .hostlog import HostLog
 from .oqaresults import OpenQAResult, OpenQAResults
@@ -20,6 +20,7 @@ from .urls import URLs
 
 __all__ = [
     "CommandLog",
+    "ExecutionMode",
     "FileList",
     "HostLog",
     "OpenQAResult",
@@ -27,9 +28,11 @@ __all__ = [
     "Package",
     "Product",
     "RPMVersion",
+    "RequestKind",
     "RequestReviewID",
     "System",
     "TargetMeta",
+    "TargetState",
     "Test",
     "URLs",
     "assignment",

--- a/mtui/types/enums.py
+++ b/mtui/types/enums.py
@@ -45,7 +45,7 @@ class ExecutionMode(Enum):
 
     Plain :class:`Enum` (not :class:`StrEnum`): this concept was previously
     encoded as ``Target.exclusive: bool`` so there is no legacy string
-    surface to preserve.
+    surface to preserve. Migrated to ``Target.mode`` in the same change.
     """
 
     PARALLEL = "parallel"

--- a/mtui/types/enums.py
+++ b/mtui/types/enums.py
@@ -1,4 +1,13 @@
-"""Enumerations for HTTP request methods and pull request assignment states."""
+"""Enumerations used across mtui.
+
+Includes HTTP request methods, pull-request assignment states, and the
+domain enums introduced by the Phase 5b/C9 refactor:
+
+* :class:`TargetState` -- per-host execution state (enabled/dryrun/disabled).
+* :class:`ExecutionMode` -- whether a host runs commands in parallel with
+  the rest of its group or holds the group in a serial barrier.
+* :class:`RequestKind` -- kind component of an OBS Request Review ID.
+"""
 
 from enum import Enum, StrEnum, auto
 
@@ -16,3 +25,67 @@ class assignment(Enum):
     ASSIGNED_USER = auto()
     UNASSIGNED = auto()
     ASSIGNED_OTHER = auto()
+
+
+class TargetState(StrEnum):
+    """Per-host execution state.
+
+    StrEnum so that legacy string comparisons such as
+    ``target.state == "enabled"`` continue to work byte-identically with
+    the existing CLI, config, and test surface.
+    """
+
+    ENABLED = "enabled"
+    DRYRUN = "dryrun"
+    DISABLED = "disabled"
+
+
+class ExecutionMode(Enum):
+    """Whether a host runs commands in parallel or under a serial barrier.
+
+    Plain :class:`Enum` (not :class:`StrEnum`): this concept was previously
+    encoded as ``Target.exclusive: bool`` so there is no legacy string
+    surface to preserve.
+    """
+
+    PARALLEL = "parallel"
+    SERIAL = "serial"
+
+
+class RequestKind(Enum):
+    """Kind component of an OBS Request Review ID.
+
+    Plain :class:`Enum`: production code branches on the kind in seven
+    places and migrating those to enum members catches typos that a
+    string field would silently swallow. The wire form is preserved via
+    :attr:`Enum.value` (e.g. ``RequestKind.SLFO.value == "SLFO"``).
+    """
+
+    SLFO = "SLFO"
+    MAINTENANCE = "Maintenance"
+    PI = "PI"
+
+    @classmethod
+    def from_token(cls, raw: str) -> "RequestKind":
+        """Parse the short or long form of a request kind.
+
+        Accepts both the single-letter aliases (``S``/``M``/``P``) used by
+        users on the command line and the canonical long forms
+        (``SLFO``/``Maintenance``/``PI``) used in the wire format.
+
+        Raises:
+            ValueError: if ``raw`` is not a recognised kind.
+
+        """
+        aliases = {
+            "S": cls.SLFO,
+            "SLFO": cls.SLFO,
+            "M": cls.MAINTENANCE,
+            "Maintenance": cls.MAINTENANCE,
+            "P": cls.PI,
+            "PI": cls.PI,
+        }
+        try:
+            return aliases[raw]
+        except KeyError:
+            raise ValueError(f"unknown request kind: {raw!r}") from None

--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Sequence
 from itertools import zip_longest
 from typing import Any, final
 
+from .enums import RequestKind
+
 
 def apply_parser(f, x, cnt):
     from ..exceptions import (
@@ -160,25 +162,22 @@ class RequestReviewID:
             apply_parser(*ys)
             for ys in zip_longest(parsers, xs, range(1, len(parsers) + 1))
         ]
-        self.project, self.kind, self.maintenance_id, self.review_id = xs
+        self.project, raw_kind, self.maintenance_id, self.review_id = xs
 
         if self.project == "S":
             self.project = "SUSE"
 
-        if self.kind == "M":
-            self.kind = "Maintenance"
-        elif self.kind == "S":
-            self.kind = "SLFO"
-        elif self.kind == "P":
-            self.kind = "PI"
+        self.kind: RequestKind = RequestKind.from_token(raw_kind)
 
     def __str__(self) -> str:
         """Returns a string representation of the `RequestReviewID` object."""
-        return f"{self.project}:{self.kind}:{self.maintenance_id}:{self.review_id}"
+        return (
+            f"{self.project}:{self.kind.value}:{self.maintenance_id}:{self.review_id}"
+        )
 
     def __repr__(self) -> str:
         """Returns a string representation of the `RequestReviewID` object."""
-        return f"<RRID - {self.project}:{self.kind}:{self.maintenance_id}:{self.review_id}>"
+        return f"<RRID - {self.project}:{self.kind.value}:{self.maintenance_id}:{self.review_id}>"
 
     def __hash__(self) -> int:
         """Returns the hash of the `RequestReviewID` object."""

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -29,6 +29,7 @@ from ..template.sltestreport import SLTestReport
 from ..template.testreport import TestReport
 from ..utils import prompt_user
 from . import RequestReviewID
+from .enums import RequestKind
 
 logger = getLogger("mtui.types.updateid")
 
@@ -133,9 +134,9 @@ class UpdateID(ABC):
             The `TestReport` class for the given ID.
 
         """
-        if id_.kind == "SLFO":
+        if id_.kind is RequestKind.SLFO:
             return SLTestReport
-        if id_.kind == "PI":
+        if id_.kind is RequestKind.PI:
             return PITestReport
         return OBSTestReport
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mtui.types import HostLog, Package, Product
+from mtui.types import HostLog, Package, Product, RequestKind
 from mtui.types.rpmver import RPMVersion
 from mtui.types.systems import System
 
@@ -133,6 +133,6 @@ def mock_rrid():
     rrid = MagicMock()
     rrid.maintenance_id = "12345"
     rrid.review_id = "67890"
-    rrid.kind = "SLE"
+    rrid.kind = RequestKind.MAINTENANCE
     rrid.__str__ = lambda self: "SUSE:Maintenance:12345:67890"
     return rrid

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,7 @@
 from io import StringIO
 
 from mtui import display
-from mtui.types import System
+from mtui.types import ExecutionMode, System
 
 
 class MockSystem(System):
@@ -50,7 +50,7 @@ def test_list_host():
     output = StringIO()
     d = display.CommandPromptDisplay(output)
     system = MockSystem("test_system")
-    d.list_host("test_host", system, False, "enabled", "")
+    d.list_host("test_host", system, False, "enabled", ExecutionMode.PARALLEL)
     output_str = output.getvalue()
     assert "test_host" in output_str
     assert "Enabled" in output_str

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,98 @@
+"""Tests for the C9 domain enums in mtui.types.enums."""
+
+import pytest
+
+from mtui.types import ExecutionMode, RequestKind, TargetState
+
+
+class TestTargetState:
+    """TargetState is a StrEnum so legacy string consumers keep working."""
+
+    def test_members_carry_legacy_string_values(self):
+        assert TargetState.ENABLED.value == "enabled"
+        assert TargetState.DRYRUN.value == "dryrun"
+        assert TargetState.DISABLED.value == "disabled"
+
+    def test_str_enum_compares_equal_to_raw_string(self):
+        # The whole point of StrEnum here: every existing
+        # ``target.state == "enabled"`` test site keeps passing.
+        assert TargetState.ENABLED == "enabled"
+        assert TargetState.DRYRUN == "dryrun"
+        assert TargetState.DISABLED == "disabled"
+
+    def test_str_enum_match_case_accepts_raw_string_subject(self):
+        # Confirms the production match/case in Target.run /
+        # Target.query_versions still hits the right arm when an external
+        # caller assigns ``target.state = "dryrun"`` (raw str).
+        for raw, expected in (
+            ("enabled", TargetState.ENABLED),
+            ("dryrun", TargetState.DRYRUN),
+            ("disabled", TargetState.DISABLED),
+        ):
+            match raw:
+                case TargetState.ENABLED:
+                    hit = TargetState.ENABLED
+                case TargetState.DRYRUN:
+                    hit = TargetState.DRYRUN
+                case TargetState.DISABLED:
+                    hit = TargetState.DISABLED
+                case _:
+                    hit = None
+            assert hit is expected, raw
+
+    def test_construction_from_value_returns_member(self):
+        assert TargetState("enabled") is TargetState.ENABLED
+
+    def test_construction_from_unknown_raises(self):
+        with pytest.raises(ValueError, match="serial"):
+            TargetState("serial")  # historical bug: never a valid state
+
+
+class TestExecutionMode:
+    """ExecutionMode is a plain Enum; no implicit string coercion."""
+
+    def test_has_only_two_members(self):
+        assert {m.name for m in ExecutionMode} == {"PARALLEL", "SERIAL"}
+
+    def test_value_matches_cli_vocabulary(self):
+        # set_host_state accepts "parallel"/"serial" as CLI args and
+        # constructs the enum via ExecutionMode(state).
+        assert ExecutionMode("parallel") is ExecutionMode.PARALLEL
+        assert ExecutionMode("serial") is ExecutionMode.SERIAL
+
+    def test_does_not_compare_equal_to_raw_string(self):
+        # Plain Enum (not StrEnum): the typo-catching is exactly that
+        # ExecutionMode.PARALLEL != "parallel".
+        assert ExecutionMode.PARALLEL != "parallel"
+        assert ExecutionMode.SERIAL != "serial"
+
+
+class TestRequestKind:
+    """RequestKind is a plain Enum; from_token() handles long+short forms."""
+
+    def test_canonical_values_match_wire_format(self):
+        assert RequestKind.SLFO.value == "SLFO"
+        assert RequestKind.MAINTENANCE.value == "Maintenance"
+        assert RequestKind.PI.value == "PI"
+
+    @pytest.mark.parametrize(
+        ("token", "expected"),
+        [
+            ("S", RequestKind.SLFO),
+            ("SLFO", RequestKind.SLFO),
+            ("M", RequestKind.MAINTENANCE),
+            ("Maintenance", RequestKind.MAINTENANCE),
+            ("P", RequestKind.PI),
+            ("PI", RequestKind.PI),
+        ],
+    )
+    def test_from_token_accepts_long_and_short_forms(self, token, expected):
+        assert RequestKind.from_token(token) is expected
+
+    def test_from_token_rejects_unknown(self):
+        with pytest.raises(ValueError, match="unknown request kind"):
+            RequestKind.from_token("SLE")  # historical typo found in fixtures
+
+    def test_does_not_compare_equal_to_raw_string(self):
+        # Same typo-catching benefit as ExecutionMode.
+        assert RequestKind.SLFO != "SLFO"

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from mtui.connector.oscqam import OSC
+from mtui.types import RequestKind
 
 
 @pytest.fixture
@@ -88,7 +89,7 @@ class TestOSCOperations:
     @patch("mtui.connector.oscqam.check_call")
     def test_skip_template_for_pi(self, mock_check_call, osc):
         """Test --skip-template is added for PI kind."""
-        osc.rrid.kind = "PI"
+        osc.rrid.kind = RequestKind.PI
         osc.approve(["qam-sle"])
 
         cmd = mock_check_call.call_args[0][0]

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -97,8 +97,8 @@ class TestOSCOperations:
 
     @patch("mtui.connector.oscqam.check_call")
     def test_no_skip_template_for_sle(self, mock_check_call, osc):
-        """Test --skip-template is NOT added for SLE kind."""
-        osc.rrid.kind = "SLE"
+        """Test --skip-template is NOT added for non-PI/non-SLFO kinds."""
+        osc.rrid.kind = RequestKind.MAINTENANCE
         osc.approve(["qam-sle"])
 
         cmd = mock_check_call.call_args[0][0]

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -174,7 +174,7 @@ def test_run_dryrun_does_not_execute(mock_config):
     """Test run() in dryrun state does not execute command."""
     target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
-    target.state = "dryrun"  # ty: ignore[invalid-assignment]
+    target.state = "dryrun"
 
     target.run("rm -rf /")
 
@@ -553,7 +553,7 @@ def test_query_versions_enabled_updates_packages(mock_target, monkeypatch):
 
 def test_query_versions_dryrun_logs_and_appends(mock_config):
     target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
-    target.state = "dryrun"  # ty: ignore[invalid-assignment]
+    target.state = "dryrun"
     target.packages = {"bash": Package("bash")}
     target.query_versions()
     assert target.lastout() == "dryrun\n"

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mtui.target import Target, TargetLockedError
-from mtui.types import HostLog, Package
+from mtui.types import ExecutionMode, HostLog, Package
 from mtui.types.product import Product
 from mtui.types.rpmver import RPMVersion
 
@@ -25,7 +25,7 @@ def test_target_init_defaults(mock_config):
     assert target.port == ""
     assert target.state == "enabled"
     assert target._timeout == 300
-    assert target.exclusive is False
+    assert target.mode is ExecutionMode.PARALLEL
     assert target.transactional is False
     assert target.packages == {}
 
@@ -61,9 +61,9 @@ def test_target_init_with_timeout(mock_config):
 
 
 def test_target_init_with_exclusive(mock_config):
-    """Test Target initialization with exclusive mode."""
-    target = Target(mock_config, "host.example.com", exclusive=True)  # type: ignore[arg-type]
-    assert target.exclusive is True
+    """Test Target initialization with serial execution mode."""
+    target = Target(mock_config, "host.example.com", mode=ExecutionMode.SERIAL)  # type: ignore[arg-type]
+    assert target.mode is ExecutionMode.SERIAL
 
 
 def test_target_init_custom_classes(mock_config):
@@ -348,7 +348,7 @@ def test_report_self_calls_sink(mock_target):
         mock_target.system,
         mock_target.transactional,
         mock_target.state,
-        mock_target.exclusive,
+        mock_target.mode,
     )
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -49,7 +49,7 @@ def test_target_init_with_packages(mock_config):
 
 def test_target_init_with_state(mock_config):
     """Test Target initialization with different states."""
-    for state in ("enabled", "disabled", "serial", "parallel"):
+    for state in ("enabled", "disabled", "dryrun"):
         target = Target(mock_config, "host.example.com", state=state)  # type: ignore[arg-type]
         assert target.state == state
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,7 +7,7 @@ from mtui.exceptions import (
     MissingComponentError,
     TooManyComponentsError,
 )
-from mtui.types import RequestReviewID
+from mtui.types import RequestKind, RequestReviewID
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def test_RRID_ok(r_review_id, m_review_id, rrid):
     rr = RequestReviewID(rrid.format(mid, rid))
 
     assert rr.review_id == rid
-    if rr.kind != "SLFO":
+    if rr.kind is not RequestKind.SLFO:
         assert rr.maintenance_id == mid
     else:
         assert isinstance(rr.maintenance_id, str)


### PR DESCRIPTION
## Summary

First cluster of [Phase 5b refactors](../blob/main/PLAN.md) (C9 in the plan).
Replaces three families of string literals with proper enums, with no
intentional behaviour change to the user-facing surface:

- **`TargetState`** (StrEnum) -- `enabled` / `dryrun` / `disabled`. Replaces
  the stale `Literal["enabled","disabled","serial","parallel"]` annotation
  on `Target.state` (which was wrong: it omitted `dryrun`, the value
  actually used by `Target.run` / `query_versions`, and listed
  `serial`/`parallel`, which were never assigned to `state`).
- **`ExecutionMode`** (plain Enum) -- `parallel` / `serial`. Replaces
  `Target.exclusive: bool`. The `set_host_state` command now writes
  `Target.mode = ExecutionMode.SERIAL` instead of toggling a bool buried
  inside an `if state in ("serial","parallel"):` block.
- **`RequestKind`** (plain Enum) -- `SLFO` / `Maintenance` / `PI`. Replaces
  the seven `rrid.kind == "SLFO"` / `in ("PI","SLFO")` style comparisons
  scattered across `mtui/connector/*` and `mtui/commands/apicall.py`.
  `RequestKind.from_token()` understands both the long forms and the
  `S`/`M`/`P` short aliases the RRID parser accepts.

`if/elif self.state == ...` chains in `Target.run` and `Target.query_versions`
become `match/case` (the three-branch sites; two-branch sites keep `==`,
which still works under StrEnum).

## Surfaced bugs

Two test-only bugs landed in dedicated `fix(test):` follow-up commits per
the project policy:

1. `tests/test_target.py::test_target_init_with_state` was iterating over
   `("enabled","disabled","serial","parallel")` -- the latter two were never
   valid `state` values; they belong to the (now separate) `ExecutionMode`.
   Only worked because the old `Literal` annotation had no runtime teeth.
2. `tests/conftest.py:136` and `tests/test_oscqam.py:101` set
   `rrid.kind = "SLE"` on a `MagicMock`. The conftest fixture's own `__str__`
   already advertised `"SUSE:Maintenance:..."`, confirming the intent was
   `MAINTENANCE`. Both updated to `RequestKind.MAINTENANCE`.

The new `tests/test_enums.py::TestRequestKind::test_from_token_rejects_unknown`
asserts that `"SLE"` is not a real kind, locking in the fix.

## Commits

```
1977f67 refactor(types): add TargetState, ExecutionMode, RequestKind enums
419ec77 fix(test): drop invalid serial/parallel values from test_target_init_with_state
f9f7198 refactor(target): use TargetState enum and match/case for state branches
04b10bb refactor(target): replace Target.exclusive bool with Target.mode: ExecutionMode
60c7014 refactor(rrid): use RequestKind enum across the request-kind comparison sites
56bc147 test(enums): cover TargetState, ExecutionMode, RequestKind
552437d fix(test): replace invalid 'SLE' rrid.kind with RequestKind.MAINTENANCE
05b055f docs(changelog): note the Target.state validation tightening from C9
```

Each refactor commit is independently reviewable; the test fixes are
sequenced as their own commits so a future bisect points at the actual
fault rather than blaming the refactor that surfaced it.

## Compatibility

- **`TargetState`** is a `StrEnum`, so the ~30 `target.state == "enabled"`
  test sites and any external callers comparing `state` against raw strings
  keep working byte-identically. `match self.state: case TargetState.ENABLED:`
  also matches a raw `"enabled"` subject (verified).
- **`ExecutionMode`** is a plain `Enum`. Its `.value` matches the CLI
  vocabulary (`"parallel"`/`"serial"`), so `set_host_state` argparse and the
  display string are unchanged. Comparisons against raw strings deliberately
  return `False` -- the typo-catching property that motivated picking plain
  `Enum`.
- **`RequestKind`** is a plain `Enum`. `__str__`/`__repr__` of
  `RequestReviewID` render via `.value`, so the wire form
  (`SUSE:SLFO:1.2:3`) is byte-identical.

## User-visible change

One, surfaced as a `Fixed` entry in `CHANGELOG.md`:

> `Target.state` is now validated at construction; previously an invalid
> value (`serial`/`parallel`) would silently sit in the field until a
> downstream branch quietly took the wrong arm. `TargetState` now raises
> `ValueError` on unknown inputs.

Everything else is internal restructuring.

## Verification

All four CI gates pass locally:

- `uv run ruff format --check .` -- 163 files clean
- `uv run ruff check .` -- clean
- `uv run ty check` -- clean (no warnings; `error-on-warning` is on, and
  `mtui/types/**` + `mtui/connector/**` are under the strict `all = error`
  override)
- `uv run pytest` -- **549 passed** (532 baseline + 17 new tests in
  `tests/test_enums.py`)
- `uv run python -m mtui --help` and `-V` -- both succeed

Coverage delta is non-negative; the Codecov project floor (66%) is unchanged
in this PR.