### PR TITLE
fix(checkout): clear error and exit when a test report does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Loading a non-existent test report now fails with a clear message
+  instead of a raw SVN error. For any update kind, when the report's SVN
+  checkout fails mtui reports `Test report for <RRID> does not exist.
+  Please check <reports-url>/<RRID>/log for potential issues.` and the cryptic
+  `svn: E170000: URL ... doesn't exist` line is suppressed (shown only at
+  `--debug`). When the report was requested explicitly on the command
+  line (`-a` / `-k`), mtui now exits non-zero instead of dropping into an
+  empty interactive session.
 - `set_location` now resets the working reference-host selection. Hosts
   inherited from the testreport template and from the previously
   configured location are dropped, so a subsequent `add_host` connects

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -17,6 +17,7 @@ from .messages import MetadataNotLoadedError, SvnCheckoutInterruptedError
 from .prompt import CommandPrompt
 from .prompter import Prompter
 from .systemcheck import detect_system
+from .template.nulltestreport import NullTestReport
 
 
 def main() -> int:
@@ -96,6 +97,12 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
             return 1
         except MissingGiteaTokenError:
             # _checkout already logged a user-facing message; just exit.
+            return 1
+
+        # An explicitly requested update that could not be loaded falls back
+        # to a NullTestReport. The clear "does not exist" message was already
+        # logged; quit rather than dropping into an empty interactive session.
+        if isinstance(prompt.metadata, NullTestReport):
             return 1
 
     if args.sut:

--- a/mtui/messages.py
+++ b/mtui/messages.py
@@ -89,14 +89,14 @@ class SvnCheckoutInterruptedError(ErrorMessage):
 
 
 class SvnCheckoutFailed(ErrorMessage):
-    """Raised when an SVN checkout fails."""
+    """Raised when a test report template cannot be checked out."""
 
-    _msg = "Svn checkout of {0!r} Failed\n Please check {1!s}"
+    _msg = "Test report for {0} does not exist.\nPlease check {1} for potential issues."
 
-    def __init__(self, uri, f_url: str) -> None:
-        self.uri = uri
-        self.f_url = f_url
-        self.message = self._msg.format(uri, f_url)
+    def __init__(self, rrid, report_url: str) -> None:
+        self.rrid = rrid
+        self.report_url = report_url
+        self.message = self._msg.format(rrid, report_url)
 
 
 class ConnectingTargetFailedMessage(UserMessage):

--- a/mtui/template/__init__.py
+++ b/mtui/template/__init__.py
@@ -81,9 +81,20 @@ def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:
 
     with chdir(config.template_dir):
         try:
