### PR TITLE
fix(export): improve qem-dashboard openQA export results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   GitHub issue templates and a pull-request template.
 
 ### Changed
+- `export` now reports `UNKNOWN` (previously `FAILED`) on the
+  "Installation tests done in openQA with following results:" line when
+  the openQA install results have not been fetched or have not run yet,
+  so a missing fetch is no longer indistinguishable from a real failure.
 - `export` further condenses the openQA results section for incidents
   loaded from the QEM Dashboard: zero counters are dropped from Summary
   rows, the shared aggregate `BUILD` is hoisted into one header line,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   GitHub issue templates and a pull-request template.
 
 ### Changed
+- `export` further condenses the openQA results section for incidents
+  loaded from the QEM Dashboard: zero counters are dropped from Summary
+  rows, the shared aggregate `BUILD` is hoisted into one header line,
+  all-passed groups are folded across architectures into a single row,
+  problem groups are sorted to the top, and the `Failed jobs:` subsection
+  is now nested under each group with the redundant
+  product/build/arch prefix removed and openQA URLs aligned. Cuts the
+  openQA section roughly to a third of its previous size.
+- `export` now condenses the openQA results section for incidents loaded
+  from the QEM Dashboard: passed jobs are collapsed into per-group counts
+  (version/flavor/arch for incident jobs, product/build/arch for aggregate
+  jobs), and only jobs whose result is `failed`, `incomplete` or
+  `timeout_exceeded` are listed individually under a `Failed jobs:`
+  subsection with a direct openQA URL. This shrinks the exported log from
+  hundreds of lines to a reviewable summary while keeping focus on
+  failures.
 - Documentation source switched from `README.rst` to `README.md` via
   `myst-parser`; `README.rst` has been removed.
 - Sphinx HTML theme switched to the built-in `alabaster`; copyright

--- a/mtui/connector/openqa/standard.py
+++ b/mtui/connector/openqa/standard.py
@@ -101,6 +101,7 @@ class AutoOpenQA(OpenQA):
                     "file",
                     self.config.openqa_install_logs,
                 ),
+                job["result"],
             )
             for job in jobs
             if job["test"] in ["qam-incidentinstall", "qam-incidentinstall-ha"]

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -182,6 +182,7 @@ class DashboardAutoOpenQA:
                     "file",
                     self.config.openqa_install_logs,
                 ),
