### PR TITLE
fix(prepare): report expected UpdateError without a traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   installing the previously released, lower version actually proceeds.
   Without it zypper refused to replace an installed package with an older
   one, leaving the host on the too-recent version.
+- `prepare` no longer dumps a Python traceback when a host hits an
+  expected error such as an unresolved dependency conflict. The preparer
+  check already logs the actionable detail (the zypper resolutions to
+  pick); the `UpdateError` it raises is now reported as a single concise
+  `error: Prepare failed: <host>: <reason>` line instead of a stack
+  trace. Genuinely unexpected errors still log a full traceback.
 
 ### Changed
 

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -304,6 +304,11 @@ class HostsGroup(UserDict[str, Target]):
 
         except MissingPreparerError as e:
             logger.error("%s", e)
+        except UpdateError as e:
+            # Expected outcome (e.g. an unresolved dependency conflict): the
+            # preparer check already logged the actionable detail, so report
+            # it concisely without dumping a Python traceback.
+            logger.error("Prepare failed: %s", e)
         except Exception:
             logger.exception("Error during prepare operation")
         finally:

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -1,5 +1,6 @@
 """Tests for the mtui hostgroup module."""
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -305,6 +306,43 @@ def test_perform_install_unlocks_on_error(mock_run):
         hg.perform_install(["pkg"])
 
     # unlock must still be called
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.HostsGroup._fanout_set_repo")
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_prepare_dependency_error_logged_without_traceback(
+    mock_run, mock_fanout, caplog
+):
+    """An UpdateError from the preparer check is reported cleanly (no traceback)."""
+    t1 = MagicMock()
+    t1.hostname = "h1"
+    t1.transactional = False
+    t1.is_locked.return_value = False
+    t1.lasterr.return_value = ""  # pass the early "Failed to prepare host" guard
+    # The preparer check raises the expected dependency error.
+    t1.check.return_value = MagicMock(side_effect=UpdateError("Dependency Error", "h1"))
+
+    hg = HostsGroup([t1])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    with caplog.at_level(logging.ERROR, logger="mtui.hosts.target.hostgroup"):
+        hg.perform_prepare(
+            ["pkg"], MagicMock(), force=False, installed_only=False, testing=False
+        )
+
+    # Clean, actionable error -- not a stack-trace dump.
+    failures = [
+        r
+        for r in caplog.records
+        if "Prepare failed: h1: Dependency Error" in r.getMessage()
+    ]
+    assert len(failures) == 1
+    assert failures[0].exc_info is None  # logger.error, not logger.exception
+    # The broad "Error during prepare operation" traceback path must NOT fire.
+    assert not any(
+        "Error during prepare operation" in r.getMessage() for r in caplog.records
+    )
+    # Cleanup still happens.
     t1.unlock.assert_called()
 
 


### PR DESCRIPTION
## Problem

When `prepare` hits an expected error on a host — e.g. an unresolved dependency conflict — mtui dumps a full Python traceback at the user, even though the conflict was already reported clearly one line above:

```
critical: macaw.qam.suse.cz: unresolved dependency problem. please resolve manually:
...
 Solution 1: deinstallation of nvidia-open-driver-G07-signed-64kb-devel-...
 Solution 2: do not install nvidia-open-driver-G07-signed-cuda-64kb-devel-...
Choose from above solutions by number or cancel [1/2/c/d/?] (c): c

error: Error during prepare operation
Traceback (most recent call last):
  File ".../mtui/hosts/target/hostgroup.py", line 300, in perform_prepare
    t.check("preparer")(...)
  File ".../mtui/update_workflow/checks/prepare.py", line 49, in zypper
    raise UpdateError("Dependency Error", hostname)
mtui.support.exceptions.UpdateError: macaw.qam.suse.cz: Dependency Error
info: done
```

## Cause

The preparer check (`checks/prepare.py`) detects the unresolved-dependency prompt, logs the actionable detail at `critical`, and raises `UpdateError`. But `HostsGroup.perform_prepare` caught it with a blanket `except Exception: logger.exception("Error during prepare operation")`, which logs at ERROR **with** the stack trace — treating an expected outcome like an unexpected crash.

## Fix

Catch `UpdateError` separately and log it concisely; keep the traceback only for genuinely unexpected exceptions:

```python
except MissingPreparerError as e:
    logger.error("%s", e)
except UpdateError as e:
    logger.error("Prepare failed: %s", e)
except Exception:
    logger.exception("Error during prepare operation")
```

The conflict block is unchanged; the traceback is replaced by a single line:

```
error: Prepare failed: macaw.qam.suse.cz: Dependency Error
info: done
```

Behaviour is otherwise unchanged — prepare still stops on the conflict and unlocks.

## Tests / docs

- `tests/test_hostgroup.py`: a preparer-check `UpdateError` is logged as `Prepare failed: <host>: <reason>` with `exc_info is None` (no traceback), the blanket "Error during prepare operation" path does not fire, and cleanup (`unlock`) still runs.
- `CHANGELOG.md` (Fixed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1000 passed).
