### PR TITLE
Fix formatting for addons and SFTPPut typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   not a TTY (log files and redirected output stay clean). Restores the
   "mtui is alive" feedback that was lost when the queue/spinner thread
   was retired.
+- `put` command log message no longer contains an extra `i` character;
+  fixed "uploaded /X to i/tmp/Y" → "uploaded /X to /tmp/Y".
+- `Attributes.__str__` (refhost string representation) now formats addon
+  versions consistently with product versions: only adds a dot separator
+  when the minor version exists and is numeric. Previously addons always
+  included a trailing dot ("ha 15."), while products omitted it ("sles 12").
 
 ### Known issues
 - A non-numeric value for `connection_timeout` (e.g.

--- a/mtui/commands/sftpcmd.py
+++ b/mtui/commands/sftpcmd.py
@@ -56,7 +56,7 @@ class SFTPPut(Command):
             remote = self.metadata.target_wd(filename.name)
 
             targets.sftp_put(filename, remote)
-            logger.info("uploaded %s to i%s", filename, remote)
+            logger.info("uploaded %s to %s", filename, remote)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -57,8 +57,10 @@ class Attributes:
         for addon in sorted(self.addons, key=lambda addon: addon["name"]):
             serialization = addon["name"]
             if "version" in addon and "major" in addon["version"]:
-                serialization += " " + str(addon["version"]["major"]) + "."
+                serialization += " " + str(addon["version"]["major"])
                 if "minor" in addon["version"]:
+                    if isinstance(addon["version"]["minor"], int):
+                        serialization += "."
                     serialization += str(addon["version"]["minor"])
 
             addons.append(serialization)

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -113,7 +113,7 @@ class TestAttributes:
             {"name": "ha", "version": {"major": 15}},
         ]
         # Addons are sorted alphabetically.
-        assert str(attr) == "ha 15. sdk 15.5"
+        assert str(attr) == "ha 15 sdk 15.5"
 
     def test_repr_wraps_str(self):
         attr = refhost.Attributes()


### PR DESCRIPTION
## Summary

Fixes two minor bugs:

- Remove extra 'i' in `put` command log output: "uploaded /X to i/tmp/Y" -> "uploaded /X to /tmp/Y"
- Fix inconsistent version formatting: addons now format like products ("ha 15" not "ha 15." when no minor  version)

## Changes

  - `mtui/commands/sftpcmd.py`: Remove extra "i" from upload log message format string
  - `mtui/refhost.py`: Apply same version formatting logic to addons as products (dot separator only when minor version exists and is numeric)
  - `tests/test_refhost.py`: Update `test_str_with_addons_sorted` assertion to expect "ha 15" instead of "ha 15."
  - `CHANGELOG.md`: Document both fixes in [Unreleased] Fixed section

## Checklist
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean.
- [x] `uv run pytest` passes.
- [x] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
- [ ] Documentation under `Documentation/` updated where relevant.