### PR TITLE
perf(qem-dashboard): fan out per-setting jobs fetches concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `mtui/connection.py`. The Codecov project floor is bumped from 56 % to
   66 % (current − 1, ratchets upward); patch target stays at 80 %.
 
+### Fixed
+- QEM Dashboard HTTP requests now carry a (5 s connect, 30 s read)
+  timeout, and the parallel per-setting jobs fan-out is bounded by a 60 s
+  per-future wall-clock cap. A stuck connection or unresponsive endpoint
+  no longer hangs `mtui` startup or `reloadoqa` indefinitely; a single
+  timed-out setting is logged and skipped while the rest of the batch
+  still completes.
+
 ### Known issues
 - A non-numeric value for `connection_timeout` (e.g.
   `connection_timeout = abc` under `[mtui]`) crashes `Config.__init__`

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -16,6 +16,14 @@ logger = getLogger("mtui.connector.qem_dashboard")
 # per-group summary count to keep the report short and reviewable.
 FAILED_RESULTS: frozenset[str] = frozenset({"failed", "incomplete", "timeout_exceeded"})
 
+# (connect, read) timeout for every dashboard HTTP call. Bounds a stuck
+# socket so a broken network can't hang mtui startup indefinitely.
+_HTTP_TIMEOUT: tuple[float, float] = (5.0, 30.0)
+# Wall-clock cap per future in the parallel fan-out. Defense-in-depth on
+# top of the per-request timeout above; a stuck worker won't block the
+# whole batch.
+_FUTURE_TIMEOUT: float = 60.0
+
 
 class QEMDashboardClient:
     """Small read-only client for the QEM Dashboard API."""
@@ -29,6 +37,7 @@ class QEMDashboardClient:
                 f"{self.apiurl}/{path.lstrip('/')}",
                 params=params or None,
                 headers={"Accept": "application/json"},
+                timeout=_HTTP_TIMEOUT,
             )
             response.raise_for_status()
             return response.json()
@@ -111,8 +120,12 @@ class DashboardAutoOpenQA:
             update_settings_future = executor.submit(
                 self.client.update_settings, incident_number
             )
-            incident_settings = incident_settings_future.result()
-            update_settings = update_settings_future.result()
+            incident_settings = self._await_settings(
+                incident_settings_future, "incident_settings"
+            )
+            update_settings = self._await_settings(
+                update_settings_future, "update_settings"
+            )
 
         # Build a flat task list of (source, setting, fetcher) preserving
         # the original insertion order: all incident settings first, then
@@ -148,12 +161,48 @@ class DashboardAutoOpenQA:
             ]
 
             jobs: list[dict[str, Any]] = []
-            for (source, setting, _), future in zip(tasks, futures, strict=True):
+            for (source, setting, setting_id), future in zip(
+                tasks, futures, strict=True
+            ):
+                try:
+                    setting_jobs = future.result(timeout=_FUTURE_TIMEOUT)
+                except concurrent.futures.TimeoutError:
+                    logger.warning(
+                        "QEM Dashboard %s jobs fetch for setting %s timed out "
+                        "after %.0fs; skipping",
+                        source,
+                        setting_id,
+                        _FUTURE_TIMEOUT,
+                    )
+                    future.cancel()
+                    continue
                 jobs.extend(
-                    self._normalize_job(job, source, setting) for job in future.result()
+                    self._normalize_job(job, source, setting) for job in setting_jobs
                 )
 
         return jobs
