### PR TITLE
fix: survive transactional-host reboot during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Transactional hosts no longer fail to reconnect after the post-update
+  reboot. The reboot command was run through the normal command path,
+  which on the (expected) dropped connection tried its own single,
+  immediate reconnect and gave up with `Failed to reconnect … after 1
+  retries` before the real retry loop ran. The reboot is now dispatched
+  fire-and-forget (the disconnect is expected), then mtui reconnects with
+  retries and backoff while the host comes back up.
 - Reconnect backoff now works. `Target.reconnect` passed `backoff`
   positionally into `Connection.reconnect`, whose second positional
   parameter is `timeout` — so the backoff flag was silently dropped and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Reconnect backoff now works. `Target.reconnect` passed `backoff`
+  positionally into `Connection.reconnect`, whose second positional
+  parameter is `timeout` — so the backoff flag was silently dropped and
+  the per-attempt wait collapsed to ~1s. It is now passed by keyword.
+
 - `downgrade` now passes `--oldpackage` to zypper (and the
   `transactional-update pkg in` variant on transactional systems), so
   installing the previously released, lower version actually proceeds.

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -229,6 +229,27 @@ class Connection:
                 f"Failed to reconnect to {self.hostname}:{self.port} after {count} retries"
             )
 
+    def fire_and_forget(self, command: str) -> None:
+        """Dispatches a command without waiting for it to complete.
+
+        Intended for commands that deliberately tear down the connection
+        (e.g. a reboot): the command is sent on a new session and the
+        local connection is then closed. No output or exit status is
+        collected and a dropped link is expected -- callers should follow
+        up with :meth:`reconnect`. This avoids the normal :meth:`run`
+        recovery path, which would otherwise try (and fail) to reconnect
+        to the still-rebooting host.
+
+        Args:
+            command: The command to dispatch.
+
+        """
+        logger.debug(
+            "%s: dispatching fire-and-forget command: %s", self.hostname, command
+        )
+        self.__run_command(command)
+        self.close()
+
     def new_session(self) -> Channel | None:
         """Opens a new session on the channel.
 

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -188,7 +188,13 @@ class HostsGroup(UserDict[str, Target]):
         """
         if reboot:
             logger.info("Rebooting transactional hosts %s", reboot.keys())
