### PR TITLE
refactor(target): replace queue+thread with ThreadPoolExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   now iterates `commands.registry.values()` directly.
 
 ### Fixed
+- Exceptions raised inside parallel target operations
+  (`Target.set_repo`, `Target.run`, the SFTP helpers used by `put` /
+  `get` / `remove`) now surface to the caller and abort the enclosing
+  `update` / `prepare` / `downgrade` / `install` / `uninstall` flow,
+  instead of being silently lost in a worker thread while the flow
+  pretended to succeed.
 - `update` now removes the test update repositories from every SUT after
   the update finishes (and even when the update or its post/compare
   scripts raise), instead of leaving them configured behind.
@@ -73,6 +79,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   no longer hangs `mtui` startup or `reloadoqa` indefinitely; a single
   timed-out setting is logged and skipped while the rest of the batch
   still completes.
+- Pressing `Ctrl+C` during a parallel `run` now drops queued hosts that
+  have not started yet and unblocks in-flight workers by closing their
+  SSH sessions, instead of waiting for the whole parallel batch to drain
+  before the interrupt was honoured. Workers already executing a remote
+  command will still finish their current command (Python cannot
+  interrupt a foreign blocking call), but session shutdown unblocks them
+  promptly.
+- Long-running parallel operations (`run`, file uploads / downloads /
+  deletes, `set_repo` fan-out used by `update`/`prepare`/`downgrade`)
+  now show user-visible progress again via a `|/-\` spinner on stderr
+  while work is in flight. The spinner is suppressed when stderr is
+  not a TTY (log files and redirected output stay clean). Restores the
+  "mtui is alive" feedback that was lost when the queue/spinner thread
+  was retired.
 
 ### Known issues
 - A non-numeric value for `connection_timeout` (e.g.

--- a/mtui/target/actions.py
+++ b/mtui/target/actions.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import sys
 import threading
-import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, ValuesView
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from pathlib import Path
-from queue import Empty, Queue
 from threading import Lock
 from typing import Any
 
@@ -17,35 +16,97 @@ from ..types import ExecutionMode
 from ..utils import prompt_user
 from . import Target
 
-queue: Queue[tuple[Callable[..., None], list[Any]]] = Queue()
+
+class _TtySpinner:
+    """A tiny ``|/-\\`` spinner that writes to stderr only when it is a TTY.
+
+    Drives a single daemon thread that repaints ``\\r<frame> <desc>`` on
+    a fixed cadence, then erases the line on stop. When stderr is not a
+    TTY (pytest, redirected output, log files) the spinner is a no-op so
+    test output and log files stay clean. Safe to ``stop()`` more than
+    once and from any thread.
+    """
+
+    _FRAMES = "|/-\\"
+    _INTERVAL = 0.1  # seconds
+
+    def __init__(self, desc: str) -> None:
+        self._desc = desc
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._enabled = sys.stderr.isatty()
+
+    def start(self) -> None:
+        """Start the spinner thread (no-op when stderr is not a TTY)."""
+        if not self._enabled:
+            return
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the spinner thread and erase the spinner line."""
+        if not self._enabled:
+            return
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+        # Erase the spinner line so the next caller writes from column 0.
+        with suppress(Exception):
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+
+    def _spin(self) -> None:
+        i = 0
+        while not self._stop.is_set():
+            with suppress(Exception):
+                sys.stderr.write(f"\r[{self._FRAMES[i % 4]}] {self._desc}")
+                sys.stderr.flush()
+            i += 1
+            self._stop.wait(self._INTERVAL)
 
 
-class ThreadedMethod(threading.Thread):
-    """A thread that executes a method from a queue."""
+def run_parallel(
+    work: list[tuple[Callable[..., Any], tuple[Any, ...]]],
+    desc: str | None = None,
+) -> None:
+    """Submit ``(callable, args)`` pairs to a pool and re-raise on failure.
 
-    def __init__(self, queue: Queue[tuple[Callable[..., None], list[Any]]]) -> None:
-        """Initializes the thread.
+    Each callable runs in its own worker thread. The first worker
+    exception surfaces to the caller. On any exception (including
+    ``KeyboardInterrupt``) the executor is shut down with
+    ``cancel_futures=True`` and ``wait=False`` so queued-but-not-yet-
+    started callables are dropped and the caller is not blocked on
+    in-flight workers. Note: Python cannot interrupt a foreign C-level
+    blocking call, so callables already in flight will run to
+    completion -- callers that need prompt cancellation must arrange
+    for the worker's blocking I/O to be unblocked externally (e.g. by
+    closing the underlying socket).
 
-        Args:
-            queue: The queue to get methods from.
-
-        """
-        threading.Thread.__init__(self)
-        self.queue = queue
-
-    def run(self) -> None:
-        """Runs the thread."""
-        while True:
-            try:
-                (method, parameter) = self.queue.get(timeout=10)
-            except Empty:
-                return
-
-            try:
-                method(*parameter)
-            finally:
-                with suppress(ValueError):
-                    self.queue.task_done()
+    When ``desc`` is given the helper drives a TTY-only ``|/-\\``
+    spinner labelled with ``desc`` while work is in flight. The
+    spinner is silent when stderr is not a TTY (log files, redirected
+    output, pytest), and the call is behaviourally identical to a
+    ``desc=None`` call from the worker callables' point of view.
+    """
+    if not work:
+        return
+    spinner = _TtySpinner(desc) if desc else None
+    if spinner is not None:
+        spinner.start()
+    ex = ThreadPoolExecutor(max_workers=len(work))
+    try:
+        futures = [ex.submit(fn, *args) for fn, args in work]
+        for f in as_completed(futures):
+            f.result()  # propagate any worker exception
+    except BaseException:
+        ex.shutdown(wait=False, cancel_futures=True)
+        raise
+    else:
+        ex.shutdown(wait=True)
+    finally:
+        if spinner is not None:
+            spinner.stop()
 
 
 class ThreadedTargetGroup(ABC):
@@ -60,35 +121,16 @@ class ThreadedTargetGroup(ABC):
         """
         self.targets = targets
 
-    def mk_thread(self) -> None:
-        """Creates and starts a new thread."""
-        thread = ThreadedMethod(queue)
-        thread.daemon = True
-        thread.start()
-
-    def mk_threads(self) -> None:
-        """Creates and starts a thread for each target."""
-        for _ in range(len(self.targets)):
-            self.mk_thread()
-
     def run(self) -> None:
-        """Runs the action on all targets."""
-        self.mk_threads()
-        self.setup_queue()
-
-        while queue.unfinished_tasks:
-            spinner()
-
-        queue.join()
+        """Runs the action on every target in parallel."""
+        run_parallel(
+            [self.mk_cmd(t) for t in self.targets],
+            desc=type(self).__name__,
+        )
 
     @abstractmethod
-    def mk_cmd(self, *args, **kwds) -> tuple[Callable[..., None], list[Any]]:
-        """An abstract method for creating a command to be executed."""
-
-    def setup_queue(self) -> None:
-        """Sets up the queue with commands to be executed."""
-        for t in self.targets:
-            queue.put(self.mk_cmd(t))
+    def mk_cmd(self, t: Target) -> tuple[Callable[..., Any], tuple[Any, ...]]:
+        """Build a ``(callable, args)`` pair to dispatch for one target."""
 
 
 class FileDelete(ThreadedTargetGroup):
@@ -105,17 +147,9 @@ class FileDelete(ThreadedTargetGroup):
         super().__init__(targets)
         self.path = path
 
-    def mk_cmd(self, t: Target):
-        """Creates a command to delete a file on a target.
-
-        Args:
-            t: The target to delete the file from.
-
-        Returns:
-            A tuple containing the method to execute and its arguments.
-
-        """
-        return (t.sftp_remove, [self.path])
+    def mk_cmd(self, t: Target) -> tuple[Callable[..., Any], tuple[Any, ...]]:
+        """Creates a command to delete a file on a target."""
+        return (t.sftp_remove, (self.path,))
 
 
 class FileUpload(ThreadedTargetGroup):
@@ -136,17 +170,9 @@ class FileUpload(ThreadedTargetGroup):
         self.local = local
         self.remote = remote
 
-    def mk_cmd(self, t: Target):
-        """Creates a command to upload a file to a target.
-
-        Args:
-            t: The target to upload the file to.
-
-        Returns:
-            A tuple containing the method to execute and its arguments.
-
-        """
-        return (t.sftp_put, [self.local, self.remote])
+    def mk_cmd(self, t: Target) -> tuple[Callable[..., Any], tuple[Any, ...]]:
+        """Creates a command to upload a file to a target."""
+        return (t.sftp_put, (self.local, self.remote))
 
 
 class FileDownload(ThreadedTargetGroup):
@@ -168,21 +194,13 @@ class FileDownload(ThreadedTargetGroup):
         self.remote = remote
         self.local = local
 
-    def mk_cmd(self, t: Target):
-        """Creates a command to download a file from a target.
-
-        Args:
-            t: The target to download the file from.
-
-        Returns:
-            A tuple containing the method to execute and its arguments.
-
-        """
-        return (t.sftp_get, [self.remote, self.local])
+    def mk_cmd(self, t: Target) -> tuple[Callable[..., Any], tuple[Any, ...]]:
+        """Creates a command to download a file from a target."""
+        return (t.sftp_get, (self.remote, self.local))
 
 
 class RunCommand:
-    """Runs a command on a group of targets in parallel or serial."""
+    """Runs a command on a group of targets, parallel or serial."""
 
     def __init__(
         self, targets: dict[str, Target], command: str | dict[str, Any]
@@ -197,81 +215,43 @@ class RunCommand:
         self.targets = targets
         self.command = command
 
+    def _cmd_for(self, hostname: str) -> Any:
+        """Resolve the per-host command, accepting a string or dict shape."""
+        if isinstance(self.command, dict):
+            return self.command[hostname]
+        return self.command
+
     def run(self) -> None:
-        """Runs the command on all targets."""
-        parallel: dict[str, Target] = {}
-        serial: dict[str, Target] = {}
+        """Runs the command: parallel hosts in a pool, serial hosts one at a time."""
+        parallel = {
+            h: t for h, t in self.targets.items() if t.mode is not ExecutionMode.SERIAL
+        }
+        serial = {
+            h: t for h, t in self.targets.items() if t.mode is ExecutionMode.SERIAL
+        }
         lock = Lock()
 
-        for target in self.targets:
-            if self.targets[target].mode is ExecutionMode.SERIAL:
-                serial[target] = self.targets[target]
-            else:
-                parallel[target] = self.targets[target]
-
         try:
-            for target in parallel:
-                thread = ThreadedMethod(queue)
-                thread.daemon = True
-                thread.start()
-                if isinstance(self.command, dict):
-                    queue.put((parallel[target].run, [self.command[target], lock]))
-                elif isinstance(self.command, str):
-                    queue.put((parallel[target].run, [self.command, lock]))
+            run_parallel(
+                [(t.run, (self._cmd_for(h), lock)) for h, t in parallel.items()],
+                desc="run",
+            )
 
-            while queue.unfinished_tasks:
-                spinner(lock)
-
-            queue.join()
-
-            for target in serial:
+            for h, t in serial.items():
                 prompt_user(
-                    f"press Enter key to proceed with {serial[target].hostname!s}",
+                    f"press Enter key to proceed with {t.hostname!s}",
                     "",
                 )
-                thread = ThreadedMethod(queue)
-                thread.daemon = True
-                thread.start()
-                queue.put((serial[target].run, [self.command, lock]))
-
-                while queue.unfinished_tasks:
-                    spinner(lock)
-
-                queue.join()
+                t.run(self._cmd_for(h), lock)
 
         except KeyboardInterrupt:
+            # ``run_parallel`` already cancelled queued futures and
+            # returned without joining in-flight workers. Close every
+            # session here so any worker still blocked inside
+            # ``connection.run`` unblocks promptly and exits cleanly.
             print("stopping command queue, please wait.")  # noqa: T201
-            try:
-                while queue.unfinished_tasks:
-                    spinner(lock)
-            except KeyboardInterrupt:
-                for target in self.targets:
-                    with suppress(Exception):
-                        self.targets[target].connection.close_session()
-                with suppress(ValueError):
-                    thread.queue.task_done()
-
-            queue.join()
+            for t in self.targets.values():
+                with suppress(Exception):
+                    t.connection.close_session()
             print()  # noqa: T201
             raise
-
-
-def spinner(lock: Lock | None = None) -> None:
-    """A simple spinner to show that a process is running.
-
-    Args:
-        lock: An optional lock to use when printing to the console.
-
-    """
-    for pos in ["|", "/", "-", "\\"]:
-        if lock:
-            lock.acquire()
-
-        try:
-            sys.stdout.write(f"processing... [{pos}]\r")
-            sys.stdout.flush()
-        finally:
-            if lock:
-                lock.release()
-
-        time.sleep(0.1)

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -18,9 +18,7 @@ from .actions import (
     FileDownload,
     FileUpload,
     RunCommand,
-    ThreadedMethod,
-    queue,
-    spinner,
+    run_parallel,
 )
 from .locks import TargetLockedError
 
@@ -216,31 +214,11 @@ class HostsGroup(UserDict[str, Target]):
             raise UpdateError("Hosts locked")
 
     def _fanout_set_repo(self, operation: str, testreport) -> None:
-        """Fan ``Target.set_repo(operation, testreport)`` out across every host.
-
-        The four ``perform_*`` flows used to inline this open-coded
-        ``for t: queue.put(...) ; while queue.unfinished_tasks: spinner() ;
-        queue.join()`` block four times. Centralising it keeps the perform
-        methods focused on their pre/post logic and gives the executor
-        rewrite a single seam to swap.
-
-        Spawns one worker thread per target before queueing the work; the
-        worker pool used to be pre-warmed by ``update_lock`` as a side
-        effect, which was both surprising and fragile (workers died on the
-        10s queue timeout if the put loop took too long).
-        """
-        for _ in self.data.values():
-            worker = ThreadedMethod(queue)
-            worker.daemon = True
-            worker.start()
-
-        for t in self.data.values():
-            queue.put((t.set_repo, [operation, testreport]))
-
-        while queue.unfinished_tasks:
-            spinner()
-
-        queue.join()
+        """Fan ``Target.set_repo(operation, testreport)`` out across every host."""
+        run_parallel(
+            [(t.set_repo, (operation, testreport)) for t in self.data.values()],
+            desc=f"set_repo {operation}",
+        )
 
     def perform_install(self, packages: list[str]) -> None:
         """Performs an installation on all hosts in the group.

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -208,9 +208,6 @@ class HostsGroup(UserDict[str, Target]):
                     )
             else:
                 t.lock()
-                thread = ThreadedMethod(queue)
-                thread.daemon = True
-                thread.start()
 
         if skipped:
             for t in self.data.values():
@@ -226,7 +223,17 @@ class HostsGroup(UserDict[str, Target]):
         queue.join()`` block four times. Centralising it keeps the perform
         methods focused on their pre/post logic and gives the executor
         rewrite a single seam to swap.
+
+        Spawns one worker thread per target before queueing the work; the
+        worker pool used to be pre-warmed by ``update_lock`` as a side
+        effect, which was both surprising and fragile (workers died on the
+        10s queue timeout if the put loop took too long).
         """
+        for _ in self.data.values():
+            worker = ThreadedMethod(queue)
+            worker.daemon = True
+            worker.start()
+
         for t in self.data.values():
             queue.put((t.set_repo, [operation, testreport]))
 

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -218,6 +218,23 @@ class HostsGroup(UserDict[str, Target]):
                     t.unlock()
             raise UpdateError("Hosts locked")
 
+    def _fanout_set_repo(self, operation: str, testreport) -> None:
+        """Fan ``Target.set_repo(operation, testreport)`` out across every host.
+
+        The four ``perform_*`` flows used to inline this open-coded
+        ``for t: queue.put(...) ; while queue.unfinished_tasks: spinner() ;
+        queue.join()`` block four times. Centralising it keeps the perform
+        methods focused on their pre/post logic and gives the executor
+        rewrite a single seam to swap.
+        """
+        for t in self.data.values():
+            queue.put((t.set_repo, [operation, testreport]))
+
+        while queue.unfinished_tasks:
+            spinner()
+
+        queue.join()
+
     def perform_install(self, packages: list[str]) -> None:
         """Performs an installation on all hosts in the group.
 
@@ -308,11 +325,7 @@ class HostsGroup(UserDict[str, Target]):
         self.update_lock()
 
         try:
-            for t in self.data.values():
-                queue.put((t.set_repo, [operation, testreport]))
-
-            while queue.unfinished_tasks:
-                spinner()
+            self._fanout_set_repo(operation, testreport)
             if start:
                 self.run(start)
 
@@ -370,13 +383,7 @@ class HostsGroup(UserDict[str, Target]):
         }
 
         try:
-            for t in self.data.values():
-                queue.put((t.set_repo, ["remove", testreport]))
-
-            while queue.unfinished_tasks:
-                spinner()
-
-            queue.join()
+            self._fanout_set_repo("remove", testreport)
 
             list_cmd = {
                 h: t.get_downgrader()["list_command"].safe_substitute(
@@ -503,13 +510,7 @@ class HostsGroup(UserDict[str, Target]):
 
         self.update_lock()
 
-        for t in self.data.values():
-            queue.put((t.set_repo, ["add", testreport]))
-
-        while queue.unfinished_tasks:
-            spinner()
-
-        queue.join()
+        self._fanout_set_repo("add", testreport)
 
         repa = f":p={testreport.rrid.maintenance_id}:{testreport.rrid.review_id}"
         commands = {
@@ -559,13 +560,7 @@ class HostsGroup(UserDict[str, Target]):
                 )
             else:
                 try:
-                    for t in self.data.values():
-                        queue.put((t.set_repo, ["remove", testreport]))
-
-                    while queue.unfinished_tasks:
-                        spinner()
-
-                    queue.join()
+                    self._fanout_set_repo("remove", testreport)
                 finally:
                     self.unlock()
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,61 @@
+"""Behaviour tests for ``mtui.target.actions``.
+
+These tests pin the *desired* exception-propagation contract: a worker
+callable that raises must surface its exception to the caller of
+``run()``, instead of being silently swallowed by the worker thread.
+
+Today's hand-rolled ``ThreadedMethod`` drains the queue with
+``method(*parameter)`` inside a bare ``try/finally`` that calls
+``task_done()`` but never ``.result()`` — the exception dies with the
+thread. The tests below are marked ``xfail(strict=True)`` so they
+visibly fail (then pass) once the executor-based rewrite lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ThreadedMethod silently swallows worker exceptions today; the "
+        "executor rewrite surfaces them via Future.result()."
+    ),
+)
+def test_threaded_target_group_run_propagates_worker_exception():
+    """A ``FileDelete`` worker that raises must propagate to ``run()``."""
+    from mtui.target.actions import FileDelete
+
+    target = MagicMock()
+    target.hostname = "h1"
+    target.sftp_remove.side_effect = RuntimeError("delete failed")
+
+    action = FileDelete([target], Path("/tmp/x"))
+    with pytest.raises(RuntimeError, match="delete failed"):
+        action.run()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "RunCommand uses the same hand-rolled queue, so a failing "
+        "Target.run is silently swallowed today."
+    ),
+)
+def test_run_command_run_propagates_worker_exception():
+    """A parallel ``Target.run`` failure must propagate to ``RunCommand.run()``."""
+    from mtui.target.actions import RunCommand
+    from mtui.types import ExecutionMode
+
+    target = MagicMock()
+    target.hostname = "h1"
+    target.mode = ExecutionMode.PARALLEL
+    target.run.side_effect = RuntimeError("ssh broke")
+
+    cmd = RunCommand({"h1": target}, "true")
+    with pytest.raises(RuntimeError, match="ssh broke"):
+        cmd.run()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,31 +1,28 @@
 """Behaviour tests for ``mtui.target.actions``.
 
-These tests pin the *desired* exception-propagation contract: a worker
-callable that raises must surface its exception to the caller of
-``run()``, instead of being silently swallowed by the worker thread.
+The module fans worker callables out across a host group via a
+``ThreadPoolExecutor``. The contract these tests pin:
 
-Today's hand-rolled ``ThreadedMethod`` drains the queue with
-``method(*parameter)`` inside a bare ``try/finally`` that calls
-``task_done()`` but never ``.result()`` — the exception dies with the
-thread. The tests below are marked ``xfail(strict=True)`` so they
-visibly fail (then pass) once the executor-based rewrite lands.
+* a worker callable's exception is re-raised to the caller via
+  ``Future.result()`` (rather than dying inside the worker thread, as
+  the old hand-rolled ``ThreadedMethod`` did);
+* ``run_parallel`` still works on an empty work list;
+* ``RunCommand`` runs serial-mode hosts strictly one at a time and
+  bypasses the executor for them (the old code used the same queue
+  for both, which made the serial branch indistinguishable from the
+  parallel one).
 """
 
 from __future__ import annotations
 
+import logging
+import threading
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "ThreadedMethod silently swallows worker exceptions today; the "
-        "executor rewrite surfaces them via Future.result()."
-    ),
-)
 def test_threaded_target_group_run_propagates_worker_exception():
     """A ``FileDelete`` worker that raises must propagate to ``run()``."""
     from mtui.target.actions import FileDelete
@@ -34,18 +31,11 @@ def test_threaded_target_group_run_propagates_worker_exception():
     target.hostname = "h1"
     target.sftp_remove.side_effect = RuntimeError("delete failed")
 
-    action = FileDelete([target], Path("/tmp/x"))
+    action = FileDelete([target], Path("/tmp/x"))  # type: ignore[list-item]  # ty: ignore[invalid-argument-type]
     with pytest.raises(RuntimeError, match="delete failed"):
         action.run()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "RunCommand uses the same hand-rolled queue, so a failing "
-        "Target.run is silently swallowed today."
-    ),
-)
 def test_run_command_run_propagates_worker_exception():
     """A parallel ``Target.run`` failure must propagate to ``RunCommand.run()``."""
     from mtui.target.actions import RunCommand
@@ -56,6 +46,127 @@ def test_run_command_run_propagates_worker_exception():
     target.mode = ExecutionMode.PARALLEL
     target.run.side_effect = RuntimeError("ssh broke")
 
-    cmd = RunCommand({"h1": target}, "true")
+    cmd = RunCommand({"h1": target}, "true")  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
     with pytest.raises(RuntimeError, match="ssh broke"):
         cmd.run()
+
+
+def test_run_parallel_no_work_is_noop():
+    """``run_parallel([])`` must not allocate an executor."""
+    from mtui.target.actions import run_parallel
+
+    # Should simply return; no exception, no thread spawned.
+    run_parallel([])
+
+
+def test_run_parallel_runs_each_callable_once():
+    """Each ``(callable, args)`` pair runs exactly once with the given args."""
+    from mtui.target.actions import run_parallel
+
+    a = MagicMock()
+    b = MagicMock()
+    run_parallel([(a, (1, 2)), (b, ("x",))])
+    a.assert_called_once_with(1, 2)
+    b.assert_called_once_with("x")
+
+
+def test_run_command_serial_runs_sequentially_after_prompt():
+    """Serial-mode hosts skip the pool and run one-at-a-time after a prompt."""
+    from mtui.target.actions import RunCommand
+    from mtui.types import ExecutionMode
+
+    t1 = MagicMock()
+    t1.hostname = "h1"
+    t1.mode = ExecutionMode.SERIAL
+    t2 = MagicMock()
+    t2.hostname = "h2"
+    t2.mode = ExecutionMode.SERIAL
+
+    cmd = RunCommand({"h1": t1, "h2": t2}, "echo hi")  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+    with patch("mtui.target.actions.prompt_user") as mock_prompt:
+        cmd.run()
+
+    # Each host was prompted before running, and ran exactly once.
+    assert mock_prompt.call_count == 2
+    t1.run.assert_called_once()
+    t2.run.assert_called_once()
+
+
+def test_run_parallel_keyboard_interrupt_cancels_queued_work():
+    """``KeyboardInterrupt`` from a worker propagates and drops queued work.
+
+    The pool is sized to the work list, so up to ``len(work)`` callables
+    can start in parallel; we keep most of them blocked on an event so
+    they stay "in flight" while one worker raises. With
+    ``cancel_futures=True`` the still-blocked workers' futures must be
+    cancelled rather than awaited, and the never-started callables
+    inside the cancelled futures must not have run.
+    """
+    from mtui.target.actions import run_parallel
+
+    # ThreadPoolExecutor schedules submitted callables eagerly when
+    # workers are available, so we can't rely on "queued but not
+    # started" with a pool sized to the work. Cap the pool by sizing
+    # the work list larger than max_workers via a separate executor
+    # path is not available; instead, observe that ``cancel_futures``
+    # only cancels not-yet-running futures. Here we assert the
+    # contract by building work where the *first* future raises KI
+    # before the others get a CPU slot: at minimum the KI propagates
+    # and the run_parallel call returns promptly without joining the
+    # held-open workers.
+    release = threading.Event()
+    started = threading.Event()
+    other_finished = threading.Event()
+
+    def raiser():
+        started.wait(timeout=5)
+        raise KeyboardInterrupt
+
+    def blocker():
+        # Signal that we're in flight, then block until released.
+        started.set()
+        release.wait(timeout=5)
+        other_finished.set()
+
+    work = [(blocker, ()), (raiser, ())]
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            run_parallel(work)  # ty: ignore[invalid-argument-type]
+    finally:
+        # Let the in-flight blocker terminate so the test thread does
+        # not leak a worker into the next test.
+        release.set()
+
+    # Contract: KI propagated. The blocker may or may not have
+    # finished by the time KI surfaced -- what matters is run_parallel
+    # did not wait for it.
+    assert started.is_set()
+
+
+def test_run_parallel_emits_no_log_records(caplog):
+    """``run_parallel`` must stay silent on the logging API.
+
+    The TTY spinner is the only progress channel; per-completion log
+    lines were dropped because they buried real diagnostics in noise on
+    multi-host runs. A regression here would re-introduce that noise.
+    """
+    from mtui.target.actions import run_parallel
+
+    with caplog.at_level(logging.DEBUG, logger="mtui.target.actions"):
+        run_parallel([(MagicMock(), ()), (MagicMock(), ())], desc="probe")
+
+    assert caplog.records == []
+
+
+def test_tty_spinner_is_silent_when_stderr_not_a_tty(capsys):
+    """``_TtySpinner`` must be a no-op when stderr is not a TTY (pytest case)."""
+    from mtui.target.actions import _TtySpinner
+
+    s = _TtySpinner("anything")
+    s.start()
+    s.stop()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    # Internal: no thread should have been spawned in non-TTY mode.
+    assert s._thread is None  # noqa: SLF001

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -230,9 +230,7 @@ def test_hostgroup_names():
 # --- update_lock ---
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
-def test_update_lock_locks_unlocked_hosts(mock_queue, mock_thread_cls):
+def test_update_lock_locks_unlocked_hosts():
     """Test update_lock() locks hosts that are not locked."""
     t1 = MagicMock()
     t1.hostname = "h1"
@@ -244,9 +242,7 @@ def test_update_lock_locks_unlocked_hosts(mock_queue, mock_thread_cls):
     t1.lock.assert_called_once()
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
-def test_update_lock_raises_when_locked_by_other(mock_queue, mock_thread_cls):
+def test_update_lock_raises_when_locked_by_other():
     """Test update_lock() raises UpdateError when host is locked by another user."""
     t1 = MagicMock()
     t1.hostname = "h1"
@@ -269,10 +265,8 @@ def test_update_lock_raises_when_locked_by_other(mock_queue, mock_thread_cls):
 # --- perform_install ---
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_install_runs_and_unlocks(mock_run, mock_queue, mock_thread):
+def test_perform_install_runs_and_unlocks(mock_run):
     """Test perform_install runs commands and always unlocks."""
     t1 = MagicMock()
     t1.hostname = "h1"
@@ -291,10 +285,8 @@ def test_perform_install_runs_and_unlocks(mock_run, mock_queue, mock_thread):
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_install_unlocks_on_error(mock_run, mock_queue, mock_thread):
+def test_perform_install_unlocks_on_error(mock_run):
     """Test perform_install unlocks even when commands raise."""
     t1 = MagicMock()
     t1.hostname = "h1"
@@ -426,9 +418,7 @@ def test_reboot_empty_dict_is_noop():
 # ---------------------------------------------------------------------------
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
-def test_update_lock_logs_other_user_comment(mock_queue, mock_thread, caplog):
+def test_update_lock_logs_other_user_comment(caplog):
     """When the locking user left a comment, it is logged at info level."""
     t1 = _stub_target("h1", is_locked=True, is_mine=False)
     t1._lock.time.return_value = "Mon 01.01.2024"
@@ -448,10 +438,8 @@ def test_update_lock_logs_other_user_comment(mock_queue, mock_thread, caplog):
 # ---------------------------------------------------------------------------
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_uninstall_runs_and_unlocks(mock_run, mock_queue, mock_thread):
+def test_perform_uninstall_runs_and_unlocks(mock_run):
     t1 = _stub_target("h1")
     t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
     t1.get_uninstaller_check.return_value = MagicMock()
@@ -461,10 +449,8 @@ def test_perform_uninstall_runs_and_unlocks(mock_run, mock_queue, mock_thread):
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_uninstall_unlocks_on_error(mock_run, mock_queue, mock_thread):
+def test_perform_uninstall_unlocks_on_error(mock_run):
     t1 = _stub_target("h1")
     t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
     hg = HostsGroup([t1])
@@ -474,12 +460,8 @@ def test_perform_uninstall_unlocks_on_error(mock_run, mock_queue, mock_thread):
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_uninstall_transactional_triggers_reboot(
-    mock_run, mock_queue, mock_thread
-):
+def test_perform_uninstall_transactional_triggers_reboot(mock_run):
     t1 = _stub_target("h1", transactional=True)
     t1.get_uninstaller.return_value = _doer_dict(
         command="transactional-update -n pkg remove pkg",
@@ -497,13 +479,8 @@ def test_perform_uninstall_transactional_triggers_reboot(
 # ---------------------------------------------------------------------------
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_prepare_runs_per_package_command(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_prepare_runs_per_package_command(mock_run):
     """``perform_prepare`` runs the command-template once per package."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = ""
@@ -511,22 +488,15 @@ def test_perform_prepare_runs_per_package_command(
         command="zypper in $package", reboot="", start_command=""
     )
     t1.get_preparer_check.return_value = MagicMock()
-    # ``queue.unfinished_tasks`` is used as a loop sentinel; force it to 0.
-    mock_queue.unfinished_tasks = 0
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]
     hg.perform_prepare(["pkg-a", "pkg-b"], MagicMock())
     # 2 packages → 2 RunCommand invocations beyond the lock cleanup.
     assert mock_run.call_count >= 2
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_prepare_filters_branding_upstream(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_prepare_filters_branding_upstream(mock_run):
     """The hard-coded ``branding-upstream`` name is excluded from per-pkg cmds."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = ""
@@ -534,8 +504,7 @@ def test_perform_prepare_filters_branding_upstream(
         command="zypper in $package", reboot="", start_command=""
     )
     t1.get_preparer_check.return_value = MagicMock()
-    mock_queue.unfinished_tasks = 0
-    hg = HostsGroup([t1])
+    hg = HostsGroup([t1])  # type: ignore[arg-type]
     hg.perform_prepare(["pkg-a", "branding-upstream", "pkg-b"], MagicMock())
     # 2 surviving packages.
     per_pkg_calls = [
@@ -546,13 +515,8 @@ def test_perform_prepare_filters_branding_upstream(
     assert len(per_pkg_calls) == 2
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_prepare_aborts_on_set_repo_error(
-    mock_run, mock_queue, mock_thread, mock_spinner, caplog
-):
+def test_perform_prepare_aborts_on_set_repo_error(mock_run, caplog):
     """``set_repo`` failure (non-empty ``lasterr``) logs critical and returns early."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = "repo failure"
@@ -561,7 +525,6 @@ def test_perform_prepare_aborts_on_set_repo_error(
     t1.get_preparer.return_value = _doer_dict(
         command="zypper in $package", reboot="", start_command=""
     )
-    mock_queue.unfinished_tasks = 0
     hg = HostsGroup([t1])
     with caplog.at_level("CRITICAL", logger="mtui.target.hostgroup"):
         hg.perform_prepare(["pkg-a"], MagicMock())
@@ -581,13 +544,8 @@ def test_perform_prepare_aborts_on_set_repo_error(
 # ---------------------------------------------------------------------------
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_downgrade_picks_highest_version_then_runs(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
     """The list_command output is parsed and the newest version is chosen."""
     t1 = _stub_target("h1")
     # Pretend list_command output is parsed: ``pkg-a = 1.0`` and ``pkg-a = 1.5``.
@@ -600,7 +558,6 @@ def test_perform_downgrade_picks_highest_version_then_runs(
         ),
     }
     t1.get_downgrader_check.return_value = MagicMock()
-    mock_queue.unfinished_tasks = 0
     hg = HostsGroup([t1])
     hg.perform_downgrade(["pkg-a"], MagicMock())
     # Confirm the per-package command was substituted with the higher version.
@@ -609,13 +566,8 @@ def test_perform_downgrade_picks_highest_version_then_runs(
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_downgrade_unlocks_on_error(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_downgrade_unlocks_on_error(mock_run):
     t1 = _stub_target("h1")
     t1.lastout.return_value = ""
     t1.get_downgrader.return_value = {
@@ -623,7 +575,6 @@ def test_perform_downgrade_unlocks_on_error(
         "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
         "command": MagicMock(safe_substitute=MagicMock(return_value="x")),
     }
-    mock_queue.unfinished_tasks = 0
     hg = HostsGroup([t1])
     mock_run.return_value.run.side_effect = RuntimeError("downgrade boom")
     with pytest.raises(RuntimeError, match="downgrade boom"):
@@ -636,19 +587,13 @@ def test_perform_downgrade_unlocks_on_error(
 # ---------------------------------------------------------------------------
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_update_runs_full_flow_with_noprepare_and_noscript(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_update_runs_full_flow_with_noprepare_and_noscript(mock_run):
     """``noprepare`` skips prepare; ``noscript`` skips Pre/Post/Compare scripts."""
     t1 = _stub_target("h1")
     t1.packages = {}  # short-circuit package_check
     t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
     t1.get_updater_check.return_value = MagicMock()
-    mock_queue.unfinished_tasks = 0
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -661,13 +606,8 @@ def test_perform_update_runs_full_flow_with_noprepare_and_noscript(
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_update_runs_pre_post_and_compare_scripts(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_update_runs_pre_post_and_compare_scripts(mock_run):
     """Default flow runs Pre, Post and Compare scripts when not in auto mode."""
     from mtui.hooks import CompareScript, PostScript, PreScript
 
@@ -680,7 +620,6 @@ def test_perform_update_runs_pre_post_and_compare_scripts(
     )
     t1.get_preparer_check.return_value = MagicMock()
     t1.lasterr.return_value = ""
-    mock_queue.unfinished_tasks = 0
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -695,17 +634,11 @@ def test_perform_update_runs_pre_post_and_compare_scripts(
     assert CompareScript in script_classes_called
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_update_unlocks_when_run_fails(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_update_unlocks_when_run_fails(mock_run):
     t1 = _stub_target("h1")
     t1.packages = {}
     t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
-    mock_queue.unfinished_tasks = 0
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -718,19 +651,14 @@ def test_perform_update_unlocks_when_run_fails(
     t1.unlock.assert_called()
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
+@patch.object(HostsGroup, "_fanout_set_repo")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_update_removes_repos_at_end(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
-    """``perform_update`` queues set_repo('remove', ...) after the update."""
+def test_perform_update_removes_repos_at_end(mock_run, mock_fanout):
+    """``perform_update`` fans out set_repo('add') first, then ('remove')."""
     t1 = _stub_target("h1")
     t1.packages = {}
     t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
     t1.get_updater_check.return_value = MagicMock()
-    mock_queue.unfinished_tasks = 0
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -739,28 +667,19 @@ def test_perform_update_removes_repos_at_end(
     hg = HostsGroup([t1])
     hg.perform_update(testreport, ["noprepare", "noscript"])
 
-    set_repo_calls = [
-        call.args[0]
-        for call in mock_queue.put.call_args_list
-        if call.args and call.args[0][0] is t1.set_repo
-    ]
+    operations = [c.args[0] for c in mock_fanout.call_args_list]
     # The repo lifecycle is: add at the start, remove at the end.
-    assert set_repo_calls[0] == (t1.set_repo, ["add", testreport])
-    assert set_repo_calls[-1] == (t1.set_repo, ["remove", testreport])
+    assert operations[0] == "add"
+    assert operations[-1] == "remove"
 
 
-@patch("mtui.target.hostgroup.spinner")
-@patch("mtui.target.hostgroup.ThreadedMethod")
-@patch("mtui.target.hostgroup.queue")
+@patch.object(HostsGroup, "_fanout_set_repo")
 @patch("mtui.target.hostgroup.RunCommand")
-def test_perform_update_removes_repos_even_when_run_fails(
-    mock_run, mock_queue, mock_thread, mock_spinner
-):
+def test_perform_update_removes_repos_even_when_run_fails(mock_run, mock_fanout):
     """Repo cleanup runs even when the updater command itself raises."""
     t1 = _stub_target("h1")
     t1.packages = {}
     t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
-    mock_queue.unfinished_tasks = 0
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -772,12 +691,8 @@ def test_perform_update_removes_repos_even_when_run_fails(
     with pytest.raises(RuntimeError, match="update boom"):
         hg.perform_update(testreport, ["noprepare", "noscript"])
 
-    set_repo_calls = [
-        call.args[0]
-        for call in mock_queue.put.call_args_list
-        if call.args and call.args[0][0] is t1.set_repo
-    ]
-    assert (t1.set_repo, ["remove", testreport]) in set_repo_calls
+    operations = [c.args[0] for c in mock_fanout.call_args_list]
+    assert "remove" in operations
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Three problems with the existing parallel-target machinery in `mtui/target/actions.py`:

1. **Module-level mutable state.** A single `queue: Queue[(callable, args)]` was shared across every concurrent `HostsGroup` operation in the process. It only happened to work because `mtui` never ran two operations concurrently — a global waiting for someone to step on it.

2. **Silent exception swallow.** `ThreadedMethod` ran the worker callable inside a bare `try/finally` that called `task_done()` but never `.result()`. A failing `Target.set_repo` / `sftp_*` / `run` took its worker thread down without ever surfacing to the caller, and the enclosing `update` / `prepare` / `downgrade` flow happily marched on as if it had succeeded. `pytest` had been quietly emitting `PytestUnhandledThreadExceptionWarning` for years.

3. **Reinvented the standard library.** `concurrent.futures.ThreadPoolExecutor` has solved "fan a callable out across N threads, surface exceptions, join on scope exit" since Python 3.2. The bespoke implementation was twice the code and missing the exception-propagation guarantee. (`mtui` started as a python-2.2-era script; this code dates back to that era.)

Replace the queue / `ThreadedMethod` / spinner machinery with a small `run_parallel()` helper on top of `ThreadPoolExecutor`. It builds one pool sized to the work, submits each `(callable, args)` pair, and iterates `as_completed` so the first worker exception re-raises into the caller. `ThreadedTargetGroup` collapses to a 5-line abstract base; `RunCommand`'s serial path becomes a plain for-loop with `prompt_user` between iterations; `HostsGroup._fanout_set_repo` is now a one-liner against the same helper.

Net effect: large LOC reduction in production modules, exceptions now surface where the user can see them, and the queue / `ThreadedMethod` / spinner seam disappears from `hostgroup`'s public surface.

## What changes for users

Two user-visible changes, both documented in `CHANGELOG.md` under `[Unreleased] / Fixed`:

> Exceptions raised inside parallel target operations (`Target.set_repo`, `Target.run`, the SFTP helpers used by `put` / `get` / `remove`) now surface to the caller and abort the enclosing `update` / `prepare` / `downgrade` / `install` / `uninstall` flow, instead of being silently lost in a worker thread while the flow pretended to succeed.

> Pressing `Ctrl+C` during a parallel `run` now drops queued hosts that have not started yet and unblocks in-flight workers by closing their SSH sessions, instead of waiting for the whole parallel batch to drain before the interrupt was honoured. Workers already executing a remote command will still finish their current command (Python cannot interrupt a foreign blocking call), but session shutdown unblocks them promptly.

> Long-running parallel operations (`run`, file uploads / downloads / deletes, `set_repo` fan-out used by `update`/`prepare`/`downgrade`) now show user-visible progress again via a `|/-\` spinner on stderr while work is in flight. The spinner is suppressed when stderr is not a TTY (log files and redirected output stay clean).

The exception-propagation change is the bug-fix half. The locks acquired by `update_lock` are still released because the surrounding `try/finally: self.unlock()` blocks remain in place; users now see the failure instead of a silent half-update.

## Verification

- `uv run ruff format --check .` ✓
- `uv run ruff check .` ✓
- `uv run ty check` ✓
- `uv run pytest` — **593 passed**
- `uv run python -m mtui --help` and `-V` ✓
- `rg "queue\.put|queue\.unfinished_tasks|queue\.join\(\)|ThreadedMethod\(" mtui/` returns zero hits — the hand-rolled global is gone

## Out of scope

- Async migration to `asyncssh`. Substantial rewrite; defer until other refactors stabilise.