### PR TITLE
fix(hostgroup): handle missing doer commands gracefully instead of crashing

### DIFF
--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -9,7 +9,13 @@ from typing import Self, final
 
 from ..exceptions import UpdateError
 from ..hooks import CompareScript, PostScript, PreScript
-from ..messages import HostIsNotConnectedError
+from ..messages import (
+    HostIsNotConnectedError,
+    MissingDowngraderError,
+    MissingInstallerError,
+    MissingPreparerError,
+    MissingUninstallerError,
+)
 from ..types import Package
 from ..types.rpmver import RPMVersion
 from . import Target
@@ -221,23 +227,23 @@ class HostsGroup(UserDict[str, Target]):
         )
 
     def perform_install(self, packages: list[str]) -> None:
-        """Performs an installation on all hosts in the group.
+        """Performs an installation on all hosts in the group."""
+        try:
+            commands = {
+                t.hostname: t.get_installer()["command"].substitute(
+                    packages=" ".join(packages)
+                )
+                for t in self.data.values()
+            }
+            reboot = {
+                t.hostname: t.get_installer()["reboot"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+        except MissingInstallerError as e:
+            logger.error("%s", e)
+            return
 
-        Args:
-            packages: A list of packages to install.
-
-        """
-        commands = {
-            t.hostname: t.get_installer()["command"].substitute(
-                packages=" ".join(packages)
-            )
-            for t in self.data.values()
-        }
-        reboot = {
-            t.hostname: t.get_installer()["reboot"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
         self.update_lock()
         try:
             self.run(commands)
@@ -296,16 +302,20 @@ class HostsGroup(UserDict[str, Target]):
         pkgs = [p for p in packages if p != "branding-upstream"]
         # big change, all packages prepared in one step, so we dont need reboot transactional systems too many times
 
-        reboot = {
-            t.hostname: t.get_preparer()["reboot"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
-        start = {
-            t.hostname: t.get_preparer()["start_command"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
+        try:
+            reboot = {
+                t.hostname: t.get_preparer()["reboot"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+            start = {
+                t.hostname: t.get_preparer()["start_command"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+        except MissingPreparerError as e:
+            logger.error("%s", e)
+            return
 
         self.update_lock()
 
@@ -339,6 +349,8 @@ class HostsGroup(UserDict[str, Target]):
                 )
             self._reboot(reboot)
 
+        except MissingUninstallerError as e:
+            logger.error("%s", e)
         except Exception:
             logger.exception("Error during prepare operation")
         finally:
@@ -356,27 +368,35 @@ class HostsGroup(UserDict[str, Target]):
         versions: dict[str, dict[str, str]] = {}
         self.update_lock()
 
-        reboot = {
-            t.hostname: t.get_downgrader()["reboot"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
-        init_snapshot = {
-            t.hostname: t.get_downgrader()["init_snapshot"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
+        try:
+            reboot = {
+                t.hostname: t.get_downgrader()["reboot"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+            init_snapshot = {
+                t.hostname: t.get_downgrader()["init_snapshot"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+        except MissingDowngraderError as e:
+            logger.error("%s", e)
+            return
 
         try:
             self._fanout_set_repo("remove", testreport)
+            try:
+                list_cmd = {
+                    h: t.get_downgrader()["list_command"].safe_substitute(
+                        packages=" ".join(packages)
+                    )
+                    for h, t in self.data.items()
+                    if "list_command" in t.get_downgrader()
+                }
+            except MissingInstallerError as e:
+                logger.error("%s", e)
+                raise e
 
-            list_cmd = {
-                h: t.get_downgrader()["list_command"].safe_substitute(
-                    packages=" ".join(packages)
-                )
-                for h, t in self.data.items()
-                if "list_command" in t.get_downgrader()
-            }
             self.run(list_cmd)
 
             for hn, t in self.data.items():
@@ -417,7 +437,8 @@ class HostsGroup(UserDict[str, Target]):
                         )
 
             self._reboot(reboot)
-
+        except MissingDowngraderError:
+            return
         finally:
             self.unlock()
 
@@ -498,17 +519,22 @@ class HostsGroup(UserDict[str, Target]):
         self._fanout_set_repo("add", testreport)
 
         repa = f":p={testreport.rrid.maintenance_id}:{testreport.rrid.review_id}"
-        commands = {
-            hn: t.get_updater()["command"].safe_substitute(
-                repa=repa, packages=" ".join(testreport.get_package_list())
-            )
-            for hn, t in self.data.items()
-        }
-        reboot = {
-            t.hostname: t.get_updater()["reboot"].substitute()
-            for t in self.data.values()
-            if t.transactional
-        }
+        try:
+            commands = {
+                hn: t.get_updater()["command"].safe_substitute(
+                    repa=repa, packages=" ".join(testreport.get_package_list())
+                )
+                for hn, t in self.data.items()
+            }
+            reboot = {
+                t.hostname: t.get_updater()["reboot"].substitute()
+                for t in self.data.values()
+                if t.transactional
+            }
+        except MissingInstallerError as e:
+            logger.error("%s", e)
+            self._fanout_set_repo("remove", testreport)
+            return
 
         try:
             try:


### PR DESCRIPTION
## Description

When a host's doer command configuration (installer, preparer, downgrader, or updater) was missing or incomplete, the `perform_*` methods would crash with an unhandled exception, stopping the entire operation.

## Changes

- Imported missing doer exception types from messages module
- Wrapped command dictionary comprehensions in try/except blocks for:
  * `perform_install()` — installer command
  * `perform_prepare()` — preparer command and reboot config
  * `perform_downgrade()` — downgrader initialization and list commands
  * `perform_update()` — updater command and reboot config
- Each error handler logs the exception and returns early to prevent further execution

## Impact

Methods now gracefully handle missing doer configuration and provide clear debugging information instead of crashing.