### PR TITLE
feat(locks): reap stale reference-host locks on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Stale reference-host locks are now reaped automatically on connect.
+  When `add_host` (or any connect) finds a pre-existing `/var/lock/mtui.lock`
+  older than a configurable threshold, mtui force-removes it regardless of
+  owner — including exclusive (commented) locks — since such a lock is
+  almost always left over from a crashed or abandoned session. The removal
+  is logged at `WARNING` (`<host>: removing stale lock held by <user>
+  (<N> h old)`). Controlled by two new `[lock]` config options:
+  `reap_stale` (default `true`) and `stale_age` in seconds (default
+  `86400`, i.e. one day); set `reap_stale = false` or `stale_age = 0` to
+  restore the previous behaviour of only warning. Fresh locks are still
+  only reported, never removed.
+
 ### Tests
 
 - Phase 6 test backfill: total suite grew from 697 to 952 tests

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -384,6 +384,35 @@ Gitea API access token, this config has higher prio than environment
 variable. Token must have full access to the issue API.
 
 
+``lock.reap_stale``
+~~~~~~~~~~~~~~~~~~~
+
+  | **type**
+  |     bool
+  | **default**
+  |     ``True``
+
+When connecting to a reference host, force-remove a pre-existing
+``/var/lock/mtui.lock`` that is older than ``lock.stale_age`` regardless
+of which user or session created it (including exclusive, commented
+locks). Such a lock is almost always left over from a crashed or
+abandoned session. Set to ``false`` to only warn about pre-existing
+locks, as in older releases. Fresh locks are never removed.
+
+
+``lock.stale_age``
+~~~~~~~~~~~~~~~~~~
+
+  | **type**
+  |     int (seconds)
+  | **default**
+  |     86400
+
+Age, in seconds, beyond which a remote lock is considered stale and
+eligible for automatic removal (see ``lock.reap_stale``). A value of
+``0`` disables reaping.
+
+
 Example
 =======
 
@@ -407,3 +436,7 @@ Example
 
   [gitea]
   token = s3cr3t_token
+
+  [lock]
+  reap_stale = true
+  stale_age = 86400

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -83,6 +83,8 @@ class Config:
     threshold: int
     gitea_token: str
     ssh_strict_host_key_checking: str
+    lock_reap_stale: bool
+    lock_stale_age: int
 
     # -- Attributes set externally in main.py --
     kernel: bool
@@ -370,6 +372,23 @@ class Config:
                 "auto_add",
                 str,
                 get,
+            ),
+            # On connect, force-remove a pre-existing remote lock older
+            # than ``lock_stale_age`` seconds regardless of owner. Set
+            # ``reap_stale = false`` (or ``stale_age = 0``) to disable.
+            ConfigOption(
+                "lock_reap_stale",
+                ("lock", "reap_stale"),
+                True,
+                bool,
+                getboolean,
+            ),
+            ConfigOption(
+                "lock_stale_age",
+                ("lock", "stale_age"),
+                86400,
+                int,
+                getint,
             ),
         ]
 

--- a/mtui/target/locks.py
+++ b/mtui/target/locks.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+import time
 from datetime import datetime
 from logging import getLogger
 from pathlib import Path
@@ -127,6 +128,7 @@ class TargetLock:
 
         """
         self.connection = connection
+        self.config = config
         self.i_am_user = config.session_user
         self.i_am_pid = os.getpid()
         """
@@ -163,6 +165,57 @@ class TargetLock:
         """
         self.load()
         return bool(self._lock.user)
+
+    def age_seconds(self) -> int | None:
+        """Returns the age of the current remote lock in seconds.
+
+        Returns:
+            The lock age in seconds, or None when there is no lock or the
+            stored timestamp is missing/malformed (so callers treat such a
+            lock as "leave it alone").
+
+        """
+        self.load()
+        if not self._lock.user or not self._lock.timestamp:
+            return None
+        try:
+            return int(time.time()) - int(self._lock.timestamp)
+        except ValueError:
+            logger.debug(
+                "%s: malformed lock timestamp %r",
+                self.connection.hostname,
+                self._lock.timestamp,
+            )
+            return None
+
+    def reap_if_stale(self) -> bool:
+        """Force-removes the remote lock if it is older than the threshold.
+
+        Controlled by the ``lock_reap_stale`` (default on) and
+        ``lock_stale_age`` (seconds, default 86400) config options. Applies
+        to every lock, including exclusive (commented) ones and locks owned
+        by other users, since a sufficiently old lock is almost always left
+        over from a crashed or abandoned session.
+
+        Returns:
+            True if a stale lock was removed, False otherwise.
+
+        """
+        if not self.config.lock_reap_stale or self.config.lock_stale_age <= 0:
+            return False
+
+        age = self.age_seconds()
+        if age is None or age <= self.config.lock_stale_age:
+            return False
+
+        logger.warning(
+            "%s: removing stale lock held by %s (%d h old)",
+            self.connection.hostname,
+            self._lock.user,
+            age // 3600,
+        )
+        self.unlock(force=True)
+        return True
 
     def lock(self, comment: str = "") -> None:
         """Locks the target system.

