### PR TITLE
feat(lock): auto-lock reference hosts while testing a Product Increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `set_location` now resets the working reference-host selection. Hosts
+  inherited from the testreport template and from the previously
+  configured location are dropped, so a subsequent `add_host` connects
+  only hosts from the newly selected location (the per-testplatform
+  fallback to the `default` location is unchanged). Previously the
+  template/old-location hosts lingered in the accumulated host set and
+  `add_host` connected them alongside the new location's hosts.
 - Parallel target operations no longer race for `stdin` when an SSH
   command times out on multiple hosts simultaneously. The timeout
   prompt (`command "..." timed out on <host>. wait? (Y/n)`) is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Reference hosts are now automatically locked while testing a Product
+  Increment (PI). Running `assign` on a PI locks every connected
+  reference host with the comment `testing of SUSE:PI:<id>:<review>`
+  (an exclusive lock that blocks other sessions); hosts added via
+  `add_host` while the assignment is active are locked too. The locks
+  are released at the end of testing — `unassign`, `approve`, or
+  `reject` — and only this session's locks are removed (a host locked by
+  someone else is left alone). Controlled by a new `[lock] pi_autolock`
+  option (default `true`); set it to `false` to disable.
 - Stale reference-host locks are now reaped automatically on connect.
   When `add_host` (or any connect) finds a pre-existing `/var/lock/mtui.lock`
   older than a configurable threshold, mtui force-removes it regardless of

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -413,6 +413,21 @@ eligible for automatic removal (see ``lock.reap_stale``). A value of
 ``0`` disables reaping.
 
 
+``lock.pi_autolock``
+~~~~~~~~~~~~~~~~~~~~
+
+  | **type**
+  |     bool
+  | **default**
+  |     ``True``
+
+When testing a Product Increment (PI), automatically lock all reference
+hosts on ``assign`` with a comment naming the request, and unlock this
+session's locks at the end of testing (``unassign`` / ``approve`` /
+``reject``). Reference hosts added with ``add_host`` while the
+assignment is active are locked too. Set to ``false`` to disable.
+
+
 Example
 =======
 
@@ -440,3 +455,4 @@ Example
   [lock]
   reap_stale = true
   stale_age = 86400
+  pi_autolock = true

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -10,7 +10,7 @@ implementations for `approve`, `assign`, `unassign`, `reject`, and
 from abc import ABC, abstractmethod
 from argparse import REMAINDER
 from logging import getLogger
-from typing import final
+from typing import ClassVar, final
 
 from ..argparse import ArgumentParser
 from ..commands import Command
@@ -26,6 +26,11 @@ logger = getLogger("mtui.command.apicalls")
 
 class BaseApiCall(Command, ABC):
     """An abstract base class for commands that interact with backend APIs."""
+
+    # For a Product Increment, ``assign`` locks all reference hosts and the
+    # end-of-testing operations unlock them. Subclasses set this to "lock"
+    # or "unlock"; ``None`` (the default, e.g. ``comment``) does neither.
+    _pi_action: ClassVar[str | None] = None
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -58,6 +63,36 @@ class BaseApiCall(Command, ABC):
             self.gitea()
         else:
             self.osc()
+        self._pi_autolock()
+
+    def _pi_autolock(self) -> None:
+        """Locks/unlocks reference hosts around PI testing.
+
+        On ``assign`` of a Product Increment, lock every connected
+        reference host with a comment naming the request, and remember the
+        comment so hosts added later (via ``add_host``) are locked too. On
+        ``unassign`` / ``approve`` / ``reject``, unlock this session's
+        locks. No-op unless the request is a PI and ``lock_pi_autolock`` is
+        enabled.
+        """
+        if self._pi_action is None or not self.config.lock_pi_autolock:
+            return
+        if self.metadata.rrid.kind is not RequestKind.PI:
+            return
+
+        if self._pi_action == "lock":
+            comment = f"testing of {self.metadata.rrid}"
+            self.metadata.lock_comment = comment
+            logger.info("Locking reference hosts for %s", self.metadata.rrid)
+            self.targets.lock(comment)
+        else:  # "unlock"
+            logger.info(
+                "Unlocking reference hosts after %s of %s",
+                self.command,
+                self.metadata.rrid,
+            )
+            self.targets.unlock()
+            self.metadata.lock_comment = ""
 
     @abstractmethod
     def osc(self) -> None:
@@ -80,6 +115,7 @@ class Approve(BaseApiCall):
     """A command to approve a review request."""
 
     command = "approve"
