### PR TITLE
fix(updateid): surface missing Gitea token instead of crashing on SLFO load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Loading an SLFO or PI update with no `GITEA_TOKEN` configured no longer
+  crashes with an uncaught traceback. Missing tokens are now reported with
+  a clear configuration hint and exit with a non-zero status. Transient
+  Gitea API failures and hash mismatches raised during the post-checkout
+  template retry now reach the same handlers (`TestReportNotLoadedError`
+  and the force-continue prompt) as failures from the initial read.
+- `GiteaError` now derives from `Exception` instead of `BaseException`,
+  so the interactive command loop's catch-all handler traps Gitea errors
+  cleanly instead of letting them tear down the prompt.
+
 ### Changed
 
 - Internal refactor: `Target` was decomposed into four focused

--- a/mtui/exceptions.py
+++ b/mtui/exceptions.py
@@ -118,7 +118,7 @@ class UpdateError(Exception):
         return f"{self.host!s}: {self.reason!s}"
 
 
-class GiteaError(BaseException):
+class GiteaError(Exception):
     """Base exception for Gitea-related errors."""
 
 

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -12,6 +12,7 @@ from .colorctl import set_mode as set_color_mode
 from .colorlog import create_logger
 from .config import Config
 from .display import CommandPromptDisplay
+from .exceptions import MissingGiteaTokenError
 from .messages import MetadataNotLoadedError, SvnCheckoutInterruptedError
 from .prompt import CommandPrompt
 from .systemcheck import detect_system
@@ -87,6 +88,9 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
             MetadataNotLoadedError,
         ) as e:
             logger.error(e)
+            return 1
+        except MissingGiteaTokenError:
+            # _checkout already logged a user-facing message; just exit.
             return 1
 
     if args.sut:

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -71,23 +71,30 @@ class UpdateID(ABC):
         trpath: Path = trdir / "log"
 
         try:
-            tr.read(trpath)
-        except TemplateIOError as e:
-            if e.errno != ENOENT:
-                raise
             try:
-                self._vcs_checkout(config, config.svn_path, self.id)
-            except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
-                logger.error("SVN checkout failed")
-                raise TestReportNotLoadedError from e
-            else:
+                tr.read(trpath)
+            except TemplateIOError as e:
+                if e.errno != ENOENT:
+                    raise
                 try:
-                    tr.read(trpath)
-                except Exception as e:
-                    raise e
-        except (MissingGiteaTokenError, FailedGiteaCallError):
-            logger.error("Gitea error")
-            logger.warning("TestReport ins't loaded")
+                    self._vcs_checkout(config, config.svn_path, self.id)
+                except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
+                    logger.error("SVN checkout failed")
+                    raise TestReportNotLoadedError from e
+                # Retry the read now that the template is on disk. Any
+                # Gitea-related error raised here must reach the outer
+                # except clauses below, so we let it propagate.
+                tr.read(trpath)
+        except MissingGiteaTokenError:
+            logger.error(
+                "Gitea API token is not configured. "
+                "Pass -g/--gitea_token, set GITEA_TOKEN in your environment, "
+                "or add a [gitea] token entry to ~/.mtuirc."
+            )
+            raise
+        except FailedGiteaCallError:
+            logger.error("Gitea API call failed")
+            logger.warning("TestReport isn't loaded")
             raise TestReportNotLoadedError from None
 
         except InvalidGiteaHashError:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -36,6 +36,11 @@ def test_gitea_error():
     """Test GiteaError and its subclasses."""
     from mtui.types import assignment
 
+    # GiteaError must derive from Exception, not BaseException, so that
+    # broad ``except Exception`` clauses (e.g. the cmdloop catch-all in
+    # prompt.py) still trap it instead of letting it crash the process.
+    assert issubclass(exceptions.GiteaError, Exception)
+
     with pytest.raises(exceptions.GiteaError):
         raise exceptions.GiteaError()
 

--- a/tests/test_updateid.py
+++ b/tests/test_updateid.py
@@ -8,15 +8,28 @@ Regression coverage for commit cc2147a, which:
   partially-checked-out template directory that must be removed before
   relaunching MTUI -- but only if the directory actually exists, and only
   when the user did *not* force-continue.
