### PR TITLE
fix(downgrade): pass --oldpackage so older versions install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- `downgrade` now passes `--oldpackage` to zypper (and the
+  `transactional-update pkg in` variant on transactional systems), so
+  installing the previously released, lower version actually proceeds.
+  Without it zypper refused to replace an installed package with an older
+  one, leaving the host on the too-recent version.
+
 ### Changed
 
 - `commit` without `-m` no longer opens an editor to ask for a message.

--- a/mtui/update_workflow/actions/downgrade.py
+++ b/mtui/update_workflow/actions/downgrade.py
@@ -23,7 +23,7 @@ done \
 | awk -F "|" '{{ print $2,"=",$4 }}'
 """
 
-    cmd_template = "rpm -q $package &>/dev/null  && zypper -n in -C --force-resolution -y $package=$version"
+    cmd_template = "rpm -q $package &>/dev/null  && zypper -n in -C --force-resolution --oldpackage -y $package=$version"
 
     return {
         "list_command": Template(list_command_template),
@@ -48,7 +48,7 @@ done \
 | awk -F "|" '{{ print $2,"=",$4 }}'
 """
 
-    cmd_template = "rpm -q $package &>/dev/null && transactional-update -c pkg in -C --force-resolution -y $package=$version"
+    cmd_template = "rpm -q $package &>/dev/null && transactional-update -c pkg in -C --force-resolution --oldpackage -y $package=$version"
     reboot = "systemctl reboot"
     init_snapshot = "transactional-update run true"
 

--- a/tests/test_actions_downgrade.py
+++ b/tests/test_actions_downgrade.py
@@ -1,0 +1,23 @@
+"""Tests for ``mtui.update_workflow.actions.downgrade``."""
+
+from __future__ import annotations
+
+from mtui.update_workflow.actions.downgrade import slmicro, zypper
+
+
+def test_zypper_downgrade_uses_oldpackage() -> None:
+    """The zypper downgrade command allows installing an older version."""
+    sub = zypper()["command"].safe_substitute(package="bash", version="1.2-3")
+    assert "zypper -n in" in sub
+    assert "--oldpackage" in sub
+    assert "--force-resolution" in sub
+    assert "bash=1.2-3" in sub
+
+
+def test_slmicro_downgrade_uses_oldpackage() -> None:
+    """The transactional-update downgrade command also allows older versions."""
+    sub = slmicro()["command"].safe_substitute(package="bash", version="1.2-3")
+    assert "transactional-update -c pkg in" in sub
+    assert "--oldpackage" in sub
+    assert "--force-resolution" in sub
+    assert "bash=1.2-3" in sub


### PR DESCRIPTION
## Problem

When a reference host carries a package version that is *too recent* (e.g. a newer maintenance update already installed), running `downgrade` in mtui did nothing useful — the host stayed on the too-recent version.

## Cause

`downgrade` removes the update-under-test repo, finds the released version of each package via `zypper search`, and then runs (per package):

```sh
rpm -q $package &>/dev/null && zypper -n in -C --force-resolution -y $package=$version
```

That has no `--oldpackage`, so zypper refuses to replace an installed package with an older version and the downgrade is effectively a no-op.

## Fix

Add `--oldpackage` to both zypper-based downgrade command templates in `mtui/update_workflow/actions/downgrade.py`:

- normal SLE hosts → `zypper -n in -C --force-resolution --oldpackage -y $package=$version`
- transactional (`slmicro`) hosts → `transactional-update -c pkg in -C --force-resolution --oldpackage -y $package=$version`

`yum` is unchanged (`yum -y downgrade` already installs older versions).

## Scope / note

`--oldpackage` only *permits* going backward; it does not change which version is selected (still the highest available in the released repos after the test repo is removed). Verified via unit tests and the full gate run; not yet exercised against a live host.

## Tests / docs

- `tests/test_actions_downgrade.py`: assert `--oldpackage` (and `--force-resolution`, `pkg=version`) in both the zypper and slmicro command templates.
- `CHANGELOG.md` (Fixed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1001 passed).