+    _pi_action = "unlock"
 
     def osc(self) -> None:
         """Approves the request in OSC."""
@@ -121,6 +157,7 @@ class Assign(BaseApiCall):
     """A command to assign a review request to a user or group."""
 
     command = "assign"
+    _pi_action = "lock"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -161,6 +198,7 @@ class Unassign(BaseApiCall):
     """A command to unassign a review request."""
 
     command = "unassign"
+    _pi_action = "unlock"
 
     def osc(self) -> None:
         """Unassigns the request in OSC."""
@@ -183,6 +221,7 @@ class Reject(BaseApiCall):
     """A command to reject a review request."""
 
     command = "reject"
+    _pi_action = "unlock"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -59,6 +59,18 @@ class SetLocation(Command):
         old: str = self.config.location
         new: str = self.args.site[0]
         self.config.location = new
+        if self.config.location != new:
+            # The config setter rejected the location (and logged why);
+            # leave the working refhost set untouched.
+            return
+
+        # A manual location change resets the working refhost selection:
+        # drop hosts inherited from the testreport template and from the
+        # previously configured location so a subsequent ``add_host``
+        # derives hosts only from the newly selected location. The
+        # per-testplatform fallback to the ``default`` location in
+        # ``Refhosts.search`` still applies.
+        self.metadata.hostnames.clear()
         logger.info(messages.LocationChangedMessage(old, new))
 
     @staticmethod

--- a/mtui/config.py
+++ b/mtui/config.py
@@ -85,6 +85,7 @@ class Config:
     ssh_strict_host_key_checking: str
     lock_reap_stale: bool
     lock_stale_age: int
+    lock_pi_autolock: bool
 
     # -- Attributes set externally in main.py --
     kernel: bool
@@ -389,6 +390,17 @@ class Config:
                 86400,
                 int,
                 getint,
+            ),
+            # When testing a Product Increment (PI), automatically lock all
+            # reference hosts on ``assign`` and unlock them at end of testing
+            # (``unassign`` / ``approve`` / ``reject``). Set to false to
+            # disable.
+            ConfigOption(
+                "lock_pi_autolock",
+                ("lock", "pi_autolock"),
+                True,
+                bool,
+                getboolean,
             ),
         ]
 

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -8,6 +8,7 @@ import shutil
 import stat
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from contextlib import suppress
 from errno import EEXIST, ENOENT
 from json import loads
 from json.decoder import JSONDecodeError
@@ -22,7 +23,7 @@ from ..exceptions import InvalidGiteaHashError, UpdateError
 from ..fileops import ensure_dir_exists
 from ..messages import MetadataNotLoadedError
 from ..refhost import Attributes, RefhostsFactory, RefhostsResolveFailedError
-from ..target import Target
+from ..target import Target, TargetLockedError
 from ..target.hostgroup import HostsGroup
 from ..template import TemplateIOError, TestReportAlreadyLoadedError
 from ..types import OpenQAResults, Product, TargetMeta
