### PR TITLE
fix(dashboard): exclude SLFO jobs from QAM install job list

### DIFF
--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -181,6 +181,7 @@ class DashboardAutoOpenQA:
             for job in jobs
             if (
                 "qam-incidentinstall" in job.get("test")
+                and "SLFO" not in job.get("test")
                 and self._normalize_result(job.get("result"))
             )
         ]


### PR DESCRIPTION
fix(dashboard): exclude SLFO jobs from QAM install job list

Why this change was needed:
SLFO test jobs have unpredictable names for install logs in openQA,
which prevents downloading their logs and causes errors in the dashboard.

What changed:
- Added "SLFO" not-in-test filter to DashboardAutoOpenQA job list

Problem solved:
SLFO jobs no longer cause log download failures in the dashboard.