### PR TITLE
feat(approve): record reviewer and commit testreport in one step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- The `approve` command now accepts `-r REVIEWER` / `--reviewer REVIEWER`.
+  It records the reviewer in the testreport's `Test Plan Reviewer:` line,
+  commits the testreport to SVN, and then approves the update — all in one
+  step. If the testreport has no `Test Plan Reviewer:` line or the SVN
+  commit fails, the approval is aborted and nothing is approved. Running
+  `approve` without `-r` behaves exactly as before.
 - Reference hosts are now automatically locked while testing a Product
   Increment (PI). Running `assign` on a PI locks every connected
   reference host with the comment `testing of SUSE:PI:<id>:<review>`

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -943,10 +943,15 @@ approve
 
 ::
 
-    approve [-h] [-g [GROUP]]
+    approve [-h] [-g [GROUP]] [-r REVIEWER]
 
 Wrapper around the `osc qam approve`_ command; approves current update. It is
 possible to specify more QA groups for approval.
+
+When ``-r REVIEWER`` is given, the reviewer is recorded in the testreport (the
+``Test Plan Reviewer:`` line), the testreport is committed to SVN, and only
+then is the update approved. If the testreport has no ``Test Plan Reviewer:``
+line or the SVN commit fails, the approval is aborted.
 
 .. _osc qam approve: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#approve
 
@@ -955,6 +960,11 @@ possible to specify more QA groups for approval.
 .. option:: -g [GROUP], --group [GROUP]
 
   QA group to approve under.
+
+.. option:: -r REVIEWER, --reviewer REVIEWER
+
+  Record REVIEWER in the testreport, commit it to SVN, then approve. Aborts the
+  approval if recording the reviewer or the SVN commit fails.
 
 
 reject

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -1,10 +1,9 @@
 """Commands for interacting with backend APIs (OSC and Gitea).
 
-This module defines a set of commands for interacting with backend APIs
-like OSC and Gitea. It uses a base class `BaseApiCall` to handle the
-dispatch logic between the two backends, and then provides concrete
-implementations for `approve`, `assign`, `unassign`, `reject`, and
-`comment`.
+This module defines the :class:`BaseApiCall` base class, which handles the
+dispatch logic between the OSC and Gitea backends, along with the concrete
+`assign`, `unassign`, `reject`, and `comment` commands. The `approve`
+command lives in :mod:`mtui.commands.approve`.
 """
 
 from abc import ABC, abstractmethod
@@ -16,9 +15,8 @@ from ..argparse import ArgumentParser
 from ..commands import Command
 from ..completion import complete_choices
 from ..connector import OSC, Gitea
-from ..exceptions import GiteaError, InvalidGiteaHashError
+from ..exceptions import GiteaError
 from ..misc import requires_update
-from ..term import prompt_user
 from ..types import RequestKind
 
 logger = getLogger("mtui.command.apicalls")
@@ -108,48 +106,6 @@ class BaseApiCall(Command, ABC):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices([("-g", "--group"), ("-u", "--user")], line, text)
-
-
-@final
-class Approve(BaseApiCall):
-    """A command to approve a review request."""
-
-    command = "approve"
-    _pi_action = "unlock"
-
-    def osc(self) -> None:
-        """Approves the request in OSC."""
-        logger.info("Approving request %s", self.metadata.rrid.review_id)
-        osc = OSC(self.config, self.metadata.rrid)
-        osc.approve(self.args.group)
-
-    def gitea(self) -> None:
-        """Approves the pull request in Gitea."""
-        logger.info("Approving PR %s", self.metadata.id)
-        try:
-            gitea = Gitea(self.config, self.metadata.giteaprapi)
-            result, old_hash, new_hash = self.metadata.check_hash()
-            if not result:
-                logger.error(
-                    "GiteaPR hash is different from testreport, please reconsider approval\n Testreport %s ->repo %s",
-                    old_hash,
-                    new_hash,
-                )
-                if prompt_user(
-                    "Do you really want approve this update ?",
-                    ["Yes", "Y", "yes", "y", "Ja", "ja"],
-                    self.prompt.interactive,
-                ):
-                    gitea.approve(self.args.user)
-                else:
-                    raise InvalidGiteaHashError(
-                        self.metadata.id, self.metadata.giteacohash, new_hash
-                    )
-            else:
-                gitea.approve(self.args.user)
-
-        except GiteaError as e:
-            logger.error(e)
 
 
 @final