--- a/mtui/target/target.py
+++ b/mtui/target/target.py
@@ -154,7 +154,7 @@ class Target:
             raise e
 
         self._lock = self.TargetLock(self.connection, self.config)
-        if self.is_locked():
+        if self.is_locked() and not self._lock.reap_if_stale():
             logger.warning(self._lock.locked_by_msg())
 
         # get system

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -248,6 +249,95 @@ class TestTargetLock:
 
         result = lock.time()
         assert "UTC" in result
+
+
+# --- Stale lock reaping ---
+
+
+class TestTargetLockReaping:
+    @pytest.fixture
+    def lock(self, mock_config):
+        """A TargetLock with stale-reaping enabled (1 day threshold)."""
+        mock_config.session_user = "testuser"
+        mock_config.lock_reap_stale = True
+        mock_config.lock_stale_age = 86400
+        conn = MagicMock()
+        conn.hostname = "host1.example.com"
+        return TargetLock(conn, mock_config)
+
+    @staticmethod
+    def _set_lockfile(lock, contents):
+        """Make the mocked remote return a lockfile with the given line."""
+        mock_file = MagicMock()
+        mock_file.readline.return_value = contents
+        lock.connection.sftp_open.return_value = mock_file
+
+    def test_age_seconds_none_when_unlocked(self, lock):
+        """age_seconds() returns None when no lockfile exists."""
+        lock.connection.sftp_open.side_effect = OSError(errno.ENOENT, "not found")
+        assert lock.age_seconds() is None
+
+    def test_age_seconds_none_on_malformed_timestamp(self, lock):
+        """age_seconds() returns None for a non-numeric timestamp."""
+        self._set_lockfile(lock, "not-a-number:otheruser:99999")
+        assert lock.age_seconds() is None
+
+    def test_age_seconds_computes_age(self, lock):
+        """age_seconds() returns roughly the elapsed time since the lock."""
+        old = int(time.time()) - 3600
+        self._set_lockfile(lock, f"{old}:otheruser:99999")
+        age = lock.age_seconds()
+        assert age is not None
+        assert 3590 <= age <= 3700
+
+    def test_reap_removes_stale_foreign_lock(self, lock):
+        """A lock older than the threshold is force-removed regardless of owner."""
+        stale = int(time.time()) - 200000  # > 1 day
+        self._set_lockfile(lock, f"{stale}:otheruser:99999")
+
+        assert lock.reap_if_stale() is True
+        lock.connection.sftp_remove.assert_called_once()
+
+    def test_reap_removes_stale_exclusive_lock(self, lock):
+        """Exclusive (commented) locks are reaped too once stale."""
+        stale = int(time.time()) - 200000
+        self._set_lockfile(lock, f"{stale}:otheruser:99999:do not touch")
+
+        assert lock.reap_if_stale() is True
+        lock.connection.sftp_remove.assert_called_once()
+
+    def test_reap_keeps_fresh_lock(self, lock):
+        """A lock younger than the threshold is left untouched."""
+        fresh = int(time.time()) - 60
+        self._set_lockfile(lock, f"{fresh}:otheruser:99999")
+
+        assert lock.reap_if_stale() is False
+        lock.connection.sftp_remove.assert_not_called()
+
+    def test_reap_disabled_by_flag(self, lock):
+        """reap_if_stale() does nothing when lock_reap_stale is False."""
+        lock.config.lock_reap_stale = False
+        stale = int(time.time()) - 200000
+        self._set_lockfile(lock, f"{stale}:otheruser:99999")
+
+        assert lock.reap_if_stale() is False
+        lock.connection.sftp_remove.assert_not_called()
+
+    def test_reap_disabled_by_zero_age(self, lock):
+        """A non-positive lock_stale_age disables reaping."""
+        lock.config.lock_stale_age = 0
+        stale = int(time.time()) - 200000
+        self._set_lockfile(lock, f"{stale}:otheruser:99999")
+
+        assert lock.reap_if_stale() is False
+        lock.connection.sftp_remove.assert_not_called()
+
+    def test_reap_keeps_malformed_lock(self, lock):
+        """A lock with an unparseable timestamp is left untouched."""
+        self._set_lockfile(lock, "garbage:otheruser:99999")
+
+        assert lock.reap_if_stale() is False
+        lock.connection.sftp_remove.assert_not_called()
 
 
 # --- LockedTargets context manager ---

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -479,10 +479,11 @@ def test_connect_success_wires_up_lock_and_system(mock_config, monkeypatch):
 
 
 def test_connect_warns_when_already_locked(mock_config, monkeypatch, caplog):
