### PR TITLE
fix(connection): serialise SSH timeout prompt across worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Parallel target operations no longer race for `stdin` when an SSH
+  command times out on multiple hosts simultaneously. The timeout
+  prompt (`command "..." timed out on <host>. wait? (Y/n)`) is now
+  serialised through a single `mtui.prompter.Prompter` constructed in
+  `main()` and threaded down through `CommandPrompt` / `TestReport` /
+  `Target` to `Connection`. Previously the prompt was raised from the
+  SSH worker thread via a bare `input()` call; with several hosts in
+  flight two workers could attempt to read the same line of input and
+  prompt text was interleaved with sibling stdout writes. Library
+  callers that build `Connection` directly without wiring a prompter
+  now silently wait on timeout (matching the historical Enter / Y
+  default) and emit one `WARNING` log line so the silence is
+  observable (Phase 5b / C6).
 - `Config` now logs an error and falls back to the documented default when
   an INI value fails to parse. Previously `connection_timeout = abc`
   crashed startup with an uncaught `ValueError`, and malformed typed

--- a/mtui/connection.py
+++ b/mtui/connection.py
@@ -13,7 +13,7 @@ import stat
 import sys
 import termios
 import tty
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from logging import getLogger
 from pathlib import Path
@@ -82,6 +82,7 @@ class Connection:
 
     __slots__ = [
         "_policy",
+        "_timeout_prompt",
         "client",
         "command",
         "hostname",
@@ -98,6 +99,7 @@ class Connection:
         port: int | str,
         timeout: int,
         missing_host_key_policy: paramiko.MissingHostKeyPolicy | None = None,
+        timeout_prompt: Callable[[str], str] | None = None,
     ) -> None:
         """Opens an SSH channel to the specified host.
 
@@ -111,8 +113,19 @@ class Connection:
             missing_host_key_policy: paramiko policy applied to unknown
                 host keys. ``None`` (the default) preserves the legacy
                 behaviour of ``AutoAddPolicy``.
+            timeout_prompt: Optional callable invoked with prompt text
+                when a remote command times out. Returns the user's
+                response (Enter / ``y`` to wait, ``n`` to abort). When
+                ``None`` (the default) the timeout branch silently
+                loops back to wait for the command — matching the
+                long-standing Enter / Y default — and emits one WARNING
+                log line so the silence is observable. Wire a
+                :class:`mtui.prompter.Prompter`'s ``ask`` method here
+                to surface a serialised, race-free prompt to the user
+                when multiple targets run a command in parallel.
 
         """
+        self._timeout_prompt = timeout_prompt
         self.hostname = hostname
 
         try:
@@ -380,24 +393,30 @@ class Connection:
                         f"Session lost during command execution on {self.hostname}"
                     )
 
-                # writing on stdout needs locking as all run threads could
-                # write at the same time to stdout
-                if lock:
-                    lock.acquire()
+                # No prompt callback wired: silently wait. Matches the
+                # long-standing Enter / Y default but emits a WARNING
+                # so the silence is observable in logs.
+                if self._timeout_prompt is None:
+                    logger.warning(
+                        'command "%s" timed out on %s; no prompt callback wired, '
+                        "waiting for completion",
+                        command,
+                        self.hostname,
+                    )
+                    continue
 
