### PR TITLE
fix(set_location): reset working refhost set on manual location change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `set_location` now resets the working reference-host selection. Hosts
+  inherited from the testreport template and from the previously
+  configured location are dropped, so a subsequent `add_host` connects
+  only hosts from the newly selected location (the per-testplatform
+  fallback to the `default` location is unchanged). Previously the
+  template/old-location hosts lingered in the accumulated host set and
+  `add_host` connected them alongside the new location's hosts.
 - Parallel target operations no longer race for `stdin` when an SSH
   command times out on multiple hosts simultaneously. The timeout
   prompt (`command "..." timed out on <host>. wait? (Y/n)`) is now

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -59,6 +59,18 @@ class SetLocation(Command):
         old: str = self.config.location
         new: str = self.args.site[0]
         self.config.location = new
+        if self.config.location != new:
+            # The config setter rejected the location (and logged why);
+            # leave the working refhost set untouched.
+            return
+
+        # A manual location change resets the working refhost selection:
+        # drop hosts inherited from the testreport template and from the
+        # previously configured location so a subsequent ``add_host``
+        # derives hosts only from the newly selected location. The
+        # per-testplatform fallback to the ``default`` location in
+        # ``Refhosts.search`` still applies.
+        self.metadata.hostnames.clear()
         logger.info(messages.LocationChangedMessage(old, new))
 
     @staticmethod

--- a/tests/test_simpleset.py
+++ b/tests/test_simpleset.py
@@ -1,8 +1,45 @@
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-from mtui.commands.simpleset import SetWorkflow
+from mtui.commands.simpleset import SetLocation, SetWorkflow
 from mtui.types import OpenQAResults, RequestReviewID
+
+
+class _FakeConfig:
+    """Minimal config whose location setter mimics Config's accept/reject."""
+
+    def __init__(self, accept: bool) -> None:
+        self._loc = "foo"
+        self._accept = accept
+
+    @property
+    def location(self) -> str:
+        return self._loc
+
+    @location.setter
+    def location(self, value: str) -> None:
+        # Real Config rejects an unknown location and keeps the old value.
+        if self._accept:
+            self._loc = value
+
+
+def _run_set_location(accept: bool, site: str, initial_hosts):
+    prompt = MagicMock()
+    prompt.metadata.hostnames = set(initial_hosts)
+    SetLocation(Namespace(site=[site]), _FakeConfig(accept), MagicMock(), prompt)()
+    return prompt.metadata
+
+
+def test_set_location_resets_hostnames_on_change():
+    """A successful set_location drops template/old-location refhosts."""
+    meta = _run_set_location(True, "bar", ["foo-host-1", "foo-host-2"])
+    assert meta.hostnames == set()
+
+
+def test_set_location_keeps_hostnames_when_rejected():
+    """A rejected location leaves the working refhost set untouched."""
+    meta = _run_set_location(False, "atlantis", ["foo-host-1"])
+    assert meta.hostnames == {"foo-host-1"}
 
 
 def test_set_workflow_auto_uses_rrid(mock_config):


### PR DESCRIPTION
## Problem

With `mtui.location = foo` configured, opening an update in automatic mode and then running:

```
set_location bar
set_workflow manual
add_host
```

connects reference hosts from **both** `foo` and `bar`.

### Root cause

`TestReport.hostnames` is a cumulative set:

- At load, the testreport template is parsed and every recorded `... (reference host: <host> ...)` line is added to `hostnames` (`ReducedMetadataParser`, `mtui/parsemeta.py`), invoked from `TestReport._parse_template`. These are `foo`'s hosts from when the report was created.
- `add_host` with no `-t` calls `refhosts_from_tp()` for each testplatform, which **unions** the new location's matches into `hostnames` (it never clears it), then `connect_targets()` connects everything in `hostnames` that isn't already connected.

So after `set_location bar`, `hostnames` is `{foo hosts from template} ∪ {bar hosts}` and both get connected. `set_location` had no effect on the already-accumulated set.

## Fix

`set_location` now clears `TestReport.hostnames` when the location change is accepted, so a subsequent `add_host` derives hosts **only** from the newly selected location. The per-testplatform fallback to the `default` location in `Refhosts.search` is intentionally left unchanged. If the config setter rejects an unknown location (it already logs why), the working host set is left untouched and no "changed" message is logged.

## Scope / note

This resets the *pending* host set. In the reported flow (automatic mode, install results present) nothing is connected at `set_location` time, so this fully addresses it. Hosts from a previous location that were *already connected* (e.g. via the manual-mode autoconnect-at-load path) remain live `Target` sessions until `remove_host`; tearing those down on `set_location` was deliberately left out of this change.

## Tests

- `tests/test_simpleset.py`: `hostnames` is reset on an accepted change and preserved when the location is rejected.
- Full suite: 964 passed; `ruff format --check`, `ruff check`, and `ty check` clean.