### PR TITLE
feat(commit): default message from export footer instead of editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ tags
 
 # Coverage / profile artefacts
 *.profraw
+
+# Claude Code session artefacts
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- `commit` without `-m` no longer opens an editor to ask for a message.
+  It now commits non-interactively with a generated message that reuses
+  the testreport export footer, e.g. `committed from MTUI:<version>,
+  paramiko <version> on <distro>-<verid> (kernel: <kernel>) by <user>`.
+  Passing `-m` still uses the given message.
+
 - Internal: reorganized the `mtui/` package layout. No public CLI behaviour
   change. The 24 loose top-level modules are now grouped into six
   subpackages — `mtui/cli/`, `mtui/hosts/`, `mtui/data_sources/`,

--- a/mtui/commands/commit.py
+++ b/mtui/commands/commit.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 from ..cli.completion import complete_choices
 from ..support.misc import requires_update
+from ..support.systemcheck import system_info
 from ..test_reports.svn_io import svn_commit_testreport
 from . import Command
 
@@ -32,9 +33,20 @@ class Commit(Command):
         """Executes the `commit` command."""
         checkout = self.metadata.report_wd()
 
-        msg = []
         if self.args.msg:
             msg = ["-m", '"' + " ".join(self.args.msg[0]) + '"']
+        else:
+            # No -m given: commit non-interactively with a generated message
+            # reusing the testreport export footer (instead of letting svn
+            # open an editor to ask for one).
+            default_message = system_info(
+                self.config.distro,
+                self.config.distro_ver,
+                self.config.distro_kernel,
+                self.config.session_user,
+                prefix="committed from",
+            ).rstrip()
+            msg = ["-m", default_message]
 
         try:
             svn_commit_testreport(checkout, self.config.install_logs, msg)

--- a/mtui/support/systemcheck.py
+++ b/mtui/support/systemcheck.py
@@ -42,7 +42,9 @@ def detect_system() -> tuple[str, str, str]:
     return distro, verid, kernel
 
 
-def system_info(distro: str, verid: str, kernel: str, user: str) -> str:
+def system_info(
+    distro: str, verid: str, kernel: str, user: str, prefix: str = "## export"
+) -> str:
     """Formats system information into a string.
 
     Args:
@@ -50,10 +52,13 @@ def system_info(distro: str, verid: str, kernel: str, user: str) -> str:
         verid: The version ID of the distribution.
         kernel: The kernel version.
         user: The current user.
+        prefix: Leading text before the version details. Defaults to
+            ``"## export"`` (the testreport export footer); the ``commit``
+            command reuses this with ``"committed from"``.
 
     Returns:
         A formatted string containing the system information.
 
     """
-    string = f"## export MTUI:{mtui_version}, paramiko {paramiko_version} on {distro}-{verid} (kernel: {kernel}) by {user}\n"
+    string = f"{prefix} MTUI:{mtui_version}, paramiko {paramiko_version} on {distro}-{verid} (kernel: {kernel}) by {user}\n"
     return string

--- a/tests/test_cmd_commit.py
+++ b/tests/test_cmd_commit.py
@@ -54,6 +54,54 @@ def test_commit_swallows_subprocess_error(mock_config, tmp_path, caplog):
     assert any("committing template.failed" in r.message for r in caplog.records)
 
 
