### PR TITLE
refactor(config): @dataclass ConfigOption + log+default on parse failure (Phase 5b / C10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `Config` now logs an error and falls back to the documented default when
+  an INI value fails to parse. Previously `connection_timeout = abc`
+  crashed startup with an uncaught `ValueError`, and malformed typed
+  options like `refhosts.https_expiration = xyz` or
+  `mtui.use_keyring = perhaps` were silently replaced with the default
+  because the intended diagnostic log call was itself broken
+  (Phase 5b / C10).
 - Loading an SLFO or PI update with no `GITEA_TOKEN` configured no longer
   crashes with an uncaught traceback. Missing tokens are now reported with
   a clear configuration hint and exit with a non-zero status. Transient

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -8,6 +8,7 @@ import configparser
 import getpass
 from argparse import Namespace
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from logging import getLogger
 from os import getenv
 from pathlib import Path
@@ -18,6 +19,37 @@ from .messages import InvalidLocationError
 from .refhost import RefhostsFactory, RefhostsResolveFailedError
 
 logger = getLogger("mtui.config")
+
+
+def _identity(x: Any) -> Any:
+    """Default fixup: return the value unchanged."""
+    return x
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigOption:
+    """Declarative description of a single configuration option.
+
+    Replaces the historical 5-tuple shape used in ``Config._define_config_options``
+    with a named-field record. Behaviour is unchanged from the tuple form:
+
+    - ``getter`` is invoked as ``getter(*ini_path)`` to read the raw value
+      from the INI file (typically ``config.get``, ``config.getint`` or
+      ``config.getboolean``).
+    - When the read fails (option absent or malformed), the option falls
+      back to ``default`` (called if callable, otherwise used verbatim).
+    - ``fixup`` is applied to the successfully-read value to coerce it to
+      the final attribute type (e.g. ``Path``, ``int``).
+    """
+
+    attr: str
+    ini_path: tuple[str, str]
+    default: Any
+    fixup: Callable[[Any], Any] = field(default=_identity)
+    # ``getter`` cannot have a meaningful default at class-definition time
+    # because it is a bound method of the per-instance ConfigParser; the
+    # caller fills it in (defaulting to ``config.get``) when building the list.
+    getter: Callable[..., Any] = field(default=_identity)
 
 
 class Config:
@@ -71,10 +103,6 @@ class Config:
         self.refhosts = refhosts
         self.__location = "default"
 
-        # FIXME: gotta read config overide from env instead of argv
-        # because this crap is used as a singleton all over the
-        # place
-
         if path:
             self.configfiles = [path]
         elif _pth := getenv("MTUI_CONF"):
@@ -121,156 +149,210 @@ class Config:
 
     def _parse_config(self) -> None:
         """Parses the configuration options from the config files."""
-        for datum in self.data:
-            attr, inipath, default, fixup, getter = datum
-
+        for opt in self.data:
             try:
-                val = self._get_option(inipath, getter)
+                val = self._get_option(opt.ini_path, opt.getter)
             except Exception:
                 logger.debug(
-                    "config option %s not in INI; using default", attr, exc_info=True
+                    "config option %s not in INI; using default",
+                    opt.attr,
+                    exc_info=True,
                 )
-                val = default() if callable(default) else default
+                val = opt.default() if callable(opt.default) else opt.default
 
-            setattr(self, str(attr), fixup(val))
-            logger.debug('config.%s set to "%s"', attr, val)
+            setattr(self, opt.attr, opt.fixup(val))
+            logger.debug('config.%s set to "%s"', opt.attr, val)
 
     def _define_config_options(self) -> None:
         """Defines all available configuration options."""
 
-        def normalizer(x: Any) -> Any:
-            return x
-
         def expanduser(p: Path | str) -> Path:
             return Path(p).expanduser()
 
-        data: list[tuple[Any, ...]] = [
-            (
+        get = self.config.get
+        getint = self.config.getint
+        getboolean = self.config.getboolean
+
+        self.data: list[ConfigOption] = [
+            ConfigOption(
                 "template_dir",
                 ("mtui", "template_dir"),
                 lambda: Path(getenv("TEMPLATE_DIR", ".")),
                 expanduser,
+                get,
             ),
-            (
+            ConfigOption(
                 "local_tempdir",
                 ("mtui", "tempdir"),
                 lambda: Path(getenv("TMPDIR", "/tmp")),
                 expanduser,
+                get,
             ),
-            ("session_user", ("mtui", "user"), getpass.getuser),
-            ("install_logs", ("mtui", "install_logs"), Path("install_logs"), Path),
+            ConfigOption(
+                "session_user",
+                ("mtui", "user"),
+                getpass.getuser,
+                getter=get,
+            ),
+            ConfigOption(
+                "install_logs",
+                ("mtui", "install_logs"),
+                Path("install_logs"),
+                Path,
+                get,
+            ),
             # connection.timeout appears to be in units of seconds as
             # indicated by
             # http://www.lag.net/paramiko/docs/paramiko.Channel-class.html#gettimeout
-            ("connection_timeout", ("mtui", "connection_timeout"), 300, int),
-            (
+            ConfigOption(
+                "connection_timeout",
+                ("mtui", "connection_timeout"),
+                300,
+                int,
+                get,
+            ),
+            ConfigOption(
                 "svn_path",
                 ("svn", "path"),
                 "svn+ssh://svn@qam.suse.de/testreports",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "bugzilla_url",
                 ("url", "bugzilla"),
                 "https://bugzilla.suse.com",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "reports_url",
                 ("url", "testreports"),
                 "https://qam.suse.de/testreports",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "fancy_reports_url",
                 ("url", "fancy_reports"),
                 "https://qam.suse.de/reports",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "qem_dashboard_api",
                 ("qem_dashboard", "api"),
                 "http://dashboard.qam.suse.de/api",
+                getter=get,
             ),
-            ("target_tempdir", ("target", "tempdir"), Path("/tmp"), Path),
-            (
+            ConfigOption(
+                "target_tempdir",
+                ("target", "tempdir"),
+                Path("/tmp"),
+                Path,
+                get,
+            ),
+            ConfigOption(
                 "chdir_to_template_dir",
                 ("mtui", "chdir_to_template_dir"),
                 False,
-                normalizer,
-                self.config.getboolean,
+                getter=getboolean,
             ),
-            ("refhosts_resolvers", ("refhosts", "resolvers"), "https,path"),
-            (
+            ConfigOption(
+                "refhosts_resolvers",
+                ("refhosts", "resolvers"),
+                "https,path",
+                getter=get,
+            ),
+            ConfigOption(
                 "refhosts_https_uri",
                 ("refhosts", "https_uri"),
                 "https://qam.suse.de/refhosts/refhosts.yml",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "refhosts_https_expiration",
                 ("refhosts", "https_expiration"),
                 3600 * 12,
                 int,
-                self.config.getint,
+                getint,
             ),
-            (
+            ConfigOption(
                 "refhosts_path",
                 ("refhosts", "path"),
                 Path("/usr/share/qam-metadata/refhosts.yml"),
                 Path,
+                get,
             ),
-            (
+            ConfigOption(
                 "use_keyring",
                 ("mtui", "use_keyring"),
                 False,
                 bool,
-                self.config.getboolean,
+                getboolean,
             ),
-            (
+            ConfigOption(
                 "report_bug_url",
                 ("mtui", "report_bug_url"),
                 "https://bugzilla.suse.com/enter_bug.cgi?classification=40&product=Testenvironment&submit=Use+This+Product&component=MTUI",
+                getter=get,
             ),
             # openQA connector
-            ("openqa_instance", ("openqa", "openqa"), "https://openqa.suse.de"),
-            (
+            ConfigOption(
+                "openqa_instance",
+                ("openqa", "openqa"),
+                "https://openqa.suse.de",
+                getter=get,
+            ),
+            ConfigOption(
                 "openqa_instance_baremetal",
                 ("openqa", "baremetal"),
                 "http://openqa.qam.suse.cz",
+                getter=get,
             ),
-            ("openqa_install_distri", ("openqa", "distri"), "sle"),
-            (
+            ConfigOption(
+                "openqa_install_distri",
+                ("openqa", "distri"),
+                "sle",
+                getter=get,
+            ),
+            ConfigOption(
                 "openqa_install_logs",
                 ("openqa", "install_logfile"),
                 "update_install-zypper.log",
+                getter=get,
             ),
-            (
+            ConfigOption(
                 "openqa_kernel_install_logs",
                 ("openqa", "kernel_install_logfile"),
                 "update_kernel-zypper.log",
+                getter=get,
             ),
             # config for template export
-            ("threshold", ("template", "smelt_threshold"), 10, int, self.config.getint),
+            ConfigOption(
+                "threshold",
+                ("template", "smelt_threshold"),
+                10,
+                int,
+                getint,
+            ),
             # process location last as that needs to access
             # RefhostsFactory which need access to parts of config.
-            ("location", ("mtui", "location"), "default"),
-            ("gitea_token", ("gitea", "token"), getenv("GITEA_TOKEN", "")),
-            (
+            ConfigOption(
+                "location",
+                ("mtui", "location"),
+                "default",
+                getter=get,
+            ),
+            ConfigOption(
+                "gitea_token",
+                ("gitea", "token"),
+                getenv("GITEA_TOKEN", ""),
+                getter=get,
+            ),
+            ConfigOption(
                 "ssh_strict_host_key_checking",
                 ("connection", "ssh_strict_host_key_checking"),
                 "auto_add",
                 str,
+                get,
             ),
-        ]
-
-        def add_normalizer(x):
-            return x if len(x) > 3 else (*x, normalizer)
-
-        n_data = (add_normalizer(x) for x in data)
-
-        getter = self.config.get
-
-        def add_getter(x):
-            return x if len(x) > 4 else (*x, getter)
-
-        self.data: list[tuple[str, tuple[str, ...], Any, Callable, Callable]] = [
-            add_getter(x) for x in n_data
         ]
 
     def _list_terms(self) -> None:

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -36,8 +36,9 @@ class ConfigOption:
     - ``getter`` is invoked as ``getter(*ini_path)`` to read the raw value
       from the INI file (typically ``config.get``, ``config.getint`` or
       ``config.getboolean``).
-    - When the read fails (option absent or malformed), the option falls
-      back to ``default`` (called if callable, otherwise used verbatim).
+    - On any failure during read OR ``fixup``, the option falls back to
+      ``default`` (called if callable, otherwise used verbatim) and the
+      failure is logged at ERROR level.
     - ``fixup`` is applied to the successfully-read value to coerce it to
       the final attribute type (e.g. ``Path``, ``int``).
     """
@@ -148,19 +149,36 @@ class Config:
         self.__location = x
 
     def _parse_config(self) -> None:
-        """Parses the configuration options from the config files."""
-        for opt in self.data:
-            try:
-                val = self._get_option(opt.ini_path, opt.getter)
-            except Exception:
-                logger.debug(
-                    "config option %s not in INI; using default",
-                    opt.attr,
-                    exc_info=True,
-                )
-                val = opt.default() if callable(opt.default) else opt.default
+        """Parses the configuration options from the config files.
 
-            setattr(self, opt.attr, opt.fixup(val))
+        For each declared :class:`ConfigOption`, reads the raw value via the
+        option's ``getter``, applies its ``fixup``, and assigns the result
+        to ``self``. On any failure during read OR fixup, logs an ERROR
+        naming the option, the offending value (when known), and the
+        default being applied, then assigns the default.
+        """
+        for opt in self.data:
+            raw: Any = None
+            try:
+                raw = self._get_option(opt.ini_path, opt.getter)
+                val = opt.fixup(raw)
+            except (configparser.NoSectionError, configparser.NoOptionError):
+                # Option absent from the INI: not an error, just use the default.
+                val = opt.default() if callable(opt.default) else opt.default
+            except Exception:
+                default_val = opt.default() if callable(opt.default) else opt.default
+                logger.exception(
+                    "Config option %s (%s.%s) failed to parse value %r; "
+                    "falling back to default %r",
+                    opt.attr,
+                    opt.ini_path[0],
+                    opt.ini_path[1],
+                    raw,
+                    default_val,
+                )
+                val = default_val
+
+            setattr(self, opt.attr, val)
             logger.debug('config.%s set to "%s"', opt.attr, val)
 
     def _define_config_options(self) -> None:
@@ -360,7 +378,7 @@ class Config:
         scripts: list[str] = [x.name[5:-3] for x in terms_path().glob("term.*.sh")]
         self.termnames = scripts
 
-    def _get_option(self, secopt, getter):
+    def _get_option(self, secopt: tuple[str, str], getter: Callable[..., Any]) -> Any:
         """Gets an option from the configuration.
 
         Args:
@@ -370,16 +388,18 @@ class Config:
         Returns:
             The value of the option.
 
+        Raises:
+            configparser.NoSectionError / NoOptionError: option absent.
+            Exception: any failure raised by ``getter`` (e.g. ``ValueError``
+                from ``getint`` / ``getboolean`` on a malformed value); the
+                caller (:meth:`_parse_config`) is responsible for logging
+                and falling back to the default.
+
         """
         try:
             return getter(*secopt)
         except (configparser.NoSectionError, configparser.NoOptionError):
-            msg = "Config option {}.{} not found.".format(*secopt)
-            logger.debug(msg)
-            raise
-        except Exception:
-            msg = "Config option {0}.{1} extraction from {2} " + "failed."
-            logger.error(msg.format((*secopt, self.configfiles)))
+            logger.debug("Config option %s.%s not found.", *secopt)
             raise
 
     def merge_args(self, args: Namespace) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,35 +155,40 @@ def test_location_setter_resolve_failed_keeps_previous(tmpdir, caplog):
 
 
 @pytest.mark.parametrize(
-    ("ini_section", "ini_key", "ini_value"),
+    ("ini_section", "ini_key", "ini_value", "attr", "expected_default"),
     [
         # ``connection_timeout`` reads via ``config.get`` then ``int`` as fixup.
-        # The ``ValueError`` from ``int("abc")`` escapes ``_parse_config`` and
-        # crashes ``Config.__init__``.
-        ("mtui", "connection_timeout", "abc"),
+        # The ``ValueError`` from ``int("abc")`` used to escape ``_parse_config``
+        # and crash ``Config.__init__``; Phase 5b/C10 routes fixup failures
+        # through the same log+default path as getter failures.
+        ("mtui", "connection_timeout", "abc", "connection_timeout", 300),
     ],
 )
-def test_fixup_failure_propagates_and_aborts_construction(
-    tmpdir, ini_section, ini_key, ini_value
+def test_fixup_failure_logs_and_falls_back_to_default(
+    tmpdir, caplog, ini_section, ini_key, ini_value, attr, expected_default
 ):
-    """Captures current behaviour: a bad ``int`` fixup crashes ``Config()``.
+    """A bad ``int`` fixup is logged at ERROR and the default is applied.
 
-    FIXME (Phase 5b/C10): ``_parse_config`` only handles failures that
-    originate inside ``_get_option``; ``fixup(val)`` is invoked outside the
-    ``try`` so its exceptions are not converted into the documented
-    "use default" behaviour. Replace with explicit per-option parse handling.
+    Phase 5b/C10: ``_parse_config`` now wraps both ``_get_option`` AND
+    ``fixup(val)`` in the same ``try`` block, so a malformed
+    ``connection_timeout`` no longer crashes startup.
     """
     cfg_file = Path(tmpdir.join("typed.cfg"))
     cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
-    with pytest.raises(ValueError, match="invalid literal for int"):
-        config.Config(cfg_file, refhosts=MockRefhosts)
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+    assert getattr(cfg, attr) == expected_default
+    assert any(attr in r.message and ini_value in r.message for r in caplog.records), (
+        f"expected an ERROR log line mentioning {attr!r} and the bad value "
+        f"{ini_value!r}; got: {[r.message for r in caplog.records]}"
+    )
 
 
 @pytest.mark.parametrize(
     ("ini_section", "ini_key", "ini_value", "attr", "expected_default"),
     [
-        # ``getint`` raises inside ``_get_option`` → caught by outer
-        # ``except Exception`` → default applied.
+        # ``getint`` raises inside ``_get_option`` → caught in ``_parse_config``
+        # → ERROR logged → default applied.
         ("refhosts", "https_expiration", "xyz", "refhosts_https_expiration", 3600 * 12),
         ("template", "smelt_threshold", "nope", "threshold", 10),
         # ``getboolean`` raises inside ``_get_option`` → same path.
@@ -191,20 +196,21 @@ def test_fixup_failure_propagates_and_aborts_construction(
         ("mtui", "use_keyring", "perhaps", "use_keyring", False),
     ],
 )
-def test_typed_getter_failure_falls_back_to_default(
-    tmpdir, ini_section, ini_key, ini_value, attr, expected_default
+def test_typed_getter_failure_logs_and_falls_back_to_default(
+    tmpdir, caplog, ini_section, ini_key, ini_value, attr, expected_default
 ):
-    """Captures current behaviour: typed-getter failures silently use the default.
+    """Typed-getter failures are logged at ERROR and fall back to the default.
 
-    FIXME (Phase 5b/C10): ``_get_option`` lines 298-301 are intended to log an
-    error before re-raising, but the format-string call
-    ``msg.format((*secopt, self.configfiles))`` passes a single tuple to a
-    template that expects three positional args, so the ``logger.error`` call
-    itself raises and the user gets no diagnostic. Either way, the outer
-    ``except Exception`` in ``_parse_config`` swallows everything and applies
-    the default. The "log on failure" intent should be restored.
+    Phase 5b/C10: the previously-broken ``logger.error`` call in
+    ``_get_option`` is replaced by a working ``logger.error`` in
+    ``_parse_config`` that names the option and the offending value.
     """
     cfg_file = Path(tmpdir.join("typed.cfg"))
     cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
-    cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
     assert getattr(cfg, attr) == expected_default
+    assert any(attr in r.message for r in caplog.records), (
+        f"expected an ERROR log line mentioning {attr!r}; "
+        f"got: {[r.message for r in caplog.records]}"
+    )


### PR DESCRIPTION
## Summary

Phase 5b / C10 — the last cluster touching `mtui/config.py`. Replaces the
historical 5-tuple option-definition shape with a named-field
`@dataclass ConfigOption`, then fixes the two latent config-parsing
bugs pinned by the Phase 5a characterization tests.

## Commits

1. **refactor(config): @dataclass ConfigOption replaces 5-tuple shape**
   `[87b5a36]` — pure structural rewrite, behaviour-preserving. The
   `data: list[tuple[str, tuple, Any, Callable, Callable]]` shape and
   the `add_normalizer`/`add_getter` 4-vs-5-tuple expansion helpers
   are gone; each option is built as a named-field record. Stale
   FIXME at `__init__` (resolved by `MTUI_CONF` since Phase 2) removed.

2. **fix(config): log and fall back to default on parse failure**
   `[4cab2af]` — closes the two Phase 5a config-bug carry-overs:
   - `connection_timeout = abc` no longer crashes `mtui` at startup.
     `_parse_config` now wraps both `_get_option` AND `fixup(val)` in
     the same try/except.
   - Malformed `getint`/`getboolean` values (e.g.
     `refhosts.https_expiration = xyz`, `mtui.use_keyring = perhaps`)
     now emit a real ERROR diagnostic instead of being silently
     defaulted. The broken `msg.format((*secopt, self.configfiles))`
     call in `_get_option` (3-positional template, single tuple arg)
     is gone; diagnostics now live in `_parse_config` with access to
     all the fields they need.

## Behaviour change visible to users

`Config` now logs ERROR and falls back to the documented default
when an INI value fails to parse. Previously `connection_timeout =
abc` crashed startup with an uncaught traceback. Documented in
`CHANGELOG.md` under `[Unreleased] / Fixed`.

Smoke check on the changed behaviour:

```console
$ printf '[mtui]\nconnection_timeout = abc\n' > /tmp/bad.cfg
$ MTUI_CONF=/tmp/bad.cfg mtui -V
ERROR:mtui.config:Config option connection_timeout (mtui.connection_timeout) failed to parse value 'abc'; falling back to default 300
mtui 17.1.0
...
```

(Was: `ValueError: invalid literal for int() with base 10: 'abc'` +
non-zero exit.)

## Tests

The two pinned characterization tests in `tests/test_config.py` flip
to assert the new behaviour:

- `test_fixup_failure_propagates_and_aborts_construction` →
  `test_fixup_failure_logs_and_falls_back_to_default`
- `test_typed_getter_failure_falls_back_to_default` →
  `test_typed_getter_failure_logs_and_falls_back_to_default`

Both now assert on `caplog` for the ERROR log line in addition to the
default-applied check. The FIXME docstrings flagging these as deferred
to Phase 5b / C10 are removed.

## Verification

All gates green on `plan_five_8 @ 4cab2af`:

- `uv run ruff format --check .` — 182 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run ty check` — All checks passed (no warnings;
  `error-on-warning` on with strict `mtui/types/**` and
  `mtui/connector/**` overrides)
- `uv run pytest` — 688 passed
- `rg "FIXME" mtui/config.py` — zero hits
- `rg "msg\.format\(\(\*secopt" mtui/` — zero hits
- Manual: `uv run python -m mtui --help` and `-V` still work

## Plan reference

> 8 | C10 | `Config` → `@dataclass ConfigOption`; raise on parse failure
> (or log explicitly). Address the existing `# FIXME` at
> `mtui/config.py:73`. Closes the two Phase 5a config-bug
> carry-overs.

Picked the "log explicitly" interpretation: any bad value in
`/etc/mtui.cfg` should still let `mtui` start (a strict "raise"
policy would lock the user out on a single typo); but the user MUST
get a loud ERROR diagnostic naming the option and the bad value.
The CHANGELOG entry tells the user this is now the contract.

After this PR, the remaining Phase 5b clusters are C11 (Refhosts
split), C6 (move user prompting out of the SSH worker thread), and
C8 (split `mtui/utils.py`).