### PR TITLE
fix(test): suppress pytest warnings from TestReportNotLoadedError

### DIFF
--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -123,6 +123,8 @@ class MissingPackagesError(UserError):
 class TestReportNotLoadedError(UserError):
     """Raised when a test report is not loaded."""
 
+    __test__ = False
+
     def __str__(self) -> str:
         return "TestReport not loaded"
 


### PR DESCRIPTION
Why this change was needed:
Pytest was emitting deprecation or collection warnings about the
TestReportNotLoadedError class during test discovery. Adding `__test__ = False`
tells pytest to skip collecting it as a test class.

Problem solved:
Cleaner CI output with no spurious warnings from application error classes
that pytest was mistakenly trying to collect as tests.

What changed:
- Added `__test__ = False` attribute to TestReportNotLoadedError class