-                try:
-                    if input(
-                        f'command "{command}" timed out on {self.hostname}. wait? (Y/n) ',
-                    ).lower() not in ("no", "n", "ne", "nein"):
-                        continue
-                    # if the user don't want to wait, raise CommandTimeoutError
-                    # and procceed
-                    raise CommandTimeoutError
-                finally:
-                    # release lock to allow other command threads to write to
-                    # stdout
-                    if lock:
-                        lock.release()
+                # Prompt callback wired: ask the user. The callback is
+                # responsible for any cross-thread serialisation (the
+                # production wiring uses ``Prompter.ask`` which holds a
+                # single lock so workers don't race for stdin).
+                answer = self._timeout_prompt(
+                    f'command "{command}" timed out on {self.hostname}. wait? (Y/n) ',
+                )
+                if answer.lower() not in ("no", "n", "ne", "nein"):
+                    continue
+                # If the user don't want to wait, raise CommandTimeoutError
+                # and procceed.
+                raise CommandTimeoutError
 
             try:
                 # wait for data on the session's stdout/stderr. if debug is enabled,

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -15,6 +15,7 @@ from .display import CommandPromptDisplay
 from .exceptions import MissingGiteaTokenError
 from .messages import MetadataNotLoadedError, SvnCheckoutInterruptedError
 from .prompt import CommandPrompt
+from .prompter import Prompter
 from .systemcheck import detect_system
 
 
@@ -69,7 +70,11 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
 
     config.distro, config.distro_ver, config.distro_kernel = detect_system()
 
-    prompt = CommandPrompt(config, logger, sys, CommandPromptDisplay)
+    # One Prompter for the whole process: serialises SSH command-timeout
+    # prompts across worker threads behind a single lock so they reach
+    # the user one at a time (no stdin races, no interleaved prompt text).
+    prompter = Prompter()
+    prompt = CommandPrompt(config, logger, sys, CommandPromptDisplay, prompter=prompter)
     prompt.interactive = not args.noninteractive
     if args.update:
         if args.update.kind == "kernel":

--- a/mtui/prompt.py
+++ b/mtui/prompt.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from .prompter import Prompter
+
 from mtui import notification
 
 from . import commands, messages
@@ -97,7 +99,9 @@ class CommandPrompt(cmd.Cmd):
     # frameworks. Eg. cement. Maybe there's something in twisted, which
     # would be great if it could replace the ssh layer as well.
 
-    def __init__(self, config, log, sys, display_factory) -> None:
+    def __init__(
+        self, config, log, sys, display_factory, prompter: "Prompter | None" = None
+    ) -> None:
         """Initializes the command prompt.
 
         Args:
@@ -105,14 +109,20 @@ class CommandPrompt(cmd.Cmd):
             log: The logger instance.
             sys: The sys module.
             display_factory: A factory for creating display objects.
+            prompter: Optional :class:`mtui.prompter.Prompter` forwarded
+                to every constructed :class:`TestReport` so that SSH
+                command-timeout prompts surface to the user with
+                cross-thread serialisation. ``None`` (the default)
+                disables the prompt: command timeouts silently wait.
 
         """
         self.sys = sys
+        self.prompter = prompter
 
         super().__init__(stdout=self.sys.stdout, stdin=self.sys.stdin)
         self.interactive: bool = True
         self.display = display_factory(self.sys.stdout)
-        self.metadata = NullTestReport(config)
+        self.metadata = NullTestReport(config, prompter=prompter)
         self.targets = self.metadata.targets
         """
         alias to ease refactoring
@@ -317,7 +327,12 @@ class CommandPrompt(cmd.Cmd):
             autoconnect: Whether to automatically connect to hosts.
 
         """
-        tr = update.make_testreport(self.config, autoconnect, self.interactive)
+        tr = update.make_testreport(
+            self.config,
+            autoconnect,
+            self.interactive,
+            prompter=self.prompter,
+        )
         self.metadata = tr
         self.targets = tr.targets
         self.set_prompt(None)

