### PR TITLE
refactor(prompt): pre-bind command dispatch methods, drop __getattr__ (Phase 5b / C4)

### DIFF
--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -8,10 +8,12 @@ handles command dispatching, tab completion, and history.
 import cmd
 import readline
 import subprocess
-from collections.abc import Callable
 from logging import DEBUG, getLogger
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from mtui import notification
 
@@ -168,6 +170,14 @@ class CommandPrompt(cmd.Cmd):
     def _add_subcommand(self, cmd: type[Command]) -> None:
         """Adds a subcommand to the prompt.
 
+        Binds ``do_<name>``, ``help_<name>``, and ``complete_<name>`` as
+        instance attributes so that normal Python attribute lookup (and
+        ``cmd.Cmd.onecmd``'s ``getattr(self, "do_" + cmd, None)``) resolves
+        them directly, without going through a ``__getattr__`` synthesis
+        path. ``setattr`` accepts attribute names that aren't valid Python
+        identifiers, so command names containing ``-`` (e.g. ``report-bug``)
+        work the same way as the underscore-only ones.
+
         Args:
             cmd: The command class to add.
 
@@ -175,6 +185,38 @@ class CommandPrompt(cmd.Cmd):
         if cmd.command in self.commands:
             raise CommandAlreadyBoundError(cmd.command)
         self.commands[cmd.command] = cmd
+
+        name = cmd.command
+        c = cmd  # bind once for each closure
+
+        def do(arg) -> None:
+            try:
+                args = c.parse_args(arg, self.sys)
+            except ArgsParseFailureError:
+                return
+            c(args, self.config, self.sys, self)()
+
+        def help() -> None:
+            c.argparser(self.sys).print_help()
+
+        def complete(*args, **kw):
+            try:
+                return c.complete(
+                    {
+                        "hosts": self.targets.select(),
+                        "metadata": self.metadata,
+                        "config": self.config,
+                    },
+                    *args,
+                    **kw,
+                )
+            except Exception as e:
+                logger.exception(e)
+                raise e
+
+        setattr(self, f"do_{name}", do)
+        setattr(self, f"help_{name}", help)
+        setattr(self, f"complete_{name}", complete)
 
     def set_cmdqueue(self, queue: list[str]) -> None:
         """Sets the command queue for prerun commands.
@@ -237,55 +279,15 @@ class CommandPrompt(cmd.Cmd):
         names += ["help_" + x for x in self.commands]
         return names
 
-    def __getattr__(self, x: str) -> Callable:
-        """Dynamically gets attributes for commands, help, and completion."""
-        if x.startswith("help_"):
-            y = x.replace("help_", "", 1)
-            if y in self.commands:
-                c = self.commands[y]
-
-                def help() -> None:
-                    c.argparser(self.sys).print_help()
-
-                return help
-
-        elif x.startswith("do_"):
-            y = x.replace("do_", "", 1)
-            if y in self.commands:
-                c = self.commands[y]
-
-                def do(arg) -> None:
-                    try:
-                        args = c.parse_args(arg, self.sys)
-                    except ArgsParseFailureError:
-                        return
-                    c(args, self.config, self.sys, self)()
-
-                return do
-
-        elif x.startswith("complete_"):
-            y = x.replace("complete_", "", 1)
-            if y in self.commands:
-                c = self.commands[y]
-
-                def complete(*args, **kw):
-                    try:
-                        return c.complete(
-                            {
-                                "hosts": self.targets.select(),
-                                "metadata": self.metadata,
-                                "config": self.config,
-                            },
-                            *args,
-                            **kw,
-                        )
-                    except Exception as e:
-                        logger.exception(e)
-                        raise e
-
-                return complete
-
-        raise AttributeError(str(x))
+    if TYPE_CHECKING:
+        # Typing-only escape hatch. The ``do_<name>``, ``help_<name>``,
+        # and ``complete_<name>`` attributes are bound at runtime by
+        # ``_add_subcommand`` via ``setattr``; the type checker can't see
+        # through that. This stub tells ``ty`` (and IDEs) that any
+        # attribute access on a ``CommandPrompt`` is callable, mirroring
+        # the previous runtime ``__getattr__`` typing contract without
+        # the lazy synthesis. Runtime lookups never reach this method.
+        def __getattr__(self, name: str) -> "Callable[..., Any]": ...
 
     def emptyline(self) -> bool:
         """Called when an empty line is entered."""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -338,6 +338,50 @@ def test_set_prompt_kernel_mode():
     assert p.prompt == "mtui-kernel> "
 
 
