### PR TITLE
feat(checkout): offer to delete template on Gitea hash mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- When a loaded template's hash differs from the Gitea PR and you decline
+  to force-continue, mtui now offers to delete the checked-out template
+  (`Delete checked out template <path>? [Y/n]:`, default yes). Declining
+  keeps the checkout. Non-interactive runs never delete automatically.
+
 - The `approve` command now accepts `-r REVIEWER` / `--reviewer REVIEWER`.
   It records the reviewer in the testreport's `Test Plan Reviewer:` line,
   commits the testreport to SVN, and then approves the update — all in one

--- a/mtui/cli/term.py
+++ b/mtui/cli/term.py
@@ -56,16 +56,27 @@ def filter_ansi(text: str) -> str:
     return text
 
 
-def prompt_user(text: str, options: Collection[str], interactive: bool = True) -> bool:
+def prompt_user(
+    text: str,
+    options: Collection[str],
+    interactive: bool = True,
+    default: bool = False,
+) -> bool:
     """Prompts the user with a question and waits for a response.
 
     Args:
         text: The prompt to display to the user.
         options: A collection of strings that are considered "yes" answers.
         interactive: If False, the prompt is printed but no input is requested.
+        default: Result returned when the user submits an empty response
+            (just presses Enter) in interactive mode. Lets a prompt have a
+            preselected answer, e.g. ``[Y/n]``. Non-interactive mode always
+            returns False so a defaulted prompt never auto-confirms an
+            unattended (e.g. destructive) action.
 
     Returns:
-        True if the user's response is in `options`, False otherwise.
+        True if the user's response is in `options` (or empty and
+        ``default`` is True), False otherwise.
 
     """
     result = False
@@ -77,7 +88,9 @@ def prompt_user(text: str, options: Collection[str], interactive: bool = True) -
 
     try:
         response = input(text).lower()
-        if response and response in options:
+        if not response:
+            result = default
+        elif response in options:
             result = True
     except KeyboardInterrupt:
         pass

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -1,5 +1,6 @@
 """Classes for handling different types of update IDs."""
 
+import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from errno import ENOENT
@@ -122,10 +123,14 @@ class UpdateID(ABC):
             if not prompt_user(
                 "Force continue loading template ? [y/N]: ", ["yes", "y"], interactive
             ):
-                if trdir.exists():
-                    logger.warning(
-                        "Make sure to remove %s before relaunching MTUI", trdir
-                    )
+                if trdir.exists() and prompt_user(
+                    f"Delete checked out template {trdir}? [Y/n]: ",
+                    ["yes", "y"],
+                    interactive,
+                    default=True,
+                ):
+                    shutil.rmtree(trdir, ignore_errors=True)
+                    logger.info("Removed checked out template %s", trdir)
                 raise TestReportNotLoadedError from None
             logger.warning("Template is loaded, but hash differs")
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -1,8 +1,12 @@
 """Tests for the helpers in :mod:`mtui.term`."""
 
+from unittest.mock import patch
+
+import pytest
+
 from mtui.cli import colors as colorctl
 from mtui.cli.colors import green
-from mtui.cli.term import filter_ansi
+from mtui.cli.term import filter_ansi, prompt_user
 
 
 def test_filter_ansi():
@@ -15,3 +19,23 @@ def test_filter_ansi():
         assert filter_ansi(ansi_text) == text
     finally:
         colorctl.set_mode(saved)
+
+
+@pytest.mark.parametrize(
+    ("response", "default", "expected"),
+    [
+        ("", True, True),  # empty input takes the default
+        ("", False, False),
+        ("y", False, True),  # explicit yes overrides default
+        ("n", True, False),  # explicit no overrides default
+    ],
+)
+def test_prompt_user_default_on_empty_input(response, default, expected):
+    """An empty interactive response falls back to ``default``."""
+    with patch("builtins.input", return_value=response):
+        assert prompt_user("? ", ["yes", "y"], True, default=default) is expected
+
+
+def test_prompt_user_non_interactive_ignores_default():
+    """Non-interactive mode never auto-confirms, even with default=True."""
+    assert prompt_user("? ", ["yes", "y"], False, default=True) is False