-            self.run(reboot)
+            # Dispatch the reboot fire-and-forget on every host first: the
+            # command intentionally drops the connection, so running it
+            # through the normal ``run`` path would trip its retry=0
+            # recovery and fail before we reconnect. Then reconnect each
+            # host with retries + backoff while it comes back up.
+            for hn, command in reboot.items():
+                self.data[hn].reboot(command)
             for hn in reboot:
                 self.data[hn].reconnect(retry=10, backoff=True)
 

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -184,7 +184,9 @@ class Target:
             backoff: Whether to use exponential backoff for retries.
 
         """
-        self.connection.reconnect(retry, backoff)
+        # ``backoff`` must be passed by keyword: ``Connection.reconnect``'s
+        # second positional parameter is ``timeout``, not ``backoff``.
+        self.connection.reconnect(retry, backoff=backoff)
 
     def reload_system(self) -> None:
         """Reloads the system information for the target host."""

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -176,6 +176,18 @@ class Target:
         self.packages = self._parse_packages()
         self.query_versions()
 
+    def reboot(self, command: str) -> None:
+        """Sends a reboot command without waiting for it to return.
+
+        The command is expected to drop the SSH connection; callers
+        should follow up with :meth:`reconnect`.
+
+        Args:
+            command: The reboot command to dispatch.
+
+        """
+        self.connection.fire_and_forget(command)
+
     def reconnect(self, retry, backoff) -> None:
         """Reconnects to the target host.
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -455,6 +455,23 @@ def test_reconnect_raises_after_exhausting_retries(
         conn.reconnect(retry=2, timeout=0)
 
 
+def test_fire_and_forget_dispatches_and_closes(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """fire_and_forget sends the command on a session, then closes the link."""
+    conn = Connection("h", 22, 300)
+    session = MagicMock()
+    # Connection has __slots__, so patch on the class, not the instance.
+    with (
+        patch.object(Connection, "new_session", return_value=session),
+        patch.object(Connection, "close") as close,
+    ):
+        conn.fire_and_forget("systemctl reboot")
+
+    session.exec_command.assert_called_once_with("systemctl reboot")
+    close.assert_called_once()
+
+
 def test_reconnect_backoff_grows_timeout(
     mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
 ):

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -436,11 +436,14 @@ def test_sftp_remove_delegates_to_filedelete(mock_rm):
 
 @patch("mtui.hosts.target.hostgroup.RunCommand")
 def test_reboot_runs_commands_and_reconnects(mock_run):
-    """Non-empty reboot dict triggers run + per-host reconnect."""
+    """Non-empty reboot dict fires the reboot then reconnects per host."""
     t1 = _stub_target("h1", transactional=True)
     hg = HostsGroup([t1])
     hg._reboot({"h1": "systemctl reboot"})
-    mock_run.return_value.run.assert_called_once()
+    # Fire-and-forget reboot (not via the normal run/RunCommand path)...
+    t1.reboot.assert_called_once_with("systemctl reboot")
+    mock_run.return_value.run.assert_not_called()
+    # ...then a robust reconnect with retries + backoff.
     t1.reconnect.assert_called_once_with(retry=10, backoff=True)
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -264,6 +264,18 @@ def test_run_handles_generic_exception(mock_config):
     assert target.lastexit() == -1
 
 
+# --- reboot ---
+
+
+def test_target_reboot_dispatches_fire_and_forget(mock_config):
+    """reboot() sends the command fire-and-forget via the connection."""
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    target.connection = MagicMock()
+
+    target.reboot("systemctl reboot")
+    target.connection.fire_and_forget.assert_called_once_with("systemctl reboot")
+
+
 # --- reconnect ---
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -268,13 +268,17 @@ def test_run_handles_generic_exception(mock_config):
 
 
 def test_reconnect_delegates(mock_config):
-    """Test reconnect() delegates to connection."""
+    """Test reconnect() delegates to connection, passing backoff by keyword.
+
+    ``Connection.reconnect``'s second positional parameter is ``timeout``,
+    so ``backoff`` must be passed by keyword or it is silently dropped.
+    """
     target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
 
     target.reconnect(3, True)
 
-    target.connection.reconnect.assert_called_once_with(3, True)
+    target.connection.reconnect.assert_called_once_with(3, backoff=True)
 
 
 # --- set_timeout ---


### PR DESCRIPTION
## Problem

`update` (e.g. `update --noprepare`) against a transactional host (SL Micro) fails right after the post-update reboot:

```
info: Rebooting transactional hosts dict_keys(['ulysse.qam.suse.cz'])
error: No valid connection to ulysse.qam.suse.cz:22
critical: failed to update target systems
error: Unexpected error: Failed to reconnect to ulysse.qam.suse.cz:22 after 1 retries
```

The host never gets the chance to come back up.

## Cause

Two distinct issues, fixed in two commits:

1. **The reboot is run as an ordinary command.** `HostsGroup._reboot` did `self.run(reboot)` to run `systemctl reboot`. Rebooting intentionally drops the SSH session, so `Connection.run`'s recovery path kicks in and calls `self.reconnect()` with the **default `retry=0`** — a single immediate attempt against the still-rebooting host. That raises `Failed to reconnect … after 1 retries` **before** `_reboot`'s intended `reconnect(retry=10, backoff=True)` loop is ever reached.

2. **Backoff was silently disabled.** `Target.reconnect(retry, backoff)` forwarded positionally to `Connection.reconnect(retry, timeout=10, backoff=False)`, so `backoff` landed on `timeout`. Even once the retry loop is reached, backoff never applied and the per-attempt wait collapsed to ~1s.

## Fix

**Commit 1 — `fix(connection): pass reconnect backoff by keyword`**
`Target.reconnect` now calls `Connection.reconnect(retry, backoff=backoff)`.

**Commit 2 — `fix(reboot): dispatch transactional reboot fire-and-forget`**
- New `Connection.fire_and_forget(command)`: dispatch on a new session, then close the link — the disconnect is expected; it bypasses the normal `run` retry=0 recovery.
- New `Target.reboot(command)` delegating to it.
- `HostsGroup._reboot` now sends the reboot fire-and-forget on every host, then reconnects each with `retry=10, backoff=True` while it comes back up.

## Tests / docs

- `tests/test_target.py`: `reconnect` passes `backoff` by keyword; `reboot` delegates to `fire_and_forget`.
- `tests/test_connection.py`: `fire_and_forget` dispatches on a session and closes.
- `tests/test_hostgroup.py`: `_reboot` fires the reboot (not via `RunCommand`) then reconnects with retries+backoff.
- `CHANGELOG.md` (Fixed, two entries).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1004 passed). Not yet verified against a live transactional reboot.
