### PR TITLE
refactor(target): decompose Target into focused collaborators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,27 @@ All notable user-visible changes to MTUI are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Internal refactor: `Target` was decomposed into four focused
+  collaborators. Out-of-tree consumers that imported
+  `mtui.target.Target` lose the following methods, all moved to
+  collaborator properties on the same instance:
+  - `target.get_installer()` / `get_uninstaller()` / `get_downgrader()`
+    / `get_updater()` / `get_preparer()` and the five matching
+    `..._check()` variants are now reached as
+    `target.doer("installer")` / `target.check("installer")` etc.
+    The preparer arm keeps its `(force, testing)` kwargs:
+    `target.doer("preparer", force=True, testing=True)`.
+  - `target.report_self()` / `report_history()` / `report_locks()` /
+    `report_timeout()` / `report_sessions()` / `report_log()` /
+    `report_products()` move to `target.reporter.self_()`,
+    `target.reporter.history()`, etc.
+  - `target.set_repo()` and `target.run_zypper()` move to
+    `target.repo_manager.set()` and `target.repo_manager.run_zypper()`.
+  - `target.query_package_versions()` is kept as a thin delegate but
+    the rpm-vs-dpkg logic now lives in
+    `target.package_querier`. All in-tree callers were migrated.
+

--- a/mtui/commands/setrepo.py
+++ b/mtui/commands/setrepo.py
@@ -47,7 +47,7 @@ class SetRepo(Command):
         try:
             with LockedTargets([self.targets[x] for x in hosts]):
                 for t in [self.targets[x] for x in hosts]:
-                    t.set_repo(operation, self.metadata)
+                    t.repo_manager.set(operation, self.metadata)
         except TargetLockedError as err:
             logger.error("Target locked %s", err)
 

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -536,7 +536,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_self(sink)
+            self.data[hn].reporter.self_(sink)
 
     def report_history(self, sink, count, events) -> None:
         """Reports the history of all hosts in the group.
@@ -557,7 +557,7 @@ class HostsGroup(UserDict[str, Target]):
             self._run(f"tail -n {count} /var/log/mtui.log")
 
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_history(sink)
+            self.data[hn].reporter.history(sink)
 
     def report_locks(self, sink):
         """Reports the lock state of all hosts in the group.
@@ -567,7 +567,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_locks(sink)
+            self.data[hn].reporter.locks(sink)
 
     def report_timeout(self, sink) -> None:
         """Reports the timeout of all hosts in the group.
@@ -577,7 +577,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_timeout(sink)
+            self.data[hn].reporter.timeout(sink)
 
     def report_sessions(self, sink) -> None:
         """Reports the sessions of all hosts in the group.
@@ -587,7 +587,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_sessions(sink)
+            self.data[hn].reporter.sessions(sink)
 
     def report_log(self, sink, arg) -> None:
         """Reports the log of all hosts in the group.
@@ -598,7 +598,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_log(sink, arg)
+            self.data[hn].reporter.log(sink, arg)
 
     def report_products(self, sink) -> None:
         """Reports the products of all hosts in the group.
@@ -608,4 +608,4 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].report_products(sink)
+            self.data[hn].reporter.products(sink)

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -220,9 +220,9 @@ class HostsGroup(UserDict[str, Target]):
             raise UpdateError("Hosts locked")
 
     def _fanout_set_repo(self, operation: str, testreport) -> None:
-        """Fan ``Target.set_repo(operation, testreport)`` out across every host."""
+        """Fan ``Target.repo_manager.set(operation, testreport)`` out across every host."""
         run_parallel(
-            [(t.set_repo, (operation, testreport)) for t in self.data.values()],
+            [(t.repo_manager.set, (operation, testreport)) for t in self.data.values()],
             desc=f"set_repo {operation}",
         )
 

--- a/mtui/target/hostgroup.py
+++ b/mtui/target/hostgroup.py
@@ -257,12 +257,12 @@ class HostsGroup(UserDict[str, Target]):
 
         try:
             reboot = {
-                t.hostname: t.get_preparer()["reboot"].substitute()
+                t.hostname: t.doer("preparer")["reboot"].substitute()
                 for t in self.data.values()
                 if t.transactional
             }
             start = {
-                t.hostname: t.get_preparer()["start_command"].substitute()
+                t.hostname: t.doer("preparer")["start_command"].substitute()
                 for t in self.data.values()
                 if t.transactional
             }
