### PR TITLE
fix(apicall): use rrid instead of id when unassigning in OSC

### DIFF
--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -162,8 +162,8 @@ class Unassign(BaseApiCall):
 
     def osc(self) -> None:
         """Unassigns the request in OSC."""
-        logger.info("Unassign request %s", self.metadata.id.review_id)
-        osc = OSC(self.config, self.metadata.id)
+        logger.info("Unassign request %s", self.metadata.rrid.review_id)
+        osc = OSC(self.config, self.metadata.rrid)
         osc.unassign(self.args.group)
 
     def gitea(self) -> None:


### PR DESCRIPTION
## Why this change was needed

The Unassign command was passing `self.metadata.id` (a string) to OSC,
but OSC expects a RequestReviewID object. This type mismatch caused
the unassign operation to fail when reaching the OSC layer.

## Problem solved

Unassigning requests through OSC now works correctly because the proper
RequestReviewID object is passed instead of a bare string.

## What changed

- `mtui/commands/apicall.py`: replaced `self.metadata.id` with
  `self.metadata.rrid` in both the log call and OSC constructor