-    """A pre-existing lock is logged at warning but does not abort connect."""
+    """A fresh pre-existing lock is logged at warning but does not abort connect."""
     conn_class = MagicMock()
     lock_class = MagicMock()
     lock_class.return_value.is_locked.return_value = True
+    lock_class.return_value.reap_if_stale.return_value = False
     lock_class.return_value.locked_by_msg.return_value = "locked by alice"
     fake_system = MagicMock()
     fake_system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
@@ -498,6 +499,30 @@ def test_connect_warns_when_already_locked(mock_config, monkeypatch, caplog):
     with caplog.at_level("WARNING", logger="mtui.target"):
         target.connect()
     assert any("locked by alice" in r.message for r in caplog.records)
+
+
+def test_connect_reaps_stale_lock_without_warning(mock_config, monkeypatch, caplog):
+    """A stale lock is reaped on connect; no 'locked by' warning is emitted."""
+    conn_class = MagicMock()
+    lock_class = MagicMock()
+    lock_class.return_value.is_locked.return_value = True
+    lock_class.return_value.reap_if_stale.return_value = True
+    fake_system = MagicMock()
+    fake_system.get_base.return_value = Product("SLES", "15-SP5", "x86_64")
+    monkeypatch.setattr(
+        "mtui.target.target.parse_system", lambda _conn: (fake_system, False)
+    )
+    target = Target(  # type: ignore[arg-type]
+        mock_config,
+        "host.example.com",
+        connection=conn_class,  # ty: ignore[invalid-argument-type]
+        lock=lock_class,  # ty: ignore[invalid-argument-type]
+    )
+    with caplog.at_level("WARNING", logger="mtui.target"):
+        target.connect()
+    lock_class.return_value.reap_if_stale.assert_called_once()
+    lock_class.return_value.locked_by_msg.assert_not_called()
+    assert not any("locked by" in r.message for r in caplog.records)
 
 
 def test_connect_failure_logs_critical_and_reraises(mock_config, caplog):


### PR DESCRIPTION
## Summary

Reference hosts are shared, and their `/var/lock/mtui.lock` is cooperative/advisory. Today, when `add_host` (or any connect) hits a host that is already locked, mtui only logs a warning — even when the lock is days old and the owning session is long gone. Testers then have to manually `unlock -f` shared hosts before they can work.

This change makes mtui **force-remove a pre-existing lock that is older than a configurable threshold** on connect, regardless of which user or session created it (including exclusive/commented locks), since such a lock is almost always left over from a crashed or abandoned session. Fresh locks are still only reported, never removed.

The removal is logged at `WARNING` so it stays observable:

```
<host>: removing stale lock held by <user> (<N> h old)
```

## Configuration

New `[lock]` section, default-on with a one-day threshold:

| Option | Type | Default | Meaning |
| --- | --- | --- | --- |
| `reap_stale` | bool | `true` | Reap stale locks on connect; `false` restores warn-only behaviour |
| `stale_age` | int (seconds) | `86400` | Age beyond which a lock is stale; `0` also disables reaping |

A missing or malformed lock timestamp is treated as "leave alone".

## Implementation

- `TargetLock` gains `age_seconds()` (epoch math on the existing lockfile timestamp) and `reap_if_stale()` (honours the config, force-unlocks when stale). It now also stores the `config` reference.
- `Target.connect()` changes one line: `if self.is_locked() and not self._lock.reap_if_stale(): warn(...)`.
- Two new `ConfigOption`s in `mtui/config.py`.

## Tests / docs

- `tests/test_locks.py`: new `TestTargetLockReaping` (age computation, foreign + exclusive reap, fresh-lock kept, both disable switches, malformed-timestamp kept).
- `tests/test_target.py`: updated the existing locked-connect test for the new path + added a reaped-lock test.
- `CHANGELOG.md` (Added) and `Documentation/cfg.rst` (option docs + example).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (707 passed), and `sphinx-build -W`.