### PR TITLE
refactor(refhost): typed Host/Attributes schema + Resolver registry (Phase 5b / C11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `mtui.use_keyring = perhaps` were silently replaced with the default
   because the intended diagnostic log call was itself broken
   (Phase 5b / C10).
+- Malformed host rows in `refhosts.yml` are now logged at ERROR level and
+  dropped; previously they were silently skipped at search time with no
+  operator-visible signal (Phase 5b / C11).
 - Loading an SLFO or PI update with no `GITEA_TOKEN` configured no longer
   crashes with an uncaught traceback. Missing tokens are now reported with
   a clear configuration hint and exit with a non-zero status. Transient
@@ -47,4 +50,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - `target.query_package_versions()` is kept as a thin delegate but
     the rpm-vs-dpkg logic now lives in
     `target.package_querier`. All in-tree callers were migrated.
+- Internal refactor: `mtui.refhost` was rewritten around a typed schema
+  and a `Resolver` registry. Behaviour is unchanged for in-tree
+  callers; out-of-tree consumers may need to migrate (Phase 5b / C11):
+  - `Attributes` is now a `@dataclass` with typed fields (`arch: str`,
+    `product: Product | None`, `addons: list[Addon]`). The historical
+    free-form `setattr` shape and the undocumented `tags=(name)` /
+    `<other>=name(...)` segments in `testplatform` strings are no
+    longer parsed; unknown segments log an ERROR and are skipped. SMELT
+    never emitted those forms, and no field in `refhosts-ng.yml`
+    matched them, so this prunes dead grammar.
+  - `Refhosts.data` is now `dict[str, list[Host]]` (was
+    `dict[str, list[dict]]`). The `Host` dataclass and the matcher work
+    against typed fields; `is_candidate_match` no longer iterates
+    `vars(attribute)`.
+  - `_RefhostsFactory` now takes a `dict[str, Resolver]` registry
+    instead of five positional collaborators. Use
+    `_RefhostsFactory({"https": HttpsResolver(...), "path": PathResolver()})`.
+    The `getattr(self, f"resolve_{name}")` reflection is gone; the
+    `resolve_https` / `resolve_path` methods and the cache-refresh
+    helpers (`_is_https_cache_refresh_needed`,
+    `refresh_https_cache_if_needed`, `refresh_https_cache`) move to
+    `HttpsResolver` as private methods.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,589 @@
+# MTUI Improvement Plan
+
+This plan was distilled from a read-only review of the MTUI codebase, tests,
+CI, and documentation. It is organised as a sequence of shippable phases, one
+PR per phase, with deeper architectural refactors gated behind a
+characterization-test safety net.
+
+- **Strategy**: tests-first for refactors.
+- **Branching**: one PR per phase (Phase 5 split into clusters for
+  reviewability).
+- **Conventions**: Conventional Commits; CI must stay green; coverage ratchet
+  enforced from Phase 3 onwards.
+- **Decisions already locked**:
+  - README.md is canonical; `README.rst` will be removed and Sphinx will
+    consume the MD via `myst-parser`.
+  - SSH host-key policy gains a config knob; default behaviour stays
+    backward compatible (auto-add).
+  - Codecov floor = current % − 1, ratchet upward over time.
+  - Track C deep refactors in scope (`C2`, `C4`, `C10`, `C11`) plus extras
+    `C1`, `C3`, `C5`, `C6`, `C7`, `C8`, `C9`.
+
+---
+
+## Phases 1–4 Summary — ✅ DONE
+
+Foundational work shipped across four PRs. Test count grew from baseline
+to 351; coverage instrumentation and CI hardening landed before any
+refactors began.
+
+### Phase 1 — Quick wins (PR #1)
+Mechanical low-blast-radius fixes: switched to `contextlib.chdir`,
+`shlex.split` for argument parsing, narrowed `BaseException` catches,
+fixed call-stack walking in `colorlog`, stripped literal `\n` from
+argparse help strings, repaired `.gitignore`, removed legacy
+`Documentation/README`, replaced the `Documentation/index.rst` symlink
+with a proper include, and synced docs with the actual command set
+(`analyze_diff`, `show_diff`, `comment`, `EOF`).
+
+### Phase 2 — Latent bugs + test foundation (PR #2)
+Configured pytest (`addopts`, `testpaths`, registered markers), fixed
+`Target.__hash__`/`__eq__` contract, replaced silent
+`except Exception: pass` with debug logs, narrowed `BaseException`
+handlers in `actions.py`/`target.py`/`refhost.py`/`config.py`/
+`commands/__init__.py`, added warning when SSH port falls back to 22,
+introduced the `ssh_strict_host_key_checking` config knob
+(`auto_add`/`warn`/`reject`), and added CLI smoke tests with a new
+`mtui/__main__.py` entrypoint. Also unblocked `mtui/target/` from a
+mis-anchored gitignore rule.
+
+### Phase 3 — CI / tooling (PR #3)
+Committed `uv.lock`, cleaned up Phase 1/2 ruff and ty carry-overs,
+replaced `requirements_*.txt` with `uv sync`, dropped `osc` from the
+Python install set (it's a CLI not an import), extended the CI matrix
+to 3.11/3.12/3.13/3.14, widened ruff scope to the whole repo, reset
+Codecov to a 56% floor (current 57% − 1) with 80% patch target,
+aligned mergify on `main`, added `[tool.ty]` config with strict
+overrides for `mtui/types/**` and `mtui/connector/**`
+(`error-on-warning = true`), added `.pre-commit-config.yaml`, added
+dependabot for pip and github-actions, and fixed `MANIFEST.in` to
+recursively include Documentation.
+
+### Phase 4 — UX & documentation hygiene (PR #4)
+Added `CHANGELOG.md` (Keep-a-Changelog 1.1.0) with backfilled Phase
+1–3 sections, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor
+Covenant 2.1), `SECURITY.md`, GitHub issue forms (blank issues
+disabled), and a PR template. Fixed `Documentation/conf.py` (dropped
+non-existent templates path, switched theme to `alabaster`, refreshed
+copyright), deleted the empty static dir, deleted `README.rst` in
+favour of `README.md` via `myst-parser`, rewrote
+`Documentation/installation.rst` with full source-build coverage,
+documented `ssh_strict_host_key_checking` in `cfg.rst`, rewrote
+`developer.rst` with project layout / dev setup / CI gates / how-to-
+add-a-command walkthrough. UX: `--color {auto,always,never}` flag
+honouring `NO_COLOR` and `isatty()` (default behaviour change: colours
+now off when stderr isn't a TTY); `-V/--version` prints versions of
+`mtui`, Python, paramiko, and openqa-client; optional `[completion]`
+extra providing `argcomplete` integration.
+
+---
+
+## Phase 5a — Characterization tests (PR #5) — ✅ DONE
+
+Tests-first safety net before any internal restructuring. Each module
+got public-API tests that capture current behaviour so refactors can be
+verified.
+
+Status: shipped on `main` in 6 `test(...)` commits
+(`349b972`..`38e8d4f`) plus a `chore: refresh uv.lock` (`35d0811`),
+a coverage-floor bump to 66 % (`48a32a1`), and a follow-up changelog
+note documenting the surfaced config bugs (`599c518`). One unrelated
+bug fix (`6894757`, recover missing install logs in dashboard) and an
+agent-guidelines doc (`48cddbf`) also landed on the same branch.
+
+Test count rose from 351 (end of Phase 4) to 532. Coverage rose from
+57 % to 67 %; Codecov project floor bumped from 56 % to 66 %.
+
+| Module | Reference | Commit |
+| --- | --- | --- |
+| `mtui/config.py` — env var, malformed INI, location setter, typed-getter parse failures | `mtui/config.py` | ✅ `349b972` |
+| `mtui/prompt.py` — notify, history, dispatch failures, `cmdloop` error paths | `mtui/prompt.py` | ✅ `1c9e945` |
+| `mtui/refhost.py` — `Attributes`, `Refhosts`, resolver factory | `mtui/refhost.py` | ✅ `43c0334` |
+| `mtui/target/target.py` — connect, queries, `run_zypper`, sftp helpers, `report_*` sinks | `mtui/target/target.py` | ✅ `b22488b` |
+| `mtui/target/hostgroup.py` — four `perform_*` flows + group helpers | `mtui/target/hostgroup.py` | ✅ `ce0272f` |
+| `mtui/connection.py` — reconnect, sftp lifecycle, remainder of `run()` | `mtui/connection.py` | ✅ `38e8d4f` |
+
+**Surfaced bugs** (documented under `[Unreleased] / Known issues` in
+`CHANGELOG.md` rather than fixed in the same PR per the
+characterization-tests-first discipline):
+
+- `Config.__init__` crashes with `ValueError` on a non-numeric
+  `connection_timeout` instead of falling back to the documented 300 s
+  default.
+- The error path for the `configparser.getint`/`getboolean` config
+  options has a malformed format string, so a bad value is silently
+  replaced with the default and no log line is emitted.
+
+**Carry-overs surfaced during Phase 5a (handled in later phases):**
+
+- The two config bugs above are deferred to Phase 5b / C10
+  (`Config` → `@dataclass ConfigOption`; raise on parse failure).
+- The new coverage % (67 %) is the new ratchet baseline; the floor sits
+  at current − 1 = 66 % and ratchets upward as Phase 5b/6 land.
+
+---
+
+## Phase 5b — Track C refactors (PR #6 … PR #N)
+
+Each cluster is an independent PR within the Phase 5 track and is
+driven by the characterization tests added in Phase 5a.
+
+| Order | ID  | Change | Status |
+| --- | --- | --- | --- |
+| 1   | C9  | Introduce `Enum`s for target state (`enabled/dryrun/disabled`, `serial/parallel`) and request kind (`S/M/P/SLFO/Maintenance`); use `match/case` where it clarifies. | ✅ DONE — see below |
+| 2   | C5  | Replace filesystem-glob + `globals()` plugin loading with `Command.__init_subclass__` registry (or `@register` decorator). | ✅ DONE — see below |
+| 3   | C1  | Scope `actions.queue` to `HostsGroup` (or pass per call); kill the module-level mutable global. Modernised in flight: replaced the hand-rolled `Queue`+`ThreadedMethod` machinery with `concurrent.futures.ThreadPoolExecutor` since killing the global meant rewriting all the call sites anyway, and the executor surfaces worker exceptions instead of swallowing them. | ✅ DONE — see below |
+| 4   | C7  | Add `@contextmanager _sftp(self)` and reuse the SFTP client across multi-step operations. Wider scope (per plan-mode review): also expose a public `Connection.sftp_session()` so external callers can batch their own multi-step flows; migrate `parsers/system.parse_system` as the first such caller. | ✅ DONE — see below |
+| 5   | C3  | `class Operation` template method consolidating install/uninstall in `HostsGroup`. Scope narrowed during plan-mode review: `perform_prepare`, `perform_downgrade`, and `perform_update` have unique extras (per-package loops, fanout-set-repo, nested two-phase try/finally for guaranteed repo cleanup) that would force the template to grow several optional hooks until it became harder to read than the originals. | ✅ DONE — see below |
+| 6   | C2  | Decompose `Target` into `PackageQuerier` (rpm/dpkg), `RepoManager` (zypper), `Reporter` (the seven `report_*` sinks) and a `Doer` registry replacing the seven `get_*er` methods. | ✅ DONE — see below |
+| 7   | C4  | `CommandPrompt`: register `do_/help_/complete_` methods at construction; remove the per-attribute `__getattr__` synthesis. | ✅ DONE — see below |
+| 8   | C10 | `Config` → `@dataclass ConfigOption`; raise on parse failure (or log explicitly). Address the existing `# FIXME` at `mtui/config.py:73`. Closes the two Phase 5a config-bug carry-overs. | pending |
+| 9   | C11 | Split `Refhosts.Attributes` into a `TypedDict`/`dataclass` schema; split resolvers into separate classes. | ✅ DONE — see below |
+| 10  | C6  | Move user prompting out of the SSH worker thread; surface via callback/event to the main thread. | pending |
+| 11  | C8  | Split `mtui/utils.py` into `term.py`, `completion.py`, `fileops.py`, `colors.py`. | pending |
+
+### Phase 5b / C9 — Domain enums (PR #6 / openSUSE/mtui#111) — ✅ DONE
+
+Status: shipped on branch `phase_five_b1` in 8 commits
+(`1977f67`..`05b055f`); PR https://github.com/openSUSE/mtui/pull/111.
+All gates green: `uv run ruff format --check .` (163 files), `uv run
+ruff check .` clean, `uv run ty check` clean (no warnings;
+`error-on-warning` is on with the strict `mtui/types/**` and
+`mtui/connector/**` overrides), `uv run pytest` 549 passed
+(Phase 5a baseline 532 + 17 new in `tests/test_enums.py`).
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C9.1 | Add three enums under `mtui/types/enums.py`: `TargetState` (StrEnum, enabled/dryrun/disabled), `ExecutionMode` (plain Enum, parallel/serial), `RequestKind` (plain Enum, SLFO/Maintenance/PI with a `from_token()` classmethod accepting both long and `S`/`M`/`P` short forms). Re-exported from `mtui.types`. | `mtui/types/enums.py`, `mtui/types/__init__.py` | ✅ `1977f67` |
+| C9.2a | Drop invalid `serial`/`parallel` values from `tests/test_target.py::test_target_init_with_state` (preparatory test-bug fix; the values were never valid `state`s, just hidden by the wrong Literal annotation). Standalone commit so the next refactor commit stays green and a future bisect blames the right change. | `tests/test_target.py` | ✅ `419ec77` |
+| C9.2b | Wire `TargetState` into `Target` (`Literal[...]` → `TargetState | str`, runtime coercion via `TargetState(state)`); convert the three-branch `if/elif self.state == ...` chains in `Target.run` and `Target.query_versions` to `match/case`. Two-branch sites (`sftp_put`, `sftp_get`, `add_history`) keep `==` (works under StrEnum). `mtui/display.py` learns the enum members for readability. Drops two stale `# ty: ignore[invalid-assignment]` workarounds in `tests/test_target.py`. | `mtui/target/target.py`, `mtui/display.py`, `tests/test_target.py` | ✅ `f9f7198` |
+| C9.3 | Replace `Target.exclusive: bool` → `Target.mode: ExecutionMode` (default `PARALLEL`). Updates the four call sites: `mtui/target/actions.py` (`is ExecutionMode.SERIAL` instead of truthy bool), `mtui/commands/hoststate.py` (the `if state in [...]` ladder becomes `match/case`; the `serial`/`parallel` arm constructs the enum via `ExecutionMode(state)`), `mtui/display.py::list_host` (accepts the enum, renders via `.value`; drops the inline ternary), `mtui/target/target.py::report_self` (Callable signature now advertises `ExecutionMode` instead of `bool`). | `mtui/target/target.py`, `mtui/target/actions.py`, `mtui/commands/hoststate.py`, `mtui/display.py`, `tests/test_target.py`, `tests/test_display.py` | ✅ `04b10bb` |
+| C9.4 | Wire `RequestKind` into `RequestReviewID` (`if/elif self.kind == "M"...` chain → `RequestKind.from_token(raw_kind)`; `__str__`/`__repr__` render via `.value` so the `SUSE:SLFO:1.2:3` wire form is byte-identical). Migrate the seven production comparison sites: `mtui/connector/qem_dashboard.py:63`, `mtui/connector/oscqam.py:69` (the `in (...)` tuple), `mtui/connector/openqa/base.py:39`, `mtui/commands/apicall.py:49`, `mtui/types/updateid.py:136,138`. Test migration: `tests/test_types.py:43` (`!= "SLFO"` → `is not RequestKind.SLFO`) and `tests/test_oscqam.py:91` (the valid `"PI"` mock assignment → `RequestKind.PI`). | `mtui/types/rrid.py`, `mtui/connector/qem_dashboard.py`, `mtui/connector/oscqam.py`, `mtui/connector/openqa/base.py`, `mtui/commands/apicall.py`, `mtui/types/updateid.py`, `tests/test_types.py`, `tests/test_oscqam.py` | ✅ `60c7014` |
+| C9.5 | New `tests/test_enums.py` with 17 focused tests: `TargetState` StrEnum equality / match-case-against-raw-string / unknown-raises; `ExecutionMode` two-member surface, CLI-vocabulary round-trip, no-string-equality (typo-catching); `RequestKind` canonical values, `from_token()` parametrised matrix (six long/short combos), `"SLE"` rejection (locks in the C9.6 fixture fix), no-string-equality. | `tests/test_enums.py` (new) | ✅ `56bc147` |
+| C9.6 | Fix the two `rrid.kind = "SLE"` fixture typos surfaced by C9.4 (the `MagicMock` assignments bypass `RequestKind.from_token` so the bug had been latent for years). The conftest fixture's own `__str__` already advertised `"SUSE:Maintenance:..."`, confirming the intent was `MAINTENANCE`. `tests/test_oscqam.py::test_no_skip_template_for_sle` docstring updated to reflect the actual invariant ("not PI and not SLFO"). | `tests/conftest.py:136`, `tests/test_oscqam.py:101` | ✅ `552437d` |
+| C9.7 | `CHANGELOG.md` `[Unreleased] / Fixed` entry documenting the one user-visible side-effect: `Target(state=...)` now raises `ValueError` on invalid values (previously silently accepted `serial`/`parallel`). Per AGENTS.md, the rest of C9 is internal refactor and does not warrant a changelog line. | `CHANGELOG.md` | ✅ `05b055f` |
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`. Also confirmed
+`rg "Literal\[.*enabled.*disabled.*serial.*parallel.*\]" mtui/`
+returns zero hits (the stale Literal is gone).
+
+**Carry-overs surfaced during Phase 5b / C9 (handled in later
+clusters or PRs):**
+
+- None. The two test-fixture bugs surfaced (C9.2a invalid
+  `serial`/`parallel` values and C9.6 `"SLE"` typos) were both fixed
+  in dedicated `fix(test):` follow-up commits inside this PR per the
+  agreed policy.
+- The pre-existing LSP-only complaints in `tests/test_target.py`
+  (`MagicMock` arguments to typed `lock` / `connection` parameters) and
+  `mtui/target/actions.py:252` (`thread possibly unbound`) remain;
+  they predate C9 and are out of scope.
+
+### Phase 5b / C1 — ThreadPoolExecutor for parallel target ops (PR ?) — ✅ DONE
+
+Status: shipped on branch `phase_five_b3` in 4 Conventional Commits
+(`ce8f738`..`fe2c03a`) plus the doc updates here. All gates green:
+`uv run ruff format --check .` (167 files), `uv run ruff check .`
+clean, `uv run ty check` clean, `uv run pytest` 590 passed
+(C9 baseline 549 + 36 commands tests merged since C9 + 5 new in
+`tests/test_actions.py`).
+
+The plan literally said "scope `actions.queue` to `HostsGroup` (or
+pass per call); kill the module-level mutable global". Killing the
+global meant rewriting every call site anyway, so the in-flight
+modernisation went one step further: replace the bespoke
+`Queue`+`ThreadedMethod`+busy-poll-spinner machinery with
+`concurrent.futures.ThreadPoolExecutor`. The bespoke implementation
+also silently swallowed any exception raised by a worker callable
+(no `.result()` ever called) — pytest had been emitting
+`PytestUnhandledThreadExceptionWarning` for years; the executor's
+`Future.result()` surfaces them.
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C1.1 | Pin the desired exception-propagation contract with two `xfail(strict=True)` regression tests in `tests/test_actions.py` (one against `ThreadedTargetGroup` via `FileDelete`, one against `RunCommand`). They flip to passing the moment the executor lands; the strict marker means a forgotten flip would also break CI. | `tests/test_actions.py` (new) | ✅ `ce8f738` |
+| C1.2 | Extract `HostsGroup._fanout_set_repo(operation, testreport)` and replace the four open-coded `for t: queue.put(...) ; while queue.unfinished_tasks: spinner() ; queue.join()` blocks in `perform_prepare`, `perform_downgrade`, and the two sites inside `perform_update` with calls to it. Pure inlining: the helper still drives the module-level `queue` + `ThreadedMethod` + `spinner` for now, so the existing test patches against `mtui.target.hostgroup.queue` etc. stay valid and the next commit can swap the mechanism without touching the perform_* call sites again. | `mtui/target/hostgroup.py` | ✅ `55d8370` |
+| C1.3 | Move the worker-pool bootstrap inside `_fanout_set_repo`. `update_lock` used to spawn one `ThreadedMethod` per locked host as a side effect; the perform_* flows that came afterwards relied on those workers picking up the `set_repo` tasks within the 10s `Queue.get` timeout. Coupling-by-side-effect plus a latent timing bug (slow lock IO would have killed the workers before the puts arrived). Make the helper own its workers, drop the spawn from `update_lock`. | `mtui/target/hostgroup.py` | ✅ `534bcbe` |
+| C1.4 | Rewrite `mtui/target/actions.py` around `ThreadPoolExecutor`. New module-level `run_parallel(work)` helper builds one pool sized to the work, submits each `(callable, args)` pair, iterates `as_completed`, and re-raises the first worker exception via `Future.result()`. `ThreadedTargetGroup.run` collapses to a 1-line call into `run_parallel`; `RunCommand.run` does the same for parallel hosts and a plain for-loop with `prompt_user` between iterations for serial hosts (one worker is not a pool). `KeyboardInterrupt` still prints the original "stopping command queue" line and closes target sessions before re-raising. `_fanout_set_repo` becomes a one-liner against `run_parallel`. Drops `queue`, `ThreadedMethod`, `spinner`, `mk_thread`, `mk_threads`, `setup_queue`. Net −163 LOC in production. The hostgroup test patches against `queue`/`ThreadedMethod`/`spinner` are dropped (the symbols are gone); the two tests that inspected `mock_queue.put.call_args_list` to confirm add-then-remove repo lifecycle now inspect `mock_fanout.call_args_list` against the helper itself — same invariant, observed at a more honest level. `tests/test_actions.py` grows to five tests covering exception propagation through both `ThreadedTargetGroup` and `RunCommand`, the empty-work-list edge, the `(callable, args)` dispatch contract, and the serial-mode prompt path. Two stale `# ty: ignore[invalid-argument-type]` directives in `tests/test_hostgroup.py` (now redundant after the patch reduction tightened the inferred type) are dropped. | `mtui/target/actions.py`, `mtui/target/hostgroup.py`, `tests/test_actions.py`, `tests/test_hostgroup.py` | ✅ `fe2c03a` |
+| C1.5 | `CHANGELOG.md` `[Unreleased] / Fixed` entry documenting the one user-visible side-effect: exceptions raised by parallel target operations now surface to the caller and abort the enclosing flow instead of being silently swallowed. | `CHANGELOG.md` | ✅ this commit |
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`. Also confirmed
+`rg "queue\.put|queue\.unfinished_tasks|queue\.join\(\)|ThreadedMethod\(" mtui/`
+returns zero hits (the hand-rolled global is gone).
+
+**Carry-overs surfaced during Phase 5b / C1 (handled in later
+clusters or PRs):**
+
+- The visual `processing... [|/-\\]` spinner is gone — it was bound to
+  the busy-poll `while queue.unfinished_tasks` loop that the executor
+  replaced. Most users won't notice (per-host worker output dominates),
+  but if asked-for it's a 10-line follow-up using
+  `concurrent.futures.wait(futures, timeout=0.1)`.
+- `Phase 5b / C9` carry-over still stands: pre-existing LSP-only
+  complaints in `tests/test_target.py` (`MagicMock` for typed
+  `lock` / `connection` parameters). The `mtui/target/actions.py:252`
+  carry-over from C9 is now obsolete (the file was rewritten and the
+  `thread possibly unbound` warning is gone).
+
+### Phase 5b / C7 — SFTP session context manager (PR ?) — ✅ DONE
+
+Status: shipped on branch `phase_five_b4` in 5 Conventional Commits
+(`f6aa040`..`8a4ce05`). All gates green: `uv run ruff format --check .`
+(167 files), `uv run ruff check .` clean, `uv run ty check` clean
+(no warnings; `error-on-warning` is on), `uv run pytest` 597 passed
+(C1 baseline 593 + 4 new in `tests/test_connection.py`).
+
+The plan literally said "Add `@contextmanager _sftp(self)` and reuse
+the SFTP client across multi-step operations." Plan-mode review
+locked the wider interpretation: also expose a public
+`Connection.sftp_session()` so external callers can batch their own
+multi-step flows; migrate `parsers/system.parse_system` as the first
+such caller. Reconnect-on-failure semantics intentionally do **not**
+extend into the session block (mid-session paramiko errors propagate;
+each public `sftp_*` method still does its own one-shot reconnect at
+the CM entry, preserving today's per-call resilience).
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C7.1 | Add private `@contextmanager _sftp(self) -> Iterator[SFTPClient]` and a thin public re-export `sftp_session()` in `mtui/connection.py`. Both call `__sftp_reconnect()` at entry, yield the client, and unconditionally `client.close()` in a `finally`. Rewrite the seven simple public methods (`sftp_put`, `sftp_get`, `sftp_get_folder`, `sftp_listdir`, `sftp_remove`, `sftp_rmdir`, `sftp_readlink`) to `with self._sftp() as sftp: ...`, dropping their manual reconnect + close pairs. `sftp_open` keeps its manual lifetime: the returned `SFTPFile` holds a strong reference to the SFTP channel, so routing through `_sftp()` would close the client on exit and break the file handle (documented with an inline comment). Behaviour byte-identical: each public call still opens one client, does one op, closes. | `mtui/connection.py` | ✅ `f6aa040` |
+| C7.2 | Internal multi-step reuse: rewrite `sftp_get_folder` to call `sftp.listdir(str(remote))` directly inside its `_sftp()` block instead of going through `self.sftp_listdir` (which would open a second client). Same treatment for `sftp_rmdir`: one block doing `sftp.listdir` + per-file `sftp.remove` + final `sftp.rmdir`. Per-file `OSError` handling preserved by wrapping the inlined `sftp.remove` in `try/except OSError: logger.exception(...)` (matches the prior `Connection.sftp_remove` behaviour). Net handshake count drops from N+2 to 1 per call. | `mtui/connection.py` | ✅ `b5d2a98` |
+| C7.3 | Migrate `mtui/target/parsers/system.py::parse_system` to wrap its entire body in `with connection.sftp_session() as sftp:`, calling `sftp.listdir` / `sftp.open` / `sftp.readlink` directly. Exception types preserved (paramiko raises `OSError` for missing listdir and `FileNotFoundError` for missing open — same as the prior `Connection.sftp_*` wrappers because `OSError(ENOENT)` auto-promotes to `FileNotFoundError`). The `Path()` wrapping is dropped (sftp methods take `str`), which also drops the now-unused `from pathlib import Path`. SUSE-path handshake count drops from 6+ to 1; non-SUSE path drops from 2 to 1. Tests in `tests/test_target_parsers.py` rewired to mock `conn.sftp_session().__enter__()` returning an SFTP mock with `.listdir/.open/.readlink`, plus an assertion that `conn.sftp_session` is called exactly once per `parse_system` invocation. | `mtui/target/parsers/system.py`, `tests/test_target_parsers.py` | ✅ `17aa42b` |
+| C7.4 | Four new tests in `tests/test_connection.py`: `test_sftp_session_reuses_single_client` (one `open_sftp` call across a multi-op `sftp_session` block, one `close` on exit); `test_sftp_session_propagates_paramiko_errors` (mid-block `paramiko.SSHException` exits the CM, client still closed, no retry); `test_sftp_get_folder_uses_one_session` and `test_sftp_rmdir_uses_one_session` (pin the C7.2 handshake-count drop). | `tests/test_connection.py` | ✅ `5755999` |
+| C7.5 | `CHANGELOG.md` `[Unreleased] / Changed`: one entry documenting the multi-step SFTP batching (parse_system, sftp_get_folder, sftp_rmdir). `[Unreleased] / Known issues`: surface the latent dead-code branch in `Connection.__sftp_open`'s except-clause (`if "sftp" in locals()` is unreachable because the named paramiko exceptions are raised by the very assignment that would bind `sftp`). Per Phase 5a discipline, surfaced bugs are documented rather than fixed in the same refactor PR. | `CHANGELOG.md` | ✅ `8a4ce05` |
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`. Also confirmed
+`rg "self\.__sftp_reconnect\(\)" mtui/connection.py` returns 2 hits
+(one inside `_sftp`, one in the unchanged `sftp_open`); was 8 before.
+`rg "sftp\.close\(\)" mtui/connection.py` returns 2 hits (`_sftp`
+finally + `sftp_open` cleanup); was 9 before.
+
+**Carry-overs surfaced during Phase 5b / C7 (handled in later
+clusters or PRs):**
+
+- The `Connection.__sftp_open` dead-code defensive branch is logged
+  under `[Unreleased] / Known issues`. A one-line cleanup (drop the
+  `if "sftp" in locals()` guard, unconditionally `return None`) is
+  deferred to a follow-up fix PR per the Phase 5a "surface, don't
+  also fix" discipline.
+- The `sftp_put` reconnect-on-`mkdir`-failure loop reassigns `sftp`
+  inside the `with self._sftp()` block when the original client errors
+  mid-mkdir. The old client is shadowed but never explicitly closed
+  (the CM's `finally` only sees the latest binding) — but the legacy
+  code had the same leak, so this is a behaviour-preserving carry-over
+  rather than a new bug. Worth fixing alongside the wider rework of
+  `sftp_put` whenever it's revisited.
+
+### Phase 5b / C3 — Operation ABC for install/uninstall (PR ?) — ✅ DONE
+
+Status: shipped on `main` in 2 Conventional Commits — `205c22d`
+(`refactor(hostgroup): extract Operation ABC for install/uninstall`)
+and a follow-up bug fix `94a5267`
+(`fix(hostgroup): catch MissingPreparerError instead of Wrong error
+class`). All gates green at landing: `uv run ruff format --check .`,
+`uv run ruff check .` clean, `uv run ty check` clean (no warnings;
+`error-on-warning` is on), `uv run pytest` 666 passed (C7 baseline
+660 + 6 new in `tests/test_operation.py`).
+
+Plan-mode review narrowed the scope: only the two near-twin flows
+(`perform_install`, `perform_uninstall`) — which shared the same
+lock → run → check → reboot → unlock skeleton and differed only in
+which `Target.get_*er` they consulted and which `MissingXerError`
+they caught — get the template. The other three (`perform_prepare`,
+`perform_downgrade`, `perform_update`) each have unique extras
+(per-package loops, fanout-set-repo, nested two-phase try/finally
+for guaranteed repo cleanup) and were left alone; folding them into
+the same template would have required several optional hooks until
+the abstraction was harder to read than the originals.
+
+Net: ~62 LOC of structural duplication removed; install/uninstall
+collapse to one-line delegations; the ABC fails fast (via
+`@abstractmethod`) if a future subclass forgets either hook.
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C3.1 | New `mtui/target/operation.py` with `Operation(ABC)` holding the shared `collect()` / `run()` skeleton and two `@abstractmethod` hooks (`get_doer`, `get_check`). Concrete `InstallOperation` and `UninstallOperation` subclasses pair each hook with the corresponding `Target.get_*er` / `Target.get_*er_check` and the matching `MissingXerError` class. `HostsGroup` forward reference declared under `TYPE_CHECKING` to break the `hostgroup` ↔ `operation` import cycle. `HostsGroup.perform_install` and `perform_uninstall` collapse to one-line delegations; unused `MissingUninstallerError` import dropped from `hostgroup.py`. | `mtui/target/operation.py` (new), `mtui/target/hostgroup.py` | ✅ `205c22d` |
+| C3.2 | Six focused unit tests in `tests/test_operation.py`: the `collect()` shape, the missing-error early-return contract, the `finally`-unlock invariant on a raising `run`, the per-target `check` call signature, the install-vs-uninstall doer routing, and ABC enforcement (`TypeError` on bare construction plus `__isabstractmethod__` flags). | `tests/test_operation.py` (new) | ✅ `205c22d` |
+| C3.3 | Follow-up bug fix surfaced after C3.1 landed: the `except` clause in one of the perform_* flows was catching `MissingUninstallerError` on a code path that actually involves a *preparer*, so `MissingPreparerError` would never be caught and was silently re-raised through the generic `Exception` handler. One-line change to swap the exception class. | `mtui/target/hostgroup.py` | ✅ `94a5267` |
+
+Strict isomorphic refactor: zero user-visible behaviour change for
+the templated flows. All 45 pre-existing `tests/test_hostgroup.py`
+tests pass byte-for-byte unchanged. Public API preserved
+(`perform_install` / `perform_uninstall` keep their signatures).
+Per AGENTS.md and the Phase 5b/C9 precedent, no `CHANGELOG` entry
+for the refactor itself: internal-only.
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`.
+
+**Carry-overs surfaced during Phase 5b / C3 (handled in later
+clusters or PRs):**
+
+- `perform_prepare`, `perform_downgrade`, and `perform_update` were
+  intentionally left out of the template (see scope note above). If
+  a future flow turns out to share the prepare/downgrade/update
+  shape, that is the moment to revisit — not now.
+- The `MissingPreparerError` miscatch fixed in `94a5267` had been
+  latent for a long time; no test covered it before. A targeted
+  regression test for the preparer-missing path is queued under
+  Phase 6 / D1 (per-command happy-path + error-path tests).
+
+### Phase 5b / C2 — Target collaborator decomposition (PR ?) — ✅ DONE
+
+Status: shipped on `main` in 12 Conventional Commits
+(`941211b`..`ce04896`). All gates green: `uv run ruff format --check .`,
+`uv run ruff check .` clean, `uv run ty check` clean (no warnings;
+`error-on-warning` is on with the strict `mtui/types/**` and
+`mtui/connector/**` overrides), `uv run pytest` green.
+
+The plan literally said "Decompose `Target` into `PackageQuerier`
+(rpm/dpkg), `RepoManager` (zypper), `Reporter` (the seven `report_*`
+sinks) and a `Doer` registry replacing the seven `get_*er` methods."
+Shipped as four narrowly-scoped extractions, each landed as a
+refactor + tests pair, ordered so every intermediate commit kept the
+test suite green:
+
+1. **Doer registry first** — collapses the seven near-identical
+   `get_<role>er()` / `get_<role>er_check()` accessors into
+   `Target.doer(role)` / `Target.check(role)` dispatch. Call sites
+   (`Operation` hooks, `HostsGroup.perform_*`, `Template`) rewired in
+   the same series so the old accessors could be deleted in one go.
+2. **Reporter** — moves the seven `report_*` sinks out of `Target`
+   into a dedicated `Reporter` collaborator, accessed via
+   `target.reporter.<name>(sink)`.
+3. **PackageQuerier** — splits the rpm-vs-dpkg branching that lived
+   inline in `Target.query_versions` into its own collaborator
+   covering both code paths plus the parsing.
+4. **RepoManager** — extracts `set_repo` and `run_zypper` (and the
+   bespoke zypper-output handling) into the third collaborator.
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C2.1 | Collapse seven `get_<role>er` / `get_<role>er_check` methods into `Target.doer(role)` / `Target.check(role)` dispatch. | `mtui/target/target.py` | ✅ `941211b` |
+| C2.2 | Route `Operation` hooks through the new `Target.doer/check` dispatch. | `mtui/target/operation.py` | ✅ `58b948a` |
+| C2.3 | Route `HostsGroup.perform_*` and the `run_zypper`-adjacent template paths through `Target.doer/check`. | `mtui/target/hostgroup.py`, `mtui/template/*` | ✅ `7dafb39` |
+| C2.4 | Rewire existing `tests/test_target.py` / `tests/test_hostgroup.py` / `tests/test_operation.py` mocks from `get_*er` to `doer/check`. | `tests/test_target.py`, `tests/test_hostgroup.py`, `tests/test_operation.py` | ✅ `685bb41` |
+| C2.5 | New focused tests for the `Target.doer(role)` / `check(role)` dispatch surface. | `tests/test_doers.py` (new) | ✅ `88b7698` |
+| C2.6 | Extract `Reporter` collaborator for the seven `report_*` sinks; expose via `target.reporter`. | `mtui/target/reporter.py` (new), `mtui/target/target.py` | ✅ `a3a448b` |
+| C2.7 | Move/rewire the `report_*` tests to a dedicated `tests/test_reporter.py`. | `tests/test_reporter.py` (new), `tests/test_target.py` | ✅ `34701f1` |
+| C2.8 | Extract `PackageQuerier` (rpm-vs-dpkg branch + parsing) out of `Target.query_versions`. | `mtui/target/package_querier.py` (new), `mtui/target/target.py` | ✅ `f1c614a` |
+| C2.9 | Focused tests for the rpm / dpkg branch and the parser. | `tests/test_package_querier.py` (new) | ✅ `befd990` |
+| C2.10 | Extract `RepoManager` (`set_repo` + `run_zypper`) collaborator. | `mtui/target/repo_manager.py` (new), `mtui/target/target.py` | ✅ `9e5a61e` |
+| C2.11 | Move the `set_repo` / `run_zypper` tests into `tests/test_repo_manager.py`. | `tests/test_repo_manager.py` (new), `tests/test_target.py` | ✅ `90efac7` |
+| C2.12 | `CHANGELOG.md` `[Unreleased] / Changed`: document the migration map for out-of-tree consumers that imported `mtui.target.Target` directly (ten public methods moved to collaborator properties on the same instance). Per AGENTS.md the rest is internal-only, but this one external-API change warrants a line. | `CHANGELOG.md` | ✅ `ce04896` |
+
+Migration map (from the `ce04896` changelog entry):
+
+    get_<role>er() / _check()      -> doer(role) / check(role)
+    report_<name>(sink)             -> reporter.<name>(sink)
+    set_repo(op, tr)                -> repo_manager.set(op, tr)
+    run_zypper(cmd, ...)            -> repo_manager.run_zypper(cmd, ...)
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`.
+
+**Carry-overs surfaced during Phase 5b / C2 (handled in later
+clusters or PRs):**
+
+- None new. `Target` is now thin enough that the remaining `CommandPrompt`
+  cleanup (C4) and `Refhosts` split (C11) are unblocked.
+
+### Phase 5b / C4 — CommandPrompt method pre-binding (PR ?) — ✅ DONE
+
+Status: shipped on branch `phase_five_b7` in 1 Conventional Commit
+(this commit). All gates green: `uv run ruff format --check .`
+(182 files), `uv run ruff check .` clean, `uv run ty check` clean
+(no warnings; `error-on-warning` is on with the strict
+`mtui/types/**` and `mtui/connector/**` overrides), `uv run pytest`
+685 passed (C2 baseline 682 + 3 new in `tests/test_prompt.py`).
+
+The plan literally said "register `do_/help_/complete_` methods at
+construction; remove the per-attribute `__getattr__` synthesis."
+Plan-mode review locked the strict reading: pre-bind the closures
+via `setattr` in `_add_subcommand`, drop the runtime `__getattr__`
+entirely, let unknown attributes fall through to Python's default
+`AttributeError`. The four existing `tests/test_prompt.py` cases
+(`test_dispatching`, `test_get_names_includes_registered_commands`,
+`test_do_handles_argsparse_failure`, `test_complete_logs_and_reraises`,
+plus the two `test_getattr_unknown_*`) already pin all four dispatch
+paths and continue to pass byte-for-byte unchanged. The 3 new tests
+lock in the new shape.
+
+One typing-only escape hatch kept under `if TYPE_CHECKING:` — a
+no-runtime-effect `__getattr__` stub returning `Callable[..., Any]`.
+The previous runtime `__getattr__` annotation made `ty` believe any
+attribute access on `CommandPrompt` returned `Callable`; deleting it
+outright would have flagged 8 attribute-access sites (1 production
+in `mtui/main.py:95`, 7 in tests). The stub preserves the typing
+contract without reintroducing lazy synthesis; runtime lookups never
+reach it. This is a documented deviation from the strict success
+criterion "`rg \"__getattr__\" mtui/prompt.py` returns zero hits"
+agreed during plan mode — the spirit (no runtime synthesis) holds.
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C4.1 | Rewrite `_add_subcommand` to construct three closures (`do`, `help`, `complete` — verbatim from the old `__getattr__` branches) at registration time and bind them via `setattr(self, f"do_{name}", do)` etc. `setattr` accepts attribute names containing `-`, so the lone dash-named production command (`report-bug`) round-trips unchanged. | `mtui/prompt.py` | ✅ this commit |
+| C4.2 | Delete the runtime `__getattr__` (lines 240–288 of the pre-refactor file). Drop the `from collections.abc import Callable` runtime import. Add a `TYPE_CHECKING`-guarded stub re-exporting the prior typing contract so `ty` (and IDEs) continue to accept `prompt.do_<name>` accesses without per-call-site `# ty: ignore`. | `mtui/prompt.py` | ✅ this commit |
+| C4.3 | Three new tests in `tests/test_prompt.py`: `test_add_subcommand_binds_methods_to_instance` (asserts `do_/help_/complete_alpha` land in `p.__dict__` after `_add_subcommand` — proves pre-binding); `test_command_prompt_has_no_getattr` (asserts `"__getattr__" not in vars(prompt.CommandPrompt)` — locks in the runtime deletion, the `TYPE_CHECKING` stub does not appear in `vars()` because the class block skips the guard at class-creation time when `TYPE_CHECKING` is `False`); `test_dash_in_command_name_dispatches` (registers a mock with `command = "dash-cmd"`, calls `getattr(p, "do_dash-cmd")("args")`, asserts the mock was driven — proves dash-named commands still round-trip). | `tests/test_prompt.py` | ✅ this commit |
+
+`get_names` is intentionally left unchanged. With `do_X`/`help_X` now
+real instance attributes, `cmd.Cmd.get_names()` (which iterates the
+class via `dir(self.__class__)`) does NOT pick them up — instance
+attributes are invisible there. The existing override augmenting the
+list with the registered command names is therefore still required.
+
+Per AGENTS.md and the C3 precedent ("internal-only. no `CHANGELOG`
+entry for the refactor itself"), no changelog line: the `AttributeError`
+message format for unknown attrs may shift from `"x"` (custom) to
+Python's default `"'CommandPrompt' object has no attribute 'x'"`, but
+that surface is only visible inside interactive REPL introspection;
+both existing `pytest.raises(AttributeError, match=...)` checks
+continue to pass because the matcher is a substring search.
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m mtui
+--help` and `uv run python -m mtui -V`. Also confirmed
+`rg "def __getattr__" mtui/prompt.py` returns exactly one hit (the
+`TYPE_CHECKING`-guarded typing-only stub); was 1 before and the
+runtime body has been deleted.
+
+**Carry-overs surfaced during Phase 5b / C4 (handled in later
+clusters or PRs):**
+
+- None. The `TYPE_CHECKING` typing stub is the only deviation from
+  the strict "delete `__getattr__` entirely" success criterion and is
+  documented in the section header above; it is not a carry-over
+  because no follow-up action is required.
+
+### Phase 5b / C11 — Refhost typed schema + Resolver registry (PR ?) — ✅ DONE
+
+Status: shipped on branch `phase_five_b9` in 2 Conventional Commits
+(`25f7328` `refactor(refhost): typed Host/Attributes dataclasses +
+Resolver registry`, `706963a` `docs(changelog): note refhost typed
+schema and resolver split`). All gates green: `uv run ruff format
+--check .` (182 files), `uv run ruff check .` clean, `uv run ty
+check` clean (no warnings; `error-on-warning` is on with the strict
+`mtui/types/**` and `mtui/connector/**` overrides), `uv run pytest`
+691 passed (C4 baseline 688 + 56 in the rewritten `test_refhost.py`
+− 53 retired old `test_refhost.py` cases = net +3 collected).
+
+The plan literally said "Split `Refhosts.Attributes` into a
+`TypedDict`/`dataclass` schema; split resolvers into separate
+classes." Plan-mode review locked five decisions:
+
+- **Scope**: both refactors in one PR (single file, one commit).
+- **Schema shape**: nested `@dataclass` for `Version`/`Product`/`Addon`/`Host`,
+  not `TypedDict`, because the call-site ergonomics
+  (`attribute.product.version.major`) are visibly cleaner than dict
+  subscript.
+- **Tags/unknown-segment prune**: when asked how to handle the
+  historical `tags=(name)` and `<other>=name(...)` paths in
+  `Attributes.from_testplatform` (which used `setattr(attribute, …)`
+  to inject arbitrary attributes that were later iterated via
+  `vars(attribute)` in `is_candidate_match`), the user pointed at the
+  live `https://qam.suse.de/refhosts/refhosts-ng.yml`: the schema is
+  only `name/arch/product{name,version{major,minor}}/addons[{name,
+  version{...}}]`. The dynamic-attribute paths were dead grammar
+  (SMELT's `parsemetajson.py` only forwards `base=…;arch=…;addon=…`
+  triples per the `tests/test_metadataparsers.py` fixtures, and no
+  field in the live YAML matched the injected attribute names). Both
+  paths were pruned; unknown segments now log ERROR and are skipped.
+- **Resolver split shape**: `Resolver` ABC + concrete
+  `HttpsResolver`/`PathResolver`; factory holds a `dict[str, Resolver]`
+  registry. Closes the existing `# FIXME: split resolvers into
+  separate classes` at the head of `_RefhostsFactory`.
+- **YAML schema failures**: when asked whether `_host_from_dict`
+  should raise or log+drop on missing required fields, the user
+  asked for "log.error and drop host from candidate" to preserve the
+  best-effort load semantics with the only added wrinkle being an
+  operator-visible signal.
+
+| ID  | Change | Reference | Status |
+| --- | --- | --- | --- |
+| C11.1 | New typed schema: `Version(major: int|str, minor: int|str|None = None)`, `Product(name, version)`, `Addon(name, version)` — all frozen. `Host(name, arch, product, addons=())` frozen — the YAML row shape. `Attributes(arch="", product=None, addons=[])` mutable — the search-query shape, built incrementally by `from_testplatform`. The `minor == ""` sentinel for "candidate must NOT have a minor" is preserved in `Attributes`/`Version`; `minor is None` means "ignore minor". | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.2 | Rewrite `Attributes.from_testplatform` to a strict three-token grammar (`base=`, `arch=[...]`, `addon=`). Drop the `tags=(name)` and `<other>=name(...)` `setattr`-into-Attributes branches. Unknown segments log ERROR via the same `logger.error('unknown testplatform segment …')` shape as the existing malformed-line log. Helpers `_parse_named_version` and `_format_named_version` extract the repeated `name(major=X,minor=Y)` parse/render logic out of the per-call inline code. `copy.deepcopy` (not `copy.copy`) in the arch fan-out because the typed addons list now holds frozen Addon dataclasses and the safer default is documented in the commit. | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.3 | Replace `Refhosts._parse_refhosts`'s raw `dict[str, list[dict]]` shape with `dict[str, list[Host]]` via `_host_from_dict`. On `KeyError`/`TypeError` from a malformed row, log `"refhosts: dropping malformed host row %r: %s"` at ERROR and return `None`; the loader filters `None`s. YAML parse failures themselves still propagate (unchanged). New test `test_parse_refhosts_drops_malformed_host_and_logs` pins this. | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.4 | Rewrite `Refhosts.is_candidate_match` and friends to walk the three typed fields (`arch`, `product`, `addons`) directly. Three helper statics replace the dict-walking `_includes_*` cluster: `_product_matches`, `_version_matches`, `_addons_match`. The empty-field-skips-constraint semantics are preserved: `attribute.arch == ""` → no arch filter; `attribute.product is None` → no product filter; `attribute.addons == []` → no addon filter. The dead `_includes_simple_attributes` dict-key-walking branch (only exercised by the deleted `test_includes_simple_attributes_missing_key_returns_false` test, since no field in `refhosts.yml` ever had arbitrary nested keys) goes away. | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.5 | New `Resolver(ABC)` with one `resolve(config) -> Refhosts` method. `PathResolver(refhosts_factory=Refhosts)` — minimal, two-line `resolve`. `HttpsResolver(time_now_getter, statter, urlopener, file_writer, cache_path, refhosts_factory=Refhosts)` — owns the cache-refresh logic (`_refresh_if_needed`, `_is_refresh_needed`, `_refresh` are now private methods). | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.6 | Slim `_RefhostsFactory` to a dispatcher: `__init__(self, resolvers: dict[str, Resolver])`, `__call__` iterates `config.refhosts_resolvers.split(",")`, looks up each name in the registry (warning + skip on unknown), runs `resolver.resolve(config)` and returns on first success, raises `RefhostsResolveFailedError` if all fail. The `getattr(self, f"resolve_{name}")` reflection is gone. Module-level `RefhostsFactory` singleton now constructs `{"https": HttpsResolver(...), "path": PathResolver()}` explicitly. | `mtui/refhost.py` | ✅ `25f7328` |
+| C11.7 | Rewrite `tests/test_refhost.py`: `TestAttributes` swaps `attr.arch = ...` for kwarg construction (`Attributes(arch="x86_64")`); `TestFromTestplatform` drops `test_tags_sets_named_attribute` and `test_unknown_property_setattr_branch` (those paths are gone), adds `test_unknown_segment_logged_and_skipped`; `TestIsCandidateMatch` swaps dict-candidate fixtures for `Host(...)` construction via a private `_host(**kwargs)` builder, drops `test_includes_simple_attributes_missing_key_returns_false` (dead path), adds three new addon-matching cases (`test_addon_missing_on_candidate_returns_false`, `test_addon_version_mismatch_returns_false`, `test_addon_name_only_matches_any_version`); new `TestPathResolver` (1 test) and `TestHttpsResolver` (7 tests) carve the cache-refresh and resolve-path tests out of the old `TestRefhostsFactory`; `TestRefhostsFactory` is rewritten around the registry shape (5 tests covering first-success / fallback-on-failure / all-fail / unknown-skip / all-unknown). Two `# ty: ignore` directives added on test helpers (MagicMock-into-typed-`refhosts_factory` parameter; same pattern as the prior `_make_factory` helper had). | `tests/test_refhost.py` | ✅ `25f7328` |
+| C11.8 | `CHANGELOG.md` `[Unreleased] / Fixed`: one entry documenting the malformed-row ERROR log (previously silent). `[Unreleased] / Changed`: one entry documenting the migration map for out-of-tree consumers — `Attributes` is now a typed dataclass with the dynamic-segment grammar pruned, `Refhosts.data` is now `dict[str, list[Host]]`, `_RefhostsFactory` now takes a `{name: Resolver}` registry instead of five positional collaborators. Per AGENTS.md, internal-only mechanics aren't called out; only the surfaces that an external caller could observe. | `CHANGELOG.md` | ✅ `706963a` |
+
+Net diff: `mtui/refhost.py` 483→545 lines (+62; the typed schema and
+the four `_*_matches` helpers cost more lines than the `vars()`
+walker but the `_RefhostsFactory` shrinks dramatically). The
+historical `# FIXME: split resolvers into separate classes` at the
+old line 342 is gone. `tests/test_refhost.py` net +3 tests
+(56 vs 53 prior); coverage of the matcher's branches (addon
+fallback, version-only product, name-only addon) went up.
+
+**Verification**: `uv run ruff format --check .`, `uv run ruff check .`,
+`uv run ty check`, `uv run pytest`, plus manual `uv run python -m
+mtui --help` and `uv run python -m mtui -V`. Also confirmed:
+
+- `rg "vars\(attribute\)|setattr\(attribute" mtui/refhost.py` → 0 hits.
+- `rg "getattr\(self, f\"resolve_" mtui/refhost.py` → 0 hits.
+- `rg "FIXME" mtui/refhost.py` → 0 hits.
+- `rg "def __getattr__" mtui/refhost.py` → 0 hits (the historical
+  `vars()`-iteration over dynamic attributes used the implicit
+  `getattr` lookup, now gone).
+
+**Carry-overs surfaced during Phase 5b / C11 (handled in later
+clusters or PRs):**
+
+- None new. The `# ty: ignore[invalid-argument-type]` /
+  `[unresolved-attribute]` directives on the resolver test helpers
+  match the prior pattern from the deleted `_make_factory` helper
+  (MagicMock standing in for the typed `refhosts_factory` parameter);
+  this is a known LSP-vs-test ergonomics gap rather than a fresh
+  issue.
+- All four Track C / Phase 5b refactors that touched `Refhosts` /
+  `Attributes` (`C9` for the request enums, `C2` for the `Target`
+  decomposition, `C7` for the SFTP session, and now `C11`) are now
+  done; the remaining Phase 5b items (`C6` user-prompting out of the
+  SSH worker thread, `C8` `mtui/utils.py` split) are independent of
+  the refhost subsystem.
+
+---
+
+## Phase 6 — Test backfill (final PR)
+
+- **D1** — Per-command happy-path + error-path tests for the ~29 untested
+  commands; fill in tests for `mtui/actions/*`, `mtui/checks/*`,
+  `mtui/template/*`, and the deeper paths of `mtui/connection.py` (sftp,
+  reconnect, host keys, channel/stderr).
+- **D3** — Consolidate near-duplicate tests using `parametrize` (e.g. the
+  ten `test_target_init_*` cases).
+- **D4** — Audit `tests/fixtures/*.json` (~1.1 MB) and delete what is unused.
+- **D5** — Populate or remove the zero-byte `tests/fixtures/mtuirc`.
+- Final ratchet of the Codecov floor.
+
+---
+
+## Per-PR conventions
+
+- Each PR limited to a single phase; rebased on `main`.
+- Conventional Commits messages.
+- Refactor PRs in Phase 5b ship with (or reference) their characterization
+  tests.
+- CI green is mandatory; coverage ratchet enforced from Phase 3 onward.
+- No behaviour changes outside the explicitly listed scope of each PR.
+
+---
+
+## Open questions / future work (out of scope for this plan)
+
+- Async migration of `Connection` to `asyncssh` would simplify a lot of
+  the threading model but is a substantial rewrite; defer until after the
+  Track C refactors stabilise.
+- Machine-readable output (`--output {text,json}`, item F2) deferred until
+  CLI display layer is consolidated.
+- Bandit / pip-audit security scanning (item E9) deferred until pre-commit
+  + dependabot are in place.

--- a/mtui/refhost.py
+++ b/mtui/refhost.py
@@ -1,8 +1,32 @@
 """Manages and parses `refhosts.yml` files.
 
-This module provides classes for representing the attributes of a
-reference host, parsing and searching `refhosts.yml` files, and
-creating `Refhosts` instances from different sources.
+This module provides typed dataclasses for the refhost schema
+(:class:`Version`, :class:`Product`, :class:`Addon`, :class:`Host`,
+:class:`Attributes`), the :class:`Refhosts` loader/search, and a
+:class:`_RefhostsFactory` that resolves the YAML source via a registry
+of :class:`Resolver` implementations (`https`, `path`).
+
+The YAML schema:
+
+.. code-block:: yaml
+
+    <location_str>:
+      - name: <hostname>
+        arch: <arch>
+        product:
+          name: <name>
+          version:
+            major: <int|str>
+            minor: <int|str>     # optional
+        addons:                  # optional, list
+          - name: <name>
+            version:
+              major: <int|str>
+              minor: <int|str>   # optional
+
+Top-level keys are user-supplied location names (``default``,
+``nuremberg``, etc.); the ``default`` location is consulted as a
+fallback when a per-location search yields no match.
 """
 
 import copy
@@ -10,6 +34,8 @@ import errno
 import os
 import re
 import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
@@ -25,184 +51,292 @@ from .xdg import save_cache_path
 logger = getLogger("mtui.refhost")
 
 
-@final
-class Attributes:
-    """Represents the attributes of a reference host.
+# ---------------------------------------------------------------------------
+# Typed schema
+# ---------------------------------------------------------------------------
 
-    This class is used to both define the attributes of a refhost and
-    to create objects for searching for refhosts.
+
+@dataclass(frozen=True, slots=True)
+class Version:
+    """A product or addon version.
+
+    ``minor == ""`` is a sentinel used in *queries* (Attributes) to mean
+    "match candidates that have no minor set". In *candidates* (Host),
+    ``minor`` is ``None`` when the YAML omits the key.
     """
 
-    def __init__(self) -> None:
-        """Initializes the Attributes object."""
-        self.arch = ""
-        self.addons = []
-        self.product = {}
+    major: int | str
+    minor: int | str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Product:
+    """A base product (``sles``, ``SLE_RT``, …) with optional version."""
+
+    name: str
+    version: Version | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Addon:
+    """An addon (module / extension) shipped on a refhost."""
+
+    name: str
+    version: Version | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Host:
+    """One refhost row loaded from ``refhosts.yml``.
+
+    Required fields (``name``, ``arch``, ``product``) come from the
+    live ``refhosts-ng.yml`` schema; ``addons`` defaults to an empty
+    list because hosts without addons omit the key entirely.
+    """
+
+    name: str
+    arch: str
+    product: Product
+    addons: tuple[Addon, ...] = ()
+
+
+@final
+@dataclass(slots=True)
+class Attributes:
+    """Search query against a :class:`Refhosts` database.
+
+    Each field is optional (empty/None sentinel); the matcher skips
+    constraints on unset fields. This dataclass is *mutable* because
+    :meth:`from_testplatform` builds it incrementally segment by segment.
+    """
+
+    arch: str = ""
+    product: Product | None = None
+    addons: list[Addon] = field(default_factory=list)
 
     def __str__(self) -> str:
-        """Returns a human-readable string representation of the attributes."""
-        product: str = ""
-        if "name" in self.product:
-            product = self.product["name"]
-            if "version" in self.product:
-                product += " " + str(self.product["version"]["major"])
-                if "minor" in self.product["version"]:
-                    # If it's numbers, then a.b, if it's strings then ab
-                    if isinstance(self.product["version"]["minor"], int):
-                        product += "."
+        """Return a human-readable string representation of the query."""
+        parts: list[str] = []
 
-                    product += str(self.product["version"]["minor"])
+        if self.product is not None:
+            parts.append(_format_named_version(self.product.name, self.product.version))
 
-        addons: list[str] = []
-        for addon in sorted(self.addons, key=lambda addon: addon["name"]):
-            serialization = addon["name"]
-            if "version" in addon and "major" in addon["version"]:
-                serialization += " " + str(addon["version"]["major"])
-                if "minor" in addon["version"]:
-                    if isinstance(addon["version"]["minor"], int):
-                        serialization += "."
-                    serialization += str(addon["version"]["minor"])
+        if self.arch:
+            parts.append(self.arch)
 
-            addons.append(serialization)
+        # Addons are sorted alphabetically for stable output.
+        parts.extend(
+            _format_named_version(a.name, a.version)
+            for a in sorted(self.addons, key=lambda a: a.name)
+        )
 
-        representation = " ".join([product, self.arch, " ".join(addons)])
-
-        # remove the double spaces
-        representation = re.sub(r"\s+", " ", representation.strip())
-        # make ' ' to be ''. Just to pass the tests :-)
-        return re.sub(r"^\s+$", "", representation)
+        return " ".join(p for p in parts if p)
 
     def __repr__(self) -> str:
         return f"<Attributes: {self!s}>"
 
-    # Used in the tests
     def __bool__(self) -> bool:
-        """Returns True if any attributes have been set."""
-        return bool(str(self))
+        """Truthy when any constraint is set."""
+        return bool(self.arch) or self.product is not None or bool(self.addons)
 
     @staticmethod
-    def from_testplatform(testplatform) -> list["Attributes"]:
-        """Creates a list of Attributes objects from a testplatform string.
+    def from_testplatform(testplatform: str) -> list["Attributes"]:
+        """Parse a SMELT ``testplatform`` string into one Attributes per arch.
 
-        Args:
-            testplatform: The testplatform string to parse.
+        Grammar: ``base=<name>(major=X,minor=Y);arch=[a,b,c];addon=<name>(...)``.
+        Unknown segments are logged at ERROR and skipped.
 
-        Returns:
-            A list of Attributes objects.
+        Example:
+
+        .. code-block:: text
+
+            base=sles(major=15,minor=5);arch=[x86_64,aarch64];addon=sdk(major=15,minor=5)
 
         """
-        attributes_list = []
-        # typical string:
-        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11,minor=sp4)  # noqa: ERA001
-        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11,minor=)
-        # base=sles(major=11,minor=sp4);arch=[i386,s390x,x86_64];addon=sdk(major=11)  # noqa: ERA001
         attribute = Attributes()
-        arch_list = []
+        arch_list: list[str] = []
+
         for pattern in testplatform.split(";"):
             try:
                 property_name, content = pattern.split("=", 1)
             except ValueError:
                 logger.error('error when parsing line "%s"', testplatform)
                 continue
-            # special case: arch
-            # *- arch because is a list so it will create a list of several attributes
-            # --
-            # The rest of elements contains a version
+
             if property_name == "arch":
                 if capture := re.match(r"\[(.*)\]", content):
                     arch_list = [x.strip() for x in capture.group(1).split(",")]
-            elif property_name == "tags":
-                if capture := re.match(r"\((.*)\)", content):
-                    setattr(attribute, capture.group(1), {"enabled": True})
+            elif property_name == "base":
+                if parsed := _parse_named_version(content):
+                    attribute.product = Product(name=parsed[0], version=parsed[1])
+            elif property_name == "addon":
+                if parsed := _parse_named_version(content):
+                    attribute.addons.append(Addon(name=parsed[0], version=parsed[1]))
             else:
-                complex_property: dict[str, Any] = {"version": {}}
-                if capture := re.match(r"(.*)\((.*)\)", content):
-                    complex_property["name"] = capture.group(1)
-                    for element in capture.group(2).split(","):
-                        [key, value] = element.split("=")
-                        # Note: When the minor is '' then it's used to search for unset values
-                        # We want number as numbers not as strings
-                        try:
-                            complex_property["version"][key] = int(value)
-                        except ValueError:
-                            complex_property["version"][key] = value
+                logger.error(
+                    'unknown testplatform segment %r in "%s"',
+                    property_name,
+                    testplatform,
+                )
 
-                    if property_name == "base":
-                        attribute.product = complex_property
-                    elif property_name == "addon":
-                        attribute.addons.append(complex_property)
-                    else:
-                        setattr(attribute, property_name, complex_property)
+        # Fan out one Attributes per arch; deepcopy because addons is
+        # a mutable list of (frozen) Addon dataclasses.
+        return [
+            _attributes_with_arch(copy.deepcopy(attribute), arch) for arch in arch_list
+        ]
 
-        for arch in arch_list:
-            attribute_copy = copy.copy(attribute)  # no need for deepcopy
-            attribute_copy.arch = arch
-            attributes_list.append(attribute_copy)
 
-        return attributes_list
+def _attributes_with_arch(attr: Attributes, arch: str) -> Attributes:
+    """Return ``attr`` with ``arch`` set (used by ``from_testplatform``)."""
+    attr.arch = arch
+    return attr
+
+
+def _format_named_version(name: str, version: Version | None) -> str:
+    """Render ``name`` + optional ``version`` like ``"sles 15.5"`` / ``"sles 12sp4"``."""
+    if version is None:
+        return name
+    out = f"{name} {version.major}"
+    if version.minor is not None and version.minor != "":
+        # int minor uses a dot separator; string minor is concatenated.
+        sep = "." if isinstance(version.minor, int) else ""
+        out += f"{sep}{version.minor}"
+    return out
+
+
+def _parse_named_version(content: str) -> tuple[str, Version | None] | None:
+    """Parse ``name(major=X,minor=Y)`` → ``(name, Version(...))``.
+
+    Returns ``None`` if ``content`` does not match the grammar. ``minor``
+    is preserved as the empty string ``""`` when the source has
+    ``minor=`` (sentinel for "candidate has no minor"), as ``int`` when
+    numeric, or as ``str`` otherwise.
+    """
+    capture = re.match(r"(.*)\((.*)\)", content)
+    if not capture:
+        return None
+    name = capture.group(1)
+    fields: dict[str, int | str] = {}
+    for element in capture.group(2).split(","):
+        try:
+            key, value = element.split("=")
+        except ValueError:
+            continue
+        try:
+            fields[key] = int(value)
+        except ValueError:
+            fields[key] = value
+
+    if "major" not in fields:
+        return name, None
+    version = Version(major=fields["major"], minor=fields.get("minor"))
+    return name, version
+
+
+def _version_from_dict(d: Any) -> Version | None:
+    """Convert a YAML version dict to a :class:`Version` (or None).
+
+    Raises :class:`TypeError` if ``d`` is non-None but not a mapping,
+    or :class:`KeyError` if the required ``major`` key is missing.
+    """
+    if d is None:
+        return None
+    if not isinstance(d, dict):
+        raise TypeError(f"expected version dict, got {type(d).__name__}")
+    if "major" not in d:
+        raise KeyError("major")
+    return Version(major=d["major"], minor=d.get("minor"))
+
+
+def _host_from_dict(d: Any) -> Host | None:
+    """Convert one YAML row to a :class:`Host`.
+
+    On schema failure (missing required field, wrong nesting type),
+    logs at ERROR level and returns ``None`` so the loader can drop the
+    bad row without aborting.
+    """
+    try:
+        if not isinstance(d, dict):
+            raise TypeError(f"expected mapping, got {type(d).__name__}")
+        product_raw: Any = d["product"]
+        if not isinstance(product_raw, dict):
+            raise TypeError(
+                f"product must be a mapping, got {type(product_raw).__name__}"
+            )
+        product = Product(
+            name=product_raw["name"],
+            version=_version_from_dict(product_raw.get("version")),
+        )
+        addons_raw: Any = d.get("addons") or []
+        addons = tuple(
+            Addon(name=a["name"], version=_version_from_dict(a.get("version")))
+            for a in addons_raw
+        )
+        return Host(name=d["name"], arch=d["arch"], product=product, addons=addons)
+    except (KeyError, TypeError) as e:
+        logger.error("refhosts: dropping malformed host row %r: %s", d, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Refhosts loader / search
+# ---------------------------------------------------------------------------
 
 
 class Refhosts:
-    """Manages and parses the `refhosts.yml` file."""
+    """Loads and searches ``refhosts.yml`` for hosts matching :class:`Attributes`."""
 
     _default_location = "default"
 
     def __init__(self, hostmap: Path, location: str | None = None) -> None:
-        """Initializes the Refhosts object.
+        """Initialize the Refhosts object.
 
         Args:
-            hostmap: The path to the `refhosts.yml` file.
-            location: The location to load hosts from.
+            hostmap: Path to ``refhosts.yml``.
+            location: Location key to search; defaults to ``"default"``.
 
         """
-        # default refhosts location is 'default' which is basically fallback
-        if location is None:
-            self.location = self._default_location
-        else:
-            self.location = location
-
+        self.location = location if location is not None else self._default_location
         self._parse_refhosts(hostmap)
 
     def _parse_refhosts(self, hostmap: Path) -> None:
-        """Parses the `refhosts.yml` file.
+        """Load ``hostmap`` and convert each row to a :class:`Host`.
 
-        Args:
-            hostmap: The path to the `refhosts.yml` file.
-
+        Malformed rows are logged at ERROR and dropped; YAML parse
+        failures propagate.
         """
         try:
             with hostmap.open() as f:
-                self.data = YAML(typ="safe").load(f)
-
+                raw = YAML(typ="safe").load(f)
         except Exception:
-            # nothing to do for us if we can't load the hosts
             logger.error("failed to parse refhosts.yml")
             raise
 
-    def search(self, attributes) -> list[str]:
-        """Searches for hosts that match a given set of attributes.
+        self.data: dict[str, list[Host]] = {}
+        for loc, rows in (raw or {}).items():
+            self.data[loc] = [
+                h for h in (_host_from_dict(row) for row in rows or []) if h is not None
+            ]
 
-        Args:
-            attributes: A list of `Attributes` objects to search for.
+    def search(self, attributes: list[Attributes]) -> list[str]:
+        """Return hostnames matching any of the given :class:`Attributes`.
 
-        Returns:
-            A list of hostnames that match the given attributes.
-
+        For each query attribute, search the configured location first;
+        if it yields no match and the configured location is not
+        ``default``, fall back to ``default``.
         """
         results: list[str] = []
-
         for attribute in attributes:
-            host = []
             host = [
-                candidate["name"]
-                for candidate in self.data[self.location]
+                candidate.name
+                for candidate in self.data.get(self.location, [])
                 if self.is_candidate_match(candidate, attribute)
             ]
 
-            if host == [] and self.location != self._default_location:
+            if not host and self.location != self._default_location:
                 host = [
-                    candidate["name"]
-                    for candidate in self.data[self._default_location]
+                    candidate.name
+                    for candidate in self.data.get(self._default_location, [])
                     if self.is_candidate_match(candidate, attribute)
                 ]
 
@@ -210,138 +344,104 @@ class Refhosts:
 
         return results
 
-    def is_candidate_match(self, candidate, attribute) -> bool:
-        """Checks if a candidate host matches a given set of attributes.
-
-        Args:
-            candidate: A dictionary representing a host from `refhosts.yml`.
-            attribute: An `Attributes` object to match against.
-
-        Returns:
-            True if the candidate matches the attributes, False otherwise.
-
-        """
-        for key in vars(attribute):
-            if getattr(attribute, key):
-                if key not in candidate:
-                    return False
-                if key == "addons":
-                    if not self._includes_addons_list(
-                        candidate[key], getattr(attribute, key)
-                    ):
-                        return False
-                elif isinstance(
-                    candidate[key], (str, int, bool)
-                ):  # scalar options. Options that are non iterable
-                    if getattr(attribute, key) != candidate[key]:
-                        return False
-                elif not self._includes_simple_attributes(
-                    candidate[key], getattr(attribute, key)
-                ):
-                    return False
-
-        return True
-
-    def _includes_simple_attributes(self, candidate, attribute) -> bool:
-        """Checks if a candidate's simple attributes match.
-
-        Args:
-            candidate: The candidate's attributes.
-            attribute: The attributes to match against.
-
-        Returns:
-            True if the attributes match, False otherwise.
-
-        """
-        for k in attribute:
-            if k not in candidate:
-                return False
-            if k == "version":
-                if not self._includes_version(
-                    candidate["version"], attribute["version"]
-                ):
-                    return False
-            elif attribute[k] != candidate[k]:
-                return False
-
-        return True
-
-    def _includes_version(self, candidate, element) -> bool:
-        """Checks if a candidate's version matches.
-
-        Args:
-            candidate: The candidate's version.
-            element: The version to match against.
-
-        Returns:
-            True if the versions match, False otherwise.
-
-        """
-        if "minor" in element and element["minor"] != "":
-            if "minor" not in candidate or element["minor"] != candidate["minor"]:
-                return False
-        elif "minor" in element and element["minor"] == "" and "minor" in candidate:
+    def is_candidate_match(self, candidate: Host, attribute: Attributes) -> bool:
+        """Return True iff ``candidate`` satisfies all set fields of ``attribute``."""
+        if attribute.arch and attribute.arch != candidate.arch:
             return False
 
-        # major is mandatory
-        return element["major"] == candidate["major"]
+        if attribute.product is not None and not self._product_matches(
+            candidate.product, attribute.product
+        ):
+            return False
 
-    def _includes_addons_list(self, candidate_addons, element_addons) -> bool:
-        """Checks if a candidate's addons match.
+        return not (
+            attribute.addons
+            and not self._addons_match(candidate.addons, attribute.addons)
+        )
 
-        Args:
-            candidate_addons: The candidate's addons.
-            element_addons: The addons to match against.
+    @staticmethod
+    def _product_matches(candidate: Product, query: Product) -> bool:
+        """Return True iff ``candidate`` has the queried name and version."""
+        if query.name != candidate.name:
+            return False
+        if query.version is None:
+            return True
+        return Refhosts._version_matches(candidate.version, query.version)
 
-        Returns:
-            True if the addons match, False otherwise.
+    @staticmethod
+    def _version_matches(candidate: Version | None, query: Version) -> bool:
+        """Match a candidate version against a query version.
 
+        ``query.minor == ""`` is the "candidate must NOT have a minor"
+        sentinel; ``query.minor is None`` means "ignore minor".
         """
-        element_addons_map = {addon["name"]: addon for addon in element_addons}
-        candidate_addons_map = {addon["name"]: addon for addon in candidate_addons}
+        if candidate is None:
+            return False
+        if query.major != candidate.major:
+            return False
 
-        for addon in element_addons_map:
-            if addon not in candidate_addons_map:
+        if query.minor == "":
+            # Sentinel: candidate must have no minor.
+            return candidate.minor is None
+        if query.minor is None:
+            return True
+        return query.minor == candidate.minor
+
+    @staticmethod
+    def _addons_match(
+        candidate_addons: tuple[Addon, ...], query_addons: list[Addon]
+    ) -> bool:
+        """Return True iff every queried addon is present on the candidate."""
+        candidate_by_name = {a.name: a for a in candidate_addons}
+        for query in query_addons:
+            candidate = candidate_by_name.get(query.name)
+            if candidate is None:
                 return False
-            if not self._includes_simple_attributes(
-                candidate_addons_map[addon], element_addons_map[addon]
-            ):
+            if query.version is None:
+                continue
+            if not Refhosts._version_matches(candidate.version, query.version):
                 return False
         return True
 
-    def check_location_sanity(self, location) -> None:
-        """Checks if a location is valid.
-
-        Args:
-            location: The location to check.
-
-        Raises:
-            messages.InvalidLocationError: If the location is not valid.
-
-        """
+    def check_location_sanity(self, location: str) -> None:
+        """Raise :class:`InvalidLocationError` if ``location`` is unknown."""
         if location not in self.data:
             raise messages.InvalidLocationError(location, self.get_locations())
 
     def get_locations(self) -> set[str]:
-        """Returns a set of all available locations.
-
-        Returns:
-            A set of location names.
-
-        """
+        """Return the set of known location names."""
         return set(self.data.keys())
 
 
 class RefhostsResolveFailedError(RuntimeError):
-    """Raised when a `refhosts.yml` file cannot be resolved."""
+    """Raised when no resolver can produce a usable ``refhosts.yml`` source."""
 
 
-class _RefhostsFactory:
-    """A factory for creating `Refhosts` instances."""
+# ---------------------------------------------------------------------------
+# Resolvers
+# ---------------------------------------------------------------------------
 
-    # FIXME: split resolvers into separate classes
-    # should help with the ammount of injected dependencies in each one
-    # of the classes
+
+class Resolver(ABC):
+    """A strategy for producing a :class:`Refhosts` instance from a source."""
+
+    @abstractmethod
+    def resolve(self, config) -> Refhosts:
+        """Return a :class:`Refhosts` built from this resolver's source."""
+
+
+class PathResolver(Resolver):
+    """Resolve refhosts from a local file at ``config.refhosts_path``."""
+
+    def __init__(self, refhosts_factory: type[Refhosts] = Refhosts) -> None:
+        self.refhosts_factory = refhosts_factory
+
+    def resolve(self, config) -> Refhosts:
+        return self.refhosts_factory(config.refhosts_path, config.location)
+
+
+class HttpsResolver(Resolver):
+    """Resolve refhosts from an HTTPS URL, with on-disk caching."""
 
     def __init__(
         self,
@@ -349,90 +449,39 @@ class _RefhostsFactory:
         statter,
         urlopener,
         file_writer,
-        cache_path,
+        cache_path: Path,
         refhosts_factory: type[Refhosts] = Refhosts,
     ) -> None:
-        """Initializes the factory.
+        """Initialize the resolver.
 
         Args:
-            time_now_getter: A function that returns the current time.
-            statter: A function that returns file stats.
-            urlopener: A function that opens a URL.
-            file_writer: A function that writes to a file.
-            cache_path: The path to the cache file.
-            refhosts_factory: The factory for creating `Refhosts` instances.
+            time_now_getter: Callable returning the current epoch time.
+            statter: Callable returning file stats (``os.stat``).
+            urlopener: Callable returning an HTTP response object.
+            file_writer: Callable ``(bytes, path) -> None`` to persist
+                the downloaded payload.
+            cache_path: On-disk cache path for the downloaded YAML.
+            refhosts_factory: Factory for the :class:`Refhosts` instance.
 
         """
         self._time_now = time_now_getter
         self._stat = statter
         self._urlopen = urlopener
         self._write_file = file_writer
-
-        self.refhosts_cache_path = cache_path
+        self.cache_path = cache_path
         self.refhosts_factory = refhosts_factory
 
-    def __call__(self, config):
-        """Resolves and returns a `Refhosts` instance.
+    def resolve(self, config) -> Refhosts:
+        self._refresh_if_needed(config)
+        return self.refhosts_factory(self.cache_path, config.location)
 
-        Args:
-            config: The application configuration.
+    def _refresh_if_needed(self, config) -> None:
+        if self._is_refresh_needed(config.refhosts_https_expiration):
+            self._refresh(config.refhosts_https_uri)
 
-        Returns:
-            A `Refhosts` instance.
-
-        """
-        for resolver in [x.strip() for x in config.refhosts_resolvers.split(",")]:
-            try:
-                return self._resolve_one(resolver, config)
-            except Exception:
-                logger.warning("Refhosts: resolver %s failed", resolver)
-                logger.debug(format_exc())
-
-        raise RefhostsResolveFailedError()
-
-    def _resolve_one(self, name, config):
-        """Resolves a `Refhosts` instance from a single source.
-
-        Args:
-            name: The name of the resolver to use.
-            config: The application configuration.
-
-        Returns:
-            A `Refhosts` instance.
-
-        """
+    def _is_refresh_needed(self, expiration: int) -> bool:
         try:
-            resolver = getattr(self, f"resolve_{name}")
-        except AttributeError:
-            logger.warning("Refhosts: invalid resolver: %s", name)
-            raise
-        else:
-            return resolver(config)
-
-    def refresh_https_cache_if_needed(self, path: Path, config) -> None:
-        """Refreshes the HTTPS cache if it is expired.
-
-        Args:
-            path: The path to the cache file.
-            config: The application configuration.
-
-        """
-        if self._is_https_cache_refresh_needed(path, config.refhosts_https_expiration):
-            self.refresh_https_cache(path, config.refhosts_https_uri)
-
-    def _is_https_cache_refresh_needed(self, path, expiration) -> bool:
-        """Checks if the HTTPS cache needs to be refreshed.
-
-        Args:
-            path: The path to the cache file.
-            expiration: The expiration time in seconds.
-
-        Returns:
-            True if the cache needs to be refreshed, False otherwise.
-
-        """
-        try:
-            statinfo = self._stat(path)
+            statinfo = self._stat(self.cache_path)
         except OSError as e:
             if e.errno == errno.ENOENT:
                 return True
@@ -440,44 +489,54 @@ class _RefhostsFactory:
 
         return self._time_now() - statinfo.st_mtime > expiration
 
-    def refresh_https_cache(self, path, uri) -> None:
-        """Refreshes the HTTPS cache.
+    def _refresh(self, uri: str) -> None:
+        self._write_file(self._urlopen(uri).read(), self.cache_path)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class _RefhostsFactory:
+    """Dispatches to a configured :class:`Resolver` to build a :class:`Refhosts`."""
+
+    def __init__(self, resolvers: dict[str, Resolver]) -> None:
+        """Initialize the factory.
 
         Args:
-            path: The path to the cache file.
-            uri: The URI to fetch the cache from.
+            resolvers: Mapping of resolver name → resolver instance. The
+                ``config.refhosts_resolvers`` comma-separated string
+                selects which resolvers to try, in order.
 
         """
-        self._write_file(self._urlopen(uri).read(), path)
+        self.resolvers = resolvers
 
-    def resolve_https(self, config) -> Refhosts:
-        """Resolves a `Refhosts` instance from an HTTPS source.
+    def __call__(self, config) -> Refhosts:
+        """Try each configured resolver in order; return the first success."""
+        for name in (x.strip() for x in config.refhosts_resolvers.split(",")):
+            resolver = self.resolvers.get(name)
+            if resolver is None:
+                logger.warning("Refhosts: invalid resolver: %s", name)
+                continue
+            try:
+                return resolver.resolve(config)
+            except Exception:
+                logger.warning("Refhosts: resolver %s failed", name)
+                logger.debug(format_exc())
 
-        Args:
-            config: The application configuration.
-
-        Returns:
-            A `Refhosts` instance.
-
-        """
-        f = self.refhosts_cache_path
-        self.refresh_https_cache_if_needed(f, config)
-
-        return self.refhosts_factory(f, config.location)
-
-    def resolve_path(self, config) -> Refhosts:
-        """Resolves a `Refhosts` instance from a local file path.
-
-        Args:
-            config: The application configuration.
-
-        Returns:
-            A `Refhosts` instance.
-
-        """
-        return self.refhosts_factory(config.refhosts_path, config.location)
+        raise RefhostsResolveFailedError()
 
 
 RefhostsFactory = _RefhostsFactory(
-    time.time, os.stat, urlopen, atomic_write_file, save_cache_path("refhosts.yml")
+    {
+        "https": HttpsResolver(
+            time.time,
+            os.stat,
+            urlopen,
+            atomic_write_file,
+            save_cache_path("refhosts.yml"),
+        ),
+        "path": PathResolver(),
+    }
 )

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -1,4 +1,4 @@
-"""Tests for the mtui refhost module - specifically the eval() fix."""
+"""Tests for the mtui refhost module."""
 
 import errno
 import re
@@ -86,38 +86,44 @@ class TestAttributes:
         assert str(attr) == ""
 
     def test_str_with_product_major_only(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 12}}
+        attr = refhost.Attributes(
+            product=refhost.Product(name="sles", version=refhost.Version(major=12))
+        )
         assert str(attr) == "sles 12"
 
     def test_str_with_product_int_minor_uses_dot(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 15, "minor": 5}}
+        attr = refhost.Attributes(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor=5)
+            )
+        )
         assert str(attr) == "sles 15.5"
 
     def test_str_with_product_string_minor_concatenated(self):
         """SP-style minor versions render without a dot separator."""
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 12, "minor": "sp4"}}
+        attr = refhost.Attributes(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=12, minor="sp4")
+            )
+        )
         assert str(attr) == "sles 12sp4"
 
     def test_str_with_arch(self):
-        attr = refhost.Attributes()
-        attr.arch = "x86_64"
+        attr = refhost.Attributes(arch="x86_64")
         assert str(attr) == "x86_64"
 
     def test_str_with_addons_sorted(self):
-        attr = refhost.Attributes()
-        attr.addons = [
-            {"name": "sdk", "version": {"major": 15, "minor": 5}},
-            {"name": "ha", "version": {"major": 15}},
-        ]
+        attr = refhost.Attributes(
+            addons=[
+                refhost.Addon(name="sdk", version=refhost.Version(major=15, minor=5)),
+                refhost.Addon(name="ha", version=refhost.Version(major=15)),
+            ]
+        )
         # Addons are sorted alphabetically.
         assert str(attr) == "ha 15 sdk 15.5"
 
     def test_repr_wraps_str(self):
-        attr = refhost.Attributes()
-        attr.arch = "x86_64"
+        attr = refhost.Attributes(arch="x86_64")
         assert repr(attr) == "<Attributes: x86_64>"
 
 
@@ -134,35 +140,45 @@ class TestFromTestplatform:
         # One Attributes per arch.
         assert [a.arch for a in attrs] == ["i386", "s390x", "x86_64"]
         for a in attrs:
-            assert a.product == {
-                "name": "sles",
-                "version": {"major": 11, "minor": 4},
-            }
-            assert a.addons == [{"name": "sdk", "version": {"major": 11, "minor": 4}}]
+            assert a.product == refhost.Product(
+                name="sles", version=refhost.Version(major=11, minor=4)
+            )
+            assert a.addons == [
+                refhost.Addon(name="sdk", version=refhost.Version(major=11, minor=4))
+            ]
 
     def test_addon_with_string_minor_kept_as_string(self):
         tp = "base=sles(major=12,minor=sp4);arch=[x86_64];addon=ha(major=12,minor=sp4)"
         attrs = refhost.Attributes.from_testplatform(tp)
         assert len(attrs) == 1
-        assert attrs[0].product["version"]["minor"] == "sp4"
-        assert attrs[0].addons[0]["version"]["minor"] == "sp4"
+        assert attrs[0].product is not None
+        assert attrs[0].product.version is not None
+        assert attrs[0].product.version.minor == "sp4"
+        assert attrs[0].addons[0].version is not None
+        assert attrs[0].addons[0].version.minor == "sp4"
 
     def test_addon_with_empty_minor(self):
         """``minor=`` with no value sentinels a search-for-unset query."""
         tp = "base=sles(major=11);arch=[x86_64];addon=sdk(major=11,minor=)"
         attrs = refhost.Attributes.from_testplatform(tp)
-        assert attrs[0].addons[0]["version"] == {"major": 11, "minor": ""}
+        assert attrs[0].addons[0].version == refhost.Version(major=11, minor="")
 
     def test_addon_major_only(self):
         tp = "base=sles(major=11);arch=[x86_64];addon=sdk(major=11)"
         attrs = refhost.Attributes.from_testplatform(tp)
-        assert attrs[0].addons[0]["version"] == {"major": 11}
+        assert attrs[0].addons[0].version == refhost.Version(major=11, minor=None)
 
-    def test_tags_sets_named_attribute(self):
+    def test_unknown_segment_logged_and_skipped(self, caplog):
+        """A non-base/arch/addon segment is logged at error and the rest still parses."""
         tp = "base=sles(major=15,minor=5);arch=[x86_64];tags=(kernel)"
-        attrs = refhost.Attributes.from_testplatform(tp)
-        # ``tags=(name)`` sets ``name`` as a dynamic attribute on Attributes.
-        assert getattr(attrs[0], "kernel") == {"enabled": True}  # noqa: B009
+        with caplog.at_level("ERROR", logger="mtui.refhost"):
+            attrs = refhost.Attributes.from_testplatform(tp)
+        # The base/arch segments still parse cleanly.
+        assert len(attrs) == 1
+        assert attrs[0].product is not None
+        assert attrs[0].product.name == "sles"
+        # The unknown segment was logged.
+        assert any("unknown testplatform segment" in r.message for r in caplog.records)
 
     def test_malformed_segment_logged_and_skipped(self, caplog):
         """A segment without ``=`` is logged at error and the rest still parses."""
@@ -170,7 +186,8 @@ class TestFromTestplatform:
         with caplog.at_level("ERROR", logger="mtui.refhost"):
             attrs = refhost.Attributes.from_testplatform(tp)
         assert len(attrs) == 1
-        assert attrs[0].product["name"] == "sles"
+        assert attrs[0].product is not None
+        assert attrs[0].product.name == "sles"
         assert any(
             "garbage_no_equals" in r.message or "parsing" in r.message
             for r in caplog.records
@@ -181,15 +198,6 @@ class TestFromTestplatform:
         tp = "base=sles(major=15,minor=5)"
         attrs = refhost.Attributes.from_testplatform(tp)
         assert attrs == []
-
-    def test_unknown_property_setattr_branch(self):
-        """A non-base/non-addon complex property is set as a named attribute."""
-        tp = "base=sles(major=15);arch=[x86_64];other=thing(major=1)"
-        attrs = refhost.Attributes.from_testplatform(tp)
-        assert getattr(attrs[0], "other") == {  # noqa: B009
-            "name": "thing",
-            "version": {"major": 1},
-        }
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +228,26 @@ class TestRefhosts:
         ):
             refhost.Refhosts(broken)
         assert any("failed to parse refhosts.yml" in r.message for r in caplog.records)
+
+    def test_parse_refhosts_drops_malformed_host_and_logs(self, tmp_path, caplog):
+        """Rows missing required fields are logged at ERROR and dropped."""
+        bad = tmp_path / "bad.yml"
+        bad.write_text(
+            "default:\n"
+            "  - name: good-host\n"
+            "    arch: x86_64\n"
+            "    product:\n"
+            "      name: sles\n"
+            "      version:\n"
+            "        major: 15\n"
+            "  - name: bad-host\n"
+            "    arch: x86_64\n"
+            # missing product
+        )
+        with caplog.at_level("ERROR", logger="mtui.refhost"):
+            rh = refhost.Refhosts(bad)
+        assert [h.name for h in rh.data["default"]] == ["good-host"]
+        assert any("dropping malformed host row" in r.message for r in caplog.records)
 
     def test_get_locations(self):
         rh = refhost.Refhosts(REFHOSTS_FIXTURE)
@@ -280,72 +308,108 @@ class TestIsCandidateMatch:
     def setup_method(self):
         self.rh = refhost.Refhosts(REFHOSTS_FIXTURE)
 
-    def test_attribute_key_missing_in_candidate_returns_false(self):
+    def _host(self, **kwargs) -> refhost.Host:
+        defaults: dict = {
+            "name": "h",
+            "arch": "x86_64",
+            "product": refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor=5)
+            ),
+            "addons": (),
+        }
+        defaults.update(kwargs)
+        return refhost.Host(**defaults)
+
+    def test_unset_attribute_does_not_filter(self):
+        """An empty Attributes() matches every candidate."""
         attr = refhost.Attributes()
-        attr.arch = "x86_64"
-        candidate = {"name": "h", "product": {"name": "sles"}}  # no arch
-        assert self.rh.is_candidate_match(candidate, attr) is False
+        assert self.rh.is_candidate_match(self._host(), attr) is True
 
     def test_scalar_mismatch_returns_false(self):
-        attr = refhost.Attributes()
-        attr.arch = "aarch64"
-        candidate = {"arch": "x86_64"}
-        assert self.rh.is_candidate_match(candidate, attr) is False
+        attr = refhost.Attributes(arch="aarch64")
+        assert self.rh.is_candidate_match(self._host(arch="x86_64"), attr) is False
 
     def test_scalar_match_returns_true(self):
-        attr = refhost.Attributes()
-        attr.arch = "x86_64"
-        candidate = {"arch": "x86_64"}
-        assert self.rh.is_candidate_match(candidate, attr) is True
+        attr = refhost.Attributes(arch="x86_64")
+        assert self.rh.is_candidate_match(self._host(arch="x86_64"), attr) is True
 
     def test_includes_version_empty_minor_excludes_when_candidate_has_minor(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 15, "minor": ""}}
-        candidate = {"product": {"name": "sles", "version": {"major": 15, "minor": 5}}}
+        attr = refhost.Attributes(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor="")
+            )
+        )
+        candidate = self._host(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor=5)
+            )
+        )
         assert self.rh.is_candidate_match(candidate, attr) is False
 
     def test_includes_version_empty_minor_matches_when_candidate_has_no_minor(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 15, "minor": ""}}
-        candidate = {"product": {"name": "sles", "version": {"major": 15}}}
+        attr = refhost.Attributes(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor="")
+            )
+        )
+        candidate = self._host(
+            product=refhost.Product(name="sles", version=refhost.Version(major=15))
+        )
         assert self.rh.is_candidate_match(candidate, attr) is True
 
     def test_includes_version_minor_mismatch_returns_false(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 15, "minor": 5}}
-        candidate = {"product": {"name": "sles", "version": {"major": 15, "minor": 4}}}
+        attr = refhost.Attributes(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor=5)
+            )
+        )
+        candidate = self._host(
+            product=refhost.Product(
+                name="sles", version=refhost.Version(major=15, minor=4)
+            )
+        )
         assert self.rh.is_candidate_match(candidate, attr) is False
 
     def test_includes_version_major_mismatch_returns_false(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "version": {"major": 15}}
-        candidate = {"product": {"name": "sles", "version": {"major": 12}}}
+        attr = refhost.Attributes(
+            product=refhost.Product(name="sles", version=refhost.Version(major=15))
+        )
+        candidate = self._host(
+            product=refhost.Product(name="sles", version=refhost.Version(major=12))
+        )
         assert self.rh.is_candidate_match(candidate, attr) is False
 
-    def test_includes_simple_attributes_missing_key_returns_false(self):
-        attr = refhost.Attributes()
-        attr.product = {"name": "sles", "extra_key": "x"}
-        candidate = {"product": {"name": "sles"}}  # no extra_key
+    def test_addon_missing_on_candidate_returns_false(self):
+        attr = refhost.Attributes(
+            addons=[refhost.Addon(name="sdk", version=refhost.Version(major=15))]
+        )
+        candidate = self._host(addons=())
         assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_addon_version_mismatch_returns_false(self):
+        attr = refhost.Attributes(
+            addons=[
+                refhost.Addon(name="sdk", version=refhost.Version(major=15, minor=5))
+            ]
+        )
+        candidate = self._host(
+            addons=(
+                refhost.Addon(name="sdk", version=refhost.Version(major=15, minor=4)),
+            )
+        )
+        assert self.rh.is_candidate_match(candidate, attr) is False
+
+    def test_addon_name_only_matches_any_version(self):
+        attr = refhost.Attributes(addons=[refhost.Addon(name="sdk")])
+        candidate = self._host(
+            addons=(refhost.Addon(name="sdk", version=refhost.Version(major=99)),)
+        )
+        assert self.rh.is_candidate_match(candidate, attr) is True
 
 
 # ---------------------------------------------------------------------------
-# _RefhostsFactory
+# Resolvers and _RefhostsFactory
 # ---------------------------------------------------------------------------
-
-
-def _make_factory(**overrides):
-    """Build a ``_RefhostsFactory`` with all collaborators mocked."""
-    defaults: dict[str, object] = {
-        "time_now_getter": MagicMock(return_value=1_000_000),
-        "statter": MagicMock(),
-        "urlopener": MagicMock(),
-        "file_writer": MagicMock(),
-        "cache_path": Path("/tmp/refhosts.yml"),
-        "refhosts_factory": MagicMock(),
-    }
-    defaults.update(overrides)
-    return refhost._RefhostsFactory(**defaults)  # ty: ignore[invalid-argument-type]
 
 
 def _make_config(**overrides):
@@ -360,117 +424,154 @@ def _make_config(**overrides):
     return SimpleNamespace(**base)
 
 
-class TestRefhostsFactory:
-    def test_call_returns_first_successful_resolver(self):
-        factory = _make_factory()
-        cfg = _make_config(refhosts_resolvers="path")
-        rh = factory(cfg)
-        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "default")
-        assert rh is factory.refhosts_factory.return_value
+def _make_https_resolver(**overrides) -> refhost.HttpsResolver:
+    """Build an ``HttpsResolver`` with all collaborators mocked."""
+    defaults: dict[str, object] = {
+        "time_now_getter": MagicMock(return_value=1_000_000),
+        "statter": MagicMock(),
+        "urlopener": MagicMock(),
+        "file_writer": MagicMock(),
+        "cache_path": Path("/tmp/refhosts.yml"),
+        "refhosts_factory": MagicMock(),
+    }
+    defaults.update(overrides)
+    return refhost.HttpsResolver(**defaults)  # ty: ignore[invalid-argument-type]
 
-    def test_call_falls_back_to_next_resolver_on_failure(self, caplog):
-        """A failing first resolver is logged and the second one is tried."""
-        factory = _make_factory()
-        # First resolver name is invalid (no resolve_invalid method).
-        cfg = _make_config(refhosts_resolvers="invalid,path")
-        with caplog.at_level("DEBUG", logger="mtui.refhost"):
-            factory(cfg)
-        assert any("invalid" in r.message for r in caplog.records)
-        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "default")
 
-    def test_call_raises_when_all_resolvers_fail(self):
-        factory = _make_factory()
-        cfg = _make_config(refhosts_resolvers="invalid_a,invalid_b")
-        with pytest.raises(refhost.RefhostsResolveFailedError):
-            factory(cfg)
+class TestPathResolver:
+    def test_resolve_uses_configured_path(self):
+        factory_mock = MagicMock()
+        resolver = refhost.PathResolver(refhosts_factory=factory_mock)  # ty: ignore[invalid-argument-type]
+        cfg = _make_config(location="nuremberg")
+        rh = resolver.resolve(cfg)
+        factory_mock.assert_called_once_with(REFHOSTS_FIXTURE, "nuremberg")
+        assert rh is factory_mock.return_value
 
-    def test_resolve_one_unknown_resolver_logs_and_raises(self, caplog):
-        factory = _make_factory()
-        cfg = _make_config()
-        with (
-            caplog.at_level("WARNING", logger="mtui.refhost"),
-            pytest.raises(AttributeError),
-        ):
-            factory._resolve_one("nonexistent", cfg)
-        assert any("invalid resolver" in r.message for r in caplog.records)
 
-    def test_is_https_cache_refresh_needed_missing_file(self):
-        statter = MagicMock(side_effect=OSError(errno.ENOENT, "missing"))
-        factory = _make_factory(statter=statter)
-        assert factory._is_https_cache_refresh_needed(Path("/nope"), 3600) is True
-
-    def test_is_https_cache_refresh_needed_other_oserror_raises(self):
-        statter = MagicMock(side_effect=OSError(errno.EACCES, "denied"))
-        factory = _make_factory(statter=statter)
-        with pytest.raises(OSError, match="denied"):
-            factory._is_https_cache_refresh_needed(Path("/denied"), 3600)
-
-    def test_is_https_cache_refresh_needed_fresh_cache(self):
+class TestHttpsResolver:
+    def test_resolve_uses_cache_path_after_refresh_check(self):
+        """``resolve`` runs the cache-refresh check then builds via the factory."""
         statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
-        factory = _make_factory(
+        resolver = _make_https_resolver(
+            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
+        )
+        cfg = _make_config(location="nuremberg")
+        rh = resolver.resolve(cfg)
+        resolver.refhosts_factory.assert_called_once_with(  # ty: ignore[unresolved-attribute]
+            resolver.cache_path, "nuremberg"
+        )
+        assert rh is resolver.refhosts_factory.return_value  # ty: ignore[unresolved-attribute]
+
+    def test_is_refresh_needed_missing_file(self):
+        statter = MagicMock(side_effect=OSError(errno.ENOENT, "missing"))
+        resolver = _make_https_resolver(statter=statter)
+        assert resolver._is_refresh_needed(3600) is True
+
+    def test_is_refresh_needed_other_oserror_raises(self):
+        statter = MagicMock(side_effect=OSError(errno.EACCES, "denied"))
+        resolver = _make_https_resolver(statter=statter)
+        with pytest.raises(OSError, match="denied"):
+            resolver._is_refresh_needed(3600)
+
+    def test_is_refresh_needed_fresh_cache(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
+        resolver = _make_https_resolver(
             statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
         )
         # delta = 1; expiration = 3600 → no refresh.
-        assert factory._is_https_cache_refresh_needed(Path("/x"), 3600) is False
+        assert resolver._is_refresh_needed(3600) is False
 
-    def test_is_https_cache_refresh_needed_stale_cache(self):
+    def test_is_refresh_needed_stale_cache(self):
         statter = MagicMock(return_value=SimpleNamespace(st_mtime=0))
-        factory = _make_factory(
+        resolver = _make_https_resolver(
             statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
         )
-        assert factory._is_https_cache_refresh_needed(Path("/x"), 3600) is True
+        assert resolver._is_refresh_needed(3600) is True
 
-    def test_refresh_https_cache_writes_url_payload(self):
+    def test_refresh_writes_url_payload(self):
         url_resp = MagicMock()
         url_resp.read.return_value = b"yaml-bytes"
         urlopener = MagicMock(return_value=url_resp)
         file_writer = MagicMock()
-        factory = _make_factory(urlopener=urlopener, file_writer=file_writer)
-        factory.refresh_https_cache(Path("/dst"), "https://x/refhosts.yml")
+        resolver = _make_https_resolver(
+            urlopener=urlopener,
+            file_writer=file_writer,
+            cache_path=Path("/dst"),
+        )
+        resolver._refresh("https://x/refhosts.yml")
         urlopener.assert_called_once_with("https://x/refhosts.yml")
         file_writer.assert_called_once_with(b"yaml-bytes", Path("/dst"))
 
-    def test_refresh_https_cache_if_needed_skips_when_fresh(self):
+    def test_refresh_if_needed_skips_when_fresh(self):
         statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
-        factory = _make_factory(
+        resolver = _make_https_resolver(
             statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
         )
-        # urlopener untouched.
-        factory.refresh_https_cache_if_needed(Path("/x"), _make_config())
-        factory._urlopen.assert_not_called()
+        resolver._refresh_if_needed(_make_config())
+        resolver._urlopen.assert_not_called()
 
-    def test_refresh_https_cache_if_needed_refreshes_when_stale(self):
+    def test_refresh_if_needed_refreshes_when_stale(self):
         statter = MagicMock(return_value=SimpleNamespace(st_mtime=0))
         url_resp = MagicMock()
         url_resp.read.return_value = b"payload"
         urlopener = MagicMock(return_value=url_resp)
         file_writer = MagicMock()
-        factory = _make_factory(
+        resolver = _make_https_resolver(
             statter=statter,
             time_now_getter=MagicMock(return_value=1_000_000),
             urlopener=urlopener,
             file_writer=file_writer,
+            cache_path=Path("/x"),
         )
-        factory.refresh_https_cache_if_needed(Path("/x"), _make_config())
+        resolver._refresh_if_needed(_make_config())
         urlopener.assert_called_once()
         file_writer.assert_called_once_with(b"payload", Path("/x"))
 
-    def test_resolve_https_uses_cache_path(self):
-        """``resolve_https`` runs the cache-refresh check then builds via the factory."""
-        statter = MagicMock(return_value=SimpleNamespace(st_mtime=999_999))
-        factory = _make_factory(
-            statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
-        )
-        cfg = _make_config(location="nuremberg")
-        rh = factory.resolve_https(cfg)
-        factory.refhosts_factory.assert_called_once_with(
-            factory.refhosts_cache_path, "nuremberg"
-        )
-        assert rh is factory.refhosts_factory.return_value
 
-    def test_resolve_path_uses_configured_path(self):
-        factory = _make_factory()
-        cfg = _make_config(location="nuremberg")
-        rh = factory.resolve_path(cfg)
-        factory.refhosts_factory.assert_called_once_with(REFHOSTS_FIXTURE, "nuremberg")
-        assert rh is factory.refhosts_factory.return_value
+class TestRefhostsFactory:
+    def test_call_returns_first_successful_resolver(self):
+        path_resolver = MagicMock(spec=refhost.Resolver)
+        factory = refhost._RefhostsFactory({"path": path_resolver})
+        cfg = _make_config(refhosts_resolvers="path")
+        rh = factory(cfg)
+        path_resolver.resolve.assert_called_once_with(cfg)
+        assert rh is path_resolver.resolve.return_value
+
+    def test_call_falls_back_to_next_resolver_on_failure(self, caplog):
+        """A failing first resolver is logged and the second one is tried."""
+        failing = MagicMock(spec=refhost.Resolver)
+        failing.resolve.side_effect = RuntimeError("boom")
+        working = MagicMock(spec=refhost.Resolver)
+        factory = refhost._RefhostsFactory({"https": failing, "path": working})
+        cfg = _make_config(refhosts_resolvers="https,path")
+        with caplog.at_level("WARNING", logger="mtui.refhost"):
+            rh = factory(cfg)
+        failing.resolve.assert_called_once_with(cfg)
+        working.resolve.assert_called_once_with(cfg)
+        assert rh is working.resolve.return_value
+        assert any("resolver https failed" in r.message for r in caplog.records)
+
+    def test_call_raises_when_all_resolvers_fail(self):
+        failing = MagicMock(spec=refhost.Resolver)
+        failing.resolve.side_effect = RuntimeError("boom")
+        factory = refhost._RefhostsFactory({"https": failing, "path": failing})
+        cfg = _make_config(refhosts_resolvers="https,path")
+        with pytest.raises(refhost.RefhostsResolveFailedError):
+            factory(cfg)
+
+    def test_call_skips_unknown_resolver_and_continues(self, caplog):
+        """Unknown resolver names log a warning but don't abort the chain."""
+        working = MagicMock(spec=refhost.Resolver)
+        factory = refhost._RefhostsFactory({"path": working})
+        cfg = _make_config(refhosts_resolvers="nonexistent,path")
+        with caplog.at_level("WARNING", logger="mtui.refhost"):
+            rh = factory(cfg)
+        working.resolve.assert_called_once_with(cfg)
+        assert rh is working.resolve.return_value
+        assert any("invalid resolver: nonexistent" in r.message for r in caplog.records)
+
+    def test_call_raises_when_only_unknown_resolvers(self):
+        factory = refhost._RefhostsFactory({"path": MagicMock(spec=refhost.Resolver)})
+        cfg = _make_config(refhosts_resolvers="invalid_a,invalid_b")
+        with pytest.raises(refhost.RefhostsResolveFailedError):
+            factory(cfg)


### PR DESCRIPTION
## What

Phase 5b / C11 from `PLAN.md`: split `Refhosts.Attributes` into a typed
dataclass schema, and split the `_RefhostsFactory` resolvers into
separate `Resolver` classes behind a registry. Closes the existing
`# FIXME: split resolvers into separate classes` at the head of
`_RefhostsFactory`.

## Why

`mtui/refhost.py` carried three loose conventions that this refactor
tightens:

1. `Attributes` was a free-form class with three known fields
   (`arch`, `addons`, `product`) plus an escape hatch in
   `from_testplatform` that did `setattr(attribute, name, ...)` for
   `tags=(name)` segments and any unknown `name=value(...)` segment.
   `is_candidate_match` then iterated `vars(attribute)` to compare
   everything. Per the live `refhosts-ng.yml` schema (only
   `name/arch/product/addons` keys), those dynamic-attribute paths
   were never matched against anything real — SMELT's
   `parsemetajson.py` only forwards `base=...;arch=...;addon=...`
   triples (per `tests/test_metadataparsers.py` fixtures).
2. `_RefhostsFactory` had a stale `# FIXME` calling for resolver
   classes and dispatched via `getattr(self, f"resolve_{name}")`
   reflection.
3. Malformed host rows in `refhosts.yml` were silently dropped at
   search time with no operator-visible signal.

## How

- Typed schema: `Version(major, minor=None)`, `Product(name, version)`,
  `Addon(name, version)`, `Host(name, arch, product, addons=())` —
  all frozen. `Attributes(arch="", product=None, addons=[])` mutable
  (the parser builds it incrementally). The `minor == ""` sentinel
  for "candidate must NOT have a minor" is preserved.
- `Attributes.from_testplatform` now uses a strict three-token
  grammar (`base=`, `arch=[...]`, `addon=`). Unknown segments log
  ERROR and are skipped.
- `_host_from_dict` validates each YAML row; on `KeyError` /
  `TypeError`, logs ERROR and returns `None` so the loader drops
  malformed rows without aborting. YAML parse errors themselves
  still propagate as before.
- `Refhosts.data` is now `dict[str, list[Host]]`;
  `is_candidate_match` walks the three typed fields directly via
  three statics (`_product_matches`, `_version_matches`,
  `_addons_match`). Location-fallback to `"default"` is unchanged.
- `Resolver(ABC)` + `PathResolver` + `HttpsResolver`. `HttpsResolver`
  owns the cache-refresh logic (`_refresh_if_needed`,
  `_is_refresh_needed`, `_refresh` as private methods).
  `_RefhostsFactory({"https": ..., "path": ...})` is now a
  dispatcher that selects resolvers from its registry by name.

In-tree public API preserved (`Attributes`,
`Attributes.from_testplatform`, `Refhosts`, `Refhosts.search`,
`Refhosts.get_locations`, `Refhosts.check_location_sanity`,
`RefhostsResolveFailedError`, `RefhostsFactory` — all unchanged).
Out-of-tree consumers that constructed `_RefhostsFactory` directly
need to migrate to the new `{name: Resolver}` constructor; see
CHANGELOG.

## Test plan

- `uv run ruff format --check .` — 182 files already formatted.
- `uv run ruff check .` — clean.
- `uv run ty check` — clean (no warnings; `error-on-warning` is on
  with the strict `mtui/types/**` and `mtui/connector/**` overrides).
- `uv run pytest` — **691 passed** (C4 baseline 688 + 56 in the
  rewritten `test_refhost.py` − 53 retired old `test_refhost.py`
  cases = net +3).
- Manual `uv run python -m mtui --help` / `-V` — OK.

Sanity searches (all 0):

- `rg "vars\(attribute\)|setattr\(attribute" mtui/refhost.py` → 0.
- `rg 'getattr\(self, f"resolve_' mtui/refhost.py` → 0.
- `rg FIXME mtui/refhost.py` → 0.

## Commits

- `25f7328` `refactor(refhost): typed Host/Attributes dataclasses + Resolver registry`
- `706963a` `docs(changelog): note refhost typed schema and resolver split`
- `93a6376` `docs(plan): mark Phase 5b / C11 as DONE`

The refactor and the test rewrite are intentionally in one commit
(`25f7328`) so HEAD stays green at every step and bisect blames the
right change. The new tests cover the same matcher branches as the
prior 53 cases plus three new addon-matching paths
(`test_addon_missing_on_candidate_returns_false`,
`test_addon_version_mismatch_returns_false`,
`test_addon_name_only_matches_any_version`) and one new schema-
validation path (`test_parse_refhosts_drops_malformed_host_and_logs`).

## Changelog

`[Unreleased] / Fixed`:

- Malformed host rows in `refhosts.yml` are now logged at ERROR level
  and dropped; previously they were silently skipped at search time
  with no operator-visible signal.

`[Unreleased] / Changed`:

- Internal refactor: `mtui.refhost` was rewritten around a typed
  schema and a `Resolver` registry. Behaviour is unchanged for
  in-tree callers; out-of-tree consumers may need to migrate.
  Migration map:
  - `Attributes` is now a `@dataclass` with typed fields. The
    historical `tags=(name)` and `<other>=name(...)` segments in
    `testplatform` strings are no longer parsed (unknown segments
    log ERROR and are skipped).
  - `Refhosts.data` is now `dict[str, list[Host]]` (was
    `dict[str, list[dict]]`); the matcher works against typed
    fields.
  - `_RefhostsFactory` now takes a `dict[str, Resolver]` registry
    instead of five positional collaborators. Use
    `_RefhostsFactory({"https": HttpsResolver(...), "path": PathResolver()})`.

## Tracking

`PLAN.md` Phase 5b / C11 — see the new section in `PLAN.md` after C4
for the full eight-task breakdown, the plan-mode decisions, and the
carry-overs (none new).
