### PR TITLE
docs: sync developer.rst, AGENTS.md, README.md with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@
 
 ## Project Shape
 - Python package entrypoint is `mtui.main:main`; run it from the checkout with `uv run python -m mtui --help` or `uv run mtui --help`.
-- `mtui/commands/` is dynamically imported at startup. Add one command module per interactive command; modules starting with `_` are skipped.
+- `mtui/commands/` is imported as a package; every `Command` subclass auto-registers via `Command.__init_subclass__` into `Command.registry`. Add one command module per interactive command; modules starting with `_` are skipped.
 - Commands subclass `mtui.commands._command.Command`, set `command`, implement `_add_arguments()` when needed, and implement `__call__()`.
-- Main runtime wiring is `mtui/main.py` -> `mtui/prompt.py` -> dynamic `mtui.commands` registry.
+- Main runtime wiring is `mtui/main.py` -> `mtui/prompt.py` -> `mtui.commands.registry`.
 - Config is INI from `MTUI_CONF`, explicit `--config`, or `/etc/mtui.cfg` plus `~/.mtuirc`; `TEMPLATE_DIR`, `TMPDIR`, and `GITEA_TOKEN` are also read.
 
 ## Development Commands

--- a/Documentation/developer.rst
+++ b/Documentation/developer.rst
@@ -22,7 +22,11 @@ Project layout
       main.py              # console-script entry point
       prompt.py            # interactive Cmd subclass (CommandPrompt)
       refhost.py           # reference-host attribute schema
-      utils.py             # term/colour/path helpers (slated to split)
+      colors.py            # ANSI colour helpers
+      completion.py        # readline completion helpers
+      fileops.py           # filesystem helpers (atomic write, ensure_dir)
+      term.py              # terminal size / prompting helpers
+      misc.py              # remaining small helpers (e.g. requires_update)
       actions/             # background SSH worker actions
       checks/              # post-update verification probes
       commands/            # one module per `do_<command>` (see below)
@@ -107,18 +111,23 @@ Every interactive ``mtui>`` command lives in its own module under
 ``mtui/commands/``. A command is a subclass of
 ``mtui.commands._command.Command`` exposing:
 
-- ``command``: the textual command name.
-- ``stable``: ``True`` for stable commands, ``False`` for experimental.
-- ``parse_args``: builds an ``argparse.ArgumentParser``.
-- ``run``: implementation; reads ``self.args`` and ``self.targets``.
-- ``complete``: optional readline completer.
+- ``command``: the textual command name (class attribute, required).
+- ``_add_arguments(cls, parser)``: classmethod that registers
+  argparse arguments on the supplied parser (optional; default no-op).
+- ``__call__(self)``: the implementation, reads ``self.args`` and
+  ``self.targets`` (required; ``Command`` is abstract on ``__call__``).
+- ``complete(state, text, line, begidx, endidx)``: optional readline
+  completer; the base class returns ``[]``.
 
-At interpreter start, ``mtui/commands/__init__.py`` imports every module
-in the directory; ``CommandPrompt`` then registers ``do_<command>``,
-``help_<command>`` and ``complete_<command>`` shims for each subclass.
-
-(Phase 5 will replace the filesystem glob with a
-``Command.__init_subclass__`` registry; see ``PLAN.md`` track C5.)
+Importing ``mtui.commands`` walks the package with
+``pkgutil.iter_modules`` and imports every submodule whose name does
+not start with ``_``. Each ``Command`` subclass that assigns ``command``
+in its own body auto-registers via ``Command.__init_subclass__`` into
+``Command.registry`` (re-exported as ``mtui.commands.registry``); two
+subclasses claiming the same ``command`` string raise
+``CommandAlreadyBoundError`` at class-creation time. ``CommandPrompt``
+iterates the registry and binds ``do_<command>``, ``help_<command>``
+and ``complete_<command>`` shims for each entry.
 
 
 How to add a new command
@@ -128,20 +137,18 @@ How to add a new command
 
    .. code-block:: python
 
+       from ..argparse import ArgumentParser
        from ._command import Command
 
 
        class Foo(Command):
            command = "foo"
-           stable = True
 
            @classmethod
-           def parse_args(cls, args, sys_):
-               parser = cls._parse_args(sys_)
+           def _add_arguments(cls, parser: ArgumentParser) -> None:
                parser.add_argument("name")
-               return parser.parse_args(cls.split_arg(args))
 
-           def run(self):
+           def __call__(self) -> None:
                self.println(f"hello, {self.args.name}")
 
 2. Add tests under ``tests/test_foo.py``: at minimum a happy-path

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ The Maintenance Test Update Installer (MTUI) allows you to run shell commands on
 
 In addition, MTUI provides convenience commands to help with maintenance update testing and integrating with other systems like Bugzilla and test report templates.
 