--- a/mtui/prompter.py
+++ b/mtui/prompter.py
@@ -1,0 +1,63 @@
+"""Cross-thread serialised user prompter.
+
+Worker threads (e.g. SSH command runners spawned by
+:func:`mtui.target.actions.run_parallel`) used to call :func:`input`
+directly. With multiple targets racing for ``stdin`` the prompt text
+got interleaved with sibling ``stdout`` writes and two workers could
+attempt to read the same line of input.
+
+:class:`Prompter` serialises those prompts behind a single
+:class:`threading.Lock`. Only one worker reads ``stdin`` at a time;
+the others queue politely on the lock until the current prompt
+returns. The lock alone is enough because :func:`input` is the only
+``stdin`` reader — there is no background dispatcher thread, no
+``queue.Queue``, no module-level singleton.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+
+class Prompter:
+    """Serialise interactive :func:`input` calls across worker threads.
+
+    The instance owns one lock. :meth:`ask` acquires it, calls the
+    injected reader (default :func:`input`), releases the lock in a
+    ``finally``. Callers from any thread are safe to call concurrently;
+    they observe strictly sequential prompts in lock-acquisition order.
+
+    The reader is injectable to keep the class unit-testable without
+    going through real ``stdin``.
+    """
+
+    __slots__ = ("_lock", "_reader")
+
+    def __init__(self, reader: Callable[[str], str] = input) -> None:
+        """Initialise the prompter.
+
+        Args:
+            reader: Callable invoked with the prompt text; must return
+                the user's response. Defaults to :func:`input`.
+
+        """
+        self._lock = threading.Lock()
+        self._reader = reader
+
+    def ask(self, text: str) -> str:
+        """Prompt the user with ``text`` and return the typed response.
+
+        Acquires the prompter's lock for the duration of the read so
+        sibling workers cannot race for ``stdin``.
+
+        Args:
+            text: The prompt text shown to the user.
+
+        Returns:
+            The string the user typed (stripped of nothing; behaviour
+            identical to :func:`input`).
+
+        """
+        with self._lock:
+            return self._reader(text)

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from pathlib import Path
 from string import Template
 from traceback import format_exc
-from typing import Any, final
+from typing import TYPE_CHECKING, Any, final
 
 from .. import messages
 from ..actions import downgrader, installer, preparer, uninstaller, updater
@@ -21,6 +21,9 @@ from . import TargetLock, TargetLockedError
 from .package_querier import PackageQuerier
 from .repo_manager import RepoManager
 from .reporter import Reporter
+
+if TYPE_CHECKING:
+    from ..prompter import Prompter
 
 logger = getLogger("mtui.target")
 
@@ -69,6 +72,7 @@ class Target:
         mode: ExecutionMode = ExecutionMode.PARALLEL,
         lock: type[TargetLock] = TargetLock,
         connection: type[Connection] = Connection,
+        prompter: "Prompter | None" = None,
     ) -> None:
         """Initializes the `Target` object.
 
@@ -82,6 +86,11 @@ class Target:
                 rest of its group or holds the group in a serial barrier.
             lock: The lock class to use for the target.
             connection: The connection class to use for the target.
+            prompter: Optional :class:`mtui.prompter.Prompter` used to
+                surface SSH command-timeout questions to the user with
+                cross-thread serialisation. ``None`` means "no prompt,
+                silently wait on timeout" — see
+                :class:`mtui.connection.Connection`.
 
         """
         self.config = config
@@ -92,6 +101,7 @@ class Target:
         self.out = HostLog()
         self.TargetLock = lock
         self.Connection = connection
+        self._prompter = prompter
 
         self.state: TargetState | str = TargetState(state)
         # default timeout for target, used only on connecting/reconnecting Target
@@ -137,6 +147,7 @@ class Target:
                 self.port,
                 self._timeout,
                 missing_host_key_policy=policy_from_config(policy_name),
+                timeout_prompt=self._prompter.ask if self._prompter else None,
             )
         except Exception as e:
             logger.critical(messages.ConnectingTargetFailedMessage(self.hostname, e))

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -14,7 +14,7 @@ from json.decoder import JSONDecodeError
 from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..config import Config
 from ..datafiles import scripts_path
@@ -26,6 +26,9 @@ from ..target.hostgroup import HostsGroup
 from ..template import TemplateIOError, TestReportAlreadyLoadedError
 from ..types import OpenQAResults, Product, TargetMeta
 from ..utils import ensure_dir_exists
+
+if TYPE_CHECKING:
+    from ..prompter import Prompter
 
 logger = getLogger("mtui.template.testreport")
 
@@ -46,15 +49,26 @@ class TestReport(ABC):
     # -- Attributes set dynamically by UpdateID subclasses --
     incident: Any
 
-    def __init__(self, config: Config, scripts_src_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        config: Config,
+        scripts_src_dir: Path | None = None,
+        prompter: "Prompter | None" = None,
+    ) -> None:
         """Initializes the `TestReport` object.
 
         Args:
             config: The application configuration.
             scripts_src_dir: The source directory for scripts.