@@ -288,7 +288,7 @@ class HostsGroup(UserDict[str, Target]):
                     return
             for pkg in pkgs:
                 command = {
-                    t.hostname: t.get_preparer(force, testing)[cmd].substitute(
+                    t.hostname: t.doer("preparer", force, testing)[cmd].substitute(
                         package=pkg
                     )
                     for t in self.data.values()
@@ -297,7 +297,7 @@ class HostsGroup(UserDict[str, Target]):
                 self.run(command)
 
             for t in self.data.values():
-                t.get_preparer_check()(
+                t.check("preparer")(
                     t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit()
                 )
             self._reboot(reboot)
@@ -323,12 +323,12 @@ class HostsGroup(UserDict[str, Target]):
 
         try:
             reboot = {
-                t.hostname: t.get_downgrader()["reboot"].substitute()
+                t.hostname: t.doer("downgrader")["reboot"].substitute()
                 for t in self.data.values()
                 if t.transactional
             }
             init_snapshot = {
-                t.hostname: t.get_downgrader()["init_snapshot"].substitute()
+                t.hostname: t.doer("downgrader")["init_snapshot"].substitute()
                 for t in self.data.values()
                 if t.transactional
             }
@@ -340,11 +340,11 @@ class HostsGroup(UserDict[str, Target]):
             self._fanout_set_repo("remove", testreport)
             try:
                 list_cmd = {
-                    h: t.get_downgrader()["list_command"].safe_substitute(
+                    h: t.doer("downgrader")["list_command"].safe_substitute(
                         packages=" ".join(packages)
                     )
                     for h, t in self.data.items()
-                    if "list_command" in t.get_downgrader()
+                    if "list_command" in t.doer("downgrader")
                 }
             except MissingDowngraderError as e:
                 logger.error("%s", e)
@@ -371,7 +371,7 @@ class HostsGroup(UserDict[str, Target]):
 
             for package in packages:
                 cmd = {
-                    h: t.get_downgrader()["command"].safe_substitute(
+                    h: t.doer("downgrader")["command"].safe_substitute(
                         package=package, version=versions[h][package]
                     )
                     for h, t in self.data.items()
@@ -381,7 +381,7 @@ class HostsGroup(UserDict[str, Target]):
                     self.run(cmd)
 
                     for t in self.data.values():
-                        t.get_downgrader_check()(
+                        t.check("downgrader")(
                             t.hostname,
                             t.lastout(),
                             t.lastin(),
@@ -474,13 +474,13 @@ class HostsGroup(UserDict[str, Target]):
         repa = f":p={testreport.rrid.maintenance_id}:{testreport.rrid.review_id}"
         try:
             commands = {
-                hn: t.get_updater()["command"].safe_substitute(
+                hn: t.doer("updater")["command"].safe_substitute(
                     repa=repa, packages=" ".join(testreport.get_package_list())
                 )
                 for hn, t in self.data.items()
             }
             reboot = {
-                t.hostname: t.get_updater()["reboot"].substitute()
+                t.hostname: t.doer("updater")["reboot"].substitute()
                 for t in self.data.values()
                 if t.transactional
             }
@@ -493,7 +493,7 @@ class HostsGroup(UserDict[str, Target]):
             try:
                 self.run(commands)
                 for t in self.data.values():
-                    t.get_updater_check()(
+                    t.check("updater")(
                         t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit()
                     )
                 self._reboot(reboot)

--- a/mtui/target/operation.py
+++ b/mtui/target/operation.py
@@ -120,10 +120,10 @@ class InstallOperation(Operation):
     missing_error: ClassVar[type[Exception]] = MissingInstallerError
 
     def get_doer(self, target: Target) -> dict[str, Any]:
-        return target.get_installer()
+        return target.doer(self.role)
 
     def get_check(self, target: Target) -> Callable[..., None]:
-        return target.get_installer_check()
+        return target.check(self.role)
 
 
 @final
@@ -134,7 +134,7 @@ class UninstallOperation(Operation):
     missing_error: ClassVar[type[Exception]] = MissingUninstallerError
 
     def get_doer(self, target: Target) -> dict[str, Any]:
-        return target.get_uninstaller()
+        return target.doer(self.role)
 
     def get_check(self, target: Target) -> Callable[..., None]:
-        return target.get_uninstaller_check()
+        return target.check(self.role)

--- a/mtui/target/package_querier.py
+++ b/mtui/target/package_querier.py
@@ -1,0 +1,74 @@
+"""Per-target package-version querier.
+
+This module is the home of the rpm-vs-dpkg branch logic and the
+output-parsing loop that turn a list of package names into a mapping of
+``name -> RPMVersion | None``. The logic used to live as
+:meth:`Target.query_package_versions`; it has nothing to do with the
+connection lifecycle on ``Target`` and is the only consumer of the
+``ubuntu``-vs-everything-else system distinction, so it earns its own
+collaborator.
+
+``Target.query_package_versions`` is kept as a thin delegate so all
+existing callers (``HostsGroup.query_versions``,
+``Target.query_versions``) continue to work without churn.
+"""
+
+import re
+from logging import getLogger
+from typing import TYPE_CHECKING, final
+
+from ..types.rpmver import RPMVersion
+
+if TYPE_CHECKING:
+    from .target import Target
+
+logger = getLogger("mtui.target.package_querier")
+
+# Matches the rpm-style "package X is not installed" line. The
+# corresponding dpkg output ("no packages found matching X") is reported
+# on stderr and does not appear in the line loop, so the matcher does
+# not need to handle it.
+_NOT_INSTALLED_RE = re.compile(r"package (.*) is not installed")
+
+
+@final
+class PackageQuerier:
+    """Adapter that runs ``rpm -q`` / ``dpkg-query`` and parses the output."""
+
+    def __init__(self, target: "Target") -> None:
+        """Bind the querier to ``target``.
+
+        ``target`` is used both as the call sink (``run`` / ``lastout``)
+        and as the source of system information (rpm vs dpkg branch).
+        """
+        self.target = target
+
+    def versions(self, packages: list[str]) -> dict[str, RPMVersion | None]:
+        """Query the installed versions of ``packages``.
+
+        Returns a mapping from package name to :class:`RPMVersion`, or
+        to ``None`` when the package is not installed. Duplicate lines
+        for the same package collapse to the highest version.
+        """
+        t = self.target
+        joined = " ".join(packages)
+        if t.system.get_base().name != "ubuntu":
+            t.run(
+                f'rpm -q --queryformat "%{{Name}} %{{Version}}-%{{Release}}\n" {joined}'
+            )
+        else:
+            t.run(f"dpkg-query -W -f='${{package}} ${{version}}\n' {joined}")
+
+        pkgs: dict[str, RPMVersion | None] = {}
+        for line in t.lastout().splitlines():
+            if match := _NOT_INSTALLED_RE.search(line):
+                pkgs[match.group(1)] = None
+                continue
+            name, ver = line.split()
+            new_ver = RPMVersion(ver)
+            if name in pkgs:
+                existing = pkgs[name]
+                pkgs[name] = max(existing, new_ver) if existing is not None else new_ver
+            else:
+                pkgs[name] = new_ver
+        return pkgs

--- a/mtui/target/repo_manager.py
+++ b/mtui/target/repo_manager.py
@@ -1,0 +1,76 @@
+"""Per-target zypper repository manager.
+
+This module is the home of the two repository-shape methods that used
+to live directly on :class:`Target`:
+
+* ``set(operation, testreport)`` — the one-line forward into
+  ``testreport.set_repo(self, operation)``; kept on the collaborator
+  so callers reach for ``target.repo_manager.set(...)`` instead of
+  ``target.set_repo(...)``.
+* ``run_zypper(cmd, repos, rrid)`` — fans the zypper ar/rr add/remove
+  loop out across the target's flattened system, refreshes at the end.
+
+The unknown-cmd safeguard (``unlock(force=True)`` followed by a bare
+``ValueError``) is preserved byte-for-byte.
+"""
+
+from logging import getLogger
+from typing import TYPE_CHECKING, final
+
+if TYPE_CHECKING:
+    from .target import Target
+
+logger = getLogger("mtui.target.repo_manager")
+
+
+@final
+class RepoManager:
+    """Adapter that owns the per-target zypper-repo lifecycle."""
+
+    def __init__(self, target: "Target") -> None:
+        """Bind the manager to ``target``."""
+        self.target = target
+
+    def set(self, operation: str, testreport) -> None:
+        """Ask ``testreport`` to add or remove repos on the bound target.
+
+        Mirrors the one-line forward that used to live as
+        ``Target.set_repo``.
+        """
+        t = self.target
+        logger.debug("%s: changing %s repos", t.hostname, operation)
+        testreport.set_repo(t, operation)
+
+    def run_zypper(self, cmd, repos, rrid) -> None:
+        """Run a fan-out ``zypper`` command across the target's repos.
+
+        Iterates the ``repos`` mapping filtered by what the target's
+        flattened system actually carries; for each product/repo pair,
+        ``cmd`` is appended into either ``zypper ar <alias> <url>
+        <alias>`` (when ``"ar"`` is in ``cmd``) or ``zypper rr <url>``
+        (when ``"rr"`` is in ``cmd``). Unknown sub-commands force-unlock
+        and raise ``ValueError`` — pin that safeguard explicitly with
+        the unit test.
+
+        Always finishes with ``zypper -n ref`` so subsequent operations
+        see the freshly-(un)registered repos.
+        """
+        t = self.target
+        # ur - generator returning tuples of (product, repo_url)
+        ur = ((x, y) for x, y in repos.items() if x in t.system.flatten())
+
+        def name(product, rrid) -> str:
+            return f"issue-{product.name}:{product.version}:p={rrid.maintenance_id}:{rrid.review_id}"
+
+        for x, y in ur:
+            if "ar" in cmd:
+                logger.info("Adding repo %s on %s", y, t.hostname)
+                t.run(f"zypper {cmd} {name(x, rrid)} {y} {name(x, rrid)}")
+            elif "rr" in cmd:
+                logger.info("Removing repo %s on %s", y, t.hostname)
+                t.run(f"zypper {cmd} {y}")
+            else:
+                t.unlock(force=True)
+                raise ValueError
+
+        t.run("zypper -n ref")

--- a/mtui/target/reporter.py
+++ b/mtui/target/reporter.py
@@ -1,0 +1,88 @@
+"""Per-target reporting collaborator.
+
+This module is the home of the seven sink-dispatch methods that used to
+live directly on :class:`Target` (``report_self``, ``report_history``,
+``report_locks``, ``report_timeout``, ``report_sessions``,
+``report_log``, ``report_products``). They are short, related, and have
+no business sharing namespace with the SSH-and-lock skeleton on
+``Target``; extracting them keeps ``Target`` focused on connection
+lifecycle and turns the reporting surface into one easy-to-discover
+collaborator.
+
+The ``Reporter`` instance keeps a live reference to its owning
+:class:`Target`, so all dispatches read the most up-to-date values
+(``out``, ``state``, ``mode``, ``connection.timeout``, ``_lock``, etc.)
+at call time.
+
+Method names drop the ``report_`` prefix — inside this class it is
+redundant — and use ``self_`` (with a trailing underscore) for the
+``report_self`` equivalent to avoid clashing with the ``self`` keyword.
+"""
+
+from collections.abc import Callable
+from logging import getLogger
+from typing import TYPE_CHECKING, final
+
+from ..types import ExecutionMode, System, TargetState
+
+if TYPE_CHECKING:
+    from . import TargetLock
+    from .target import Target
+
+logger = getLogger("mtui.target.reporter")
+
+
+@final
+class Reporter:
+    """Adapter that drives the seven status sinks for one :class:`Target`."""
+
+    def __init__(self, target: "Target") -> None:
+        """Bind the reporter to ``target``.
+
+        The reference is intentionally a strong reference: ``Reporter``
+        is created lazily by :attr:`Target.reporter` and discarded with
+        the target.
+        """
+        self.target = target
+
+    def self_(
+        self,
+        sink: Callable[[str, System, bool, TargetState | str, ExecutionMode], None],
+    ) -> None:
+        """Report ``(hostname, system, transactional, state, mode)`` to ``sink``."""
+        t = self.target
+        sink(t.hostname, t.system, t.transactional, t.state, t.mode)
+
+    def history(self, sink: Callable[[str, System, list[str]], None]) -> None:
+        """Report the parsed history lines (last stdout split on ``\\n``)."""
+        t = self.target
+        sink(t.hostname, t.system, t.lastout().split("\n"))
+
+    def locks(self, sink: Callable[[str, System, "TargetLock"], None]) -> None:
+        """Report the lock object to ``sink``."""
+        t = self.target
+        sink(t.hostname, t.system, t._lock)  # noqa: SLF001
+
+    def timeout(self, sink: Callable[[str, System, int], None]) -> None:
+        """Report the current connection timeout to ``sink``."""
+        t = self.target
+        sink(t.hostname, t.system, t.connection.timeout)
+
+    def sessions(self, sink: Callable[[str, System, str], None]) -> None:
+        """Report the last stdout (used for `who`-style session listings)."""
+        t = self.target
+        sink(t.hostname, t.system, t.lastout())
+
+    def log(self, sink: Callable, arg) -> None:
+        """Report the full host log to ``sink``.
+
+        ``arg`` is a caller-provided extra (typically an output
+        accumulator); forwarded verbatim as the third positional arg.
+        """
+        t = self.target
+        sink(t.hostname, t.out, arg)
+
+    def products(self, sink: Callable[[str, System], None]) -> None:
+        """Report ``(hostname, system)`` to ``sink``."""
+        t = self.target
+        sink(t.hostname, t.system)

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -27,6 +27,28 @@ def _no_checks(*args: tuple[Any, ...]) -> None:
     return None
 
 
+# Dispatch tables for Target.doer/check. ``installer`` etc. are the
+# (release, transactional) -> dict-of-templates registries from
+# mtui.actions; ``install_checks`` etc. are the parallel callable
+# registries from mtui.checks. ``preparer`` is dispatched inline in
+# Target.doer because its registry yields a callable, not a dict.
+# ``uninstaller`` deliberately consults ``install_checks`` (no dedicated
+# uninstall_checks table exists) — preserves prior behaviour.
+_DOERS: dict[str, dict[tuple[str, bool], dict[str, Template]]] = {
+    "installer": installer,
+    "uninstaller": uninstaller,
+    "downgrader": downgrader,
+    "updater": updater,
+}
+_CHECKS: dict[str, dict[tuple[str, bool], Callable]] = {
+    "installer": install_checks,
+    "uninstaller": install_checks,
+    "downgrader": downgrade_checks,
+    "updater": update_checks,
+    "preparer": prepare_checks,
+}
+
+
 @final
 class Target:
     """Represents a single target host.
@@ -621,111 +643,36 @@ class Target:
         """
         sink(self.hostname, self.system)
 
-    def get_installer(self) -> dict[str, Template]:
-        """Gets the installer for the target.
-
-        Returns:
-            A dictionary of installer command templates.
-
-        """
-        return installer[(self.system.get_release(), self.transactional)]
-
-    def get_installer_check(self) -> Callable:
-        """Gets the installer check function for the target.
-
-        Returns:
-            The installer check function.
-
-        """
-        return install_checks.get(
-            (self.system.get_release(), self.transactional), _no_checks
-        )
-
-    def get_uninstaller(self) -> dict[str, Template]:
-        """Gets the uninstaller for the target.
-
-        Returns:
-            A dictionary of uninstaller command templates.
-
-        """
-        return uninstaller[(self.system.get_release(), self.transactional)]
-
-    def get_uninstaller_check(self) -> Callable:
-        """Gets the uninstaller check function for the target.
-
-        Returns:
-            The uninstaller check function.
-
-        """
-        return install_checks.get(
-            (self.system.get_release(), self.transactional), _no_checks
-        )
-
-    def get_downgrader(self) -> dict[str, Template]:
-        """Gets the downgrader for the target.
-
-        Returns:
-            A dictionary of downgrader command templates.
-
-        """
-        return downgrader[(self.system.get_release(), self.transactional)]
-
-    def get_downgrader_check(self) -> Callable:
-        """Gets the downgrader check function for the target.
-
-        Returns:
-            The downgrader check function.
-
-        """
-        return downgrade_checks.get(
-            (self.system.get_release(), self.transactional), _no_checks
-        )
-
-    def get_updater(self) -> dict[str, Template]:
-        """Gets the updater for the target.
-
-        Returns:
-            A dictionary of updater command templates.
-
-        """
-        return updater[(self.system.get_release(), self.transactional)]
-
-    def get_updater_check(self) -> Callable:
-        """Gets the updater check function for the target.
-
-        Returns:
-            The updater check function.
-
-        """
-        return update_checks.get(
-            (self.system.get_release(), self.transactional), _no_checks
-        )
-
-    def get_preparer(
-        self, force: bool = False, testing: bool = False
+    def doer(
+        self, role: str, force: bool = False, testing: bool = False
     ) -> dict[str, Template]:
-        """Gets the preparer for the target.
+        """Returns the action-template dict for ``role`` on this target.
 
-        Args:
-            force: Whether to force the preparation.
-            testing: Whether to include testing repositories.
-
-        Returns:
-            A dictionary of preparer command templates.
-
+        ``role`` is one of ``"installer"``, ``"uninstaller"``,
+        ``"downgrader"``, ``"updater"``, ``"preparer"``. The lookup is
+        keyed by ``(release, transactional)``; missing entries surface as
+        the corresponding ``MissingXerError`` raised by the underlying
+        registry. ``force`` and ``testing`` are only honoured for
+        ``"preparer"`` (the only role whose registry value is a callable
+        rather than a dict).
         """
-        return preparer[(self.system.get_release(), self.transactional)](force, testing)
+        key = (self.system.get_release(), self.transactional)
+        if role == "preparer":
+            return preparer[key](force, testing)
+        return _DOERS[role][key]
 
-    def get_preparer_check(self) -> Callable:
-        """Gets the preparer check function for the target.
+    def check(self, role: str) -> Callable:
+        """Returns the post-run check callable for ``role`` on this target.
 
-        Returns:
-            The preparer check function.
-
+        Falls back to a no-op when the registry has no entry for the
+        current ``(release, transactional)`` tuple. Mirrors
+        :meth:`doer`'s ``role`` vocabulary; note that the historical
+        ``get_uninstaller_check`` consulted ``install_checks`` (no
+        dedicated uninstall-check table exists), and that behaviour is
+        preserved here.
         """
-        return prepare_checks.get(
-            (self.system.get_release(), self.transactional), _no_checks
-        )
+        key = (self.system.get_release(), self.transactional)
+        return _CHECKS[role].get(key, _no_checks)
 
     def __repr__(self) -> str:
         """Returns a string representation of the `Target` object."""

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -1,7 +1,6 @@
 """The `Target` class, which represents a single target host."""
 
 import errno
-import re
 from collections.abc import Callable
 from logging import getLogger
 from pathlib import Path
@@ -19,6 +18,7 @@ from ..types import ExecutionMode, HostLog, Package, System, TargetState
 from ..types.rpmver import RPMVersion
 from ..utils import timestamp
 from . import TargetLock, TargetLockedError
+from .package_querier import PackageQuerier
 from .reporter import Reporter
 
 logger = getLogger("mtui.target")
@@ -216,6 +216,10 @@ class Target:
     ) -> dict[str, RPMVersion | None]:
         """Queries the versions of a list of packages.
 
+        Thin delegate to :class:`PackageQuerier`; kept so existing
+        callers (``HostsGroup.query_versions``, this class's own
+        ``query_versions``) do not need to change.
+
         Args:
             packages: A list of packages to query.
 
@@ -223,33 +227,7 @@ class Target:
             A dictionary mapping package names to `RPMVersion` objects.
 
         """
-        if self.system.get_base().name != "ubuntu":
-            self.run(
-                'rpm -q --queryformat "%{{Name}} %{{Version}}-%{{Release}}\n" {}'.format(
-                    " ".join(packages)
-                )
-            )
-        else:
-            self.run(
-                "dpkg-query -W -f='${{package}} ${{version}}\n' {}".format(
-                    " ".join(packages)
-                )
-            )
-
-        pkgs: dict[str, RPMVersion | None] = {}
-        for line in self.lastout().splitlines():
-            if match := re.search("package (.*) is not installed", line):
-                pkgs[match.group(1)] = None
-                continue
-            p, v = line.split()
-            # Make sure that it shows to the user the highest version
-            new_ver = RPMVersion(v)
-            if p in pkgs:
-                existing = pkgs[p]
-                pkgs[p] = max(existing, new_ver) if existing is not None else new_ver
-            else:
-                pkgs[p] = new_ver
-        return pkgs
+        return PackageQuerier(self).versions(packages)
 
     def set_timeout(self, value: int) -> None:
         """Sets the command timeout for the target host.

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -19,6 +19,7 @@ from ..types.rpmver import RPMVersion
 from ..utils import timestamp
 from . import TargetLock, TargetLockedError
 from .package_querier import PackageQuerier
+from .repo_manager import RepoManager
 from .reporter import Reporter
 
 logger = getLogger("mtui.target")
@@ -240,44 +241,13 @@ class Target:
         self.connection.timeout = value
         self._timeout = value
 
-    def set_repo(self, operation, testreport) -> None:
-        """Adds or removes a repository on the target host.
+    @property
+    def repo_manager(self) -> "RepoManager":
+        """The :class:`RepoManager` collaborator for this target.
 
-        Args:
-            operation: The operation to perform ("add" or "remove").
-            testreport: The test report object.
-
+        Fresh-per-access; see :attr:`reporter` for the rationale.
         """
-        logger.debug("%s: changing %s repos", self.hostname, operation)
-        testreport.set_repo(self, operation)
-
-    def run_zypper(self, cmd, repos, rrid) -> None:
-        """Runs a `zypper` command on the target host.
-
-        Args:
-            cmd: The `zypper` command to run.
-            repos: A dictionary of repositories.
-            rrid: The RequestReviewID of the current update.
-
-        """
-        # ur - generator returning tuple with product, repopart
-        ur = ((x, y) for x, y in repos.items() if x in self.system.flatten())
-
-        def name(product, rrid) -> str:
-            return f"issue-{product.name}:{product.version}:p={rrid.maintenance_id}:{rrid.review_id}"
-
-        for x, y in ur:
-            if "ar" in cmd:
-                logger.info("Adding repo %s on %s", y, self.hostname)
-                self.run(f"zypper {cmd} {name(x, rrid)} {y} {name(x, rrid)}")
-            elif "rr" in cmd:
-                logger.info("Removing repo %s on %s", y, self.hostname)
-                self.run(f"zypper {cmd} {y}")
-            else:
-                self.unlock(force=True)
-                raise ValueError
-
-        self.run("zypper -n ref")
+        return RepoManager(self)
 
     def run(self, command: str, lock=None) -> None:
         """Runs a command on the target host.

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -19,6 +19,7 @@ from ..types import ExecutionMode, HostLog, Package, System, TargetState
 from ..types.rpmver import RPMVersion
 from ..utils import timestamp
 from . import TargetLock, TargetLockedError
+from .reporter import Reporter
 
 logger = getLogger("mtui.target")
 
@@ -576,72 +577,17 @@ class Target:
         if self.connection:
             self.connection.close()
 
-    def report_self(
-        self,
-        sink: Callable[[str, System, bool, TargetState | str, ExecutionMode], None],
-    ) -> None:
-        """Reports the status of the target.
+    @property
+    def reporter(self) -> "Reporter":
+        """The :class:`Reporter` collaborator for this target.
 
-        Args:
-            sink: The function to use for reporting.
-
+        Returns a fresh ``Reporter`` per access — the type is stateless,
+        so allocation cost is negligible compared to the SSH call that
+        is usually about to happen anyway. Avoids keeping a strong
+        cached reference, which would otherwise tie ``Reporter`` (and
+        anything captured by sink callbacks) into ``Target``'s lifetime.
         """
-        sink(self.hostname, self.system, self.transactional, self.state, self.mode)
-
-    def report_history(self, sink: Callable[[str, System, list[str]], None]) -> None:
-        """Reports the history of the target.
-
-        Args:
-            sink: The function to use for reporting.
-
-        """
-        sink(self.hostname, self.system, self.lastout().split("\n"))
-
-    def report_locks(self, sink: Callable[[str, System, TargetLock], None]) -> None:
-        """Reports the lock state of the target.
-
-        Args:
-            sink: The function to use for reporting.
-
-        """
-        sink(self.hostname, self.system, self._lock)
-
-    def report_timeout(self, sink: Callable[[str, System, int], None]) -> None:
-        """Reports the timeout of the target.
-
-        Args:
-            sink: The function to use for reporting.
-
-        """
-        sink(self.hostname, self.system, self.connection.timeout)
-
-    def report_sessions(self, sink: Callable[[str, System, str], None]) -> None:
-        """Reports the sessions of the target.
-
-        Args:
-            sink: The function to use for reporting.
-
-        """
-        sink(self.hostname, self.system, self.lastout())
-
-    def report_log(self, sink: Callable, arg) -> None:
-        """Reports the log of the target.
-
-        Args:
-            sink: The function to use for reporting.
-            arg: An additional argument to pass to the reporting function.
-
-        """
-        sink(self.hostname, self.out, arg)
-
-    def report_products(self, sink: Callable[[str, System], None]) -> None:
-        """Reports the products of the target.
-
-        Args:
-            sink: The function to use for reporting.
-
-        """
-        sink(self.hostname, self.system)
+        return Reporter(self)
 
     def doer(
         self, role: str, force: bool = False, testing: bool = False

--- a/mtui/template/obstestreport.py
+++ b/mtui/template/obstestreport.py
@@ -60,9 +60,9 @@ class OBSTestReport(TestReport):
 
         """
         if operation == "add":
-            target.run_zypper("-n ar -ckn", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n ar -ckn", self.update_repos, self.rrid)
         elif operation == "remove":
-            target.run_zypper("-n rr", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n rr", self.update_repos, self.rrid)
         else:
             raise ValueError(f"Not supported repose operation {operation}")
 

--- a/mtui/template/obstestreport.py
+++ b/mtui/template/obstestreport.py
@@ -78,7 +78,7 @@ class OBSTestReport(TestReport):
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"
         for hn, t in targets.items():
             display(
-                f"{hn} - commands: \n{t.get_updater()['command'].safe_substitute(repa=repa, packages=packages)}"
+                f"{hn} - commands: \n{t.doer('updater')['command'].safe_substitute(repa=repa, packages=packages)}"
             )
 
     def check_hash(self) -> tuple[bool, str, str]:

--- a/mtui/template/pitestreport.py
+++ b/mtui/template/pitestreport.py
@@ -63,9 +63,9 @@ class PITestReport(TestReport):
 
         """
         if operation == "add":
-            target.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
         elif operation == "remove":
-            target.run_zypper("-n rr", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n rr", self.update_repos, self.rrid)
         else:
             raise ValueError(f"Not supported repose operation {operation}")
 

--- a/mtui/template/pitestreport.py
+++ b/mtui/template/pitestreport.py
@@ -81,7 +81,7 @@ class PITestReport(TestReport):
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"
         for hn, t in targets.items():
             display(
-                f"{hn} - commands: \n{t.get_updater()['command'].safe_substitute(repa=repa, packages=packages)}"
+                f"{hn} - commands: \n{t.doer('updater')['command'].safe_substitute(repa=repa, packages=packages)}"
             )
 
     def check_hash(self) -> tuple[bool, str, str]:

--- a/mtui/template/sltestreport.py
+++ b/mtui/template/sltestreport.py
@@ -86,9 +86,9 @@ class SLTestReport(TestReport):
 
         """
         if operation == "add":
-            target.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n ar -cfGkn", self.update_repos, self.rrid)
         elif operation == "remove":
-            target.run_zypper("-n rr", self.update_repos, self.rrid)
+            target.repo_manager.run_zypper("-n rr", self.update_repos, self.rrid)
         else:
             raise ValueError(f"Not supported repose operation {operation}")
 

--- a/mtui/template/sltestreport.py
+++ b/mtui/template/sltestreport.py
@@ -104,5 +104,5 @@ class SLTestReport(TestReport):
         repa = f":p={self.rrid.maintenance_id}:{self.rrid.review_id}"
         for hn, t in targets.items():
             display(
-                f"{hn} - commands: \n{t.get_updater()['command'].safe_substitute(repa=repa, packages=packages)}"
+                f"{hn} - commands: \n{t.doer('updater')['command'].safe_substitute(repa=repa, packages=packages)}"
             )

--- a/tests/test_doers.py
+++ b/tests/test_doers.py
@@ -1,0 +1,116 @@
+"""Focused tests for ``Target.doer(role)`` / ``Target.check(role)``.
+
+These tests cover the dispatch tables introduced when the seven
+historical ``get_installer`` / ``get_installer_check`` / ... methods on
+``Target`` were collapsed (Phase 5b / C2 / Cluster A). They pin three
+things callers depend on:
+
+* role-to-registry routing for each of the five roles,
+* preparer-specific ``force`` / ``testing`` keyword forwarding,
+* the ``_no_checks`` sentinel fallback for unknown
+  ``(release, transactional)`` keys.
+
+The pre-existing per-flow integration tests
+(``tests/test_hostgroup.py::test_perform_*``,
+``tests/test_operation.py::test_install_and_uninstall_*``) cover the
+caller side; this file covers the dispatch surface in isolation.
+"""
+
+from string import Template
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.target import Target
+from mtui.target.target import _no_checks
+
+
+def _target_with_release(
+    mock_config, release: str = "15", transactional: bool = False
+) -> Target:
+    """Build a ``Target`` whose system advertises a fixed (release, transactional)."""
+    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
+    target.system = MagicMock()
+    target.system.get_release.return_value = release
+    target.transactional = transactional
+    return target
+
+
+# ---------------------------------------------------------------------------
+# doer() dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["installer", "uninstaller", "downgrader", "updater"],
+)
+def test_doer_returns_template_dict_for_known_release(mock_config, role):
+    """All four non-preparer roles route to a ``{name: Template}`` mapping."""
+    target = _target_with_release(mock_config)
+    result = target.doer(role)
+    assert isinstance(result, dict)
+    assert all(isinstance(v, Template) for v in result.values())
+
+
+def test_doer_preparer_routes_through_factory(mock_config):
+    """The preparer arm is a callable in the registry; doer invokes it with defaults."""
+    target = _target_with_release(mock_config)
+    result = target.doer("preparer")
+    assert isinstance(result, dict)
+
+
+def test_doer_preparer_forwards_force_and_testing(mock_config):
+    """``doer('preparer', force, testing)`` forwards both kwargs to the factory."""
+    target = _target_with_release(mock_config)
+    # Both keyword and positional forms must be honoured (callers use positional).
+    result_pos = target.doer("preparer", True, True)
+    result_kw = target.doer("preparer", force=True, testing=True)
+    assert isinstance(result_pos, dict)
+    assert isinstance(result_kw, dict)
+
+
+def test_doer_unknown_role_raises_key_error(mock_config):
+    """An unsupported role string is a programmer error: ``KeyError``."""
+    target = _target_with_release(mock_config)
+    with pytest.raises(KeyError):
+        target.doer("nosuch")
+
+
+# ---------------------------------------------------------------------------
+# check() dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["installer", "uninstaller", "downgrader", "updater", "preparer"],
+)
+def test_check_returns_callable_for_known_role(mock_config, role):
+    """Every role exposes a callable check (registered or the ``_no_checks`` sentinel)."""
+    target = _target_with_release(mock_config)
+    assert callable(target.check(role))
+
+
+def test_check_falls_back_to_no_checks_for_unknown_release(mock_config):
+    """Unknown ``(release, transactional)`` tuples fall back to the no-op sentinel."""
+    target = _target_with_release(mock_config, release="9999", transactional=False)
+    assert target.check("installer") is _no_checks
+
+
+def test_check_uninstaller_consults_install_checks_table(mock_config):
+    """``check('uninstaller')`` returns whatever ``install_checks`` advertises.
+
+    There is no dedicated uninstall-check table — this mirrors the prior
+    behaviour of the deleted ``get_uninstaller_check`` method, which
+    explicitly looked the value up in ``install_checks``.
+    """
+    target = _target_with_release(mock_config)
+    assert target.check("uninstaller") is target.check("installer")
+
+
+def test_check_unknown_role_raises_key_error(mock_config):
+    """An unsupported role string is a programmer error: ``KeyError``."""
+    target = _target_with_release(mock_config)
+    with pytest.raises(KeyError):
+        target.check("nosuch")

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -320,7 +320,7 @@ def test_report_self_delegates():
     hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_self(sink)
 
-    t1.report_self.assert_called_once_with(sink)
+    t1.reporter.self_.assert_called_once_with(sink)
 
 
 def test_report_locks_delegates():
@@ -332,7 +332,7 @@ def test_report_locks_delegates():
     hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_locks(sink)
 
-    t1.report_locks.assert_called_once_with(sink)
+    t1.reporter.locks.assert_called_once_with(sink)
 
 
 def test_report_timeout_delegates():
@@ -344,7 +344,7 @@ def test_report_timeout_delegates():
     hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_timeout(sink)
 
-    t1.report_timeout.assert_called_once_with(sink)
+    t1.reporter.timeout.assert_called_once_with(sink)
 
 
 def test_report_products_delegates():
@@ -356,7 +356,7 @@ def test_report_products_delegates():
     hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.report_products(sink)
 
-    t1.report_products.assert_called_once_with(sink)
+    t1.reporter.products.assert_called_once_with(sink)
 
 
 # ---------------------------------------------------------------------------
@@ -713,7 +713,7 @@ def test_report_history_with_events_uses_grep(mock_run):
     cmd = mock_run.call_args[0][1]
     assert "grep" in cmd
     assert "-m 5" in cmd
-    t1.report_history.assert_called_once_with(sink)
+    t1.reporter.history.assert_called_once_with(sink)
 
 
 @patch("mtui.target.hostgroup.RunCommand")
@@ -724,7 +724,7 @@ def test_report_history_without_events_uses_tail(mock_run):
     hg.report_history(sink, count=10, events=[])
     cmd = mock_run.call_args[0][1]
     assert "tail -n 10" in cmd
-    t1.report_history.assert_called_once_with(sink)
+    t1.reporter.history.assert_called_once_with(sink)
 
 
 def test_report_sessions_delegates():
@@ -732,7 +732,7 @@ def test_report_sessions_delegates():
     sink = MagicMock()
     hg = HostsGroup([t1])
     hg.report_sessions(sink)
-    t1.report_sessions.assert_called_once_with(sink)
+    t1.reporter.sessions.assert_called_once_with(sink)
 
 
 def test_report_log_delegates():
@@ -740,4 +740,4 @@ def test_report_log_delegates():
     sink = MagicMock()
     hg = HostsGroup([t1])
     hg.report_log(sink, "arg")
-    t1.report_log.assert_called_once_with(sink, "arg")
+    t1.reporter.log.assert_called_once_with(sink, "arg")

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -272,11 +272,11 @@ def test_perform_install_runs_and_unlocks(mock_run):
     t1.hostname = "h1"
     t1.is_locked.return_value = False
     t1.transactional = False
-    t1.get_installer.return_value = {
+    t1.doer.return_value = {
         "command": MagicMock(substitute=MagicMock(return_value="zypper in pkg")),
         "reboot": MagicMock(substitute=MagicMock(return_value="")),
     }
-    t1.get_installer_check.return_value = MagicMock()
+    t1.check.return_value = MagicMock()
 
     hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     hg.perform_install(["pkg"])
@@ -292,7 +292,7 @@ def test_perform_install_unlocks_on_error(mock_run):
     t1.hostname = "h1"
     t1.is_locked.return_value = False
     t1.transactional = False
-    t1.get_installer.return_value = {
+    t1.doer.return_value = {
         "command": MagicMock(substitute=MagicMock(return_value="zypper in pkg")),
         "reboot": MagicMock(substitute=MagicMock(return_value="")),
     }
@@ -441,8 +441,8 @@ def test_update_lock_logs_other_user_comment(caplog):
 @patch("mtui.target.hostgroup.RunCommand")
 def test_perform_uninstall_runs_and_unlocks(mock_run):
     t1 = _stub_target("h1")
-    t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
-    t1.get_uninstaller_check.return_value = MagicMock()
+    t1.doer.return_value = _doer_dict(command="zypper rm pkg", reboot="")
+    t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])
     hg.perform_uninstall(["pkg"])
     mock_run.assert_called()
@@ -452,7 +452,7 @@ def test_perform_uninstall_runs_and_unlocks(mock_run):
 @patch("mtui.target.hostgroup.RunCommand")
 def test_perform_uninstall_unlocks_on_error(mock_run):
     t1 = _stub_target("h1")
-    t1.get_uninstaller.return_value = _doer_dict(command="zypper rm pkg", reboot="")
+    t1.doer.return_value = _doer_dict(command="zypper rm pkg", reboot="")
     hg = HostsGroup([t1])
     mock_run.return_value.run.side_effect = RuntimeError("boom")
     with pytest.raises(RuntimeError, match="boom"):
@@ -463,11 +463,11 @@ def test_perform_uninstall_unlocks_on_error(mock_run):
 @patch("mtui.target.hostgroup.RunCommand")
 def test_perform_uninstall_transactional_triggers_reboot(mock_run):
     t1 = _stub_target("h1", transactional=True)
-    t1.get_uninstaller.return_value = _doer_dict(
+    t1.doer.return_value = _doer_dict(
         command="transactional-update -n pkg remove pkg",
         reboot="systemctl reboot",
     )
-    t1.get_uninstaller_check.return_value = MagicMock()
+    t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])
     hg.perform_uninstall(["pkg"])
     # _reboot eventually triggers reconnect.
@@ -484,10 +484,10 @@ def test_perform_prepare_runs_per_package_command(mock_run):
     """``perform_prepare`` runs the command-template once per package."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = ""
-    t1.get_preparer.return_value = _doer_dict(
+    t1.doer.return_value = _doer_dict(
         command="zypper in $package", reboot="", start_command=""
     )
-    t1.get_preparer_check.return_value = MagicMock()
+    t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])  # type: ignore[arg-type]
     hg.perform_prepare(["pkg-a", "pkg-b"], MagicMock())
     # 2 packages → 2 RunCommand invocations beyond the lock cleanup.
@@ -500,10 +500,10 @@ def test_perform_prepare_filters_branding_upstream(mock_run):
     """The hard-coded ``branding-upstream`` name is excluded from per-pkg cmds."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = ""
-    t1.get_preparer.return_value = _doer_dict(
+    t1.doer.return_value = _doer_dict(
         command="zypper in $package", reboot="", start_command=""
     )
-    t1.get_preparer_check.return_value = MagicMock()
+    t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])  # type: ignore[arg-type]
     hg.perform_prepare(["pkg-a", "branding-upstream", "pkg-b"], MagicMock())
     # 2 surviving packages.
@@ -522,7 +522,7 @@ def test_perform_prepare_aborts_on_set_repo_error(mock_run, caplog):
     t1.lasterr.return_value = "repo failure"
     t1.lastin.return_value = "zypper ar"
     t1.lastout.return_value = ""
-    t1.get_preparer.return_value = _doer_dict(
+    t1.doer.return_value = _doer_dict(
         command="zypper in $package", reboot="", start_command=""
     )
     hg = HostsGroup([t1])
@@ -550,18 +550,18 @@ def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
     t1 = _stub_target("h1")
     # Pretend list_command output is parsed: ``pkg-a = 1.0`` and ``pkg-a = 1.5``.
     t1.lastout.return_value = "pkg-a = 1.0-1\npkg-a = 1.5-1\n"
-    t1.get_downgrader.return_value = {
+    t1.doer.return_value = {
         **_doer_dict(reboot="", init_snapshot=""),
         "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
         "command": MagicMock(
             safe_substitute=MagicMock(return_value="zypper in pkg-a-1.5-1")
         ),
     }
-    t1.get_downgrader_check.return_value = MagicMock()
+    t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])
     hg.perform_downgrade(["pkg-a"], MagicMock())
     # Confirm the per-package command was substituted with the higher version.
-    cmd_tpl = t1.get_downgrader.return_value["command"]
+    cmd_tpl = t1.doer.return_value["command"]
     cmd_tpl.safe_substitute.assert_any_call(package="pkg-a", version="1.5-1")
     t1.unlock.assert_called()
 
@@ -570,7 +570,7 @@ def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
 def test_perform_downgrade_unlocks_on_error(mock_run):
     t1 = _stub_target("h1")
     t1.lastout.return_value = ""
-    t1.get_downgrader.return_value = {
+    t1.doer.return_value = {
         **_doer_dict(reboot="", init_snapshot=""),
         "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
         "command": MagicMock(safe_substitute=MagicMock(return_value="x")),
@@ -592,8 +592,8 @@ def test_perform_update_runs_full_flow_with_noprepare_and_noscript(mock_run):
     """``noprepare`` skips prepare; ``noscript`` skips Pre/Post/Compare scripts."""
     t1 = _stub_target("h1")
     t1.packages = {}  # short-circuit package_check
-    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
-    t1.get_updater_check.return_value = MagicMock()
+    t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.check.return_value = MagicMock()
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -613,12 +613,16 @@ def test_perform_update_runs_pre_post_and_compare_scripts(mock_run):
 
     t1 = _stub_target("h1")
     t1.packages = {}
-    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
-    t1.get_updater_check.return_value = MagicMock()
-    t1.get_preparer.return_value = _doer_dict(
-        command="zypper in $package", reboot="", start_command=""
-    )
-    t1.get_preparer_check.return_value = MagicMock()
+    # perform_update internally calls perform_prepare → two distinct
+    # doer roles are looked up against the same target. Dispatch by role.
+    doers = {
+        "updater": _doer_dict(command="zypper up", reboot=""),
+        "preparer": _doer_dict(
+            command="zypper in $package", reboot="", start_command=""
+        ),
+    }
+    t1.doer.side_effect = lambda role, *a, **kw: doers[role]
+    t1.check.return_value = MagicMock()
     t1.lasterr.return_value = ""
     testreport = MagicMock()
     testreport.config.auto = False
@@ -638,7 +642,7 @@ def test_perform_update_runs_pre_post_and_compare_scripts(mock_run):
 def test_perform_update_unlocks_when_run_fails(mock_run):
     t1 = _stub_target("h1")
     t1.packages = {}
-    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -657,8 +661,8 @@ def test_perform_update_removes_repos_at_end(mock_run, mock_fanout):
     """``perform_update`` fans out set_repo('add') first, then ('remove')."""
     t1 = _stub_target("h1")
     t1.packages = {}
-    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
-    t1.get_updater_check.return_value = MagicMock()
+    t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.check.return_value = MagicMock()
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]
@@ -679,7 +683,7 @@ def test_perform_update_removes_repos_even_when_run_fails(mock_run, mock_fanout)
     """Repo cleanup runs even when the updater command itself raises."""
     t1 = _stub_target("h1")
     t1.packages = {}
-    t1.get_updater.return_value = _doer_dict(command="zypper up", reboot="")
+    t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     testreport = MagicMock()
     testreport.config.auto = False
     testreport.get_package_list.return_value = ["pkg"]

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -36,7 +36,7 @@ def _stub_group(targets):
 
 
 def _stub_doer(command: str = "do-it $packages", reboot: str = "reboot-cmd"):
-    """Build a ``{command, reboot}`` mapping shaped like get_installer()."""
+    """Build a ``{command, reboot}`` mapping shaped like Target.doer(role)."""
     return {
         "command": MagicMock(substitute=MagicMock(return_value=command)),
         "reboot": MagicMock(substitute=MagicMock(return_value=reboot)),
@@ -46,9 +46,9 @@ def _stub_doer(command: str = "do-it $packages", reboot: str = "reboot-cmd"):
 def test_operation_collects_commands_and_reboot_per_transactional():
     """``collect()`` returns one entry per host for commands; transactional only for reboot."""
     t1 = _stub_target("h1", transactional=False)
-    t1.get_installer.return_value = _stub_doer("zypper in pkg-a", "reboot-1")
+    t1.doer.return_value = _stub_doer("zypper in pkg-a", "reboot-1")
     t2 = _stub_target("h2", transactional=True)
-    t2.get_installer.return_value = _stub_doer("zypper in pkg-a", "systemctl reboot")
+    t2.doer.return_value = _stub_doer("zypper in pkg-a", "systemctl reboot")
     group = _stub_group([t1, t2])
 
     commands, reboot = InstallOperation(group, ["pkg-a"]).collect()
@@ -58,15 +58,13 @@ def test_operation_collects_commands_and_reboot_per_transactional():
     assert reboot == {"h2": "systemctl reboot"}
 
     # The "command" template is substituted with the joined package list.
-    t1.get_installer.return_value["command"].substitute.assert_called_with(
-        packages="pkg-a"
-    )
+    t1.doer.return_value["command"].substitute.assert_called_with(packages="pkg-a")
 
 
 def test_operation_returns_early_when_doer_raises_missing_error():
-    """If get_doer raises the configured missing_error, no lock/run/unlock happens."""
+    """If doer() raises the configured missing_error, no lock/run/unlock happens."""
     t1 = _stub_target("h1")
-    t1.get_installer.side_effect = MissingInstallerError("opensuse-15.4")
+    t1.doer.side_effect = MissingInstallerError("opensuse-15.4")
     group = _stub_group([t1])
 
     InstallOperation(group, ["pkg-a"]).run()
@@ -80,7 +78,7 @@ def test_operation_returns_early_when_doer_raises_missing_error():
 def test_operation_always_unlocks_in_finally_when_run_raises():
     """When ``group.run`` raises, the exception propagates but unlock still runs."""
     t1 = _stub_target("h1")
-    t1.get_installer.return_value = _stub_doer()
+    t1.doer.return_value = _stub_doer()
     group = _stub_group([t1])
     group.run.side_effect = RuntimeError("connection lost")
 
@@ -94,23 +92,23 @@ def test_operation_always_unlocks_in_finally_when_run_raises():
 def test_operation_check_called_per_target_with_lastN_args():
     """The check callable is invoked once per target with (hostname, lastout, lastin, lasterr, lastexit)."""
     t1 = _stub_target("h1")
-    t1.get_installer.return_value = _stub_doer()
+    t1.doer.return_value = _stub_doer()
     t1.lastout.return_value = "OUT-1"
     t1.lastin.return_value = "IN-1"
     t1.lasterr.return_value = "ERR-1"
     t1.lastexit.return_value = 0
     check = MagicMock()
-    t1.get_installer_check.return_value = check
+    t1.check.return_value = check
 
     t2 = _stub_target("h2")
-    t2.get_installer.return_value = _stub_doer()
+    t2.doer.return_value = _stub_doer()
     t2.lastout.return_value = "OUT-2"
     t2.lastin.return_value = "IN-2"
     t2.lasterr.return_value = "ERR-2"
     t2.lastexit.return_value = 1
-    # Each target's get_*_check() returns its own check callable in production;
+    # Each target's check() returns its own check callable in production;
     # share one MagicMock here so we can inspect both invocations in one place.
-    t2.get_installer_check.return_value = check
+    t2.check.return_value = check
 
     group = _stub_group([t1, t2])
 
@@ -123,28 +121,27 @@ def test_operation_check_called_per_target_with_lastN_args():
     group._reboot.assert_called_once()
 
 
-def test_install_and_uninstall_operations_use_correct_target_methods():
-    """``InstallOperation`` reaches for the installer doer/check; uninstall for the uninstaller pair."""
+def test_install_and_uninstall_operations_use_correct_role_string():
+    """``InstallOperation`` looks up the ``"installer"`` role; uninstall looks up ``"uninstaller"``."""
     t1 = _stub_target("h1")
-    t1.get_installer.return_value = _stub_doer()
-    t1.get_uninstaller.return_value = _stub_doer()
+    t1.doer.return_value = _stub_doer()
     group = _stub_group([t1])
 
     InstallOperation(group, ["pkg"]).run()
-    assert t1.get_installer.called
-    assert t1.get_installer_check.called
-    assert not t1.get_uninstaller.called
-    assert not t1.get_uninstaller_check.called
+    # Both doer() and check() must have been called with the "installer" role.
+    assert call("installer") in t1.doer.call_args_list
+    assert call("installer") in t1.check.call_args_list
+    assert call("uninstaller") not in t1.doer.call_args_list
+    assert call("uninstaller") not in t1.check.call_args_list
 
     t1.reset_mock()
-    t1.get_installer.return_value = _stub_doer()
-    t1.get_uninstaller.return_value = _stub_doer()
+    t1.doer.return_value = _stub_doer()
 
     UninstallOperation(group, ["pkg"]).run()
-    assert t1.get_uninstaller.called
-    assert t1.get_uninstaller_check.called
-    assert not t1.get_installer.called
-    assert not t1.get_installer_check.called
+    assert call("uninstaller") in t1.doer.call_args_list
+    assert call("uninstaller") in t1.check.call_args_list
+    assert call("installer") not in t1.doer.call_args_list
+    assert call("installer") not in t1.check.call_args_list
 
     # And the subclasses advertise their configured missing_error sentinel.
     assert InstallOperation.missing_error is MissingInstallerError

--- a/tests/test_package_querier.py
+++ b/tests/test_package_querier.py
@@ -1,0 +1,89 @@
+"""Focused tests for ``PackageQuerier`` (the rpm/dpkg branch).
+
+These tests pin the contracts exposed by
+``mtui.target.package_querier.PackageQuerier``:
+
+* the rpm vs dpkg branch keyed on ``system.get_base().name``,
+* the ``"package X is not installed"`` line → ``None`` mapping,
+* per-name "keep the highest version" dedup,
+* empty-output edge.
+
+The pre-existing characterization tests in ``tests/test_target.py``
+(``test_query_package_versions_*``) cover the same surface through the
+``Target.query_package_versions`` delegate; these add explicit coverage
+at the collaborator boundary.
+"""
+
+from unittest.mock import MagicMock
+
+from mtui.target.package_querier import PackageQuerier
+from mtui.types.rpmver import RPMVersion
+
+
+def _querier_with_base(base_name: str = "SLES", stdout: str = ""):
+    """Build a PackageQuerier whose target advertises ``base_name`` and ``stdout``."""
+    target = MagicMock()
+    target.system.get_base.return_value = MagicMock(name="Product")
+    target.system.get_base.return_value.name = base_name
+    target.lastout.return_value = stdout
+    return PackageQuerier(target), target
+
+
+def test_non_ubuntu_base_uses_rpm_query():
+    """Non-ubuntu bases route through ``rpm -q --queryformat``."""
+    pq, t = _querier_with_base("SLES", stdout="bash 5.1-1\n")
+    pq.versions(["bash"])
+    cmd = t.run.call_args[0][0]
+    assert cmd.startswith("rpm -q --queryformat")
+    assert "%{Name}" in cmd
+    assert "%{Version}" in cmd
+    assert cmd.endswith(" bash")
+
+
+def test_ubuntu_base_uses_dpkg_query():
+    """Ubuntu base routes through ``dpkg-query``."""
+    pq, t = _querier_with_base("ubuntu", stdout="bash 5.1-1\n")
+    pq.versions(["bash"])
+    cmd = t.run.call_args[0][0]
+    assert cmd.startswith("dpkg-query")
+    assert "${package}" in cmd
+    assert "${version}" in cmd
+    assert cmd.endswith(" bash")
+
+
+def test_joins_multiple_packages_into_command():
+    """The full package list is joined into one command, not one per package."""
+    pq, t = _querier_with_base("SLES", stdout="bash 5.1-1\nopenssl 3.0-1\n")
+    pq.versions(["bash", "openssl"])
+    cmd = t.run.call_args[0][0]
+    assert cmd.endswith(" bash openssl")
+    # Exactly one rpm invocation.
+    assert t.run.call_count == 1
+
+
+def test_returns_version_per_installed_package():
+    """Each line yields a ``name -> RPMVersion`` entry."""
+    pq, _ = _querier_with_base("SLES", stdout="bash 5.1-1\nopenssl 3.0-1\n")
+    out = pq.versions(["bash", "openssl"])
+    assert out == {"bash": RPMVersion("5.1-1"), "openssl": RPMVersion("3.0-1")}
+
+
+def test_not_installed_line_yields_none():
+    """``"package X is not installed"`` maps the name to ``None``."""
+    pq, _ = _querier_with_base("SLES", stdout="package missing-pkg is not installed\n")
+    out = pq.versions(["missing-pkg"])
+    assert out == {"missing-pkg": None}
+
+
+def test_duplicate_lines_collapse_to_highest_version():
+    """Multiple rpm-q lines for the same name keep the highest version."""
+    pq, _ = _querier_with_base("SLES", stdout="bash 5.0-1\nbash 5.2-1\nbash 5.1-1\n")
+    out = pq.versions(["bash"])
+    assert out == {"bash": RPMVersion("5.2-1")}
+
+
+def test_empty_stdout_returns_empty_dict():
+    """No output → empty mapping. Defensive against transactional/disabled hosts."""
+    pq, _ = _querier_with_base("SLES", stdout="")
+    out = pq.versions(["bash"])
+    assert out == {}

--- a/tests/test_package_querier.py
+++ b/tests/test_package_querier.py
@@ -26,7 +26,7 @@ def _querier_with_base(base_name: str = "SLES", stdout: str = ""):
     target.system.get_base.return_value = MagicMock(name="Product")
     target.system.get_base.return_value.name = base_name
     target.lastout.return_value = stdout
-    return PackageQuerier(target), target
+    return PackageQuerier(target), target  # ty: ignore[invalid-argument-type]
 
 
 def test_non_ubuntu_base_uses_rpm_query():

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -1,0 +1,110 @@
+"""Focused tests for the ``RepoManager`` collaborator.
+
+These tests cover the two methods extracted from :class:`Target`:
+
+* ``set(operation, testreport)`` (was ``Target.set_repo``) — a one-line
+  forward into ``testreport.set_repo(target, operation)``.
+* ``run_zypper(cmd, repos, rrid)`` (was ``Target.run_zypper``) — fans
+  the zypper ar/rr add/remove loop out across the target's flattened
+  system and finishes with ``zypper -n ref``. Unknown sub-commands
+  force-unlock and raise ``ValueError``.
+
+Plus one regression for the C1 ``_fanout_set_repo`` invariant: the
+hostgroup fan-out helper still reaches ``target.repo_manager.set`` on
+each target with the right ``(operation, testreport)`` tuple.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.target.repo_manager import RepoManager
+from mtui.types import Product
+
+# ---------------------------------------------------------------------------
+# RepoManager.set
+# ---------------------------------------------------------------------------
+
+
+def test_repo_manager_property_returns_manager_bound_to_target(mock_target):
+    """``Target.repo_manager`` returns a ``RepoManager`` keeping a live ref."""
+    rm = mock_target.repo_manager
+    assert isinstance(rm, RepoManager)
+    assert rm.target is mock_target
+
+
+def test_repo_manager_property_returns_fresh_instance_each_access(mock_target):
+    """Per design the property allocates per access; pin that explicitly."""
+    assert mock_target.repo_manager is not mock_target.repo_manager
+
+
+def test_set_delegates_to_testreport(mock_target):
+    """``set(op, tr)`` forwards as ``tr.set_repo(target, op)``."""
+    tr = MagicMock()
+    mock_target.repo_manager.set("add", tr)
+    tr.set_repo.assert_called_once_with(mock_target, "add")
+
+
+# ---------------------------------------------------------------------------
+# RepoManager.run_zypper
+# ---------------------------------------------------------------------------
+
+
+def test_run_zypper_ar_emits_add_command(mock_target, mock_rrid):
+    """``ar`` (add-repo) builds an ``issue-*`` alias and runs ``zypper ar``."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    mock_target.repo_manager.run_zypper("ar", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert any("zypper ar" in c and "issue-SLES" in c for c in commands)
+    assert commands[-1] == "zypper -n ref"
+
+
+def test_run_zypper_rr_emits_remove_command(mock_target, mock_rrid):
+    """``rr`` (remove-repo) runs ``zypper rr <url>`` per matching repo."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    mock_target.repo_manager.run_zypper("rr", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert any("zypper rr https://example/repo" in c for c in commands)
+
+
+def test_run_zypper_unknown_command_unlocks_and_raises(mock_target, mock_rrid):
+    """Unknown sub-command force-unlocks and raises ``ValueError``."""
+    mock_target.state = "enabled"
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+    with pytest.raises(ValueError):  # noqa: PT011 -- bare ValueError raised by run_zypper
+        mock_target.repo_manager.run_zypper("nosuch", repos, mock_rrid)
+    mock_target._lock.unlock.assert_called_with(True)
+
+
+def test_run_zypper_skips_products_not_in_flattened_system(mock_target, mock_rrid):
+    """Repos whose product is not in the target's flattened system are skipped."""
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {
+        Product("SLES", "15-SP5", "x86_64"): "https://wanted/repo",
+        Product("opensuse", "15.4", "x86_64"): "https://other/repo",
+    }
+    mock_target.repo_manager.run_zypper("ar", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    # Wanted repo present; other repo absent. Always finishes with the ref.
+    assert any("https://wanted/repo" in c for c in commands)
+    assert not any("https://other/repo" in c for c in commands)
+    assert commands[-1] == "zypper -n ref"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,95 @@
+"""Focused tests for the ``Reporter`` collaborator.
+
+These tests cover the seven sink-dispatch methods extracted from
+:class:`mtui.target.Target` (Phase 5b / C2 / Cluster B). They mirror
+the contracts the deleted ``Target.report_*`` methods used to advertise
+and are reached through the ``Target.reporter`` property so the
+property's own behaviour (fresh-per-access binding) is covered
+implicitly by every test that asserts against ``target.reporter``.
+"""
+
+from unittest.mock import MagicMock
+
+from mtui.target.reporter import Reporter
+from mtui.types import HostLog
+
+
+def test_reporter_property_returns_reporter_bound_to_target(mock_target):
+    """``Target.reporter`` returns a ``Reporter`` keeping a live ref to the target."""
+    r = mock_target.reporter
+    assert isinstance(r, Reporter)
+    assert r.target is mock_target
+
+
+def test_reporter_property_returns_fresh_instance_each_access(mock_target):
+    """Per design the property allocates per access; pin that explicitly."""
+    assert mock_target.reporter is not mock_target.reporter
+
+
+def test_self_calls_sink_with_full_status_tuple(mock_target):
+    """``self_`` forwards (hostname, system, transactional, state, mode)."""
+    sink = MagicMock()
+    mock_target.reporter.self_(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname,
+        mock_target.system,
+        mock_target.transactional,
+        mock_target.state,
+        mock_target.mode,
+    )
+
+
+def test_history_splits_lastout_on_newline(mock_target):
+    """``history`` forwards the last stdout as a ``\\n``-split list."""
+    sink = MagicMock()
+    mock_target.out = HostLog()
+    mock_target.out.append(["cmd", "line1\nline2", "", 0, 0])
+    mock_target.reporter.history(sink)
+    sink.assert_called_once()
+    args = sink.call_args[0]
+    assert args[0] == mock_target.hostname
+    assert args[1] is mock_target.system
+    assert args[2] == ["line1", "line2"]
+
+
+def test_locks_calls_sink_with_underlying_lock_object(mock_target):
+    """``locks`` exposes the private ``_lock`` to the sink."""
+    sink = MagicMock()
+    mock_target.reporter.locks(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname, mock_target.system, mock_target._lock
+    )
+
+
+def test_timeout_reads_connection_timeout_at_call_time(mock_target):
+    """``timeout`` reflects the live ``connection.timeout`` value."""
+    mock_target.connection.timeout = 42
+    sink = MagicMock()
+    mock_target.reporter.timeout(sink)
+    sink.assert_called_once_with(mock_target.hostname, mock_target.system, 42)
+
+
+def test_sessions_forwards_full_lastout_string(mock_target):
+    """``sessions`` forwards the last stdout verbatim (used by ``who``)."""
+    sink = MagicMock()
+    mock_target.out = HostLog()
+    mock_target.out.append(["who", "alice tty1\n", "", 0, 0])
+    mock_target.reporter.sessions(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname, mock_target.system, "alice tty1\n"
+    )
+
+
+def test_log_passes_full_outlog_and_extra_arg(mock_target):
+    """``log`` forwards the full ``out`` log plus a caller-provided extra."""
+    sink = MagicMock()
+    mock_target.out = HostLog()
+    mock_target.reporter.log(sink, "some-arg")
+    sink.assert_called_once_with(mock_target.hostname, mock_target.out, "some-arg")
+
+
+def test_products_calls_sink_with_hostname_and_system(mock_target):
+    """``products`` is a minimal ``(hostname, system)`` sink."""
+    sink = MagicMock()
+    mock_target.reporter.products(sink)
+    sink.assert_called_once_with(mock_target.hostname, mock_target.system)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -488,11 +488,7 @@ def test_reload_system_replaces_system_and_transactional(mock_config, monkeypatc
     assert target.transactional is True
 
 
-def test_set_repo_delegates_to_testreport(mock_config):
-    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
-    tr = MagicMock()
-    target.set_repo("add", tr)  # ty: ignore[unresolved-attribute]
-    tr.set_repo.assert_called_once_with(target, "add")
+# NOTE: set_repo coverage moved to tests/test_repo_manager.py
 
 
 # ---------------------------------------------------------------------------
@@ -574,47 +570,7 @@ def test_query_package_versions_keeps_max_on_duplicate(mock_target):
     assert out["bash"] == RPMVersion("5.2-1")
 
 
-# ---------------------------------------------------------------------------
-# run_zypper
-# ---------------------------------------------------------------------------
-
-
-def test_run_zypper_ar_emits_add_command(mock_target, mock_rrid):
-    """``ar`` (add-repo) builds an issue-* alias and runs zypper ar."""
-    mock_target.state = "enabled"
-    mock_target.connection.run.return_value = 0
-    mock_target.connection.stdout = ""
-    mock_target.connection.stderr = ""
-    mock_target.system = MagicMock()
-    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
-    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
-    mock_target.run_zypper("ar", repos, mock_rrid)
-    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
-    assert any("zypper ar" in c and "issue-SLES" in c for c in commands)
-    assert commands[-1] == "zypper -n ref"
-
-
-def test_run_zypper_rr_emits_remove_command(mock_target, mock_rrid):
-    mock_target.state = "enabled"
-    mock_target.connection.run.return_value = 0
-    mock_target.connection.stdout = ""
-    mock_target.connection.stderr = ""
-    mock_target.system = MagicMock()
-    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
-    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
-    mock_target.run_zypper("rr", repos, mock_rrid)
-    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
-    assert any("zypper rr https://example/repo" in c for c in commands)
-
-
-def test_run_zypper_unknown_command_unlocks_and_raises(mock_target, mock_rrid):
-    mock_target.state = "enabled"
-    mock_target.system = MagicMock()
-    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
-    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
-    with pytest.raises(ValueError):  # noqa: PT011  -- bare ValueError raised by run_zypper
-        mock_target.run_zypper("nosuch", repos, mock_rrid)
-    mock_target._lock.unlock.assert_called_with(True)
+# NOTE: run_zypper coverage moved to tests/test_repo_manager.py
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -491,7 +491,7 @@ def test_reload_system_replaces_system_and_transactional(mock_config, monkeypatc
 def test_set_repo_delegates_to_testreport(mock_config):
     target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
     tr = MagicMock()
-    target.set_repo("add", tr)
+    target.set_repo("add", tr)  # ty: ignore[unresolved-attribute]
     tr.set_repo.assert_called_once_with(target, "add")
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -334,45 +334,7 @@ def test_parse_packages_none(mock_config):
     assert result == {}
 
 
-# --- report methods with assertions ---
-
-
-def test_report_self_calls_sink(mock_target):
-    """Test report_self calls sink with correct args."""
-    sink = MagicMock()
-    mock_target.report_self(sink)
-
-    sink.assert_called_once_with(
-        mock_target.hostname,
-        mock_target.system,
-        mock_target.transactional,
-        mock_target.state,
-        mock_target.mode,
-    )
-
-
-def test_report_history_calls_sink(mock_target):
-    """Test report_history calls sink with correct args."""
-    sink = MagicMock()
-    # Need output to split
-    mock_target.out = HostLog()
-    mock_target.out.append(["cmd", "line1\nline2", "", 0, 0])
-
-    mock_target.report_history(sink)
-
-    sink.assert_called_once()
-    args = sink.call_args[0]
-    assert args[0] == mock_target.hostname
-
-
-def test_report_timeout_calls_sink(mock_target):
-    """Test report_timeout calls sink with timeout."""
-    sink = MagicMock()
-    mock_target.report_timeout(sink)
-
-    sink.assert_called_once()
-    args = sink.call_args[0]
-    assert args[0] == mock_target.hostname
+# NOTE: report_* coverage moved to tests/test_reporter.py
 
 
 # --- sftp delegation ---
@@ -851,40 +813,5 @@ def test_close_poweroff(mock_target):
     mock_target.connection.close.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# remaining report_* sinks
-# ---------------------------------------------------------------------------
-
-
-def test_report_locks_calls_sink(mock_target):
-    sink = MagicMock()
-    mock_target.report_locks(sink)
-    sink.assert_called_once_with(
-        mock_target.hostname, mock_target.system, mock_target._lock
-    )
-
-
-def test_report_sessions_calls_sink(mock_target):
-    sink = MagicMock()
-    mock_target.out = HostLog()
-    mock_target.out.append(["who", "alice tty1\n", "", 0, 0])
-    mock_target.report_sessions(sink)
-    sink.assert_called_once_with(
-        mock_target.hostname, mock_target.system, "alice tty1\n"
-    )
-
-
-def test_report_log_calls_sink_with_full_outlog(mock_target):
-    sink = MagicMock()
-    mock_target.out = HostLog()
-    mock_target.report_log(sink, "some-arg")
-    sink.assert_called_once_with(mock_target.hostname, mock_target.out, "some-arg")
-
-
-def test_report_products_calls_sink(mock_target):
-    sink = MagicMock()
-    mock_target.report_products(sink)
-    sink.assert_called_once_with(mock_target.hostname, mock_target.system)
-
-
+# NOTE: report_* coverage moved to tests/test_reporter.py
 # NOTE: doer/check coverage moved to tests/test_doers.py

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -2,7 +2,6 @@
 
 import errno
 from pathlib import Path
-from string import Template
 from unittest.mock import MagicMock
 
 import pytest
@@ -888,62 +887,4 @@ def test_report_products_calls_sink(mock_target):
     sink.assert_called_once_with(mock_target.hostname, mock_target.system)
 
 
-# ---------------------------------------------------------------------------
-# Doer / check getters
-# ---------------------------------------------------------------------------
-
-
-def _target_with_release(mock_config, release: str = "15", transactional: bool = False):
-    target = Target(mock_config, "h.example.com")  # type: ignore[arg-type]
-    target.system = MagicMock()
-    target.system.get_release.return_value = release
-    target.transactional = transactional
-    return target
-
-
-@pytest.mark.parametrize(
-    "method",
-    [
-        "get_installer",
-        "get_uninstaller",
-        "get_downgrader",
-        "get_updater",
-    ],
-)
-def test_doer_getters_return_command_template_dict(mock_config, method):
-    """All non-preparer doer getters yield a ``{name: Template}`` mapping for SLES 15."""
-    target = _target_with_release(mock_config)
-    result = getattr(target, method)()
-    assert isinstance(result, dict)
-    assert all(isinstance(v, Template) for v in result.values())
-
-
-def test_get_preparer_invokes_factory_with_force_and_testing(mock_config):
-    """``preparer`` is ``Callable``; the getter forwards force/testing flags."""
-    target = _target_with_release(mock_config)
-    result = target.get_preparer(force=True, testing=True)
-    assert isinstance(result, dict)
-
-
-@pytest.mark.parametrize(
-    "method",
-    [
-        "get_installer_check",
-        "get_uninstaller_check",
-        "get_downgrader_check",
-        "get_updater_check",
-        "get_preparer_check",
-    ],
-)
-def test_check_getters_return_callable(mock_config, method):
-    target = _target_with_release(mock_config)
-    fn = getattr(target, method)()
-    assert callable(fn)
-
-
-def test_check_getter_returns_no_checks_for_unknown_release(mock_config):
-    """Unknown ``(release, transactional)`` combinations fall back to the no-op."""
-    from mtui.target.target import _no_checks
-
-    target = _target_with_release(mock_config, release="9999", transactional=False)
-    assert target.get_installer_check() is _no_checks
+# NOTE: doer/check coverage moved to tests/test_doers.py


### PR DESCRIPTION
## Summary

Decompose `Target` into four focused collaborators. `mtui/target/target.py`
loses 14 small dispatch / sink methods and gains three thin properties; the
moved code lives in three new modules:

| Was on `Target`                              | Now reached as                            | Module                              |
| -------------------------------------------- | ----------------------------------------- | ----------------------------------- |
| `get_installer()` / `get_installer_check()` and four more pairs (14 methods total) | `target.doer(role)` / `target.check(role)` | `mtui/target/target.py` (collapsed) |
| `report_self()`, `report_history()`, …, `report_products()` (7 methods) | `target.reporter.self_()`, `target.reporter.history()`, …, `target.reporter.products()` | `mtui/target/reporter.py` (new) |
| `set_repo(op, tr)`, `run_zypper(cmd, repos, rrid)` | `target.repo_manager.set(op, tr)`, `target.repo_manager.run_zypper(cmd, repos, rrid)` | `mtui/target/repo_manager.py` (new) |
| `query_package_versions(...)` rpm vs dpkg branch | kept as thin delegate; logic moved | `mtui/target/package_querier.py` (new) |

Behaviour preserved byte-for-byte; all in-tree call sites migrated. One
user-visible side-effect for out-of-tree consumers documented in `CHANGELOG.md`
under `[Unreleased] / Changed` (the old `target.report_self()` /
`target.get_installer()` etc. attribute paths are gone).

## Why

`mtui/target/target.py` was the largest module in `mtui/target/` and mixed four
unrelated responsibilities into one class:

1. **Connection / lock lifecycle** (the core of `Target`) — stays.
2. **Status reporting** — seven small `report_*` sink-dispatch methods. Move
   to `Reporter`.
3. **Action / check registry** — fourteen `get_*er` / `get_*er_check` methods
   that were tiny dict lookups keyed by `(release, transactional)`. Collapse
   to one `doer(role)` and one `check(role)` backed by two module-level
   dispatch tables.
4. **Repository management** (`set_repo`, `run_zypper`) — zypper-specific
   shape that knows nothing about Target's other state. Move to `RepoManager`.
5. **Package querying** (`query_package_versions`) — rpm-vs-dpkg branch logic
   that has nothing to do with the SSH skeleton. Move to `PackageQuerier`,
   keep `Target.query_package_versions` as a thin delegate.

After this PR `Target` is focused on connection lifecycle plus seven
helper methods (`run`, `shell`, `lastout/in/err/exit`, lock helpers, sftp
operations) and four `@property` collaborators.

## Commits (12)

```
refactor(target): collapse seven get_*er methods into doer/check
refactor(operation): route Operation hooks through Target.doer/check
refactor(hostgroup,template): route perform_* and run_zypper-adjacent through doer/check
test(target,hostgroup,operation): rewire get_*er mocks to doer/check
test(doers): focused tests for Target.doer(role)/check(role) dispatch
refactor(target): extract Reporter collaborator for the seven report_* sinks
test(reporter): move/rewire report_* tests to tests/test_reporter.py
refactor(target): extract PackageQuerier (rpm vs dpkg branch)
test(package_querier): focused tests for rpm/dpkg branch and parsing
refactor(target): extract RepoManager (set_repo + run_zypper)
test(repo_manager): move set_repo/run_zypper tests to test_repo_manager.py
docs(changelog): note Target collaborator decomposition
```

Each `refactor(...)` commit is paired with a follow-up `test(...)` commit
that either rewires the existing characterization tests onto the new
collaborator surface, or adds focused tests for the new module. Two of the
refactor commits land intentionally-red intermediate states (the
production code is consistent on its own, but the test mocks reference the
just-deleted attributes); the very next commit makes them green. Bisecting
through this PR is safe at every commit boundary.

## Tests

* New test files (38 tests total):
  * `tests/test_doers.py` — 15 tests pinning `Target.doer(role)` /
    `Target.check(role)` dispatch, preparer kwargs forwarding, unknown
    role behaviour, `_no_checks` fallback.
  * `tests/test_reporter.py` — 9 tests pinning the seven sink-dispatch
    methods plus the `Target.reporter` `@property` contract
    (fresh-per-access; live binding).
  * `tests/test_package_querier.py` — 7 tests pinning the rpm vs dpkg
    branch, line-parsing edges, and the `max()` dedup behaviour.
  * `tests/test_repo_manager.py` — 7 tests pinning `set`, `run_zypper`'s
    ar/rr branches, the unknown-command unlock-and-raise safeguard, and
    the implicit "skip products not in flattened system" filter.
* Pre-existing characterization tests on `Target.query_package_versions`
  stay green via the delegate.
* Net pytest count: **682 passed** (was 660 before this PR; +22 net
  across the new test files; equivalent tests moved out of
  `test_target.py` / `test_hostgroup.py`).

## CI gates (matches the four-gate policy in `AGENTS.md`)

* `uv run ruff format --check .` — 182 files, clean.
* `uv run ruff check .` — clean.
* `uv run ty check` — clean (no warnings; `error-on-warning = true`).
* `uv run pytest` — 682 passed.
* `uv run python -m mtui --help` / `-V` — both succeed.
* `uv run --group doc sphinx-build -W -b html Documentation /tmp/x` —
  succeeds (`CHANGELOG.md` is included via `myst-parser`).

## Risks

* **Out-of-tree consumers** that imported `mtui.target.Target` and used
  any of the 10 deleted methods will get `AttributeError`. The
  `[Unreleased] / Changed` block in `CHANGELOG.md` documents the
  migration map. No in-tree caller is affected.
* **Reporter `@property` allocates a new `Reporter` per access.** Per
  design — Reporter is stateless, avoids tying its lifetime to anything
  captured by sink callbacks. Allocation cost is negligible compared to
  the SSH call about to happen. Same applies to `RepoManager`.

## Out of scope (carry-overs)

* The pre-existing LSP-only complaints in `tests/test_target.py`
  (`MagicMock` arguments to typed `lock` / `connection` parameters) still
  stand — they predate this PR.
* `query_package_versions` is kept on `Target` as a thin delegate; the
  internal `query_versions` and `HostsGroup.query_versions` both still
  call it. A future cleanup could push the delegate down a level if no
  external consumers remain after a release cycle.
