### PR TITLE
fix(update): remove test repositories from SUTs after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   66 % (current − 1, ratchets upward); patch target stays at 80 %.
 
 ### Fixed
+- `update` now removes the test update repositories from every SUT after
+  the update finishes (and even when the update or its post/compare
+  scripts raise), instead of leaving them configured behind.
 - QEM Dashboard HTTP requests now carry a (5 s connect, 30 s read)
   timeout, and the parallel per-setting jobs fan-out is bounded by a 60 s
   per-future wall-clock cap. A stuck connection or unresponsive endpoint

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -525,25 +525,49 @@ class HostsGroup(UserDict[str, Target]):
         }
 
         try:
-            self.run(commands)
-            for t in self.data.values():
-                t.get_updater_check()(
-                    t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit()
+            try:
+                self.run(commands)
+                for t in self.data.values():
+                    t.get_updater_check()(
+                        t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit()
+                    )
+                self._reboot(reboot)
+            finally:
+                self.unlock()
+
+            if "newpackage" in params:
+                self.perform_prepare(
+                    testreport.get_package_list(), testreport, testing=True
                 )
-            self._reboot(reboot)
+
+            package_check(True)
+
+            if "noscript" not in params and not testreport.config.auto:
+                testreport.run_scripts(PostScript, self)
+                testreport.run_scripts(CompareScript, self)
         finally:
-            self.unlock()
+            # Always remove the test update repositories that were added above,
+            # even if the update / scripts raised. Repo metadata changes are
+            # not transactional, so no reboot is required for transactional
+            # systems here.
+            try:
+                self.update_lock()
+            except UpdateError:
+                logger.warning(
+                    "Could not lock hosts to remove update repositories; "
+                    "skipping repo cleanup."
+                )
+            else:
+                try:
+                    for t in self.data.values():
+                        queue.put((t.set_repo, ["remove", testreport]))
 
-        if "newpackage" in params:
-            self.perform_prepare(
-                testreport.get_package_list(), testreport, testing=True
-            )
+                    while queue.unfinished_tasks:
+                        spinner()
 
-        package_check(True)
-
-        if "noscript" not in params and not testreport.config.auto:
-            testreport.run_scripts(PostScript, self)
-            testreport.run_scripts(CompareScript, self)
+                    queue.join()
+                finally:
+                    self.unlock()
 
     def report_self(self, sink):
         """Reports the status of all hosts in the group.

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -718,6 +718,68 @@ def test_perform_update_unlocks_when_run_fails(
     t1.unlock.assert_called()
 
 
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_update_removes_repos_at_end(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """``perform_update`` queues set_repo('remove', ...) after the update."""
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.get_updater_check.return_value = MagicMock()
+    mock_queue.unfinished_tasks = 0
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1])
+    hg.perform_update(testreport, ["noprepare", "noscript"])
+
+    set_repo_calls = [
+        call.args[0]
+        for call in mock_queue.put.call_args_list
+        if call.args and call.args[0][0] is t1.set_repo
+    ]
+    # The repo lifecycle is: add at the start, remove at the end.
+    assert set_repo_calls[0] == (t1.set_repo, ["add", testreport])
+    assert set_repo_calls[-1] == (t1.set_repo, ["remove", testreport])
+
+
+@patch("mtui.target.hostgroup.spinner")
+@patch("mtui.target.hostgroup.ThreadedMethod")
+@patch("mtui.target.hostgroup.queue")
+@patch("mtui.target.hostgroup.RunCommand")
+def test_perform_update_removes_repos_even_when_run_fails(
+    mock_run, mock_queue, mock_thread, mock_spinner
+):
+    """Repo cleanup runs even when the updater command itself raises."""
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    mock_queue.unfinished_tasks = 0
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1])
+    mock_run.return_value.run.side_effect = RuntimeError("update boom")
+
+    with pytest.raises(RuntimeError, match="update boom"):
+        hg.perform_update(testreport, ["noprepare", "noscript"])
+
+    set_repo_calls = [
+        call.args[0]
+        for call in mock_queue.put.call_args_list
+        if call.args and call.args[0][0] is t1.set_repo
+    ]
+    assert (t1.set_repo, ["remove", testreport]) in set_repo_calls
+
+
 # ---------------------------------------------------------------------------
 # remaining group report methods
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `update` now removes the maintenance test repositories from every SUT after the update finishes (and even when the updater command or post/compare scripts raise), instead of leaving them configured behind.
- Cleanup is implemented as a `try/finally` around the post-`set_repo("add", ...)` block in `HostsGroup.perform_update`; lock acquisition for the cleanup is guarded so a `LockError` there cannot mask the original exception.
- No reboot is issued on transactional systems for the cleanup since repo metadata changes are not transactional.

## Why
A user reported that after `update`, the test update repositories stayed on the SUT. `perform_update` queued `set_repo("add", testreport)` at the start but never queued `set_repo("remove", testreport)`. Other flows (`perform_downgrade`, default `perform_prepare`) already pair add/remove correctly; `perform_update` was the outlier.

## Tests
- New `test_perform_update_removes_repos_at_end` pins the success path: `set_repo("add", ...)` is queued first, `set_repo("remove", ...)` is queued last.
- New `test_perform_update_removes_repos_even_when_run_fails` asserts cleanup still runs when the updater command raises.
- Full local gates pass: `uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check`, `uv run pytest` (556 passed).

## Changelog
Added a `### Fixed` entry under `[Unreleased]` describing the user-visible behaviour change.