+
+    @staticmethod
+    def _await_settings(
+        future: "concurrent.futures.Future[list[dict[str, Any]]]",
+        label: str,
+    ) -> list[dict[str, Any]]:
+        """Wait for a top-level settings future, returning [] on timeout.
+
+        Mirrors `QEMDashboardClient.{incident,update}_settings` returning
+        [] on a swallowed `_get` failure, so callers see the same shape
+        whether the failure was an HTTP error or an executor timeout.
+        """
+        try:
+            return future.result(timeout=_FUTURE_TIMEOUT)
+        except concurrent.futures.TimeoutError:
+            logger.warning(
+                "QEM Dashboard %s fetch timed out after %.0fs; treating as empty",
+                label,
+                _FUTURE_TIMEOUT,
+            )
+            future.cancel()
+            return []
 
     @staticmethod
     def _normalize_job(

--- a/mtui/connector/qem_dashboard.py
+++ b/mtui/connector/qem_dashboard.py
@@ -1,5 +1,6 @@
 """Connector for the QEM Dashboard API."""
 
+import concurrent.futures
 from logging import getLogger
 from os.path import join
 from typing import Any, Self
@@ -100,26 +101,57 @@ class DashboardAutoOpenQA:
         self.jobs: list[dict[str, Any]] = []
 
     def _load_jobs(self) -> list[dict[str, Any]]:
-        jobs: list[dict[str, Any]] = []
-        incident_settings = self.client.incident_settings(self.incident.incident_number)
+        # Fetch the two top-level settings lists concurrently; they are
+        # independent of each other.
+        incident_number = self.incident.incident_number
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            incident_settings_future = executor.submit(
+                self.client.incident_settings, incident_number
+            )
+            update_settings_future = executor.submit(
+                self.client.update_settings, incident_number
+            )
+            incident_settings = incident_settings_future.result()
+            update_settings = update_settings_future.result()
+
+        # Build a flat task list of (source, setting, fetcher) preserving
+        # the original insertion order: all incident settings first, then
+        # all update settings. Downstream pretty-printing relies on this
+        # order.
+        tasks: list[tuple[str, dict[str, Any], Any]] = []
         for setting in incident_settings:
             setting_id = setting.get("id")
             if setting_id is None:
                 continue
-            jobs.extend(
-                self._normalize_job(job, "incident", setting)
-                for job in self.client.incident_jobs(setting_id)
-            )
-
-        update_settings = self.client.update_settings(self.incident.incident_number)
+            tasks.append(("incident", setting, setting_id))
         for setting in update_settings:
             setting_id = setting.get("id")
             if setting_id is None:
                 continue
-            jobs.extend(
-                self._normalize_job(job, "aggregate", setting)
-                for job in self.client.update_jobs(setting_id)
-            )
+            tasks.append(("aggregate", setting, setting_id))
+
+        if not tasks:
+            return []
+
+        # Fan out the per-setting jobs fetches concurrently. Read futures
+        # back in submission order so the resulting `jobs` list keeps the
+        # same order as the sequential implementation.
+        def _fetch(source: str, setting_id: int) -> list[dict[str, Any]]:
+            if source == "incident":
+                return self.client.incident_jobs(setting_id)
+            return self.client.update_jobs(setting_id)
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(_fetch, source, setting_id)
+                for source, _, setting_id in tasks
+            ]
+
+            jobs: list[dict[str, Any]] = []
+            for (source, setting, _), future in zip(tasks, futures, strict=True):
+                jobs.extend(
+                    self._normalize_job(job, source, setting) for job in future.result()
+                )
 
         return jobs
 

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -1,7 +1,9 @@
 import responses
 
+from mtui.connector import qem_dashboard
 from mtui.connector.qem_dashboard import (
     DashboardAutoOpenQA,
+    QEMDashboardClient,
     QEMIncident,
 )
 from mtui.types import RequestReviewID
@@ -561,3 +563,117 @@ def test_dashboard_auto_openqa_fans_out_per_setting_fetches(mock_config):
     assert [job["test"] for job in dashboard.jobs] == [
         f"qam-incident-{sid}" for sid in incident_setting_ids
     ] + [f"mau-update-{sid}" for sid in update_setting_ids]
