### PR TITLE
refactor(commands): replace glob+globals plugin loader with __init_subclass__ registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `mtui/target/target.py`, `mtui/target/hostgroup.py` and
   `mtui/connection.py`. The Codecov project floor is bumped from 56 % to
   66 % (current − 1, ratchets upward); patch target stays at 80 %.
+- `mtui.commands` now exposes a `registry: dict[str, type[Command]]`
+  populated automatically via `Command.__init_subclass__`. The legacy
+  `cmd_list` attribute and the `globals()`-based per-class re-export have
+  been removed; the only documented consumer was `CommandPrompt`, which
+  now iterates `commands.registry.values()` directly.
 
 ### Fixed
 - `update` now removes the test update repositories from every SUT after

--- a/mtui/commands/__init__.py
+++ b/mtui/commands/__init__.py
@@ -1,40 +1,36 @@
 """This package contains the command modules for mtui.
 
-Each module in this package defines a specific command that can be
-executed from the mtui command prompt. The modules are dynamically
-imported and registered as commands.
+Each module in this package defines one or more :class:`Command` subclasses.
+Importing this package walks the package directory with
+:func:`pkgutil.iter_modules`, imports every non-underscore submodule, and
+relies on :meth:`Command.__init_subclass__` to populate
+:data:`Command.registry` as a side-effect of class creation. The registry is
+re-exported as :data:`registry` for use by ``mtui.prompt``.
 """
 
 import importlib
+import pkgutil
 from logging import getLogger
-from pathlib import Path
 
 from ._command import Command as Command
+from ._command import CommandAlreadyBoundError as CommandAlreadyBoundError
 
 logger = getLogger("mtui.commands")
 
-_rootdir = Path(__file__).resolve().parent
-cmd_list: list[str] = []
-
-for pth in _rootdir.glob("*.py"):
-    if pth.is_file():
-        modname = pth.name[:-3]
-    else:
-        continue
-
-    # skip things like __init__, __pycache__, __main__ , _commad ...
-    if modname.startswith("_"):
+# Import every submodule whose name does not start with ``_`` so that each
+# Command subclass triggers Command.__init_subclass__. We do not need the
+# returned module objects; the side-effect of import is the whole point.
+for _modinfo in pkgutil.iter_modules(__path__):
+    if _modinfo.name.startswith("_"):
         continue
     try:
-        logger.debug("loading command module %s", modname)
-        module = importlib.import_module("." + modname, "mtui.commands")
+        logger.debug("loading command module %s", _modinfo.name)
+        importlib.import_module(f".{_modinfo.name}", __name__)
     except Exception:
-        logger.exception("loading command module %s failed", modname)
+        logger.exception("loading command module %s failed", _modinfo.name)
         continue
 
-    # register classes
-    klzs = [x for x in dir(module) if hasattr(getattr(module, x), "command")]
-    cmd_list += klzs
-
-    for x in klzs:
-        globals()[x] = getattr(module, x)
+#: Public alias for :attr:`Command.registry`. Keys are the user-facing command
+#: strings (e.g. ``"set_session_name"``), values are the concrete
+#: :class:`Command` subclasses.
+registry = Command.registry

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -4,6 +4,7 @@ import shlex
 from abc import ABC, abstractmethod
 from argparse import Namespace, RawDescriptionHelpFormatter
 from logging import getLogger
+from typing import ClassVar
 
 from ..argparse import ArgumentParser
 from ..messages import HostIsNotConnectedError
@@ -12,10 +13,30 @@ from ..target.hostgroup import HostsGroup
 logger = getLogger("mtui.commands.command")
 
 
+class CommandAlreadyBoundError(RuntimeError):
+    """Raised when two ``Command`` subclasses claim the same ``command`` string.
+
+    Lives in ``mtui.commands._command`` so the ``Command.__init_subclass__``
+    hook can raise it at class-creation time. ``mtui.prompt`` re-exports the
+    name for backwards compatibility with code that imported it from there.
+    """
+
+
 class Command(ABC):
-    """An abstract base class for all commands in mtui."""
+    """An abstract base class for all commands in mtui.
+
+    Concrete subclasses are auto-registered into ``Command.registry`` keyed by
+    their ``command`` attribute. Abstract intermediate classes (those that do
+    not assign ``command`` in their own body) are skipped.
+    """
 
     command: str