+def test_add_subcommand_binds_methods_to_instance():
+    """``_add_subcommand`` must pre-bind ``do_/help_/complete_`` on the instance.
+
+    Locks in the C4 refactor: the closures are constructed at registration
+    time and stored in ``self.__dict__`` rather than synthesised lazily by
+    ``__getattr__``. A regression that reintroduces lazy synthesis would
+    leave the instance dict empty for these prefixes and fail here.
+    """
+    p = _make_prompt()
+    cmd = MagicMock()
+    cmd.command = "alpha"
+    p._add_subcommand(cmd)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    assert "do_alpha" in p.__dict__
+    assert "help_alpha" in p.__dict__
+    assert "complete_alpha" in p.__dict__
+
+
+def test_command_prompt_has_no_getattr():
+    """``CommandPrompt`` must not define ``__getattr__``.
+
+    The per-attribute synthesis path was deleted in C4; this test pins the
+    deletion so a future regression that re-adds lazy dispatch is caught.
+    """
+    assert "__getattr__" not in vars(prompt.CommandPrompt)
+
+
+def test_dash_in_command_name_dispatches():
+    """Command names containing ``-`` (e.g. ``report-bug``) still round-trip.
+
+    ``setattr`` accepts attribute names that aren't valid Python
+    identifiers, so the dash-named ``do_report-bug`` is reachable via
+    ``getattr``. This locks in compatibility with the one production
+    command that uses a dash.
+    """
+    p = _make_prompt()
+    cmd = MagicMock()
+    cmd.command = "dash-cmd"
+    p._add_subcommand(cmd)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    do = getattr(p, "do_dash-cmd")
+    do("args")
+    cmd.parse_args.assert_called_with("args", p.sys)
+    cmd.return_value.assert_called_once()
+
+
 def test_load_update_swaps_metadata_and_targets():
     """``load_update`` installs the new test report and resets the prompt."""
     p = _make_prompt()


### PR DESCRIPTION
## Summary

Pre-bind `do_<name>` / `help_<name>` / `complete_<name>` callables in
`CommandPrompt._add_subcommand` via `setattr`, and delete the runtime
`__getattr__` that previously synthesised them on each access. `cmd.Cmd`'s
`getattr(self, "do_" + cmd, None)` dispatch now resolves the bound
instance attributes directly, with no detour through a per-attribute
lazy-synthesis hook.