+
+Also covers the post-SVN-checkout retry path: Gitea errors raised by the
+*second* ``tr.read()`` (after a successful checkout populates the template
+on disk) must reach the same outer except clauses as errors raised by the
+first read. Previously, a nested ``try/except Exception: raise`` inside
+the SVN-checkout branch made these errors bypass the outer handlers and
+crash mtui with an uncaught traceback.
 """
 
 import logging
+from errno import ENOENT
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mtui.exceptions import InvalidGiteaHashError
+from mtui.exceptions import (
+    FailedGiteaCallError,
+    InvalidGiteaHashError,
+    MissingGiteaTokenError,
+)
 from mtui.messages import TestReportNotLoadedError
+from mtui.template import TemplateIOError
 from mtui.types.updateid import AutoOBSUpdateID
 
 RRID = "SUSE:Maintenance:12358:199773"
@@ -40,6 +53,28 @@ def _make_updateid() -> tuple[AutoOBSUpdateID, MagicMock]:
     tr_mock.read.side_effect = InvalidGiteaHashError(uid.id, "oldhash", "newhash")
     uid.testreport_factory = MagicMock(return_value=tr_mock)  # ty: ignore[invalid-assignment]
     return uid, tr_mock
+
+
+def _make_updateid_with_checkout_retry(
+    second_read_error: Exception,
+) -> tuple[AutoOBSUpdateID, MagicMock, MagicMock]:
+    """Build an `AutoOBSUpdateID` that exercises the post-SVN-checkout retry.
+
+    The first ``tr.read()`` raises ``TemplateIOError(ENOENT, ...)`` (simulating
+    a not-yet-checked-out template), the mocked ``_vcs_checkout`` succeeds,
+    and the second ``tr.read()`` raises ``second_read_error``. This is the
+    code path that previously bypassed the outer Gitea except clauses.
+
+    Returns ``(update_id, testreport_mock, vcs_checkout_mock)``.
+    """
+    uid = AutoOBSUpdateID(RRID)
+    tr_mock = MagicMock(name="testreport")
+    enoent = TemplateIOError(ENOENT, "No such file or directory", "log")
+    tr_mock.read.side_effect = [enoent, second_read_error]
+    uid.testreport_factory = MagicMock(return_value=tr_mock)  # ty: ignore[invalid-assignment]
+    vcs_mock = MagicMock(name="vcs_checkout")
+    uid._vcs_checkout = vcs_mock  # noqa: SLF001
+    return uid, tr_mock, vcs_mock
 
 
 def test_checkout_invalid_hash_abort_warns_when_trdir_exists(
@@ -108,3 +143,94 @@ def test_checkout_invalid_hash_force_continue_no_cleanup_warning(
     messages = [r.getMessage() for r in caplog.records]
     assert any("Template is loaded, but hash differs" in m for m in messages)
     assert not any(CLEANUP_HINT in m for m in messages)
+
+
+# --- Post-SVN-checkout retry: Gitea errors raised by the second tr.read() ---
+#
+# These guard the regression where a nested ``try/except Exception: raise``
+# inside the SVN-checkout branch let MissingGiteaTokenError, FailedGiteaCallError,
+# and InvalidGiteaHashError raised by the post-checkout read bypass the
+# outer except clauses and crash mtui with an uncaught traceback.
+
+
+def test_checkout_missing_token_after_svn_checkout_propagates(
+    mock_config, tmp_path, caplog
+):
+    """Missing GITEA_TOKEN after a successful SVN checkout is a hard failure.
+
+    The error must propagate out of ``_checkout`` (caller decides exit code)
+    and a user-facing "token is not configured" message must be logged.
+    """
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock, vcs_mock = _make_updateid_with_checkout_retry(
+        MissingGiteaTokenError("Gitea API token is empty, can't access API")
+    )
+
+    with (
+        caplog.at_level(logging.ERROR, logger="mtui.types.updateid"),
+        pytest.raises(MissingGiteaTokenError),
+    ):
+        uid._checkout(mock_config, interactive=True)  # noqa: SLF001
+
+    vcs_mock.assert_called_once()
+    error_messages = [r.getMessage() for r in caplog.records]
+    assert any("Gitea API token is not configured" in m for m in error_messages), (
+        f"expected configuration-hint error, got {error_messages!r}"
+    )
+
+
+def test_checkout_failed_gitea_call_after_svn_checkout_converts(
+    mock_config, tmp_path, caplog
+):
+    """A Gitea API failure after SVN checkout becomes TestReportNotLoadedError.
+
+    Same soft-fail behaviour as a Gitea failure on the first read: callers
+    can convert this into a NullTestReport instead of crashing.
+    """
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock, vcs_mock = _make_updateid_with_checkout_retry(
+        FailedGiteaCallError("GET - https://example.invalid returned status 500")
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)  # noqa: SLF001
+
+    vcs_mock.assert_called_once()
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("TestReport isn't loaded" in m for m in messages)
+
+
+def test_checkout_invalid_hash_after_svn_checkout_prompts(
+    mock_config, tmp_path, caplog
+):
+    """An InvalidGiteaHashError after SVN checkout still triggers the prompt.
+
+    Locks in that the post-checkout retry path shares the same hash-mismatch
+    handling (prompt, cleanup hint, force-continue support) as the first read.
+    """
+    mock_config.template_dir = tmp_path
+    rrid_obj = AutoOBSUpdateID(RRID).id
+    uid, _tr_mock, vcs_mock = _make_updateid_with_checkout_retry(
+        InvalidGiteaHashError(rrid_obj, "oldhash", "newhash")
+    )
+    # The post-checkout cleanup hint only fires when trdir exists.
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        patch(
+            "mtui.types.updateid.prompt_user", return_value=False
+        ) as prompt_user_mock,
+        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)  # noqa: SLF001
+
+    vcs_mock.assert_called_once()
+    prompt_user_mock.assert_called_once()
+    assert prompt_user_mock.call_args.args[0] == PROMPT_LABEL
+    cleanup_warnings = [r for r in caplog.records if CLEANUP_HINT in r.getMessage()]
+    assert len(cleanup_warnings) == 1


### PR DESCRIPTION
## Summary

Fixes an uncaught traceback when running `mtui -a SUSE:SLFO:1.2:<id>` (or any SLFO/PI update) against a fresh checkout with no Gitea token configured. Two collaborating bugs let `MissingGiteaTokenError` escape every existing handler; either bug alone would be enough to defeat the catch, and both are addressed here.

## Changes

- **`mtui/exceptions.py`** — `GiteaError(BaseException)` → `GiteaError(Exception)`. Inheriting from `BaseException` silently defeats every `except Exception` clause in the codebase (including the cmdloop catch-all in `prompt.py`), so any Gitea error tore down the process instead of being handled. Almost certainly an oversight.
- **`mtui/types/updateid.py`** — restructure `_checkout` so the post-SVN-checkout retry of `tr.read()` runs inside the same outer `try` as the first read. Previously it sat inside a nested `try/except Exception: raise` block, which meant `MissingGiteaTokenError`, `FailedGiteaCallError`, and `InvalidGiteaHashError` raised by the *second* read bypassed the outer sibling except clauses entirely. SLFO/PI updates always hit this path (first read fails with ENOENT → checkout → second read is what first contacts Gitea via `check_hash()`). Missing token now hard-fails with a clear hint covering all three configuration sources (`-g/--gitea_token`, `GITEA_TOKEN`, `[gitea] token` in `~/.mtuirc`); failed API calls keep the existing soft-fail behaviour (`NullTestReport` via `TestReportNotLoadedError`).
- **`mtui/main.py`** — `run_mtui` catches `MissingGiteaTokenError` and exits 1 without re-logging.
- **`tests/test_updateid.py`** — three regression tests for the post-SVN retry path (missing token propagates, failed call converts, hash mismatch still prompts) + shared helper. Existing tests only exercised the first-read path, so neither bug was caught.
- **`tests/test_exceptions.py`** — lock in `issubclass(GiteaError, Exception)`.
- **`CHANGELOG.md`** — Fixed entry under `[Unreleased]`.

### Reproducer

```
$ unset GITEA_TOKEN
$ rm -rf $TEMPLATE_DIR/SUSE:SLFO:1.2:4420
$ mtui -a SUSE:SLFO:1.2:4420
```

Before: ~30-line Python traceback ending in `MissingGiteaTokenError: Gitea API token is empty, can't access API`.
After: `ERROR: Gitea API token is not configured. Pass -g/--gitea_token, set GITEA_TOKEN in your environment, or add a [gitea] token entry to ~/.mtuirc.` and `exit 1`.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean (scoped to `mtui/` and `tests/`; the full-repo run flags untracked local scratch directories in my worktree that aren't part of the repo).
- [x] `uv run pytest` passes (688 passed, including 3 new tests).
- [x] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
- [ ] Documentation under `Documentation/` updated where relevant — N/A (no user-facing command or config changed).

## Related issues

None — discovered while loading an SLFO update locally.