+            prompter: Optional :class:`mtui.prompter.Prompter` forwarded
+                to every :class:`mtui.target.Target` built by
+                :meth:`connect_target` and :meth:`add_target`. ``None``
+                means "no prompt"; SSH command timeouts will silently
+                wait. See :class:`mtui.connection.Connection`.
 
         """
         self.config: Config = config
+        self._prompter = prompter
 
         self._scripts_src_dir: Path = scripts_src_dir or scripts_path()
 
@@ -376,6 +390,7 @@ class TestReport(ABC):
                 host,
                 self.packages,
                 timeout=self.config.connection_timeout,
+                prompter=self._prompter,
             )
             target.connect()
             new_system = str(target.system)
@@ -450,7 +465,12 @@ class TestReport(ABC):
             )
             return
         try:
-            self.targets[hostname] = Target(self.config, hostname, self.packages)
+            self.targets[hostname] = Target(
+                self.config,
+                hostname,
+                self.packages,
+                prompter=self._prompter,
+            )
             self.targets[hostname].connect()
 
             if self:

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -5,7 +5,10 @@ from collections.abc import Callable
 from errno import ENOENT
 from logging import getLogger
 from pathlib import Path
-from typing import final
+from typing import TYPE_CHECKING, final
+
+if TYPE_CHECKING:
+    from ..prompter import Prompter
 
 from mtui.exceptions import (
     FailedGiteaCallError,
@@ -56,17 +59,28 @@ class UpdateID(ABC):
         self.testreport_factory = testreport_factory
         self._vcs_checkout = testreport_svn_checkout
 
-    def _checkout(self, config: Config, interactive: bool) -> TestReport:
+    def _checkout(
+        self,
+        config: Config,
+        interactive: bool,
+        prompter: "Prompter | None" = None,
+    ) -> TestReport:
         """Checks out a test report from version control.
 
         Args:
             config: The application configuration.
+            interactive: Whether to prompt the user for confirmation on
+                template hash mismatches.
+            prompter: Optional :class:`mtui.prompter.Prompter` forwarded
+                to the constructed :class:`TestReport` so that SSH
+                command-timeout prompts can reach the user with
+                cross-thread serialisation.
 
         Returns:
             A `TestReport` instance.
 
         """
-        tr = self.testreport_factory(config)
+        tr = self.testreport_factory(config, prompter=prompter)
         trdir: Path = config.template_dir / str(self.id)
         trpath: Path = trdir / "log"
 
@@ -130,7 +144,11 @@ class UpdateID(ABC):
 
     @abstractmethod
     def make_testreport(
-        self, config: Config, autoconnect: bool = True, interactive: bool = True
+        self,
+        config: Config,
+        autoconnect: bool = True,
+        interactive: bool = True,
+        prompter: "Prompter | None" = None,
     ) -> TestReport:
         """An abstract method for creating a `TestReport` instance."""
         ...
@@ -173,22 +191,29 @@ class AutoOBSUpdateID(UpdateID):
         super().__init__(id_, self.tr_factory(id_), testreport_svn_checkout)
 
     def make_testreport(
-        self, config: Config, autoconnect: bool = True, interactive: bool = True
+        self,
+        config: Config,
+        autoconnect: bool = True,
+        interactive: bool = True,
+        prompter: "Prompter | None" = None,
     ) -> TestReport:
         """Creates a `TestReport` instance for an automatic OBS update.
 
         Args:
             config: The application configuration.
             autoconnect: Whether to automatically connect to hosts.