@@ -99,6 +100,10 @@ class TestReport(ABC):
                  repository = str
         """
         self.hostnames: set[str] = set()
+        # When non-empty, newly connected reference hosts are locked with
+        # this comment (set while a PI assignment is active). See
+        # ``mtui.commands.apicall`` and ``lock_pi_autolock``.
+        self.lock_comment: str = ""
         self.bugs: dict[str, str] = {}
         self.jira: dict[str, str] = {}
         self.testplatforms: list[str] = []
@@ -371,6 +376,23 @@ class TestReport(ABC):
             st = os.stat(i)
             os.chmod(i, st.st_mode | stat.S_IEXEC)
 
+    def _autolock_new_target(self, target: Target) -> None:
+        """Locks a freshly connected target if a PI lock is active.
+
+        When :attr:`lock_comment` is set (a PI assignment is in progress),
+        newly connected reference hosts are locked with that comment so a
+        host added via ``add_host`` after ``assign`` is covered too. A host
+        already locked by someone else is left as-is.
+
+        Args:
+            target: The freshly connected target to lock.
+
+        """
+        if not self.lock_comment:
+            return
+        with suppress(TargetLockedError):
+            target.lock(self.lock_comment)
+
     def connect_target(
         self, host
     ) -> tuple[Target, str] | tuple[Literal[False], Literal[False]]:
@@ -394,6 +416,7 @@ class TestReport(ABC):
             )
             target.connect()
             new_system = str(target.system)
+            self._autolock_new_target(target)
         except KeyboardInterrupt:
             logger.warning("Connection to %s canceled by user", host)
             return False, False
@@ -475,6 +498,8 @@ class TestReport(ABC):
 
             if self:
                 self.systems[hostname] = str(self.targets[hostname].system)
+
+            self._autolock_new_target(self.targets[hostname])
 
         except Exception:
             if hostname in self.targets:

--- a/tests/test_cmd_apicall.py
+++ b/tests/test_cmd_apicall.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mtui.commands.apicall import Approve
+from mtui.commands.apicall import Approve, Assign, Reject, Unassign
 from mtui.messages import TestReportNotLoadedError
-from mtui.types import RequestKind
+from mtui.types import RequestKind, RequestReviewID
 
 
 def _prompt() -> MagicMock:
@@ -44,3 +44,71 @@ def test_approve_without_metadata_raises(mock_config):
 
     with pytest.raises(TestReportNotLoadedError):
         Approve(args, mock_config, MagicMock(), prompt)()
+
+
+# ---------------------------------------------------------------------------
+# PI auto-lock around assign / end-of-testing
+# ---------------------------------------------------------------------------
+
+
+def _pi_prompt() -> MagicMock:
+    p = _prompt()
+    # A real RRID so kind is PI and str(rrid) renders the lock comment.
+    p.metadata.rrid = RequestReviewID("SUSE:PI:34556:1")
+    return p
+
+
+def test_assign_pi_locks_refhosts(mock_config):
+    mock_config.lock_pi_autolock = True
+    prompt = _pi_prompt()
+    args = Namespace(group=["qam-sle"], user="", force=False)
+
+    with patch("mtui.commands.apicall.OSC") as osc_cls:
+        Assign(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.assign.assert_called_once_with(["qam-sle"])
+    prompt.targets.lock.assert_called_once_with("testing of SUSE:PI:34556:1")
+    assert prompt.metadata.lock_comment == "testing of SUSE:PI:34556:1"
+
+
+def test_assign_pi_autolock_disabled(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _pi_prompt()
+    args = Namespace(group=["qam-sle"], user="", force=False)
+
+    with patch("mtui.commands.apicall.OSC"):
+        Assign(args, mock_config, MagicMock(), prompt)()
+
+    prompt.targets.lock.assert_not_called()
+
+
+def test_assign_non_pi_does_not_lock(mock_config):
+    mock_config.lock_pi_autolock = True
+    prompt = _prompt()  # MAINTENANCE kind
+    args = Namespace(group=["qam-sle"], user="", force=False)
+
+    with patch("mtui.commands.apicall.OSC"):
+        Assign(args, mock_config, MagicMock(), prompt)()
+
+    prompt.targets.lock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("cls", "extra"),
+    [
+        (Approve, {}),
+        (Unassign, {}),
+        (Reject, {"reason": "admin", "message": ["nope"]}),
+    ],
+)
+def test_end_of_testing_pi_unlocks(mock_config, cls, extra):
+    mock_config.lock_pi_autolock = True
+    prompt = _pi_prompt()
+    prompt.metadata.lock_comment = "testing of SUSE:PI:34556:1"
+    args = Namespace(group=["qam-sle"], user="", **extra)
+
+    with patch("mtui.commands.apicall.OSC"):
+        cls(args, mock_config, MagicMock(), prompt)()
+
+    prompt.targets.unlock.assert_called_once_with()
+    assert prompt.metadata.lock_comment == ""

--- a/tests/test_simpleset.py
+++ b/tests/test_simpleset.py
@@ -1,8 +1,45 @@
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-from mtui.commands.simpleset import SetWorkflow
+from mtui.commands.simpleset import SetLocation, SetWorkflow
 from mtui.types import OpenQAResults, RequestReviewID
+
+
+class _FakeConfig:
+    """Minimal config whose location setter mimics Config's accept/reject."""
+
+    def __init__(self, accept: bool) -> None:
+        self._loc = "foo"
+        self._accept = accept
+
+    @property
+    def location(self) -> str:
+        return self._loc
+
+    @location.setter
+    def location(self, value: str) -> None:
+        # Real Config rejects an unknown location and keeps the old value.
+        if self._accept:
+            self._loc = value
+
+
+def _run_set_location(accept: bool, site: str, initial_hosts):
+    prompt = MagicMock()
+    prompt.metadata.hostnames = set(initial_hosts)
+    SetLocation(Namespace(site=[site]), _FakeConfig(accept), MagicMock(), prompt)()
+    return prompt.metadata
+
+
+def test_set_location_resets_hostnames_on_change():
+    """A successful set_location drops template/old-location refhosts."""
+    meta = _run_set_location(True, "bar", ["foo-host-1", "foo-host-2"])
+    assert meta.hostnames == set()
+
+
+def test_set_location_keeps_hostnames_when_rejected():
+    """A rejected location leaves the working refhost set untouched."""
+    meta = _run_set_location(False, "atlantis", ["foo-host-1"])
+    assert meta.hostnames == {"foo-host-1"}
 
 
 def test_set_workflow_auto_uses_rrid(mock_config):