-            subprocess.check_call(["svn", "co", uri])
+            # Capture stderr so svn's cryptic "E170000: URL ... doesn't
+            # exist" line does not reach the user; it is surfaced at debug
+            # while the caller logs a clear, actionable message instead.
+            result = subprocess.run(
+                ["svn", "co", uri],
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
         except KeyboardInterrupt:
             raise SvnCheckoutInterruptedError(uri) from None
-        except subprocess.CalledProcessError:
-            f_url = join(config.fancy_reports_url, str(rrid))
-            raise SvnCheckoutFailed(uri, f_url) from None
+
+        if result.returncode != 0:
+            if result.stderr:
+                logger.debug("svn co %s failed: %s", uri, result.stderr.strip())
+            report_url = f"{config.fancy_reports_url.rstrip('/')}/{rrid}/log"
+            raise SvnCheckoutFailed(str(rrid), report_url) from None

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -93,7 +93,7 @@ class UpdateID(ABC):
                 try:
                     self._vcs_checkout(config, config.svn_path, self.id)
                 except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
-                    logger.error("SVN checkout failed")
+                    logger.error(e)
                     raise TestReportNotLoadedError from e
                 # Retry the read now that the template is on disk. Any
                 # Gitea-related error raised here must reach the outer

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,3 +83,54 @@ def test_run_mtui_with_debug():
 
             # Verify logger level was set to debug
             mock_logger.setLevel.assert_called_once_with(level=logging.DEBUG)
+
+
+def test_run_mtui_quits_when_explicit_update_not_loaded():
+    """An explicit -a update that fails to load exits 1 without a session."""
+    from mtui.template.nulltestreport import NullTestReport
+
+    mock_config = MagicMock()
+    mock_logger = MagicMock()
+
+    with (
+        patch("mtui.main.detect_system", return_value=("sles", "15", "6")),
+        patch("mtui.main.Prompter"),
+        patch("mtui.main.CommandPrompt") as cp,
+    ):
+        prompt = cp.return_value
+        # Failed checkout falls back to a NullTestReport.
+        prompt.metadata = NullTestReport(mock_config)
+        update = MagicMock()
+        update.kind = "auto"
+        args = Namespace(
+            debug=False, update=update, sut=None, prerun=None, noninteractive=False
+        )
+
+        result = run_mtui(mock_config, mock_logger, args)
+
+    assert result == 1
+    prompt.cmdloop.assert_not_called()
+
+
+def test_run_mtui_starts_session_when_update_loads():
+    """A successfully loaded explicit update proceeds to the command loop."""
+    mock_config = MagicMock()
+    mock_logger = MagicMock()
+
+    with (
+        patch("mtui.main.detect_system", return_value=("sles", "15", "6")),
+        patch("mtui.main.Prompter"),
+        patch("mtui.main.CommandPrompt") as cp,
+    ):
+        prompt = cp.return_value
+        prompt.metadata = MagicMock()  # a real (non-Null) test report
+        update = MagicMock()
+        update.kind = "auto"
+        args = Namespace(
+            debug=False, update=update, sut=None, prerun=None, noninteractive=False
+        )
+
+        result = run_mtui(mock_config, mock_logger, args)
+
+    assert result == 0
+    prompt.cmdloop.assert_called_once()

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -21,8 +21,9 @@ def test_messages():
         == "Svn checkout of 'test_uri' interrupted"
     )
     assert (
-        str(messages.SvnCheckoutFailed("test_uri", "test_url"))
-        == "Svn checkout of 'test_uri' Failed\n Please check test_url"
+        str(messages.SvnCheckoutFailed("SUSE:SLFO:1.2:9999", "test_url"))
+        == "Test report for SUSE:SLFO:1.2:9999 does not exist.\n"
+        "Please check test_url for potential issues."
     )
     assert (
         str(messages.ConnectingTargetFailedMessage("test_host", "test_reason"))

--- a/tests/test_template_svn_checkout.py
+++ b/tests/test_template_svn_checkout.py
@@ -1,0 +1,56 @@
+"""Tests for ``mtui.template.testreport_svn_checkout`` error handling."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from mtui import template
+from mtui.messages import SvnCheckoutFailed
+from mtui.types import RequestReviewID
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        template_dir=tmp_path,
+        fancy_reports_url="https://qam.suse.de/reports",
+    )
+
+
+def test_svn_checkout_missing_raises_clear_error(tmp_path: Path) -> None:
+    """A non-existent report yields a clear message pointing to the log URL."""
+    cfg = _cfg(tmp_path)
+    rrid = RequestReviewID("SUSE:SLFO:1.2:9999")
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stderr="svn: E170000: URL '...' doesn't exist\n"
+    )
+
+    with (
+        patch("mtui.template.subprocess.run", return_value=completed) as run,
+        pytest.raises(SvnCheckoutFailed) as excinfo,
+    ):
+        template.testreport_svn_checkout(
+            cfg, "svn+ssh://svn@qam.suse.de/testreports", rrid
+        )
+
+    # svn's own stderr is captured (suppressed from the terminal).
+    assert run.call_args.kwargs.get("stderr") is subprocess.PIPE
+    msg = str(excinfo.value)
+    assert "SUSE:SLFO:1.2:9999 does not exist" in msg
+    assert "https://qam.suse.de/reports/SUSE:SLFO:1.2:9999/log" in msg
+    # The cryptic svn error code is not part of the user-facing message.
+    assert "E170000" not in msg
+
+
+def test_svn_checkout_success_does_not_raise(tmp_path: Path) -> None:
+    """A successful checkout returns without raising."""
+    cfg = _cfg(tmp_path)
+    rrid = RequestReviewID("SUSE:Maintenance:1:1")
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
+
+    with patch("mtui.template.subprocess.run", return_value=completed):
+        template.testreport_svn_checkout(cfg, "svn+ssh://svn@example/testreports", rrid)


### PR DESCRIPTION
## Problem

Running mtui against a test report that does not exist produced confusing, low-value output:

```
$ mtui -a SUSE:SLFO:1.2:9999
svn: E170000: URL 'svn+ssh://svn@qam.suse.de/testreports/SUSE:SLFO:1.2:9999' doesn't exist
error: SVN checkout failed
Maintenance Test Update Installer
Mtui>
```

Three issues: the raw `svn: E170000` line is cryptic; `SVN checkout failed` doesn't name the report or where to look; and mtui then drops into an **empty interactive session** as if nothing went wrong.

### Cause

`testreport_svn_checkout` raises `SvnCheckoutFailed` — which already carried a useful message — but `UpdateID._checkout` discarded it and logged a generic string. `make_testreport` then catches `TestReportNotLoadedError` and returns a `NullTestReport`, so startup continues into the prompt.

## Fix

- **Clear, actionable message for every update kind** (`mtui/messages.py`): `SvnCheckoutFailed` now reads `Test report for <RRID> does not exist.` followed by `Please check <reports-url>/<RRID>/log for potential issues.`. All kinds (Maintenance / PI / SLFO) check out the template via the same path, so all benefit.
- **Suppress the raw svn noise** (`mtui/template/__init__.py`): svn's stderr is captured and logged only at `--debug`; `_checkout` logs the friendly message instead of the generic one.
- **Quit instead of an empty session** (`mtui/main.py`): when an update was requested explicitly on the command line (`-a` / `-k`) and the load fell back to a `NullTestReport`, `run_mtui` returns non-zero without starting the command loop. A no-arg `mtui` still starts an empty session as before.

Result:

```
$ mtui -a SUSE:SLFO:1.2:9999
error: Test report for SUSE:SLFO:1.2:9999 does not exist.
Please check https://qam.suse.de/reports/SUSE:SLFO:1.2:9999/log for potential issues.
$   # exit 1, no prompt
```

## Tests / docs

- `tests/test_template_svn_checkout.py`: clear error + `/log` URL + stderr suppression on failure; success path no-raise.
- `tests/test_main.py`: explicit failed load exits 1 with no `cmdloop`; successful load proceeds to `cmdloop`.
- `tests/test_messages.py`: updated `SvnCheckoutFailed` rendering.
- `CHANGELOG.md` (Fixed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (989 passed).