+                str(job.get("result") or ""),
             )
             for job in jobs
             if (

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -10,6 +10,11 @@ from ..types import RequestReviewID, URLs
 
 logger = getLogger("mtui.connector.qem_dashboard")
 
+# Job result statuses that should be reported individually in the exported
+# log. Every other status (passed, softfailed, ...) is collapsed into a
+# per-group summary count to keep the report short and reviewable.
+FAILED_RESULTS: frozenset[str] = frozenset({"failed", "incomplete", "timeout_exceeded"})
+
 
 class QEMDashboardClient:
     """Small read-only client for the QEM Dashboard API."""
@@ -201,24 +206,225 @@ class DashboardAutoOpenQA:
         return ret
 
     @staticmethod
+    def _job_url(host: str, job_id: Any) -> str:
+        if job_id is None:
+            return ""
+        return f"{host.rstrip('/')}/tests/{job_id}"
+
+    # Counter keys, in display order. `total` is always kept; the others
+    # are only printed when non-zero so the Summary block stays scannable.
+    _COUNT_KEYS: tuple[str, ...] = (
+        "passed",
+        "softfailed",
+        "failed",
+        "incomplete",
+        "timeout_exceeded",
+        "other",
+    )
+
+    @staticmethod
+    def _val(value: Any) -> str:
+        return str(value) if value not in (None, "") else "unknown"
+
+    @classmethod
+    def _group_key(cls, job: dict[str, Any], source: str) -> tuple[str, str, str]:
+        settings = job.get("settings") or {}
+        if source == "aggregate":
+            return (
+                cls._val(job.get("product")),
+                cls._val(settings.get("BUILD")),
+                cls._val(settings.get("ARCH")),
+            )
+        return (
+            cls._val(settings.get("VERSION")),
+            cls._val(settings.get("FLAVOR")),
+            cls._val(settings.get("ARCH")),
+        )
+
+    @classmethod
+    def _format_counts(cls, counts: dict[str, int]) -> str:
+        """Render counts dropping zero entries; `total` is always last."""
+        parts = [f"{key}: {counts[key]}" for key in cls._COUNT_KEYS if counts[key]]
+        parts.append(f"total: {counts['total']}")
+        return ", ".join(parts)
+
+    @staticmethod
+    def _empty_counts() -> dict[str, int]:
+        return {
+            "passed": 0,
+            "softfailed": 0,
+            "failed": 0,
+            "incomplete": 0,
+            "timeout_exceeded": 0,
+            "other": 0,
+            "total": 0,
+        }
+
+    @staticmethod
+    def _has_problems(counts: dict[str, int]) -> bool:
+        return bool(
+            counts["failed"]
+            or counts["incomplete"]
+            or counts["timeout_exceeded"]
+            or counts["other"]
+        )
+
+    @staticmethod
+    def _format_group_header(
+        source: str, key: tuple[str, str, str], *, hoisted_build: bool = False
+    ) -> str:
+        if source == "aggregate":
+            product, build, arch = key
+            if hoisted_build:
+                return f"    product: {product} - arch: {arch}"
+            return f"    product: {product} - build: {build} - arch: {arch}"
+        version, flavor, arch = key
+        return f"    version: {version} - flavor: {flavor} - arch: {arch}"
+
+    @staticmethod
+    def _format_folded_header(
+        source: str, fold_key: tuple[str, ...], *, hoisted_build: bool
+    ) -> str:
+        if source == "aggregate":
+            if hoisted_build:
+                (product,) = fold_key
+                return f"    product: {product}"
+            product, build = fold_key
+            return f"    product: {product} - build: {build}"
+        version, flavor = fold_key
+        return f"    version: {version} - flavor: {flavor}"
+
+    @staticmethod
+    def _failed_group_header(
+        source: str, key: tuple[str, str, str], n_failed: int, *, hoisted_build: bool
+    ) -> str:
+        if source == "aggregate":
+            product, build, arch = key
+            if hoisted_build:
+                return f"    {product} / {arch} ({n_failed} failed):\n"
+            return f"    {product} / {build} / {arch} ({n_failed} failed):\n"
+        version, flavor, arch = key
+        return f"    {version} / {flavor} / {arch} ({n_failed} failed):\n"
+
     def _pretty_print_section(
-        ret: list[str], title: str, jobs: list[dict[str, Any]], source: str
+        self,
+        ret: list[str],
+        title: str,
+        jobs: list[dict[str, Any]],
+        source: str,
     ) -> None:
         section_jobs = [job for job in jobs if job.get("source") == source]
         if not section_jobs:
             return
 
         ret.append(f"{title}:\n")
+
+        # Hoist a shared aggregate BUILD when every job in the section uses
+        # the same one; this strips ~80 redundant `build: …` repetitions.
+        hoisted_build: str | None = None
+        if source == "aggregate":
+            builds = {
+                self._val((job.get("settings") or {}).get("BUILD"))
+                for job in section_jobs
+            }
+            if len(builds) == 1:
+                hoisted_build = next(iter(builds))
+                ret.append(f"  build: {hoisted_build}\n")
+
+        # Build per-group counts in insertion order so the summary mirrors
+        # the order in which the dashboard returned the jobs.
+        groups: dict[tuple[str, str, str], dict[str, int]] = {}
+        failed_by_group: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
         for job in section_jobs:
-            settings = job["settings"]
+            key = self._group_key(job, source)
+            counts = groups.setdefault(key, self._empty_counts())
+            counts["total"] += 1
+            result = job.get("result") or "other"
+            if result in counts and result != "total":
+                counts[result] += 1
+            else:
+                counts["other"] += 1
+            if result in FAILED_RESULTS:
+                failed_by_group.setdefault(key, []).append(job)
+
+        # Split into problem and all-passed groups; problem groups stay
+        # per-arch so reviewers see exactly which arch failed. All-passed
+        # groups fold across architectures into one row.
+        problem_keys = [
+            key for key, counts in groups.items() if self._has_problems(counts)
+        ]
+        passed_keys = [
+            key for key, counts in groups.items() if not self._has_problems(counts)
+        ]
+
+        ret.append("  Summary:\n")
+
+        # Problem groups first, in original insertion order.
+        ret.extend(
+            f"  {self._format_group_header(source, key, hoisted_build=hoisted_build is not None)}"
+            f" -> {self._format_counts(groups[key])}\n"
+            for key in problem_keys
+        )
+
+        # Fold all-passed groups. For incidents, fold by (version, flavor).
+        # For aggregates, fold by (product,) when build is hoisted, else by
+        # (product, build) so the build stays visible in mixed-build sections.
+        folded: dict[tuple[str, ...], dict[str, Any]] = {}
+        for key in passed_keys:
             if source == "aggregate":
-                ret.append(
-                    f"  product: {job.get('product')} - build: {settings.get('BUILD')} - arch: {settings.get('ARCH')} - test: {job.get('test')} - result: {job.get('result')}\n"
+                product, build, arch = key
+                fold_key: tuple[str, ...] = (
+                    (product,) if hoisted_build is not None else (product, build)
                 )
             else:
+                version, flavor, arch = key
+                fold_key = (version, flavor)
+            entry = folded.setdefault(
+                fold_key,
+                {"archs": [], "counts": self._empty_counts()},
+            )
+            if arch not in entry["archs"]:
+                entry["archs"].append(arch)
+            for ckey in self._COUNT_KEYS:
+                entry["counts"][ckey] += groups[key][ckey]
+            entry["counts"]["total"] += groups[key]["total"]
+
+        for fold_key, entry in folded.items():
+            archs = ", ".join(entry["archs"])
+            n_archs = len(entry["archs"])
+            ret.append(
+                f"  {self._format_folded_header(source, fold_key, hoisted_build=hoisted_build is not None)}"
+                f" - archs: {archs}"
+                f" -> {self._format_counts(entry['counts'])}"
+                f" ({n_archs} arch{'es' if n_archs != 1 else ''})\n"
+            )
+
+        # Failed jobs, nested under their group header so the redundant
+        # product/build/arch prefix on each line disappears.
+        if failed_by_group:
+            ret.append("  Failed jobs:\n")
+            for key in problem_keys:
+                fjobs = failed_by_group.get(key, [])
+                if not fjobs:
+                    continue
                 ret.append(
-                    f"  flavor: {settings.get('FLAVOR')} - arch: {settings.get('ARCH')} - version: {settings.get('VERSION')} - test: {job.get('test')} - result: {job.get('result')}\n"
+                    self._failed_group_header(
+                        source, key, len(fjobs), hoisted_build=hoisted_build is not None
+                    )
                 )
+                # Pad test name with spaces so URLs align inside this group.
+                width = max(len(job.get("test") or "") for job in fjobs)
+                for job in fjobs:
+                    test = job.get("test") or ""
+                    url = self._job_url(self.host, job.get("id"))
+                    result = job.get("result")
+                    suffix = f"  {url}" if url else ""
+                    if result == "failed":
+                        ret.append(f"      {test.ljust(width)}{suffix}\n")
+                    else:
+                        ret.append(f"      {test.ljust(width)}  [{result}]{suffix}\n")
+        else:
+            ret.append("  All jobs passed.\n")
         ret.append("\n")
 
     def run(self) -> Self:

--- a/mtui/export/auto.py
+++ b/mtui/export/auto.py
@@ -32,7 +32,10 @@ class AutoExport(BaseExport):
         auto = self.openqa.auto
         results = auto.results if auto is not None else None
         if not results:
-            return "FAILED"
+            # No results means the install tests have not run, are still
+            # running, or could not be fetched - which is distinct from a
+            # genuine FAILED outcome.
+            return "UNKNOWN"
         return (
             "PASSED"
             if all(result.result in {"passed", "softfailed"} for result in results)

--- a/mtui/export/auto.py
+++ b/mtui/export/auto.py
@@ -20,6 +20,70 @@ no_verify = ssl._create_unverified_context()  # noqa: SLF001
 class AutoExport(BaseExport):
     """An exporter for the automatic workflow."""
 
+    @staticmethod
+    def _install_job_line(result) -> str:
+        status = result.result.upper() if result.result else "UNKNOWN"
+        job_url = result.url.rsplit("/file/", 1)[0]
+        return (
+            f"{result.distri}_{result.version}_{result.arch} => {status}: {job_url}\n"
+        )
+
+    def _install_status(self) -> str:
+        auto = self.openqa.auto
+        results = auto.results if auto is not None else None
+        if not results:
+            return "FAILED"
+        return (
+            "PASSED"
+            if all(result.result in {"passed", "softfailed"} for result in results)
+            else "FAILED"
+        )
+
+    def install_results(self) -> None:
+        """Adds installation results to the template."""
+        status_line = (
+            "Installation tests done in openQA with following results: "
+            f"{self._install_status()}\n"
+        )
+        auto = self.openqa.auto
+        results = auto.results if auto is not None else []
+        result_lines = [self._install_job_line(result) for result in results or []]
+
+        try:
+            start = self.template.index("Install tests:\n") - 1
+        except ValueError:
+            start = len(self.template)
+            if "## export MTUI:" in self.template[-1]:
+                start -= 1
+            self.template[start:start] = [
+                "##############\n",
+                "Install tests:\n",
+                "##############\n",
+                "\n",
+            ]
+
+        try:
+            end = self.template.index("Links for update logs:\n", start)
+            while end > start and self.template[end - 1] == "\n":
+                end -= 1
+        except ValueError:
+            try:
+                end = self.template.index("## export MTUI:", start)
+            except ValueError:
+                end = len(self.template)
+
+        block = [
+            "##############\n",
+            "Install tests:\n",
+            "##############\n",
+            "\n",
+            status_line,
+            "\n",
+            *result_lines,
+            "\n",
+        ]
+        self.template[start:end] = block
+
     def get_logs(self, *args, **kwds) -> list[Path]:
         """Gets the logs from openQA.
 
@@ -87,13 +151,13 @@ class AutoExport(BaseExport):
             The exported template.
 
         """
+        install_logs_current = (
+            "Installation tests done in openQA with following results:" in self.template
+            and not self.force
+        )
         self.install_results()
         self.inject_openqa()
-        if (
-            "Installation tests done in openQA with following results: PASSED\n"
-            not in self.template
-            or self.force
-        ):
+        if not install_logs_current:
             filenames = self.get_logs()
             self.installlogs_lines(filenames)
         self.add_sysinfo()

--- a/mtui/types/urls.py
+++ b/mtui/types/urls.py
@@ -18,3 +18,4 @@ class URLs(NamedTuple):
     arch: str
     version: str
     url: str
+    result: str = ""

--- a/tests/test_export_openqa.py
+++ b/tests/test_export_openqa.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.export import Export
+from mtui.export.auto import AutoExport
 from mtui.export.base import BaseExport
-from mtui.types import FileList, OpenQAResults, RequestReviewID
+from mtui.types import FileList, OpenQAResults, RequestReviewID, URLs
 
 
 class ExportProbe(BaseExport):
@@ -75,4 +76,61 @@ def test_manual_export_loads_dashboard_results_before_export(mock_config, tmp_pa
         mock_config.openqa_instance,
         prompt.metadata.incident,
         prompt.metadata.rrid,
+    )
+
+
+def test_auto_export_replaces_stale_install_results(mock_config):
+    openqa = MagicMock()
+    openqa.pp = []
+    openqa.results = [
+        URLs(
+            "sle",
+            "x86_64",
+            "15-SP7",
+            "https://openqa.example.com/tests/1001/file/install-logs.tar",
+            "passed",
+        )
+    ]
+    template = FileList(
+        [
+            "Test results by product-arch:\n",
+            "#############################\n",
+            "\n",
+            "source code change review:\n",
+            "##############\n",
+            "Install tests:\n",
+            "##############\n",
+            "\n",
+            "Installation tests done in openQA with following results: FAILED\n",
+            "\n",
+            "sle_15-SP7_x86_64 => none: https://openqa.example.com/tests/1001\n",
+            "\n",
+            "Links for update logs:\n",
+        ]
+    )
+
+    exporter = AutoExport(
+        mock_config,
+        OpenQAResults(auto=openqa),
+        template,
+        False,
+        "SUSE:Maintenance:1:1",
+        False,
+    )
+    with patch.object(exporter, "get_logs", return_value=[]):
+        result = exporter.run()
+
+    assert (
+        "Installation tests done in openQA with following results: FAILED\n"
+        not in result
+    )
+    assert (
+        "sle_15-SP7_x86_64 => none: https://openqa.example.com/tests/1001\n"
+        not in result
+    )
+    assert (
+        "Installation tests done in openQA with following results: PASSED\n" in result
+    )
+    assert (
+        "sle_15-SP7_x86_64 => PASSED: https://openqa.example.com/tests/1001\n" in result
     )

--- a/tests/test_export_openqa.py
+++ b/tests/test_export_openqa.py
@@ -134,3 +134,51 @@ def test_auto_export_replaces_stale_install_results(mock_config):
     assert (
         "sle_15-SP7_x86_64 => PASSED: https://openqa.example.com/tests/1001\n" in result
     )
+
+
+def _make_auto_exporter(mock_config, openqa) -> AutoExport:
+    return AutoExport(
+        mock_config,
+        OpenQAResults(auto=openqa),
+        FileList([]),
+        False,
+        "SUSE:Maintenance:1:1",
+        False,
+    )
+
+
+def test_install_status_unknown_when_auto_missing(mock_config):
+    """auto.results being unavailable is distinct from a FAILED outcome."""
+    exporter = _make_auto_exporter(mock_config, openqa=None)
+
+    assert exporter._install_status() == "UNKNOWN"
+
+
+def test_install_status_unknown_when_results_empty(mock_config):
+    openqa = MagicMock()
+    openqa.results = []
+    exporter = _make_auto_exporter(mock_config, openqa=openqa)
+
+    assert exporter._install_status() == "UNKNOWN"
+
+
+def test_install_status_passed_when_all_results_pass(mock_config):
+    openqa = MagicMock()
+    openqa.results = [
+        URLs("sle", "x86_64", "15-SP7", "https://o/tests/1/file/x", "passed"),
+        URLs("sle", "x86_64", "15-SP7", "https://o/tests/2/file/x", "softfailed"),
+    ]
+    exporter = _make_auto_exporter(mock_config, openqa=openqa)
+
+    assert exporter._install_status() == "PASSED"
+
+
+def test_install_status_failed_when_any_result_fails(mock_config):
+    openqa = MagicMock()
+    openqa.results = [
+        URLs("sle", "x86_64", "15-SP7", "https://o/tests/1/file/x", "passed"),
+        URLs("sle", "x86_64", "15-SP7", "https://o/tests/2/file/x", "failed"),
+    ]
+    exporter = _make_auto_exporter(mock_config, openqa=openqa)
+
+    assert exporter._install_status() == "FAILED"

--- a/tests/test_openqa_connector.py
+++ b/tests/test_openqa_connector.py
@@ -162,6 +162,7 @@ class TestGetLogsUrl:
         # Only install jobs should be included
         assert len(result) == 1
         assert "123" in result[0].url
+        assert result[0].result == "passed"
 
 
 # --- AutoOpenQA.run ---

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -1,9 +1,73 @@
 import responses
 
-from mtui.connector.qem_dashboard import DashboardAutoOpenQA, QEMIncident
+from mtui.connector.qem_dashboard import (
+    DashboardAutoOpenQA,
+    QEMIncident,
+)
 from mtui.types import RequestReviewID
 
 API = "https://dashboard.example.com/api"
+OPENQA_HOST = "https://openqa.example.com"
+
+
+def _make_dashboard(mock_config) -> DashboardAutoOpenQA:
+    """Build a DashboardAutoOpenQA without hitting the API."""
+    rrid = RequestReviewID("SUSE:Maintenance:12358:199773")
+    incident = QEMIncident.__new__(QEMIncident)
+    incident.rrid = rrid
+    incident.incident_number = 12358
+    incident.client = None  # type: ignore[assignment]
+    incident.data = {"number": 12358, "packages": ["bash"]}
+    return DashboardAutoOpenQA(mock_config, OPENQA_HOST, incident, rrid)
+
+
+def _incident_job(
+    job_id: int,
+    name: str,
+    result: str,
+    *,
+    version: str = "15-SP5",
+    flavor: str = "Server-DVD-Incidents",
+    arch: str = "x86_64",
+) -> dict:
+    return {
+        "id": job_id,
+        "test": name,
+        "result": result,
+        "source": "incident",
+        "settings": {
+            "DISTRI": "sle",
+            "FLAVOR": flavor,
+            "ARCH": arch,
+            "VERSION": version,
+            "BUILD": ":12358:bash",
+        },
+    }
+
+
+def _aggregate_job(
+    job_id: int,
+    name: str,
+    result: str,
+    *,
+    product: str = "SLES-15-SP5",
+    build: str = "20240101-1",
+    arch: str = "x86_64",
+) -> dict:
+    return {
+        "id": job_id,
+        "test": name,
+        "result": result,
+        "source": "aggregate",
+        "product": product,
+        "settings": {
+            "DISTRI": "sle",
+            "FLAVOR": "Server-DVD-Updates",
+            "ARCH": arch,
+            "VERSION": "15-SP5",
+            "BUILD": build,
+        },
+    }
 
 
 @responses.activate
@@ -157,3 +221,235 @@ def test_dashboard_auto_openqa_loads_incident_and_aggregate_jobs(mock_config):
     assert dashboard.results[0].url == (
         "https://openqa.example.com/tests/1001/file/install-logs.tar"
     )
+
+
+def test_pretty_print_collapses_passed(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    jobs = [_incident_job(2000 + i, f"qam-test-{i}", "passed") for i in range(50)]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    # All 50 jobs collapsed into a single summary row.
+    assert "Summary:" in out
+    assert "passed: 50" in out
+    assert "total: 50" in out
+    # Zero counters MUST NOT appear in the condensed Summary.
+    for noisy in (
+        "softfailed: 0",
+        "failed: 0",
+        "incomplete: 0",
+        "timeout_exceeded: 0",
+        "other: 0",
+    ):
+        assert noisy not in out
+    # No individual passed job names should be present.
+    for i in range(50):
+        assert f"qam-test-{i}" not in out
+    # No "Failed jobs" subsection because nothing failed.
+    assert "Failed jobs:" not in out
+    assert "All jobs passed." in out
+
+
+def test_pretty_print_lists_failed(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    jobs = [_incident_job(3000 + i, f"qam-pass-{i}", "passed") for i in range(10)] + [
+        _incident_job(3100, "qam-failure", "failed"),
+        _incident_job(3101, "qam-incomplete", "incomplete"),
+        _incident_job(3102, "qam-timeout", "timeout_exceeded"),
+        _incident_job(3103, "qam-soft", "softfailed"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    # Summary counts: only non-zero counters appear.
+    assert "passed: 10" in out
+    assert "softfailed: 1" in out
+    assert "failed: 1" in out
+    assert "incomplete: 1" in out
+    assert "timeout_exceeded: 1" in out
+    assert "total: 14" in out
+    # Zero counters MUST NOT appear.
+    assert "other: 0" not in out
+
+    # Only failed/incomplete/timeout_exceeded jobs are listed individually.
+    assert "Failed jobs:" in out
+    # Group header in the new nested layout.
+    assert "15-SP5 / Server-DVD-Incidents / x86_64 (3 failed):" in out
+    assert "qam-failure" in out
+    assert "qam-incomplete" in out
+    assert "qam-timeout" in out
+    # Non-failed results are tagged with [result] inside the group.
+    assert "[incomplete]" in out
+    assert "[timeout_exceeded]" in out
+    # Passed and softfailed jobs do NOT appear individually.
+    assert "qam-soft" not in out
+    for i in range(10):
+        assert f"qam-pass-{i}" not in out
+
+    # Failed-job lines include the openQA URL.
+    assert f"{OPENQA_HOST}/tests/3100" in out
+    assert f"{OPENQA_HOST}/tests/3101" in out
+    assert f"{OPENQA_HOST}/tests/3102" in out
+
+
+def test_pretty_print_aggregate_grouping(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        _aggregate_job(4000, "mau-a", "passed", product="SLES-15-SP5"),
+        _aggregate_job(4001, "mau-b", "passed", product="SLES-15-SP5"),
+        _aggregate_job(4002, "mau-c", "failed", product="SLES-15-SP6"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    assert "Aggregate jobs:" in out
+    # Shared BUILD is hoisted, not repeated per-row.
+    assert "  build: 20240101-1\n" in out
+    # Two distinct product groups, each with its own summary row.
+    assert "product: SLES-15-SP5" in out
+    assert "product: SLES-15-SP6" in out
+    # `build:` MUST NOT appear in any group / failed-job header.
+    assert " - build: " not in out
+    # SP6 (problem group) appears before the folded SP5 (all-passed).
+    assert out.index("SLES-15-SP6") < out.index("SLES-15-SP5")
+    # SP5 group has both passed jobs collapsed.
+    assert "passed: 2" in out
+    # SP6 group's failed job appears individually under a nested header.
+    assert "Failed jobs:" in out
+    assert "SLES-15-SP6 / x86_64 (1 failed):" in out
+    assert "mau-c" in out
+    # Passed aggregate jobs are not individually listed.
+    assert "mau-a" not in out
+    assert "mau-b" not in out
+
+
+def test_pretty_print_unknown_grouping_keys(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    job = _incident_job(5000, "qam-x", "passed")
+    job["settings"]["VERSION"] = None
+    job["settings"]["FLAVOR"] = ""
+    out = "".join(dashboard._pretty_print([job]))
+
+    assert "version: unknown" in out
+    assert "flavor: unknown" in out
+
+
+def test_format_counts_skips_zeros(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    counts = dashboard._empty_counts()
+    counts["passed"] = 10
+    counts["failed"] = 2
+    counts["total"] = 12
+    out = dashboard._format_counts(counts)
+
+    assert out == "passed: 10, failed: 2, total: 12"
+    assert "softfailed" not in out
+    assert "other" not in out
+
+
+def test_pretty_print_aggregate_hoists_build(mock_config):
+    """Single shared BUILD is hoisted; mixed builds keep per-row build."""
+    dashboard = _make_dashboard(mock_config)
+
+    # Single-build section: build is hoisted and absent from rows.
+    same_build = [
+        _aggregate_job(6000, "mau-x", "passed", product="A", build="20260101-1"),
+        _aggregate_job(6001, "mau-y", "passed", product="B", build="20260101-1"),
+    ]
+    out_same = "".join(dashboard._pretty_print(same_build))
+    assert "  build: 20260101-1\n" in out_same
+    assert " - build: " not in out_same
+
+    # Mixed builds: no hoist; per-row build re-appears.
+    mixed_build = [
+        _aggregate_job(6100, "mau-x", "passed", product="A", build="20260101-1"),
+        _aggregate_job(6101, "mau-y", "passed", product="B", build="20260102-2"),
+    ]
+    out_mixed = "".join(dashboard._pretty_print(mixed_build))
+    # Hoist line absent.
+    assert "  build: 20260101-1\n" not in out_mixed
+    assert "  build: 20260102-2\n" not in out_mixed
+    # Per-row build present on at least one summary row (folded/full).
+    assert "build: 20260101-1" in out_mixed
+    assert "build: 20260102-2" in out_mixed
+
+
+def test_pretty_print_problem_groups_sorted_first(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        # All-passed group inserted first.
+        _incident_job(7000, "qam-ok-1", "passed", version="15-SP4"),
+        _incident_job(7001, "qam-ok-2", "passed", version="15-SP4"),
+        # Problem group inserted second.
+        _incident_job(7100, "qam-bad", "failed", version="15-SP7"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    summary_start = out.index("Summary:")
+    failed_start = out.index("Failed jobs:")
+    summary_block = out[summary_start:failed_start]
+    # Problem group (15-SP7) appears before all-passed group (15-SP4).
+    assert summary_block.index("15-SP7") < summary_block.index("15-SP4")
+
+
+def test_pretty_print_folds_all_passed_archs(mock_config):
+    """All-passed groups across archs collapse into one folded row."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        _incident_job(8000, "t1", "passed", arch="x86_64"),
+        _incident_job(8001, "t2", "passed", arch="x86_64"),
+        _incident_job(8002, "t3", "passed", arch="aarch64"),
+        _incident_job(8003, "t4", "passed", arch="s390x"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    # One folded row instead of three per-arch rows.
+    assert "archs: x86_64, aarch64, s390x" in out
+    assert "passed: 4" in out
+    assert "total: 4" in out
+    assert "(3 arches)" in out
+    # No per-arch rows for the folded group.
+    assert "arch: x86_64" not in out
+    assert "arch: aarch64" not in out
+    assert "arch: s390x" not in out
+
+
+def test_pretty_print_does_not_fold_problem_groups(mock_config):
+    """A group with a failure stays per-arch so reviewers see which arch broke."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        _incident_job(9000, "t-pass", "passed", arch="x86_64"),
+        _incident_job(9001, "t-fail", "failed", arch="aarch64"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    # Problem group keeps its per-arch row (no fold), folded passed group also present.
+    assert "arch: aarch64" in out
+    # The all-passed x86_64 group is folded (no archs: line for it because
+    # it's the only arch in the fold, but `arch: x86_64` MUST NOT appear
+    # as a per-arch summary row).
+    assert "arch: x86_64" not in out
+    assert "archs: x86_64" in out
+
+
+def test_pretty_print_failed_jobs_grouped(mock_config):
+    """Failed-jobs subsection nests under group header, drops redundant prefix."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        _aggregate_job(10000, "test-alpha", "failed", product="P", arch="x86_64"),
+        _aggregate_job(10001, "test-beta-longer", "failed", product="P", arch="x86_64"),
+    ]
+    out = "".join(dashboard._pretty_print(jobs))
+
+    # Group header line with hoisted build (single build in section).
+    assert "P / x86_64 (2 failed):" in out
+    # Tests are listed indented under the header; URLs aligned via padding.
+    lines = [
+        line
+        for line in out.splitlines()
+        if "test-alpha" in line or "test-beta-longer" in line
+    ]
+    assert len(lines) == 2
+    # The shorter test name is padded to the longer one's width, so the URL
+    # column starts at the same offset on both rows.
+    url_offsets = [line.index(OPENQA_HOST) for line in lines]
+    assert url_offsets[0] == url_offsets[1]
+    # No `product:` / `build:` / `arch:` repeated on a per-failure line.
+    assert "product: P - " not in out.split("Failed jobs:")[1]

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -221,6 +221,7 @@ def test_dashboard_auto_openqa_loads_incident_and_aggregate_jobs(mock_config):
     assert dashboard.results[0].url == (
         "https://openqa.example.com/tests/1001/file/install-logs.tar"
     )
+    assert dashboard.results[0].result == "passed"
 
 
 def test_pretty_print_collapses_passed(mock_config):

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -301,8 +301,8 @@ def test_pretty_print_aggregate_grouping(mock_config):
     out = "".join(dashboard._pretty_print(jobs))
 
     assert "Aggregate jobs:" in out
-    # Shared BUILD is hoisted, not repeated per-row.
-    assert "  build: 20240101-1\n" in out
+    # Shared BUILD is hoisted exactly once, not repeated per-row.
+    assert out.count("  build: 20240101-1\n") == 1
     # Two distinct product groups, each with its own summary row.
     assert "product: SLES-15-SP5" in out
     assert "product: SLES-15-SP6" in out
@@ -355,7 +355,7 @@ def test_pretty_print_aggregate_hoists_build(mock_config):
         _aggregate_job(6001, "mau-y", "passed", product="B", build="20260101-1"),
     ]
     out_same = "".join(dashboard._pretty_print(same_build))
-    assert "  build: 20260101-1\n" in out_same
+    assert out_same.count("  build: 20260101-1\n") == 1
     assert " - build: " not in out_same
 
     # Mixed builds: no hoist; per-row build re-appears.
@@ -368,8 +368,9 @@ def test_pretty_print_aggregate_hoists_build(mock_config):
     assert "  build: 20260101-1\n" not in out_mixed
     assert "  build: 20260102-2\n" not in out_mixed
     # Per-row build present on at least one summary row (folded/full).
-    assert "build: 20260101-1" in out_mixed
-    assert "build: 20260102-2" in out_mixed
+    # Anchor on the per-row "- build:" prefix so we don't match the hoisted form.
+    assert "- build: 20260101-1" in out_mixed
+    assert "- build: 20260102-2" in out_mixed
 
 
 def test_pretty_print_problem_groups_sorted_first(mock_config):


### PR DESCRIPTION
## Summary

- Collapses passed qem-dashboard openQA jobs into grouped summary rows while listing only failed, incomplete, and timeout jobs individually with direct openQA links.
- Rewrites the auto-workflow `Install tests:` block from qem-dashboard data so passing install jobs are reported as `PASSED` instead of preserving stale `FAILED` output.
- Carries openQA install-job results through export so install rows render as `=> PASSED:`/`=> SOFTFAILED:` instead of `=> none:`.

## Why

Large maintenance updates can produce exported logs with hundreds of one-line openQA entries, while the install-test section could still be misleading: install logs were exported correctly, but the report showed `Installation tests ... FAILED` and rows like `=> none:`. Reviewers need the export to focus on actionable openQA failures and show the actual install-test status.

## Behaviour

- Aggregate openQA failures remain visible in the separate `Results from openQA jobs:` section; they do not make the install-test block fail.
- The `Install tests:` block is regenerated from install jobs only, replacing stale status and stale per-job rows on re-export.
- Existing openQA block markers remain unchanged, so `mtui/export/base.py::inject_openqa` continues replacing previous qem-dashboard results cleanly.
- Standard auto openQA export also carries install-job results to avoid regressions from the shared `URLs` structure.

## Tests

- Added/updated focused tests for qem-dashboard result propagation, standard auto openQA result propagation, and stale install-block replacement.
- Verified locally: `uv run pytest tests/test_qem_dashboard_connector.py tests/test_export_openqa.py tests/test_openqa_connector.py` (33 passed).
- Verified locally: `uv run ruff check ...` and `uv run ty check` passed.

## Changelog

Existing user-visible qem-dashboard export change remains documented under `[Unreleased] / Changed` in `CHANGELOG.md`.