+            interactive: Whether to prompt the user.
+            prompter: Optional :class:`mtui.prompter.Prompter` forwarded
+                to the constructed :class:`TestReport`.
 
         Returns:
             A `TestReport` instance.
 
         """
         try:
-            tr = self._checkout(config, interactive)
+            tr = self._checkout(config, interactive, prompter=prompter)
         except TestReportNotLoadedError:
-            return NullTestReport(config)
+            return NullTestReport(config, prompter=prompter)
 
         self._create_installogs_dir(config)
         tr.incident = QEMIncident(self.id, config.qem_dashboard_api)
@@ -249,22 +274,29 @@ class KernelOBSUpdateID(UpdateID):
         directory.mkdir(parents=False, exist_ok=True)
 
     def make_testreport(
-        self, config: Config, autoconnect: bool = False, interactive: bool = True
+        self,
+        config: Config,
+        autoconnect: bool = False,
+        interactive: bool = True,
+        prompter: "Prompter | None" = None,
     ) -> TestReport:
         """Creates a `TestReport` instance for a kernel OBS update.
 
         Args:
             config: The application configuration.
             autoconnect: Whether to automatically connect to hosts.
+            interactive: Whether to prompt the user.
+            prompter: Optional :class:`mtui.prompter.Prompter` forwarded
+                to the constructed :class:`TestReport`.
 
         Returns:
             A `TestReport` instance.
 
         """
         try:
-            tr = self._checkout(config, interactive)
+            tr = self._checkout(config, interactive, prompter=prompter)
         except TestReportNotLoadedError:
-            return NullTestReport(config)
+            return NullTestReport(config, prompter=prompter)
 
         self._create_installogs_dir(config)
         self.create_results_dir(config)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -104,18 +104,161 @@ def test_run_command_success(mock_ssh_client, mock_ssh_config, mock_path):
 
 
 def test_run_command_timeout(mock_ssh_client, mock_ssh_config, mock_path):
-    """Test command timeout in the 'run' method."""
-    conn = Connection("test_host", 22, 300)
+    """Timeout + callback returning 'n' must raise ``CommandTimeoutError``.
+
+    Rewritten from the prior ``patch("builtins.input", ...)`` shape:
+    the new ``Connection.__init__`` takes an injectable ``timeout_prompt``
+    callable, so the test wires one directly instead of monkey-patching
+    the global ``input`` builtin.
+    """
+    conn = Connection("test_host", 22, 300, timeout_prompt=lambda _text: "n")
 
     mock_session = MagicMock()
     mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
 
     with (
         patch("select.select", return_value=([], [], [])),
-        patch("builtins.input", return_value="n"),
         pytest.raises(CommandTimeoutError),
     ):
         conn.run("sleep 10")
+
+
+def test_run_command_timeout_wait_continues(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """Timeout + callback returning Enter (empty) must loop and complete.
+
+    First ``select.select`` returns "no fds ready" (timeout); the
+    callback returns ``""`` (Enter) which the parser treats as "wait".
+    Second ``select.select`` returns the session ready so the recv
+    loop terminates normally with exit code 0.
+    """
+    prompt_calls = []
+
+    def _prompt(text: str) -> str:
+        prompt_calls.append(text)
+        return ""  # Enter == wait
+
+    conn = Connection("test_host", 22, 300, timeout_prompt=_prompt)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"done", b""]
+    mock_session.recv_stderr.side_effect = [b""]
+    mock_session.recv_ready.side_effect = [True, False]
+    mock_session.recv_stderr_ready.side_effect = [False, False]
+
+    # Three outer iterations: (1) select times out → continue,
+    # (2) select ready → recv "done" → buffer non-empty → loop,
+    # (3) select ready → no data → break.
+    with patch(
+        "select.select",
+        side_effect=[
+            ([], [], []),
+            ([mock_session], [], []),
+            ([mock_session], [], []),
+        ],
+    ):
+        exit_code = conn.run("sleep 1")
+
+    assert exit_code == 0
+    assert len(prompt_calls) == 1
+    assert "timed out" in prompt_calls[0]
+    assert "test_host" in prompt_calls[0]
+
+
+def test_run_command_timeout_no_callback_waits_silently(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """No callback wired: loop silently after a WARNING log line.
+
+    Pins the default behaviour for library callers / scripts / tests
+    that build a ``Connection`` without a prompter. The legacy code
+    would have blocked on ``input()``; the new default emits a
+    WARNING and continues to wait, preserving the Enter / Y default.
+    """
+    import logging
+
+    conn = Connection("test_host", 22, 300)  # no timeout_prompt
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"done", b""]
+    mock_session.recv_stderr.side_effect = [b""]
+    mock_session.recv_ready.side_effect = [True, False]
+    mock_session.recv_stderr_ready.side_effect = [False, False]
+
+    # Three outer iterations: (1) select times out → WARNING → continue,
+    # (2) select ready → recv "done" → loop, (3) select ready → no data → break.
+    with (
+        caplog.at_level(logging.WARNING, logger="mtui.connection"),
+        patch(
+            "select.select",
+            side_effect=[
+                ([], [], []),
+                ([mock_session], [], []),
+                ([mock_session], [], []),
+            ],
+        ),
+    ):
+        exit_code = conn.run("sleep 1")
+
+    assert exit_code == 0
+    assert any(
+        "timed out on test_host" in rec.message
+        and "no prompt callback wired" in rec.message
+        for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+def test_run_command_timeout_callback_runs_on_calling_thread(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """The injected callback runs synchronously on ``Connection.run``'s thread.
+
+    Pins the C6 invariant: ``Connection.run`` does NOT spawn a fresh
+    thread for the prompt. Whatever serialisation the callback
+    performs (the production :class:`Prompter` holds a lock) is
+    therefore the only thing fencing concurrent worker prompts. If a
+    future change accidentally re-introduced a worker-side prompt
+    thread, this test would catch it.
+    """
+    import threading
+
+    captured_thread_ident: list[int] = []
+
+    def _prompt(_text: str) -> str:
+        captured_thread_ident.append(threading.get_ident())
+        return "n"  # abort
+
+    conn = Connection("test_host", 22, 300, timeout_prompt=_prompt)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+
+    worker_thread_ident: list[int] = []
+
+    def _drive() -> None:
+        worker_thread_ident.append(threading.get_ident())
+        with (
+            patch("select.select", return_value=([], [], [])),
+            pytest.raises(CommandTimeoutError),
+        ):
+            conn.run("sleep 10")
+
+    t = threading.Thread(target=_drive)
+    t.start()
+    t.join(timeout=5)
+    assert not t.is_alive(), "worker thread leaked"
+
+    assert len(captured_thread_ident) == 1
+    assert len(worker_thread_ident) == 1
+    assert captured_thread_ident[0] == worker_thread_ident[0], (
+        "callback must run on the same thread as Connection.run, not a "
+        "fresh one spawned by Connection itself"
+    )
 
 
 def test_connection_invalid_port_warns_and_falls_back(

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -390,7 +390,9 @@ def test_load_update_swaps_metadata_and_targets():
     update = MagicMock()
     update.make_testreport.return_value = new_tr
     p.load_update(update, autoconnect=False)
-    update.make_testreport.assert_called_once_with(p.config, False, p.interactive)
+    update.make_testreport.assert_called_once_with(
+        p.config, False, p.interactive, prompter=p.prompter
+    )
     assert p.metadata is new_tr
     assert p.targets is new_targets
     # ``set_prompt(None)`` resets the session marker to empty.

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -1,0 +1,120 @@
+"""Behaviour tests for :class:`mtui.prompter.Prompter`.
+
+The Prompter owns a single :class:`threading.Lock` so that concurrent
+worker threads asking the user for input over ``stdin`` see strictly
+sequential prompts. There must be no interleaving, no race, no second
+prompt before the first one returns.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from unittest.mock import MagicMock
+
+from mtui.prompter import Prompter
+
+
+def test_ask_returns_reader_response():
+    """``ask`` returns whatever the injected reader returns, verbatim."""
+    reader = MagicMock(return_value="hello")
+    p = Prompter(reader=reader)
+
+    assert p.ask("question? ") == "hello"
+    reader.assert_called_once_with("question? ")
+
+
+def test_default_reader_is_input():
+    """When no reader is supplied the default is :func:`input`.
+
+    Pinning the default keeps the production wiring (``Prompter()``
+    with no args) from accidentally swapping out the real ``stdin``
+    reader.
+    """
+    p = Prompter()
+    assert p._reader is input  # noqa: SLF001
+
+
+def test_concurrent_asks_are_serialised():
+    """Two concurrent ``ask`` calls never overlap; the lock fences them.
+
+    Each ``reader`` call sleeps 50 ms. If the prompts ran in parallel
+    the total wall-clock would be ~50 ms. With the lock it must be
+    ≥ 100 ms because the second thread waits for the first to release.
+    The order is pinned by an :class:`~threading.Event` that the
+    second thread waits on before calling ``ask`` so the first thread
+    is guaranteed to acquire the lock first.
+    """
+    call_order: list[str] = []
+    inside: list[str] = []
+
+    def _reader(text: str) -> str:
+        inside.append(text)
+        time.sleep(0.05)
+        call_order.append(text)
+        return text
+
+    p = Prompter(reader=_reader)
+    second_can_start = threading.Event()
+    first_acquired_lock = threading.Event()
+
+    def _first() -> None:
+        # Acquire-and-hold pattern: replace the reader with a wrapper
+        # that signals the lock has been taken before sleeping, so the
+        # second thread can start its ask() knowing the first is in
+        # flight.
+        first_acquired_lock.set()
+        p.ask("first ")
+
+    def _second() -> None:
+        second_can_start.wait(timeout=5)
+        p.ask("second ")
+
+    t1 = threading.Thread(target=_first)
+    t2 = threading.Thread(target=_second)
+
+    start = time.monotonic()
+    t1.start()
+    first_acquired_lock.wait(timeout=5)
+    # Tiny gap so t1 is definitely inside the lock before t2 contends.
+    time.sleep(0.01)
+    second_can_start.set()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    elapsed = time.monotonic() - start
+
+    assert not t1.is_alive()
+    assert not t2.is_alive()
+    assert call_order == ["first ", "second "], call_order
+    assert inside == ["first ", "second "], inside
+    # ≥ 2 × 50 ms with some scheduling slack.
+    assert elapsed >= 0.1, f"prompts ran in parallel: {elapsed:.3f}s"
+
+
+def test_reader_exception_releases_lock():
+    """A reader that raises must still release the lock for the next caller.
+
+    The ``with self._lock`` context manager guarantees release on
+    exception; this test pins that contract so a future refactor
+    can't accidentally swap to ``acquire()`` / ``release()`` without
+    a ``finally``.
+    """
+    calls = []
+
+    def _reader(text: str) -> str:
+        calls.append(text)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+        return "ok"
+
+    p = Prompter(reader=_reader)
+
+    with contextlib.suppress(RuntimeError):
+        p.ask("first ")
+
+    # If the lock was leaked, this call would deadlock; pytest would
+    # eventually time out. We assert it returns promptly.
+    assert p.ask("second ") == "ok"
+    assert calls == ["first ", "second "]