+## Features
+
+- Parallel SSH command execution across SUSE reference hosts (`run`, `prepare`, `update`, `install`, `downgrade`, …) with per-host `enabled` / `disabled` / `dryrun` states and `parallel` / `serial` execution modes.
+- OBS / IBS maintenance-request workflow: `assign`, `unassign`, `approve`, `reject`, `comment` — dispatched to either `osc` or Gitea depending on the request kind. `approve -r REVIEWER` records the reviewer in the testreport and commits to SVN in one step.
+- openQA integration: `reload_openqa`, `set_workflow {auto,manual,kernel}`, and `openqa_overview` (port of `oqa-search`) which prints PASSED/FAILED/RUNNING per SLE version, aggregated-update builds, and parsed build-check summaries, with `--export` to inject the block into the testreport's `regression tests:` section.
+- Reference-host lock management: cooperative `/var/lock/mtui.lock` files, automatic locking of every connected host while a Product Increment is under test (`[lock] pi_autolock`), and automatic reaping of stale locks left over from crashed sessions (`[lock] reap_stale`, `[lock] stale_age`).
+- Test-report lifecycle: `load_template`, `checkout`, `commit`, `edit`, `export`, with SVN and Gitea checkout backends.
+- Reference-host discovery: HTTPS- or filesystem-resolved `refhosts.yml` with location-aware fallback and configurable cache expiry.
+- File transfer: `put` (glob upload to all hosts) and `get` (download with per-host filename suffix or recursive folder mode).
+- Interactive shell with readline completion, history search, per-command `--help`, configurable log level, optional desktop notifications (`notify` extra), and OS-keyring credential storage (`keyring` extra).
+- Shell-completion script via the `completion` extra (`register-python-argcomplete mtui`).
+
 ## License
 
 This project is licensed under the GPLv2 license, see the COPYING file for details.


### PR DESCRIPTION
## Summary

Catches the user-facing and contributor-facing docs back up to the current
state of the code. No code changes; docs-only.

| File | Change |
|---|---|
| `Documentation/developer.rst` | Replace the removed `utils.py` line in the project-layout block with the five replacement modules (`colors.py`, `completion.py`, `fileops.py`, `term.py`, `misc.py`). Rewrite the command-architecture section to describe `Command.registry` / `Command.__init_subclass__` / `CommandAlreadyBoundError` and `CommandPrompt`'s shim binding. Update the `Command` attribute list to `_add_arguments` / `__call__`. Update the `Foo` sample subclass in "How to add a new command" to match. |
| `AGENTS.md` | "Dynamically imported at startup" → "imported as a package; auto-registers via `Command.__init_subclass__`". Sibling bullet's "dynamic `mtui.commands` registry" → "`mtui.commands.registry`". |
| `README.md` | Add a 9-bullet `## Features` section between the description and the `## License` heading, describing parallel SSH, OBS/IBS workflow, openQA overview, PI auto-locks and stale-lock reaping, test-report lifecycle, refhost discovery, file transfer, shell extras, and the `completion` extra. Framed as current state. |

## Why

- The Phase 5 work replaced the filesystem-glob loader in `mtui/commands/__init__.py` with a `Command.__init_subclass__` auto-registry (commits `eea4cad`, `75a6c9d`), but `developer.rst` still promised *"Phase 5 will replace the filesystem glob"* and `AGENTS.md` still called the loader *"dynamically imported at startup"*.
- The `mtui/utils.py` split (commits `e90da4d` … `98314c3`) broke that single module into five topical modules, but `developer.rst` still listed `utils.py # term/colour/path helpers (slated to split)`.
- The `Command` attribute list and the sample `Foo` subclass still showed the obsolete `parse_args` / `run` hooks rather than today's `_add_arguments` / `__call__`.
- `README.md` was a thin landing page with no feature surface, so newcomers had no signal about what mtui can actually do.

## Verifications

- `grep -n 'utils.py' Documentation/developer.rst` — clean
- `grep -nE 'Phase 5|filesystem glob|PLAN\.md' Documentation/developer.rst` — clean
- `grep -n 'dynamically imported' AGENTS.md` — clean
- `uv run ruff format --check .` — 238 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html` — `build succeeded` (warnings-as-errors gate)
- `git diff --stat` upstream/main..HEAD touches only the three planned files (+39/-20)

## Out of scope

- `CHANGELOG.md`: not touched. The repo policy in `AGENTS.md` is that user-visible changes go under `[Unreleased]`, and this is a docs-only sync that does not change behaviour; per the same policy, internal-only changes usually don't get a changelog bullet.
- `Documentation/iui.rst`: not touched. An audit (every `Command` subclass in `mtui/commands/*.py` cross-referenced against `+++`-underlined headers in `iui.rst`) found zero gaps — recent feature commits (`openqa_overview`, `approve -r`, lock changes) had already updated it.
- `Documentation/cfg.rst`: not touched. The new `[lock]` options (`reap_stale`, `stale_age`, `pi_autolock`) and the example config block were already documented.