+
+
+def test_get_passes_timeout_to_requests(monkeypatch):
+    """Every dashboard HTTP call must carry a (connect, read) timeout so a
+    stuck socket can't hang mtui forever."""
+    captured: dict = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True}
+
+    def _fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeResponse()
+
+    monkeypatch.setattr(qem_dashboard.requests, "get", _fake_get)
+
+    client = QEMDashboardClient("https://dashboard.example.com/api")
+    assert client.incident(123) == {"ok": True}
+
+    assert captured["kwargs"]["timeout"] == qem_dashboard._HTTP_TIMEOUT
+    # Sanity: the constant is a (connect, read) tuple of positive floats.
+    connect, read = qem_dashboard._HTTP_TIMEOUT
+    assert connect > 0
+    assert read > 0
+
+
+def test_load_jobs_skips_timed_out_per_setting_future(monkeypatch, mock_config, caplog):
+    """One slow per-setting fetch must not block or drop the rest."""
+    import time
+
+    # Tighten the future timeout so the test runs fast.
+    monkeypatch.setattr(qem_dashboard, "_FUTURE_TIMEOUT", 0.05)
+
+    dashboard = _make_dashboard(mock_config)
+
+    # Build a fake client: setting 12 hangs past the timeout, others return
+    # one job each.
+    class _FakeClient:
+        def incident_settings(self, _n):
+            return [{"id": sid, "settings": {}} for sid in (11, 12, 13)]
+
+        def update_settings(self, _n):
+            return []
+
+        def incident_jobs(self, sid):
+            if sid == 12:
+                time.sleep(0.5)  # > _FUTURE_TIMEOUT
+                return [
+                    {"job_id": 9999, "name": "should-not-appear", "status": "passed"}
+                ]
+            return [{"job_id": 1000 + sid, "name": f"qam-{sid}", "status": "passed"}]
+
+        def update_jobs(self, _sid):  # pragma: no cover - no update settings here
+            return []
+
+    dashboard.client = _FakeClient()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
+    with caplog.at_level("WARNING", logger="mtui.connector.qem_dashboard"):
+        jobs = dashboard._load_jobs()
+
+    names = [job["test"] for job in jobs]
+    # Settings 11 and 13 contribute; 12 is dropped.
+    assert "qam-11" in names
+    assert "qam-13" in names
+    assert "should-not-appear" not in names
+    # The warning identifies the offending setting.
+    assert any(
+        "incident jobs fetch for setting 12 timed out" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_load_jobs_top_level_settings_timeout_returns_empty(
+    monkeypatch, mock_config, caplog
+):
+    """If incident_settings hangs, _load_jobs returns [] without raising."""
+    import time
+
+    monkeypatch.setattr(qem_dashboard, "_FUTURE_TIMEOUT", 0.05)
+
+    dashboard = _make_dashboard(mock_config)
+
+    class _FakeClient:
+        def incident_settings(self, _n):
+            time.sleep(0.5)  # > _FUTURE_TIMEOUT
+            return [{"id": 1, "settings": {}}]
+
+        def update_settings(self, _n):
+            time.sleep(0.5)  # > _FUTURE_TIMEOUT
+            return [{"id": 2, "settings": {}}]
+
+        def incident_jobs(self, _sid):  # pragma: no cover - never reached
+            return []
+
+        def update_jobs(self, _sid):  # pragma: no cover - never reached
+            return []
+
+    dashboard.client = _FakeClient()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
+    with caplog.at_level("WARNING", logger="mtui.connector.qem_dashboard"):
+        jobs = dashboard._load_jobs()
+
+    assert jobs == []
+    assert any(
+        "incident_settings fetch timed out" in rec.message for rec in caplog.records
+    )
+    assert any(
+        "update_settings fetch timed out" in rec.message for rec in caplog.records
+    )

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -115,11 +115,17 @@ def test_qem_incident_uses_review_id_for_slfo_1_2(mock_config):
     DashboardAutoOpenQA(mock_config, "https://openqa.example.com", incident, rrid).run()
 
     assert incident.incident_number == 12358
-    assert [call.request.url for call in responses.calls] == [
-        f"{API}/incidents/12358",
-        f"{API}/incident_settings/12358",
-        f"{API}/update_settings/12358",
-    ]
+    # `incidents/...` runs first in QEMIncident.__init__ (synchronous);
+    # the two settings calls fan out concurrently in _load_jobs so their
+    # relative order is nondeterministic.
+    call_urls = [call.request.url for call in responses.calls]
+    assert call_urls[0] == f"{API}/incidents/12358"
+    assert sorted(call_urls[1:]) == sorted(
+        [
+            f"{API}/incident_settings/12358",
+            f"{API}/update_settings/12358",
+        ]
+    )
 
 
 @responses.activate
@@ -455,3 +461,103 @@ def test_pretty_print_failed_jobs_grouped(mock_config):
     assert url_offsets[0] == url_offsets[1]
     # No `product:` / `build:` / `arch:` repeated on a per-failure line.
     assert "product: P - " not in out.split("Failed jobs:")[1]
+
+
+@responses.activate
+def test_dashboard_auto_openqa_fans_out_per_setting_fetches(mock_config):
+    """Per-setting jobs fetches run concurrently; each URL hits exactly once
+    and the resulting jobs list preserves insertion order (incident settings
+    in order, then update settings in order).
+    """
+    rrid = RequestReviewID("SUSE:Maintenance:12358:199773")
+    responses.add(
+        responses.GET,
+        f"{API}/incidents/12358",
+        json={"number": 12358, "packages": ["bash"], "channels": []},
+        status=200,
+    )
+
+    incident_setting_ids = [11, 12, 13]
+    update_setting_ids = [21, 22, 23]
+
+    responses.add(
+        responses.GET,
+        f"{API}/incident_settings/12358",
+        json=[
+            {
+                "id": sid,
+                "incident": 12358,
+                "version": "15-SP5",
+                "flavor": "Server-DVD-Incidents",
+                "arch": "x86_64",
+                "settings": {"DISTRI": "sle"},
+            }
+            for sid in incident_setting_ids
+        ],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{API}/update_settings/12358",
+        json=[
+            {
+                "id": sid,
+                "incidents": [12358],
+                "product": "SLES-15-SP5",
+                "arch": "x86_64",
+                "build": "20240101-1",
+                "repohash": "abc123",
+                "settings": {"DISTRI": "sle", "VERSION": "15-SP5"},
+            }
+            for sid in update_setting_ids
+        ],
+        status=200,
+    )
+
+    # One job per setting, named so we can verify ordering.
+    for sid in incident_setting_ids:
+        responses.add(
+            responses.GET,
+            f"{API}/jobs/incident/{sid}",
+            json=[
+                {
+                    "job_id": 1000 + sid,
+                    "name": f"qam-incident-{sid}",
+                    "status": "passed",
+                }
+            ],
+            status=200,
+        )
+    for sid in update_setting_ids:
+        responses.add(
+            responses.GET,
+            f"{API}/jobs/update/{sid}",
+            json=[
+                {
+                    "job_id": 2000 + sid,
+                    "name": f"mau-update-{sid}",
+                    "status": "passed",
+                }
+            ],
+            status=200,
+        )
+
+    incident = QEMIncident(rrid, API)
+    dashboard = DashboardAutoOpenQA(
+        mock_config, "https://openqa.example.com", incident, rrid
+    ).run()
+
+    # Each per-setting URL is called exactly once (no duplicates from the
+    # concurrent fan-out).
+    call_urls = [call.request.url for call in responses.calls]
+    for sid in incident_setting_ids:
+        assert call_urls.count(f"{API}/jobs/incident/{sid}") == 1
+    for sid in update_setting_ids:
+        assert call_urls.count(f"{API}/jobs/update/{sid}") == 1
+
+    # Insertion order is preserved: incident jobs (in setting order) come
+    # before aggregate jobs (in setting order). This is what the
+    # pretty-printer relies on to keep summaries stable.
+    assert [job["test"] for job in dashboard.jobs] == [
+        f"qam-incident-{sid}" for sid in incident_setting_ids
+    ] + [f"mau-update-{sid}" for sid in update_setting_ids]


### PR DESCRIPTION
## Summary

- Loading one incident from the QEM Dashboard issues `N+2` sequential GETs (one per incident setting + one per update setting). The API has no batch endpoint, so on large incidents this serial chain dominates wall time of `mtui` startup and any command that pulls fresh dashboard data (`reloadoqa`, `simpleset`, `export`).
- `DashboardAutoOpenQA._load_jobs` now uses `concurrent.futures.ThreadPoolExecutor` to run `incident_settings` and `update_settings` in parallel, then fans out every per-setting `jobs/incident/{id}` / `jobs/update/{id}` request concurrently in a second executor.
- Public surface of `QEMDashboardClient` and `DashboardAutoOpenQA` is unchanged — same requests issued, same payloads, same `dashboard.jobs` / `dashboard.pp` / `dashboard.results`.

## Implementation notes

- Futures are read back in **submission order**, so the resulting `jobs` list preserves the insertion order the sequential code produced. `_pretty_print` summaries depend on this ordering and stay byte-identical for unchanged inputs.
- `_get`'s existing swallow-and-return-`None` error handling is preserved; a single failed setting fetch no longer blocks or fails the rest of the batch.
- Worker count is the stdlib default (`min(32, cpu_count + 4)`), matching the existing concurrency pattern in `mtui/export/downloader.py` and `mtui/commands/{addhost,removehost,quit}.py` — no new config knob.
- No new dependencies; `requests` calls remain thread-safe (no shared `Session`).

## Tests

- Adjusted `test_qem_incident_uses_review_id_for_slfo_1_2` so the two now-concurrent settings URLs are asserted as an unordered set; the synchronous `incidents/…` call from `QEMIncident.__init__` is still asserted first.
- Added `test_dashboard_auto_openqa_fans_out_per_setting_fetches`: mocks three incident + three update settings, verifies every per-setting URL is hit exactly once, and pins the deterministic insertion order of `dashboard.jobs`.

## Verification

All local gates green:

```
uv run ruff format --check .   # clean
uv run ruff check .            # clean
uv run ty check                # clean (strict mode applies to mtui/connector/**)
uv run pytest                  # 548 passed
```

## Risks

- Increased burst load against the dashboard host. Stdlib's default worker pool can be aggressive on large machines; if the dashboard turns out to have rate limits we'd cap `max_workers` in a follow-up.
- No behavior change for callers; `_pretty_print` output stays stable because insertion order is preserved.