+
+    #: Auto-populated registry of every concrete ``Command`` subclass that
+    #: assigns ``command`` in its own class body. Mutated by
+    #: ``__init_subclass__`` at class-creation time; consumers (notably
+    #: ``mtui.prompt.CommandPrompt``) iterate this dict to discover commands.
+    registry: ClassVar[dict[str, type["Command"]]] = {}
 
     __slots__ = [
         "args",
@@ -36,6 +57,24 @@ class Command(ABC):
         is set in parsed L{argparse.Namespace} and if not, prints an
         error message.
     """
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Auto-register concrete subclasses into ``Command.registry``.
+
+        Subclasses that do not assign ``command`` in their own body (i.e.
+        abstract intermediates such as ``BaseApiCall``) are skipped; only
+        explicit ``command = "..."`` declarations register. Duplicate
+        declarations of the same ``command`` string raise
+        ``CommandAlreadyBoundError`` at class-creation time.
+        """
+        super().__init_subclass__(**kwargs)
+        if "command" not in cls.__dict__:
+            return
+        name = cls.command
+        existing = Command.registry.get(name)
+        if existing is not None and existing is not cls:
+            raise CommandAlreadyBoundError(name)
+        Command.registry[name] = cls
 
     def __init__(self, args, config, sys, prompt) -> None:
         """Initializes the command object.

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -17,7 +17,7 @@ from mtui import notification
 
 from . import commands, messages
 from .argparse import ArgsParseFailureError
-from .commands import Command
+from .commands import Command, CommandAlreadyBoundError
 from .template.nulltestreport import NullTestReport
 
 logger = getLogger("mtui.prompt")
@@ -69,10 +69,6 @@ class CmdQueue(list):
 
         """
         self.term.stdout.write(f"{self.prompt}{val}\n")
-
-
-class CommandAlreadyBoundError(RuntimeError):
-    """Raised when a command is already bound to the prompt."""
 
 
 class CommandPrompt(cmd.Cmd):

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -127,8 +127,8 @@ class CommandPrompt(cmd.Cmd):
         self.commands: dict[str, type[Command]] = {}
 
         # register commands
-        for x in commands.cmd_list:
-            self._add_subcommand(getattr(commands, x))
+        for cls in commands.registry.values():
+            self._add_subcommand(cls)
 
         # self.stdout is used by cmd.Cmd
         self.stdout = self.sys.stdout

--- a/tests/test_command_init_subclass.py
+++ b/tests/test_command_init_subclass.py
@@ -1,0 +1,114 @@
+"""Unit tests for ``Command.__init_subclass__`` registration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from mtui.commands._command import Command, CommandAlreadyBoundError
+
+
+@pytest.fixture
+def clean_registry() -> Iterator[None]:
+    """Snapshot the registry, run the test, then restore it.
+
+    Each test in this module creates throwaway ``Command`` subclasses; without
+    this fixture they would leak into ``Command.registry`` for the rest of the
+    pytest session and pollute the characterization test in
+    ``tests/test_commands_registry.py``.
+    """
+    snapshot = dict(Command.registry)
+    try:
+        yield
+    finally:
+        Command.registry.clear()
+        Command.registry.update(snapshot)
+
+
+def test_subclass_with_command_attribute_is_registered(clean_registry):
+    class _Foo(Command):
+        command = "tmp_init_subclass_foo"
+
+        def __call__(self) -> None:
+            return None
+
+    assert Command.registry["tmp_init_subclass_foo"] is _Foo
+
+
+def test_subclass_without_command_attribute_is_skipped(clean_registry):
+    """Abstract intermediates that do not assign ``command`` are not registered."""
+    before = set(Command.registry)
+
+    class _AbstractMid(Command):
+        # No ``command`` assignment; this mirrors mtui.commands.apicall.BaseApiCall.
+        def __call__(self) -> None:
+            return None
+
+    after = set(Command.registry)
+    assert before == after
+    assert _AbstractMid not in Command.registry.values()
+
+
+def test_inherited_command_attribute_does_not_re_register(clean_registry):
+    """A subclass that does not redeclare ``command`` is skipped even if it inherits one."""
+
+    class _Parent(Command):
+        command = "tmp_init_subclass_parent"
+
+        def __call__(self) -> None:
+            return None
+
+    class _Child(_Parent):
+        # Inherits ``command`` but does not put it in ``__dict__``.
+        pass
+
+    assert Command.registry["tmp_init_subclass_parent"] is _Parent
+    # The child does not displace the parent's registry slot.
+    assert _Child not in Command.registry.values()
+
+
+def test_duplicate_command_string_raises(clean_registry):
+    class _First(Command):
+        command = "tmp_init_subclass_dup"
+
+        def __call__(self) -> None:
+            return None
+
+    with pytest.raises(CommandAlreadyBoundError, match="tmp_init_subclass_dup"):
+
+        class _Second(Command):
+            command = "tmp_init_subclass_dup"
+
+            def __call__(self) -> None:
+                return None
+
+    # The first registration survives; the second never makes it in.
+    assert Command.registry["tmp_init_subclass_dup"] is _First
+
+
+def test_aliases_via_subclassing_are_each_registered(clean_registry):
+    """Sibling subclasses that each declare ``command`` all register (the quit/exit/EOF case)."""
+
+    class _Base(Command):
+        command = "tmp_init_subclass_base"
+
+        def __call__(self) -> None:
+            return None
+
+    class _Alias1(_Base):
+        command = "tmp_init_subclass_alias1"
+
+    class _Alias2(_Base):
+        command = "tmp_init_subclass_alias2"
+
+    assert Command.registry["tmp_init_subclass_base"] is _Base
+    assert Command.registry["tmp_init_subclass_alias1"] is _Alias1
+    assert Command.registry["tmp_init_subclass_alias2"] is _Alias2
+
+
+def test_registry_is_a_class_attribute_shared_across_module_imports():
+    """The registry is the same dict whether reached via ``Command`` or ``mtui.commands``."""
+    from mtui import commands
+
+    assert commands.registry is Command.registry

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -1,0 +1,125 @@
+"""Characterization tests for the ``mtui.commands`` plugin registry.
+
+These tests pin the exact set of commands the package exposes so that the
+Phase 5b / C5 refactor (filesystem-glob + ``globals()`` -> ``__init_subclass__``
+registry) cannot silently change the public surface.
+
+The ``EXPECTED`` constant lists every ``(command_string, module, class_name)``
+triple the loader produces. The set must stay byte-identical across the
+refactor; if a real command is added or renamed in a separate change, update
+``EXPECTED`` in the same commit that introduces the change.
+"""
+
+from __future__ import annotations
+
+from mtui import commands
+
+# Snapshot taken on phase_five_b2 before the C5 refactor.
+EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        ("EOF", "mtui.commands.quit", "DEOF"),
+        ("add_host", "mtui.commands.addhost", "AddHost"),
+        ("analyze_diff", "mtui.commands.showdiff", "AnalyzeDiff"),
+        ("approve", "mtui.commands.apicall", "Approve"),
+        ("assign", "mtui.commands.apicall", "Assign"),
+        ("checkout", "mtui.commands.checkout", "Checkout"),
+        ("comment", "mtui.commands.apicall", "Comment"),
+        ("commit", "mtui.commands.commit", "Commit"),
+        ("config", "mtui.commands.config", "Config"),
+        ("downgrade", "mtui.commands.downgrade", "Downgrade"),
+        ("edit", "mtui.commands.edit", "Edit"),
+        ("exit", "mtui.commands.quit", "QExit"),
+        ("export", "mtui.commands.export", "Export"),
+        ("get", "mtui.commands.sftpcmd", "SFTPGet"),
+        ("install", "mtui.commands.zypper", "Install"),
+        ("list_bugs", "mtui.commands.simplelists", "ListBugs"),
+        ("list_history", "mtui.commands.simplelists", "ListHistory"),
+        ("list_hosts", "mtui.commands.simplelists", "ListHosts"),
+        ("list_locks", "mtui.commands.simplelists", "ListLocks"),
+        ("list_metadata", "mtui.commands.simplelists", "ListMetadata"),
+        ("list_packages", "mtui.commands.listpackages", "ListPackages"),
+        ("list_products", "mtui.commands.products", "ListProducts"),
+        ("list_sessions", "mtui.commands.simplelists", "ListSessions"),
+        ("list_timeout", "mtui.commands.simplelists", "ListTimeout"),
+        ("list_update_commands", "mtui.commands.simplelists", "ListUpdateCommands"),
+        ("list_versions", "mtui.commands.simplelists", "ListVersions"),
+        ("load_template", "mtui.commands.loadtemplate", "LoadTemplate"),
+        ("lock", "mtui.commands.hostslock", "HostLock"),
+        ("lrun", "mtui.commands.localrun", "LocalRun"),
+        ("prepare", "mtui.commands.prepare", "Prepare"),
+        ("put", "mtui.commands.sftpcmd", "SFTPPut"),
+        ("quit", "mtui.commands.quit", "Quit"),
+        ("reject", "mtui.commands.apicall", "Reject"),
+        ("reload_openqa", "mtui.commands.reloadoqa", "ReloadOpenQA"),
+        ("reload_products", "mtui.commands.reload", "ReloadProducts"),
+        ("remove_host", "mtui.commands.removehost", "RemoveHost"),
+        ("report-bug", "mtui.commands.reportbug", "ReportBug"),
+        ("run", "mtui.commands.run", "Run"),
+        ("set_host_state", "mtui.commands.hoststate", "HostState"),
+        ("set_location", "mtui.commands.simpleset", "SetLocation"),
+        ("set_log_level", "mtui.commands.simpleset", "SetLogLevel"),
+        ("set_repo", "mtui.commands.setrepo", "SetRepo"),
+        ("set_session_name", "mtui.commands.simpleset", "SessionName"),
+        ("set_timeout", "mtui.commands.simpleset", "SetTimeout"),
+        ("set_workflow", "mtui.commands.simpleset", "SetWorkflow"),
+        ("shell", "mtui.commands.shell", "Shell"),
+        ("show_diff", "mtui.commands.showdiff", "ShowDiff"),
+        ("show_log", "mtui.commands.simplelists", "ListLog"),
+        ("show_update_repos", "mtui.commands.showrepos", "Showrepos"),
+        ("terms", "mtui.commands.terms", "Terms"),
+        ("unassign", "mtui.commands.apicall", "Unassign"),
+        ("uninstall", "mtui.commands.zypper", "Uninstall"),
+        ("unlock", "mtui.commands.hostsunlock", "HostsUnlock"),
+        ("update", "mtui.commands.update", "Update"),
+        ("whoami", "mtui.commands.whoami", "Whoami"),
+    }
+)
+
+
+def _current_surface() -> frozenset[tuple[str, str, str]]:
+    """Return the live ``(command, module, class_name)`` set the loader exposes.
+
+    Reads the legacy ``cmd_list`` + ``getattr`` surface so this test passes
+    against ``main`` before the C5 refactor; it is updated in a follow-up
+    commit to read ``commands.registry`` once the registry exists.
+    """
+    out: set[tuple[str, str, str]] = set()
+    for name in commands.cmd_list:
+        cls = getattr(commands, name)
+        out.add((cls.command, cls.__module__, cls.__name__))
+    return frozenset(out)
+
+
+def test_registry_matches_expected_surface() -> None:
+    """The loader exposes exactly the snapshot commands, no more, no less."""
+    actual = _current_surface()
+    assert actual == EXPECTED, {
+        "missing": sorted(EXPECTED - actual),
+        "unexpected": sorted(actual - EXPECTED),
+    }
+
+
+def test_registry_count_matches_snapshot() -> None:
+    """Guard against silent additions: command count is part of the contract."""
+    assert len(_current_surface()) == len(EXPECTED)
+
+
+def test_abstract_base_apicall_is_not_exposed() -> None:
+    """``BaseApiCall`` is abstract and must not appear in the loader output."""
+    class_names = {cls_name for _, _, cls_name in _current_surface()}
+    assert "BaseApiCall" not in class_names
+    assert "Command" not in class_names
+
+
+def test_quit_aliases_are_distinct_classes() -> None:
+    """``quit`` / ``exit`` / ``EOF`` are three separate classes from quit.py."""
+    from mtui.commands.quit import DEOF, QExit, Quit
+
+    by_command = {cls.command: cls for cls in (Quit, QExit, DEOF)}
+    assert by_command["quit"] is Quit
+    assert by_command["exit"] is QExit
+    assert by_command["EOF"] is DEOF
+    # exit/EOF inherit from quit; multi-class-per-module discovery must
+    # keep working under __init_subclass__.
+    assert issubclass(QExit, Quit)
+    assert issubclass(DEOF, Quit)

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -77,21 +77,22 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
 
 
 def _current_surface() -> frozenset[tuple[str, str, str]]:
-    """Return the live ``(command, module, class_name)`` set the loader exposes.
+    """Return the live ``(command, module, class_name)`` set from the registry.
 
-    Reads the legacy ``cmd_list`` + ``getattr`` surface so this test passes
-    against ``main`` before the C5 refactor; it is updated in a follow-up
-    commit to read ``commands.registry`` once the registry exists.
+    Filters to classes defined under the ``mtui.commands`` package so that
+    test-only ``Command`` subclasses (e.g. ``ConcreteCommand`` in
+    ``tests/test_command_base.py``) registered earlier in the session do not
+    pollute the snapshot when tests run in arbitrary order.
     """
-    out: set[tuple[str, str, str]] = set()
-    for name in commands.cmd_list:
-        cls = getattr(commands, name)
-        out.add((cls.command, cls.__module__, cls.__name__))
-    return frozenset(out)
+    return frozenset(
+        (cls.command, cls.__module__, cls.__name__)
+        for cls in commands.registry.values()
+        if cls.__module__.startswith("mtui.commands.")
+    )
 
 
 def test_registry_matches_expected_surface() -> None:
-    """The loader exposes exactly the snapshot commands, no more, no less."""
+    """The registry exposes exactly the snapshot commands, no more, no less."""
     actual = _current_surface()
     assert actual == EXPECTED, {
         "missing": sorted(EXPECTED - actual),
@@ -104,9 +105,19 @@ def test_registry_count_matches_snapshot() -> None:
     assert len(_current_surface()) == len(EXPECTED)
 
 
-def test_abstract_base_apicall_is_not_exposed() -> None:
-    """``BaseApiCall`` is abstract and must not appear in the loader output."""
-    class_names = {cls_name for _, _, cls_name in _current_surface()}
+def test_registry_is_keyed_by_command_string() -> None:
+    """Every registry key equals its class's ``command`` attribute."""
+    for key, cls in commands.registry.items():
+        assert key == cls.command
+
+
+def test_abstract_base_apicall_is_not_registered() -> None:
+    """``BaseApiCall`` is abstract and must not appear in the registry."""
+    class_names = {
+        cls.__name__
+        for cls in commands.registry.values()
+        if cls.__module__.startswith("mtui.commands.")
+    }
     assert "BaseApiCall" not in class_names
     assert "Command" not in class_names
 
@@ -115,11 +126,21 @@ def test_quit_aliases_are_distinct_classes() -> None:
     """``quit`` / ``exit`` / ``EOF`` are three separate classes from quit.py."""
     from mtui.commands.quit import DEOF, QExit, Quit
 
-    by_command = {cls.command: cls for cls in (Quit, QExit, DEOF)}
-    assert by_command["quit"] is Quit
-    assert by_command["exit"] is QExit
-    assert by_command["EOF"] is DEOF
+    assert commands.registry["quit"] is Quit
+    assert commands.registry["exit"] is QExit
+    assert commands.registry["EOF"] is DEOF
     # exit/EOF inherit from quit; multi-class-per-module discovery must
     # keep working under __init_subclass__.
     assert issubclass(QExit, Quit)
     assert issubclass(DEOF, Quit)
+
+
+def test_legacy_cmd_list_attribute_is_gone() -> None:
+    """The legacy ``cmd_list`` and globals()-injected classes are removed."""
+    assert not hasattr(commands, "cmd_list")
+    # Spot-check that no command class is exposed as a module attribute on
+    # mtui.commands (the old loader injected each into globals()).
+    for _, _, class_name in EXPECTED:
+        assert not hasattr(commands, class_name), (
+            f"{class_name} unexpectedly re-exported on mtui.commands"
+        )


### PR DESCRIPTION
## Summary

Phase 5b / C5 of the [MTUI improvement plan](../PLAN.md): replace the
filesystem-glob + `dir()` reflection + `globals()`-injection plugin
loader in `mtui/commands/__init__.py` with a `Command.__init_subclass__`
registry. The loader still has to import every submodule (so subclass
hooks fire), but discovery is now driven by `pkgutil.iter_modules` and
the public surface collapses to a single `mtui.commands.registry:
dict[str, type[Command]]`.

- 55 commands registered, byte-identical surface to before (pinned by a
  characterization test introduced in the first commit of this PR).
- `BaseApiCall` (the abstract intermediate) is correctly skipped via
  `"command" not in cls.__dict__`.
- `quit` / `exit` / `EOF` (multi-class-per-module via subclassing) all
  register as before.
- Duplicate `command` strings now raise `CommandAlreadyBoundError` at
  class-creation time, not just at the first prompt instantiation.

## Changes

- `mtui/commands/_command.py` — add `Command.registry`,
  `__init_subclass__` hook, and relocate `CommandAlreadyBoundError` here
  so the hook can raise it.
- `mtui/commands/__init__.py` — rewrite using `pkgutil.iter_modules`;
  drop `cmd_list` and the `globals()` injection.
- `mtui/prompt.py` — iterate `commands.registry.values()` instead of the
  legacy `commands.cmd_list` + `getattr(commands, x)`; re-export
  `CommandAlreadyBoundError` for backwards compatibility.
- `tests/test_commands_registry.py` — new characterization test pinning
  the 55-entry surface and asserting the legacy attributes are gone.
- `tests/test_command_init_subclass.py` — new focused unit tests for the
  hook (skip-without-`command`, skip-when-only-inherited, duplicate-
  raises, alias-via-subclassing, registry identity).
- `CHANGELOG.md` — `[Unreleased] / Changed` entry documenting the
  module-attribute change.

## Commits

1. `test(commands): pin the loader's command surface (55 entries)` —
   characterization test, green against the pre-refactor `cmd_list`
   surface.
2. `refactor(commands): auto-register subclasses via
   Command.__init_subclass__` — adds the hook + relocates
   `CommandAlreadyBoundError`.
3. `refactor(commands): drop globals() loader for the Command.registry`
   — atomic swap of loader + consumer + characterization test (kept
   together so bisect blames a single commit).
4. `test(commands): cover Command.__init_subclass__ edge cases` — six
   focused unit tests with a `clean_registry` fixture.
5. `docs(changelog): note the Command.registry replacement of cmd_list`.

## Verification

All gates green:

- `uv run ruff format --check .` — 166 files clean
- `uv run ruff check .` — clean
- `uv run ty check` — clean (no warnings; `error-on-warning` on)
- `uv run pytest` — **585 passed** (Phase 5b/C9 baseline 549 + 4 new
  characterization + 6 new init_subclass tests + 26 already on branch)
- `uv run python -m mtui --help` and `-V` — both work
- `rg cmd_list mtui/` and `rg "globals\(\)\[" mtui/commands/` — zero
  hits

## Notes for reviewers

- The duplicate-guard semantics shift slightly: today, a duplicate
  `command` string would only blow up the first time
  `CommandPrompt._add_subcommand` saw it; from this PR on, a duplicate
  declaration anywhere in the codebase raises at import time. This is
  strictly more correct (catches packaging-time mistakes earlier). The
  per-prompt local guard in `_add_subcommand` is left in place as
  belt-and-braces.
- A grep of the repo and tests confirms the only consumers of the
  legacy `cmd_list` / `globals()` surface were the two lines in
  `mtui/prompt.py`. The `Command` re-export from `mtui.commands` is
  preserved.
- The new characterization test scopes its snapshot to classes whose
  `__module__` starts with `mtui.commands.`, so test-only `Command`
  subclasses (e.g. `ConcreteCommand` in `tests/test_command_base.py`)
  do not pollute the snapshot when tests run in arbitrary order.