This is Phase 5b / C4 of the
[improvement track](https://github.com/openSUSE/mtui/pull/128) —
internal-only refactor, no user-visible behaviour change for the
documented dispatch paths.

## Why

The old `__getattr__` in `mtui/prompt.py` was a 50-line dispatcher
that:

1. Examined the missing attribute name for a `do_` / `help_` /
   `complete_` prefix.
2. Looked the suffix up in `self.commands`.
3. Built a small closure capturing `self.commands[suffix]`.
4. Returned the closure (uncached — every access rebuilt the closure).
5. Fell through to `raise AttributeError(str(x))` otherwise.

It worked, but it pushed the binding logic off `_add_subcommand` (where
the command class is already in scope) into a string-driven hook that
ran on every dispatch. The `# TODO` block above `CommandPrompt` already
flagged "using methods as commands is quite simple but wrong way to do
that and handling classes is hacked into the function system" — this PR
fixes that hack.

After this PR, attribute access on `CommandPrompt` follows ordinary
Python rules: `prompt.do_quit` resolves through `__dict__`, unknown
attrs raise the standard `AttributeError`, and `dir(prompt)` /
`vars(prompt)` show the actual bindings.

## Changes

* `mtui/prompt.py:168` — `_add_subcommand` now constructs the three
  closures (`do`, `help`, `complete` — verbatim from the old
  `__getattr__` branches, same captures, same error handling) and
  binds them via `setattr(self, f"do_{name}", do)` etc. `setattr`
  accepts attribute names containing `-`, so the lone dash-named
  production command (`report-bug`) round-trips unchanged.
* `mtui/prompt.py` (was lines 240–288) — runtime `__getattr__`
  deleted. Unknown attribute access falls through to Python's
  default `AttributeError`. Both existing
  `pytest.raises(AttributeError, match=...)` checks still pass
  because the matcher is a substring search and Python's default
  message contains the attribute name.
* `mtui/prompt.py:281` — a `TYPE_CHECKING`-guarded `__getattr__`
  stub returning `Callable[..., Any]` is kept. The previous runtime
  `__getattr__` annotation made `ty` believe any attribute access on
  `CommandPrompt` returned `Callable`; deleting it outright would
  flag 8 attribute-access sites (1 production in `mtui/main.py:95`,
  7 in tests) that haven't changed. The stub preserves the typing
  contract without reintroducing lazy synthesis — `vars(CommandPrompt)`
  does NOT contain `__getattr__` at runtime (pinned by the new test
  below).
* `mtui/prompt.py` `get_names` — intentionally unchanged.
  `cmd.Cmd.get_names()` iterates `dir(self.__class__)` and does not
  see instance attributes, so the existing augmentation with the
  registered command names is still required for `<TAB>` completion
  of command names themselves.

## Tests

Three new tests in `tests/test_prompt.py` lock in the new shape:

* `test_add_subcommand_binds_methods_to_instance` — asserts that
  after `_add_subcommand(cmd)`, `do_<name>` / `help_<name>` /
  `complete_<name>` all land in `p.__dict__`. Proves pre-binding,
  not lazy synthesis.
* `test_command_prompt_has_no_getattr` — asserts that
  `"__getattr__" not in vars(prompt.CommandPrompt)`. The
  `TYPE_CHECKING` typing stub does not appear at runtime because the
  guard is `False`, so this remains true. A regression that
  reintroduces a runtime `__getattr__` would fail here.
* `test_dash_in_command_name_dispatches` — registers a mock with
  `command = "dash-cmd"` and drives it through
  `getattr(p, "do_dash-cmd")("args")`. Pins the compatibility with
  the production `report-bug` command.

All four pre-existing dispatch-path tests pass byte-for-byte
unchanged: `test_dispatching`, `test_get_names_includes_registered_commands`,
`test_do_handles_argsparse_failure`, `test_complete_logs_and_reraises`,
plus the two `test_getattr_unknown_*` cases.

Test count: 682 → 685.

## Verification

```
$ uv run ruff format --check .   # 182 files already formatted
$ uv run ruff check .            # All checks passed!
$ uv run ty check                # All checks passed!
$ uv run pytest                  # 685 passed in 2.40s

$ uv run python -m mtui --help   # OK
$ uv run python -m mtui -V       # mtui 17.1.0 / Python 3.12.13 / paramiko 4.0.0 / openqa-client 4.3.1

$ rg 'def __getattr__' mtui/prompt.py
mtui/prompt.py:290:        def __getattr__(self, name: str) -> "Callable[..., Any]": ...
# one hit, under `if TYPE_CHECKING:`; runtime body deleted

$ uv run python -c "from mtui import prompt; print('__getattr__' in vars(prompt.CommandPrompt))"
False  # TYPE_CHECKING stub is invisible at runtime
```

## CHANGELOG

No entry. Per AGENTS.md ("internal-only refactors usually do not
[warrant a changelog line]") and the C3 precedent in #127. The
`AttributeError` message format for unknown attrs shifts from `"x"`
(custom) to Python's default
`"'CommandPrompt' object has no attribute 'x'"`, but that surface is
only visible inside interactive REPL introspection.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean.
- [x] `uv run pytest` passes (685, +3 from baseline).
- [x] No user-visible changes → no `CHANGELOG.md` entry (internal-only).
- [x] No documentation changes required (interactive-command surface unchanged).
