### PR TITLE
fix(template): normalize TERADATA SLE15 product name variant

### DIFF
--- a/mtui/template/products/sle15.py
+++ b/mtui/template/products/sle15.py
@@ -23,6 +23,10 @@ def normalize_sle15(x):
         x[0][0] = "ERICSSON"
         x[0][1] = x[0][1].replace("-ERICSSON", "")
         return x
+    if x[0][0] == "SLE-Product-SLES" and "TERADATA" in x[0][1]:
+        x[0][0] = "SLES_TERADATA"
+        x[0][1] = x[0][1].replace("-TERADATA", "")
+        return x
     if x[0][0] == "SLE-Product-SLES":
         x[0][0] = "SLES"
         return x


### PR DESCRIPTION
## Summary

- A TERADATA-flavored SLE15 product variant appeared in a maintenance update with no normalization rule, causing the raw `SLE-Product-SLES` token to pass through unmapped instead of the canonical `SLES_TERADATA` identifier.
- Adds a TERADATA guard in `normalize_sle15` before the generic `SLE-Product-SLES` fallback, mirroring the existing ERICSSON OEM pattern.

## Details

Downstream logic that expects canonical product names would silently receive the wrong token, leading to incorrect host classification or failed lookups. The fix strips the `-TERADATA` suffix from the repo/product field and maps the product name to `SLES_TERADATA`, consistent with how `ERICSSON` variants are handled.