--- a/tests/test_updateid.py
+++ b/tests/test_updateid.py
@@ -77,10 +77,10 @@ def _make_updateid_with_checkout_retry(
     return uid, tr_mock, vcs_mock
 
 
-def test_checkout_invalid_hash_abort_warns_when_trdir_exists(
-    mock_config, tmp_path, caplog
+def test_checkout_invalid_hash_abort_declining_delete_keeps_trdir(
+    mock_config, tmp_path
 ):
-    """Abort + existing trdir -> cleanup hint logged, prompt uses [y/N]."""
+    """Abort + decline delete -> trdir kept, no further action."""
     mock_config.template_dir = tmp_path
     uid, _tr_mock = _make_updateid()
     trdir = tmp_path / str(uid.id)
@@ -90,18 +90,40 @@ def test_checkout_invalid_hash_abort_warns_when_trdir_exists(
         patch(
             "mtui.types.updateid.prompt_user", return_value=False
         ) as prompt_user_mock,
-        caplog.at_level(logging.WARNING, logger="mtui.types.updateid"),
         pytest.raises(TestReportNotLoadedError),
     ):
         uid._checkout(mock_config, interactive=True)
 
-    # Prompt label change is locked in here.
-    prompt_user_mock.assert_called_once()
-    assert prompt_user_mock.call_args.args[0] == PROMPT_LABEL
+    # Two prompts: force-continue, then (since trdir exists) delete.
+    assert prompt_user_mock.call_count == 2
+    assert prompt_user_mock.call_args_list[0].args[0] == PROMPT_LABEL
+    delete_call = prompt_user_mock.call_args_list[1]
+    assert delete_call.args[0] == f"Delete checked out template {trdir}? [Y/n]: "
+    assert delete_call.kwargs["default"] is True
+    assert trdir.exists()  # declined -> not removed
 
-    cleanup_warnings = [r for r in caplog.records if CLEANUP_HINT in r.getMessage()]
-    assert len(cleanup_warnings) == 1
-    assert str(trdir) in cleanup_warnings[0].getMessage()
+
+def test_checkout_invalid_hash_abort_accepting_delete_removes_trdir(
+    mock_config, tmp_path, caplog
+):
+    """Abort + accept delete -> trdir removed, no cleanup hint."""
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock = _make_updateid()
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        # First prompt (force-continue) -> False, second (delete) -> True.
+        patch("mtui.types.updateid.prompt_user", side_effect=[False, True]),
+        caplog.at_level(logging.INFO, logger="mtui.types.updateid"),
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)
+
+    assert not trdir.exists()  # removed
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Removed checked out template" in m for m in messages)
+    assert not any(CLEANUP_HINT in m for m in messages)
 
 
 def test_checkout_invalid_hash_abort_silent_when_trdir_missing(
@@ -230,7 +252,7 @@ def test_checkout_invalid_hash_after_svn_checkout_prompts(
         uid._checkout(mock_config, interactive=True)  # noqa: SLF001
 
     vcs_mock.assert_called_once()
-    prompt_user_mock.assert_called_once()
-    assert prompt_user_mock.call_args.args[0] == PROMPT_LABEL
-    cleanup_warnings = [r for r in caplog.records if CLEANUP_HINT in r.getMessage()]
-    assert len(cleanup_warnings) == 1
+    # Two prompts: force-continue, then delete (trdir exists, both declined).
+    assert prompt_user_mock.call_count == 2
+    assert prompt_user_mock.call_args_list[0].args[0] == PROMPT_LABEL
+    assert not any(CLEANUP_HINT in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

When a loaded test report's template hash differs from the Gitea PR, mtui raises `InvalidGiteaHashError` and asks whether to force-continue. Previously, if the user declined, mtui just printed a `Make sure to remove <dir> before relaunching MTUI` hint and left the partially-checked-out template on disk for the user to clean up by hand.

Now, on decline, mtui offers to delete the checked-out template directory with a preselected **yes**:

```
Force continue loading template ? [y/N]:  n
Delete checked out template /…/SUSE:SLFO:1.2:9999? [Y/n]:      <- Enter = delete
Removed checked out template /…/SUSE:SLFO:1.2:9999
```

Declining the delete keeps the checkout. The old "remember to remove it" warning is dropped.

## Implementation

- `mtui/term.py` — `prompt_user()` gains a `default` parameter, used when the user submits an empty (Enter) response in interactive mode, so a prompt can have a preselected answer (`[Y/n]`). Non-interactive mode still returns `False`, so an unattended run never auto-confirms a destructive action.
- `mtui/types/updateid.py` — in the `InvalidGiteaHashError` abort branch, if the checkout directory exists, prompt to delete it (default yes). Accept → `shutil.rmtree`; decline → keep it. Removed the previous cleanup-hint warning.

## Tests / docs

- `tests/test_term.py`: `default` is applied on empty input and overridden by explicit y/n; non-interactive ignores it.
- `tests/test_updateid.py`: decline keeps the directory (two prompts, correct labels/default); accept removes it and logs "Removed checked out template"; existing missing-dir and force-continue cases still hold.
- `CHANGELOG.md` (Added).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (995 passed).