### PR DESCRIPTION
## Summary

Move the SSH \`command timed out, wait? (Y/n)\` prompt out of the SSH worker thread and behind a single lock-serialised \`Prompter\` constructed once in \`main()\`.

## Why

\`Connection.run\` previously raised the timeout prompt with a bare \`input()\` call from inside the worker thread spawned by \`run_parallel\`. With multiple targets in flight two workers could both hit the \`select()\` timeout, race for \`stdin\`, and read each other's input; the prompt text itself was also interleaved with sibling debug log writes. The existing test never exposed this because it monkey-patched \`builtins.input\` on the main thread.

## What

- **New \`mtui/prompter.py\`** \u2014 \`Prompter\` class holding one \`threading.Lock\`. \`ask(text)\` acquires it for the duration of the read so concurrent workers queue politely instead of racing for \`stdin\`.
- **\`Connection.__init__\`** takes \`timeout_prompt: Callable[[str], str] | None\` (default \`None\` = silent wait + one \`WARNING\` log line so the silence is observable). The bare \`input()\` block in \`Connection.run\` is replaced by a call to the injected callback.
- **Wiring**: \`Target\`, \`TestReport\`, \`UpdateID.make_testreport\` / \`_checkout\`, and \`CommandPrompt\` all gain an optional \`prompter\` parameter and forward it through the construction chain. \`main()\` builds the single \`Prompter()\` and injects it into \`CommandPrompt\`. No module-level globals.
- **Library callers** that construct \`Connection\` directly without wiring a prompter silently wait on timeout (matching the long-standing Enter/Y default).

## Tests

- **\`tests/test_prompter.py\`** \u2014 4 new tests: reader-response, default-is-\`input\`, concurrent-serialisation (asserts two parallel \`ask()\` calls take \u2265 2\u00d7 the per-call wait), exception-releases-lock.
- **\`tests/test_connection.py\`** \u2014 existing \`test_run_command_timeout\` rewritten to inject the callback instead of patching \`builtins.input\`; 3 new tests:
  - \`test_run_command_timeout_wait_continues\` \u2014 Enter / \"\" reply continues the loop and the command completes normally.
  - \`test_run_command_timeout_no_callback_waits_silently\` \u2014 no callback wired \u2192 \`WARNING\` log + silent wait + normal completion.
  - \`test_run_command_timeout_callback_runs_on_calling_thread\` \u2014 pins that \`Connection.run\` does NOT spawn a fresh thread for the prompt; whatever serialisation the callback performs is therefore the only fence between concurrent workers.
- **\`tests/test_prompt.py\`** \u2014 \`load_update\` test updated to expect the new \`prompter=\` kwarg.

## Verification

- \`uv run ruff format --check .\` \u2192 184 files clean
- \`uv run ruff check .\` \u2192 clean
- \`uv run ty check\` \u2192 clean (strict overrides on \`mtui/types/**\` and \`mtui/connector/**\` honoured)
- \`uv run pytest\` \u2192 698 passed (+7 net new)
- \`uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html\` \u2192 build succeeded
- \`uv run python -m mtui --help\` \u2192 exit 0
- \`uv run python -m mtui -V\` \u2192 exit 0
- \`rg 'input\\(' mtui/connection.py\` \u2192 0 hits

## User-visible behaviour change

Documented under \`CHANGELOG.md\` \`[Unreleased] / Fixed\`.

## Out of scope

\`mtui/commands/apicall.py\` has two bare \`input(\"Comment: \")\` calls inside \`do_*\` command handlers. Those run on the main \`cmd.Cmd\` thread (synchronously inside \`cmdloop\`), not inside an SSH worker, so they are correctness-safe today. Routing them through the same \`Prompter\` for UX consistency would be a follow-up, not a fix.