--- a/tests/test_template_testreport.py
+++ b/tests/test_template_testreport.py
@@ -43,6 +43,39 @@ def test_get_package_list_dedups_across_versions(tmp_path: Path) -> None:
     assert sorted(out) == ["bash", "libfoo", "openssl"]
 
 
+# ---------------------------------------------------------------------------
+# PI auto-lock: locking freshly connected targets
+# ---------------------------------------------------------------------------
+
+
+def test_autolock_new_target_locks_when_comment_set(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    r.lock_comment = "testing of SUSE:PI:34556:1"
+    target = MagicMock()
+    r._autolock_new_target(target)  # ty: ignore[invalid-argument-type]
+    target.lock.assert_called_once_with("testing of SUSE:PI:34556:1")
+
+
+def test_autolock_new_target_noop_without_comment(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    assert r.lock_comment == ""
+    target = MagicMock()
+    r._autolock_new_target(target)  # ty: ignore[invalid-argument-type]
+    target.lock.assert_not_called()
+
+
+def test_autolock_new_target_suppresses_foreign_lock(tmp_path: Path) -> None:
+    from mtui.target import TargetLockedError
+
+    r = _make(tmp_path)
+    r.lock_comment = "testing of SUSE:PI:34556:1"
+    target = MagicMock()
+    target.lock.side_effect = TargetLockedError("locked by someone else")
+    # A host already locked by another user must not abort the connect flow.
+    r._autolock_new_target(target)  # ty: ignore[invalid-argument-type]
+    target.lock.assert_called_once()
+
+
 def test_get_package_list_empty(tmp_path: Path) -> None:
     r = _make(tmp_path)
     r.packages = {}


### PR DESCRIPTION
## Summary

Reference hosts are shared, and their lock (`/var/lock/mtui.lock`) is the mechanism that keeps two testers off the same box. When testing a Product Increment (PI) this should happen automatically around the review lifecycle rather than relying on manual `lock`/`unlock`.

With this change, for a **PI** request (and with the new option enabled):

- **`assign`** locks every connected reference host with the comment `testing of SUSE:PI:<id>:<review>`. A commented lock is *exclusive*, so it blocks other sessions' `run`. The comment is also recorded on the testreport, so hosts added via **`add_host`** while the assignment is active are locked on connect too.
- **`unassign` / `approve` / `reject`** release the locks at end of testing, removing **only this session's** locks — a host locked by someone else is left untouched.

Non-PI requests and the `comment` command are unaffected.

## Configuration

New `[lock]` option, default on:

| Option | Type | Default | Meaning |
| --- | --- | --- | --- |
| `pi_autolock` | bool | `true` | Auto-lock refhosts on PI `assign`; unlock at end of testing. `false` disables. |

## Implementation

- `mtui/config.py` — new `lock_pi_autolock` option (`[lock] pi_autolock`).
- `mtui/commands/apicall.py` — `BaseApiCall` gains a `_pi_action` class tag (`"lock"` on `Assign`; `"unlock"` on `Approve`/`Unassign`/`Reject`; `None` otherwise) and a `_pi_autolock()` hook run after the API dispatch. It no-ops unless the request is a PI and the option is enabled.
- `mtui/template/testreport.py` — a `lock_comment` session field plus `_autolock_new_target()`, called from both connection paths (`connect_target`, `add_target`) so later-added hosts are covered. A host already locked by another user is skipped (`TargetLockedError` suppressed), so it never aborts the connect flow.

## Note on the lock message

The lock renders to other users as `\<host\> is locked by \<user\> (testing of SUSE:PI:<id>:<review>).` — the `... is locked by \<user\> (...)` framing comes from `RemoteLock.__str__`; this change controls the parenthetical comment.

## Tests / docs

- `tests/test_cmd_apicall.py`: lock-on-assign, unlock on each of unassign/approve/reject (parametrised), config-disabled and non-PI no-ops.
- `tests/test_template_testreport.py`: `_autolock_new_target` locks when armed, no-ops when idle, and survives a foreign lock.
- `CHANGELOG.md` (Added) and `Documentation/cfg.rst` (option docs + example).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (973 passed), and `sphinx-build -W`.