--- a/mtui/commands/approve.py
+++ b/mtui/commands/approve.py
@@ -1,0 +1,128 @@
+"""The `approve` command.
+
+Approves the current update via OSC or Gitea, reusing the backend-dispatch
+logic from :class:`mtui.commands.apicall.BaseApiCall`. When ``-r/--reviewer``
+is given, the reviewer is recorded in the testreport and the template is
+committed to SVN before the approval happens.
+"""
+
+import subprocess
+from logging import getLogger
+from typing import final
+
+from ..argparse import ArgumentParser
+from ..completion import complete_choices
+from ..connector import OSC, Gitea
+from ..exceptions import GiteaError, InvalidGiteaHashError
+from ..misc import requires_update
+from ..template import TemplateFormatError, svn_commit_testreport
+from ..term import prompt_user
+from .apicall import BaseApiCall
+
+logger = getLogger("mtui.command.approve")
+
+
+@final
+class Approve(BaseApiCall):
+    """A command to approve a review request."""
+
+    command = "approve"
+    _pi_action = "unlock"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        super()._add_arguments(parser)
+        parser.add_argument(
+            "-r",
+            "--reviewer",
+            action="store",
+            default=None,
+            help="Record reviewer in the testreport, commit it to SVN, "
+            "then approve. Aborts the approval if either step fails.",
+        )
+
+    @requires_update
+    def __call__(self) -> None:
+        """The main entry point for the command.
+
+        When ``-r/--reviewer`` is given, record the reviewer in the
+        testreport and commit it to SVN before approving. If either step
+        fails, the approval is aborted.
+        """
+        if self.args.reviewer is not None and not self._record_reviewer():
+            return
+        super().__call__()
+
+    def _record_reviewer(self) -> bool:
+        """Records the reviewer and commits the testreport to SVN.
+
+        Returns:
+            ``True`` if the reviewer was recorded and committed and the
+            approval should proceed; ``False`` if it failed and the
+            approval must be aborted.
+
+        """
+        name = self.args.reviewer.strip()
+        if not name:
+            logger.error("Reviewer must be a non-empty string; not approving")
+            return False
+
+        try:
+            self.metadata.set_reviewer(name)
+        except (TemplateFormatError, ValueError, OSError) as e:
+            logger.error("Failed to record reviewer, not approving: %s", e)
+            return False
+
+        try:
+            svn_commit_testreport(
+                self.metadata.report_wd(),
+                self.config.install_logs,
+                ["-m", f"Add Test Plan Reviewer: {name}"],
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to commit testreport to SVN, not approving: %s", e)
+            return False
+
+        return True
+
+    def osc(self) -> None:
+        """Approves the request in OSC."""
+        logger.info("Approving request %s", self.metadata.rrid.review_id)
+        osc = OSC(self.config, self.metadata.rrid)
+        osc.approve(self.args.group)
+
+    def gitea(self) -> None:
+        """Approves the pull request in Gitea."""
+        logger.info("Approving PR %s", self.metadata.id)
+        try:
+            gitea = Gitea(self.config, self.metadata.giteaprapi)
+            result, old_hash, new_hash = self.metadata.check_hash()
+            if not result:
+                logger.error(
+                    "GiteaPR hash is different from testreport, please reconsider approval\n Testreport %s ->repo %s",
+                    old_hash,
+                    new_hash,
+                )
+                if prompt_user(
+                    "Do you really want approve this update ?",
+                    ["Yes", "Y", "yes", "y", "Ja", "ja"],
+                    self.prompt.interactive,
+                ):
+                    gitea.approve(self.args.user)
+                else:
+                    raise InvalidGiteaHashError(
+                        self.metadata.id, self.metadata.giteacohash, new_hash
+                    )
+            else:
+                gitea.approve(self.args.user)
+
+        except GiteaError as e:
+            logger.error(e)
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(
+            [("-g", "--group"), ("-u", "--user"), ("-r", "--reviewer")], line, text
+        )

--- a/mtui/commands/commit.py
+++ b/mtui/commands/commit.py
@@ -1,12 +1,12 @@
 """The `commit` command."""
 
-import subprocess
 from argparse import REMAINDER
 from logging import getLogger
 
 from mtui.commands import Command
 from mtui.completion import complete_choices
 from mtui.misc import requires_update
+from mtui.template import svn_commit_testreport
 
 logger = getLogger("mtui.command.commit")
 
@@ -37,25 +37,8 @@ class Commit(Command):
             msg = ["-m", '"' + " ".join(self.args.msg[0]) + '"']
 
         try:
-            subprocess.check_call(
-                f"svn add --force {self.config.install_logs!s}".split(),
-                cwd=checkout,
-            )
-            if checkout.joinpath("results").exists():
-                subprocess.call(
-                    "svn add --force {}".format("results").split(),
-                    cwd=checkout,
-                )
-            if checkout.joinpath("checkers.log").exists():
-                subprocess.check_call(
-                    "svn add --force {}".format("checkers.log").split(),
-                    cwd=checkout,
-                )
-            subprocess.check_call(["svn", "up"], cwd=checkout)
-            subprocess.check_call(["svn", "ci", *msg], cwd=checkout)
-
+            svn_commit_testreport(checkout, self.config.install_logs, msg)
             logger.info("Testreport in: %s", self.metadata.fancy_report_url())
-
         except Exception:
             logger.exception("committing template.failed")
 

--- a/mtui/template/__init__.py
+++ b/mtui/template/__init__.py
@@ -3,6 +3,7 @@
 import subprocess
 from logging import getLogger
 from os.path import join
+from pathlib import Path
 
 from ..fileops import chdir, ensure_dir_exists
 from ..messages import SvnCheckoutFailed, SvnCheckoutInterruptedError
@@ -17,6 +18,48 @@ class TemplateIOError(IOError):
 
 class TestReportAlreadyLoadedError(RuntimeError):
     """Exception raised when a test report is already loaded."""
+
+
+class TemplateFormatError(RuntimeError):
+    """Exception raised when a template does not match the expected format."""
+
+
+def svn_commit_testreport(
+    checkout: Path, install_logs: Path, msg: list[str] | None = None
+) -> None:
+    """Adds the testreport artifacts to SVN and commits the working copy.
+
+    This is the reusable core of the ``commit`` command, shared so other
+    commands (e.g. ``approve -r``) can commit the testreport too. Unlike the
+    ``commit`` command wrapper, this function lets ``subprocess`` exceptions
+    propagate so callers can decide whether to abort.
+
+    Args:
+        checkout: The testreport working directory (``report_wd()``).
+        install_logs: Path of the install logs to ``svn add``.
+        msg: Extra arguments for ``svn ci`` (e.g. ``["-m", "..."]``).
+
+    Raises:
+        subprocess.CalledProcessError: If any required ``svn`` call fails.
+
+    """
+    msg = msg or []
+    subprocess.check_call(
+        f"svn add --force {install_logs!s}".split(),
+        cwd=checkout,
+    )
+    if checkout.joinpath("results").exists():
+        subprocess.call(
+            "svn add --force {}".format("results").split(),
+            cwd=checkout,
+        )
+    if checkout.joinpath("checkers.log").exists():
+        subprocess.check_call(
+            "svn add --force {}".format("checkers.log").split(),
+            cwd=checkout,
+        )
+    subprocess.check_call(["svn", "up"], cwd=checkout)
+    subprocess.check_call(["svn", "ci", *msg], cwd=checkout)
 
 
 def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:

--- a/mtui/template/testreport.py
+++ b/mtui/template/testreport.py
@@ -25,7 +25,11 @@ from ..messages import MetadataNotLoadedError
 from ..refhost import Attributes, RefhostsFactory, RefhostsResolveFailedError
 from ..target import Target, TargetLockedError
 from ..target.hostgroup import HostsGroup
-from ..template import TemplateIOError, TestReportAlreadyLoadedError
+from ..template import (
+    TemplateFormatError,
+    TemplateIOError,
+    TestReportAlreadyLoadedError,
+)
 from ..types import OpenQAResults, Product, TargetMeta
 
 if TYPE_CHECKING:
@@ -35,6 +39,16 @@ logger = getLogger("mtui.template.testreport")
 
 
 re_ver = re.compile(r"(\S+)\s+(\S+)")
+
+
+# Matches the "Test Plan Reviewer:" metadata line in a testreport template.
+# Group 1 captures the literal label so only the value after the colon is
+# replaced. Older templates used the "Suggested Test Plan Reviewer(s):"
+# phrasing; both are matched and normalized to "Test Plan Reviewer:".
+_reviewer_line = re.compile(
+    r"^(?:Suggested )?Test Plan Reviewers?:.*$",
+    re.MULTILINE,
+)
 
 
 class TestReport(ABC):
@@ -182,6 +196,45 @@ class TestReport(ABC):
         result = self.check_hash()
         if not result[0]:
             raise InvalidGiteaHashError(self.id, result[1], result[2])
+
+    def set_reviewer(self, name: str) -> None:
+        """Records the reviewer in the loaded testreport template on disk.
+
+        Replaces the value of the ``Test Plan Reviewer:`` metadata line with
+        ``name`` and rewrites the template file atomically. The line is always
+        normalized to ``Test Plan Reviewer: <name>`` (older ``Suggested ...``
+        phrasings are replaced). The in-memory :attr:`reviewer` attribute is
+        updated only after the file is written.
+
+        Args:
+            name: The reviewer to record. Surrounding whitespace is stripped.
+
+        Raises:
+            ValueError: If ``name`` is empty or whitespace only.
+            RuntimeError: If no template is loaded (``self.path`` is ``None``).
+            TemplateFormatError: If the template has no ``Test Plan Reviewer:``
+                line to replace.
+
+        """
+        name = name.strip()
+        if not name:
+            raise ValueError("reviewer must be a non-empty string")
+        if not self.path:
+            raise RuntimeError("Called while missing path")
+
+        text = self.path.read_text(errors="replace")
+        new_text, count = _reviewer_line.subn(
+            f"Test Plan Reviewer: {name}", text, count=1
+        )
+        if count == 0:
+            raise TemplateFormatError(
+                f"no 'Test Plan Reviewer:' line found in {self.path}"
+            )
+
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(new_text)
+        os.replace(tmp, self.path)
+        self.reviewer = name
 
     @abstractmethod
     def check_hash(self) -> tuple[bool, str, str]:

--- a/tests/test_cmd_apicall.py
+++ b/tests/test_cmd_apicall.py
@@ -1,4 +1,4 @@
-"""Tests for the `approve` command (BaseApiCall dispatch)."""
+"""Tests for the API-call commands (BaseApiCall dispatch and PI auto-lock)."""
 
 from __future__ import annotations
 
@@ -7,8 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mtui.commands.apicall import Approve, Assign, Reject, Unassign
-from mtui.messages import TestReportNotLoadedError
+from mtui.commands.apicall import Assign, Reject, Unassign
 from mtui.types import RequestKind, RequestReviewID
 
 
@@ -24,26 +23,6 @@ def _prompt() -> MagicMock:
     p.display = MagicMock()
     p.targets = MagicMock()
     return p
-
-
-def test_approve_osc_branch_calls_osc_approve(mock_config):
-    prompt = _prompt()
-    args = Namespace(group=["qam-sle"], user="")
-
-    with patch("mtui.commands.apicall.OSC") as osc_cls:
-        Approve(args, mock_config, MagicMock(), prompt)()
-
-    osc_cls.assert_called_once_with(mock_config, prompt.metadata.rrid)
-    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
-
-
-def test_approve_without_metadata_raises(mock_config):
-    prompt = _prompt()
-    prompt.metadata.__bool__ = lambda self: False
-    args = Namespace(group=None, user="")
-
-    with pytest.raises(TestReportNotLoadedError):
-        Approve(args, mock_config, MagicMock(), prompt)()
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +75,6 @@ def test_assign_non_pi_does_not_lock(mock_config):
 @pytest.mark.parametrize(
     ("cls", "extra"),
     [
-        (Approve, {}),
         (Unassign, {}),
         (Reject, {"reason": "admin", "message": ["nope"]}),
     ],

--- a/tests/test_cmd_approve.py
+++ b/tests/test_cmd_approve.py
@@ -1,0 +1,129 @@
+"""Tests for the `approve` command."""
+
+from __future__ import annotations
+
+import subprocess
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mtui.commands.approve import Approve
+from mtui.messages import TestReportNotLoadedError
+from mtui.template import TemplateFormatError
+from mtui.types import RequestKind, RequestReviewID
+
+
+def _prompt() -> MagicMock:
+    p = MagicMock()
+    p.metadata = MagicMock()
+    p.metadata.__bool__ = lambda self: True
+    # MAINTENANCE -> _is_gitea_workflow returns False -> osc path
+    p.metadata.rrid = MagicMock()
+    p.metadata.rrid.kind = RequestKind.MAINTENANCE
+    p.metadata.rrid.maintenance_id = "12345"
+    p.metadata.rrid.review_id = "67890"
+    p.display = MagicMock()
+    p.targets = MagicMock()
+    return p
+
+
+def test_approve_osc_branch_calls_osc_approve(mock_config):
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with patch("mtui.commands.approve.OSC") as osc_cls:
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_called_once_with(mock_config, prompt.metadata.rrid)
+    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
+
+
+def test_approve_without_metadata_raises(mock_config):
+    prompt = _prompt()
+    prompt.metadata.__bool__ = lambda self: False
+    args = Namespace(group=None, user="", reviewer=None)
+
+    with pytest.raises(TestReportNotLoadedError):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+
+def test_approve_pi_unlocks(mock_config):
+    mock_config.lock_pi_autolock = True
+    prompt = _prompt()
+    prompt.metadata.rrid = RequestReviewID("SUSE:PI:34556:1")
+    prompt.metadata.lock_comment = "testing of SUSE:PI:34556:1"
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with patch("mtui.commands.approve.OSC"):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    prompt.targets.unlock.assert_called_once_with()
+    assert prompt.metadata.lock_comment == ""
+
+
+# ---------------------------------------------------------------------------
+# approve -r REVIEWER: record reviewer + svn commit + approve
+# ---------------------------------------------------------------------------
+
+
+def test_approve_reviewer_records_commits_then_approves(mock_config):
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer="alice")
+
+    with (
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        patch("mtui.commands.approve.svn_commit_testreport") as svn,
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    prompt.metadata.set_reviewer.assert_called_once_with("alice")
+    svn.assert_called_once()
+    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
+
+
+def test_approve_reviewer_aborts_when_set_reviewer_fails(mock_config):
+    prompt = _prompt()
+    prompt.metadata.set_reviewer.side_effect = TemplateFormatError("no line")
+    args = Namespace(group=["qam-sle"], user="", reviewer="alice")
+
+    with (
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        patch("mtui.commands.approve.svn_commit_testreport") as svn,
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    svn.assert_not_called()
+    osc_cls.assert_not_called()
+
+
+def test_approve_reviewer_aborts_when_svn_commit_fails(mock_config):
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer="alice")
+
+    with (
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        patch(
+            "mtui.commands.approve.svn_commit_testreport",
+            side_effect=subprocess.CalledProcessError(1, "svn"),
+        ),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    prompt.metadata.set_reviewer.assert_called_once_with("alice")
+    osc_cls.assert_not_called()
+
+
+def test_approve_reviewer_empty_aborts(mock_config):
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer="   ")
+
+    with (
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        patch("mtui.commands.approve.svn_commit_testreport") as svn,
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    prompt.metadata.set_reviewer.assert_not_called()
+    svn.assert_not_called()
+    osc_cls.assert_not_called()

--- a/tests/test_cmd_commit.py
+++ b/tests/test_cmd_commit.py
@@ -30,8 +30,8 @@ def test_commit_happy_runs_svn_add_up_ci(mock_config, tmp_path):
     args = Namespace(msg=None)
 
     with (
-        patch("mtui.commands.commit.subprocess.check_call") as cc,
-        patch("mtui.commands.commit.subprocess.call") as call,
+        patch("mtui.template.subprocess.check_call") as cc,
+        patch("mtui.template.subprocess.call") as call,
     ):
         Commit(args, mock_config, MagicMock(), prompt)()
 
@@ -46,9 +46,7 @@ def test_commit_swallows_subprocess_error(mock_config, tmp_path, caplog):
     caplog.set_level(logging.ERROR, logger="mtui.command.commit")
     args = Namespace(msg=None)
 
-    with patch(
-        "mtui.commands.commit.subprocess.check_call", side_effect=OSError("boom")
-    ):
+    with patch("mtui.template.subprocess.check_call", side_effect=OSError("boom")):
         Commit(args, mock_config, MagicMock(), prompt)()
 
     assert any("committing template.failed" in r.message for r in caplog.records)

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -20,7 +20,7 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("EOF", "mtui.commands.quit", "DEOF"),
         ("add_host", "mtui.commands.addhost", "AddHost"),
         ("analyze_diff", "mtui.commands.showdiff", "AnalyzeDiff"),
-        ("approve", "mtui.commands.apicall", "Approve"),
+        ("approve", "mtui.commands.approve", "Approve"),
         ("assign", "mtui.commands.apicall", "Assign"),
         ("checkout", "mtui.commands.checkout", "Checkout"),
         ("comment", "mtui.commands.apicall", "Comment"),

--- a/tests/test_testreport_set_reviewer.py
+++ b/tests/test_testreport_set_reviewer.py
@@ -1,0 +1,147 @@
+"""Tests for ``TestReport.set_reviewer`` template rewriting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mtui.template import TemplateFormatError
+from mtui.template.testreport import TestReport
+
+
+class _ConcreteReport(TestReport):
+    """Minimal instantiable TestReport for exercising set_reviewer."""
+
+    @property
+    def id(self):
+        return "test"
+
+    def check_hash(self):
+        return True, "", ""
+
+    def _parser(self):
+        return {}
+
+    def _update_repos_parser(self):
+        return {}
+
+    def list_update_commands(self, targets, display):
+        return None
+
+
+def _report(mock_config, path: Path | None) -> TestReport:
+    """Builds a minimal concrete TestReport with ``path`` set."""
+    tr = _ConcreteReport.__new__(_ConcreteReport)  # bypass __init__
+    tr.config = mock_config
+    tr.path = path
+    tr.reviewer = ""
+    return tr
+
+
+TEMPLATE = """\
+METADATA:
+=========
+Packager: slemke@suse.com
+Bugs: 12345
+{reviewer_line}
+Repository: http://example/
+"""
+
+
+def _write(tmp_path: Path, reviewer_line: str) -> Path:
+    p = tmp_path / "log"
+    p.write_text(TEMPLATE.format(reviewer_line=reviewer_line))
+    return p
+
+
+def test_replaces_existing_reviewer_value(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: #maintenance")
+    tr = _report(mock_config, p)
+
+    tr.set_reviewer("alice")
+
+    text = p.read_text()
+    assert "Test Plan Reviewer: alice" in text
+    assert "#maintenance" not in text
+    assert tr.reviewer == "alice"
+
+
+def test_replaces_empty_reviewer_value(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer:")
+    tr = _report(mock_config, p)
+
+    tr.set_reviewer("alice")
+
+    assert "Test Plan Reviewer: alice" in p.read_text()
+
+
+def test_normalizes_whitespace_and_old_suggested_phrasing(mock_config, tmp_path):
+    p = _write(tmp_path, "Suggested Test Plan Reviewers:    old.user@example.com")
+    tr = _report(mock_config, p)
+
+    tr.set_reviewer("alice")
+
+    text = p.read_text()
+    assert "Test Plan Reviewer: alice" in text
+    assert "Suggested" not in text
+    assert "old.user@example.com" not in text
+
+
+def test_strips_surrounding_whitespace_from_name(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: x")
+    tr = _report(mock_config, p)
+
+    tr.set_reviewer("  alice  ")
+
+    assert "Test Plan Reviewer: alice\n" in p.read_text()
+    assert tr.reviewer == "alice"
+
+
+def test_only_other_lines_unchanged(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: old")
+    original = p.read_text()
+    tr = _report(mock_config, p)
+
+    tr.set_reviewer("alice")
+
+    new = p.read_text()
+    # Exactly one line differs.
+    diff = [
+        (a, b)
+        for a, b in zip(original.splitlines(), new.splitlines(), strict=True)
+        if a != b
+    ]
+    assert diff == [("Test Plan Reviewer: old", "Test Plan Reviewer: alice")]
+
+
+def test_missing_line_raises(mock_config, tmp_path):
+    p = tmp_path / "log"
+    p.write_text("METADATA:\nPackager: x\nRepository: y\n")
+    original = p.read_text()
+    tr = _report(mock_config, p)
+
+    with pytest.raises(TemplateFormatError):
+        tr.set_reviewer("alice")
+
+    assert p.read_text() == original
+    assert tr.reviewer == ""
+
+
+def test_empty_name_raises_and_leaves_file(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: old")
+    original = p.read_text()
+    tr = _report(mock_config, p)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        tr.set_reviewer("   ")
+
+    assert p.read_text() == original
+    assert tr.reviewer == ""
+
+
+def test_no_path_raises(mock_config):
+    tr = _report(mock_config, None)
+
+    with pytest.raises(RuntimeError):
+        tr.set_reviewer("alice")


### PR DESCRIPTION
## Why

Approving an update required three manual steps that frequently got out of sync: edit the testreport to fill in the `Test Plan Reviewer:` line, `svn ci` the testreport, then run `approve`. Testers occasionally approved without the reviewer recorded or with an uncommitted local edit, leaving the QAM archive inconsistent with what was actually approved.

Tracks: https://progress.opensuse.org/issues/200603

## What

A single `approve -r REVIEWER` now records the reviewer, commits the testreport to SVN, and approves the update atomically. If recording the reviewer fails (no `Test Plan Reviewer:` line) or the SVN commit fails, the approval is aborted **before** any OSC call, so the archive never drifts from what was approved. Plain `approve` without `-r` is unchanged.

### Changes

- New `mtui/commands/approve.py` module hosting `Approve` with the `-r/--reviewer` flag; `apicall.py` keeps the shared `BaseApiCall` plus `Assign`/`Unassign`/`Reject`/`Comment`.
- Extracted `svn_commit_testreport` helper into `mtui/template/__init__.py`; the `commit` command and the new approve flow share it (`commit` still swallows exceptions, `approve` aborts on them so nothing is approved on partial failure).
- `TestReport.set_reviewer` rewrites the `Test Plan Reviewer:` line and raises `TemplateFormatError` when the line is missing.
- Registry snapshot (`tests/test_commands_registry.py`), `Documentation/iui.rst`, and `CHANGELOG.md` updated in the same commit.

## Tests

New tests cover the success path plus every abort condition:

- `tests/test_cmd_approve.py` — Approve dispatch, `-r` happy path (records reviewer -> svn commit -> approve), `set_reviewer` failure aborts before svn, svn failure aborts before OSC, empty/whitespace reviewer aborts, missing metadata raises `TestReportNotLoadedError`.
- `tests/test_testreport_set_reviewer.py` — line-rewrite unit tests for the template helper.
- `tests/test_cmd_commit.py` updated for the extracted helper.

Local gates all green:

```
uv run ruff format --check .   # 238 files already formatted
uv run ruff check .            # All checks passed!
uv run ty check                # All checks passed!
uv run pytest -q               # 985 passed
```