### PR TITLE
fix(updateid): clarify force-continue prompt default and warn on abort about stale template dir

### DIFF
--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -66,7 +66,8 @@ class UpdateID(ABC):
 
         """
         tr = self.testreport_factory(config)
-        trpath: Path = config.template_dir / str(self.id) / "log"
+        trdir: Path = config.template_dir / str(self.id)
+        trpath: Path = trdir / "log"
 
         try:
             tr.read(trpath)
@@ -98,8 +99,12 @@ class UpdateID(ABC):
                 self.id,
             )
             if not prompt_user(
-                "Force continue loading template ? [Y/N]: ", ["yes", "y"], interactive
+                "Force continue loading template ? [y/N]: ", ["yes", "y"], interactive
             ):
+                if trdir.exists():
+                    logger.warning(
+                        "Make sure to remove %s before relaunching MTUI", trdir
+                    )
                 raise TestReportNotLoadedError from None
             logger.warning("Template is loaded, but hash differs")
 

--- a/tests/test_updateid.py
+++ b/tests/test_updateid.py
@@ -1,0 +1,110 @@
+"""Tests for `UpdateID._checkout` hash-mismatch handling.
+
+Regression coverage for commit cc2147a, which:
+
+- Renames the force-continue prompt label from ``[Y/N]`` to ``[y/N]`` so the
+  visible default matches the actual behaviour ("no").
+- On the abort branch (user declines force-continue), warns about the
+  partially-checked-out template directory that must be removed before
+  relaunching MTUI -- but only if the directory actually exists, and only
+  when the user did *not* force-continue.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mtui.exceptions import InvalidGiteaHashError
+from mtui.messages import TestReportNotLoadedError
+from mtui.types.updateid import AutoOBSUpdateID
+
+RRID = "SUSE:Maintenance:12358:199773"
+PROMPT_LABEL = "Force continue loading template ? [y/N]: "
+CLEANUP_HINT = "Make sure to remove"
+
+
+def _make_updateid() -> tuple[AutoOBSUpdateID, MagicMock]:
+    """Build an `AutoOBSUpdateID` whose testreport read raises hash mismatch.
+
+    The factory is replaced post-construction so the production constructor
+    wiring (`tr_factory`, real `testreport_svn_checkout`) still runs, but the
+    `_checkout` call path is steered into the `InvalidGiteaHashError` branch
+    without touching the network or filesystem-via-svn.
+
+    Returns the update id and the test-report mock so tests can assert
+    identity on the returned `TestReport`.
+    """
+    uid = AutoOBSUpdateID(RRID)
+    tr_mock = MagicMock(name="testreport")
+    tr_mock.read.side_effect = InvalidGiteaHashError(uid.id, "oldhash", "newhash")
+    uid.testreport_factory = MagicMock(return_value=tr_mock)  # ty: ignore[invalid-assignment]
+    return uid, tr_mock
+
+
+def test_checkout_invalid_hash_abort_warns_when_trdir_exists(
+    mock_config, tmp_path, caplog
+):
+    """Abort + existing trdir -> cleanup hint logged, prompt uses [y/N]."""
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock = _make_updateid()
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        patch(
+            "mtui.types.updateid.prompt_user", return_value=False
+        ) as prompt_user_mock,
+        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)
+
+    # Prompt label change is locked in here.
+    prompt_user_mock.assert_called_once()
+    assert prompt_user_mock.call_args.args[0] == PROMPT_LABEL
+
+    cleanup_warnings = [r for r in caplog.records if CLEANUP_HINT in r.getMessage()]
+    assert len(cleanup_warnings) == 1
+    assert str(trdir) in cleanup_warnings[0].getMessage()
+
+
+def test_checkout_invalid_hash_abort_silent_when_trdir_missing(
+    mock_config, tmp_path, caplog
+):
+    """Abort + missing trdir -> still raises, but no cleanup hint."""
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock = _make_updateid()
+    # Deliberately do not create tmp_path / str(uid.id).
+    assert not (tmp_path / str(uid.id)).exists()
+
+    with (
+        patch("mtui.types.updateid.prompt_user", return_value=False),
+        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)
+
+    assert not any(CLEANUP_HINT in r.getMessage() for r in caplog.records)
+
+
+def test_checkout_invalid_hash_force_continue_no_cleanup_warning(
+    mock_config, tmp_path, caplog
+):
+    """Force-continue suppresses the cleanup hint even if trdir exists."""
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        patch("mtui.types.updateid.prompt_user", return_value=True),
+        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
+    ):
+        tr = uid._checkout(mock_config, interactive=True)
+
+    # Returns the same testreport instance produced by the patched factory.
+    assert tr is tr_mock
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Template is loaded, but hash differs" in m for m in messages)
+    assert not any(CLEANUP_HINT in m for m in messages)


### PR DESCRIPTION
## Why this change was needed

The `[Y/N]` prompt implied "yes" was the default, but the effective default is "no". This mismatch was confusing. Additionally, when a hash-mismatch load fails, the partially-checked-out SVN directory is left on disk; svn does not overwrite an existing checkout, so the next MTUI run hits the same failure silently.

## Problem solved

Users now see `[y/N]` so the safe default is unambiguous. When they choose to abort, a warning points to the exact directory they must remove before retrying, so the subsequent SVN checkout can succeed. The warning is suppressed when the user force-continues, where it would be incorrect advice.

## What changed

- Prompt label changed from `[Y/N]` to `[y/N]`
- Extracted `trdir` from `trpath` to reuse the template directory path
- Cleanup warning moved inside the abort branch, after `prompt_user`