+def _svn_ci_message(check_call_mock) -> str:
+    """Return the message passed to the `svn ci -m <message>` invocation."""
+    ci_calls = [
+        c for c in check_call_mock.call_args_list if c.args[0][:2] == ["svn", "ci"]
+    ]
+    assert len(ci_calls) == 1
+    cmd = ci_calls[0].args[0]
+    assert cmd[2] == "-m"
+    return cmd[3]
+
+
+def test_commit_default_message_reuses_export_footer(mock_config, tmp_path):
+    """No -m: commit non-interactively with the export-footer system info."""
+    prompt = _prompt(tmp_path)
+    mock_config.install_logs = "install_logs"
+    mock_config.distro = "openSUSE Leap"
+    mock_config.distro_ver = "16.0"
+    mock_config.distro_kernel = "6.12.0"
+    mock_config.session_user = "mpluskal"
+    args = Namespace(msg=None)
+
+    with (
+        patch("mtui.test_reports.svn_io.subprocess.check_call") as cc,
+        patch("mtui.test_reports.svn_io.subprocess.call"),
+    ):
+        Commit(args, mock_config, MagicMock(), prompt)()
+
+    message = _svn_ci_message(cc)
+    assert message.startswith("committed from MTUI:")
+    assert "on openSUSE Leap-16.0 (kernel: 6.12.0) by mpluskal" in message
+    assert not message.endswith("\n")  # rstripped for a tidy commit message
+
+
+def test_commit_explicit_message_passed_through(mock_config, tmp_path):
+    """An explicit -m message is still used verbatim."""
+    prompt = _prompt(tmp_path)
+    mock_config.install_logs = "install_logs"
+    args = Namespace(msg=[["my", "message"]])
+
+    with (
+        patch("mtui.test_reports.svn_io.subprocess.check_call") as cc,
+        patch("mtui.test_reports.svn_io.subprocess.call"),
+    ):
+        Commit(args, mock_config, MagicMock(), prompt)()
+
+    assert _svn_ci_message(cc) == '"my message"'
+
+
 def test_commit_without_metadata_raises(mock_config):
     prompt = MagicMock()
     prompt.metadata = MagicMock()

--- a/tests/test_systemcheck.py
+++ b/tests/test_systemcheck.py
@@ -22,3 +22,20 @@ def test_detect_system(monkeypatch):
     assert distro == "test_distro"
     assert verid == "test_verid"
     assert kernel == "test_kernel"
+
+
+def test_system_info_default_prefix():
+    """The export footer keeps the ``## export`` prefix."""
+    s = systemcheck.system_info("openSUSE Leap", "16.0", "6.12.0", "mpluskal")
+    assert s.startswith("## export MTUI:")
+    assert "on openSUSE Leap-16.0 (kernel: 6.12.0) by mpluskal" in s
+    assert s.endswith("\n")
+
+
+def test_system_info_custom_prefix():
+    """A custom prefix (e.g. for commit messages) replaces ``## export``."""
+    s = systemcheck.system_info(
+        "openSUSE Leap", "16.0", "6.12.0", "mpluskal", prefix="committed from"
+    )
+    assert s.startswith("committed from MTUI:")
+    assert "on openSUSE Leap-16.0 (kernel: 6.12.0) by mpluskal" in s


### PR DESCRIPTION
## Summary

Running `commit` without `-m` previously left `svn ci` to open an editor prompting for a commit message. This commits the testreport non-interactively with a generated message that reuses the testreport **export footer**, so the SVN history mirrors what's recorded at the end of the report:

```
committed from MTUI:17.1.0, paramiko 3.5.1 on openSUSE Leap-16.0 (kernel: 6.12.0-160000.29-default) by mpluskal
```

Passing `-m` still uses the supplied message verbatim.

## Implementation

- `mtui/support/systemcheck.py` — `system_info()` gains a `prefix` parameter (default `"## export"`, so the export footer is unchanged). The `commit` command reuses it with `prefix="committed from"`.
- `mtui/commands/commit.py` — when no `-m` is given, build the message via `system_info(...)` (rstripped) and pass it as `svn ci -m <message>` instead of an empty message.

## Tests / docs

- `tests/test_systemcheck.py`: `system_info` default vs. custom prefix.
- `tests/test_cmd_commit.py`: default (no `-m`) reuses the export footer with the `committed from` prefix; explicit `-m` still passes through verbatim.
- `CHANGELOG.md` (Changed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (999 passed).
