### PR TITLE
feat(reboot): add reboot command for reference hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - New `reboot` command: reboots all connected reference hosts (or only
   those given with `-t`/`--target`) and reconnects automatically, with
   retries and backoff, once each host is back up. Works for both
-  transactional and non-transactional hosts. While testing a Product
-  Increment, the per-host testing lock is re-applied after the reboot (a
-  reboot clears `/var/lock`), so it is not lost.
+  transactional and non-transactional hosts. After reconnecting, the host's
+  boot id (`/proc/sys/kernel/random/boot_id`) is compared with the value
+  taken before the reboot; if it is unchanged an error is logged because the
+  host did not actually reboot. While testing a Product Increment, the
+  per-host testing lock is re-applied after the reboot (a reboot clears
+  `/var/lock`), so it is not lost.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- New `reboot` command: reboots all connected reference hosts (or only
+  those given with `-t`/`--target`) and reconnects automatically, with
+  retries and backoff, once each host is back up. Works for both
+  transactional and non-transactional hosts. While testing a Product
+  Increment, the per-host testing lock is re-applied after the reboot (a
+  reboot clears `/var/lock`), so it is not lost.
+
 ### Fixed
 
 - Transactional hosts no longer fail to reconnect after the post-update

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -404,6 +404,24 @@ downgrade
 Downgrades all related packages to the last released version (using
 the UPDATE channel).
 
+reboot
+++++++
+
+::
+
+    reboot [-t HOST]
+
+Reboots reference hosts and reconnects once they are back up. With no
+argument all connected reference hosts are rebooted; ``-t``/``--target``
+limits it to the named hosts. The reboot is dispatched without waiting
+(the SSH connection is expected to drop) and mtui reconnects
+automatically with retries and backoff. Works for both transactional and
+non-transactional hosts.
+
+While testing a Product Increment, the per-host testing lock is
+re-applied after the reboot (a reboot clears ``/var/lock``), so it is not
+lost.
+
 update
 ++++++
 

--- a/mtui/commands/reboot.py
+++ b/mtui/commands/reboot.py
@@ -1,0 +1,51 @@
+"""The `reboot` command."""
+
+from logging import getLogger
+
+from ..cli.argparse import ArgumentParser
+from ..cli.completion import complete_choices
+from ..support.messages import NoRefhostsDefinedError
+from . import Command
+
+logger = getLogger("mtui.commands.reboot")
+
+
+class Reboot(Command):
+    """Reboots reference hosts and reconnects once they are back up.
+
+    Reboots all connected reference hosts, or only those given with
+    `-t`/`--target`. The reboot is dispatched without waiting (the SSH
+    connection is expected to drop), then mtui reconnects automatically
+    with retries and backoff while each host comes back. Works for both
+    transactional and non-transactional hosts.
+
+    While testing a Product Increment, the per-host testing lock is
+    re-applied after the reboot (a reboot clears `/var/lock`), so it is
+    not lost.
+    """
+
+    command = "reboot"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        cls._add_hosts_arg(parser)
+
+    def __call__(self) -> None:
+        """Executes the `reboot` command."""
+        targets = self.parse_hosts()
+        if not targets:
+            raise NoRefhostsDefinedError
+
+        # Re-assert an active Product Increment testing lock after the
+        # reboot: rebooting clears /var/lock (tmpfs), so the lock must be
+        # written again to survive. ``lock_comment`` is empty unless a PI
+        # assignment is active, in which case no relock happens.
+        targets.reboot(relock_comment=self.metadata.lock_comment)
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(
+            [("-t", "--target")], line, text, state["hosts"].names()
+        )

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -198,6 +198,37 @@ class HostsGroup(UserDict[str, Target]):
             for hn in reboot:
                 self.data[hn].reconnect(retry=10, backoff=True)
 
+    def reboot(
+        self, command: str = "systemctl reboot", relock_comment: str = ""
+    ) -> None:
+        """Reboots every host in the group and reconnects.
+
+        Each host is sent ``command`` fire-and-forget (the reboot drops the
+        connection), then reconnected with retries and backoff once it is
+        back up. Works for both transactional and non-transactional hosts.
+
+        Args:
+            command: The reboot command to dispatch on each host.
+            relock_comment: If non-empty, re-apply a lock with this comment
+                after reconnecting. A reboot clears ``/var/lock`` (tmpfs),
+                dropping any mtui lock, so an active lock (e.g. a Product
+                Increment testing lock) must be re-asserted to survive.
+
+        """
+        if not self.data:
+            logger.info("No hosts to reboot")
+            return
+
+        logger.info("Rebooting %s", list(self.data))
+        for t in self.data.values():
+            t.reboot(command)
+        for t in self.data.values():
+            t.reconnect(retry=10, backoff=True)
+
+        if relock_comment:
+            logger.info("Re-applying lock after reboot")
+            self.lock(relock_comment)
+
     def update_lock(self) -> None:
         """Locks all hosts in the group for an update."""
         skipped = False

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -220,14 +220,46 @@ class HostsGroup(UserDict[str, Target]):
             return
 
         logger.info("Rebooting %s", list(self.data))
+        # Record the boot id before rebooting so we can confirm afterwards
+        # that the host actually came back on a fresh boot.
+        boot_ids = {hn: t.boot_id() for hn, t in self.data.items()}
         for t in self.data.values():
             t.reboot(command)
         for t in self.data.values():
             t.reconnect(retry=10, backoff=True)
 
+        for hn, t in self.data.items():
+            self._verify_reboot(t, boot_ids[hn])
+
         if relock_comment:
             logger.info("Re-applying lock after reboot")
             self.lock(relock_comment)
+
+    @staticmethod
+    def _verify_reboot(target, old_boot_id: str) -> None:
+        """Logs an error if ``target``'s boot id did not change after a reboot.
+
+        ``/proc/sys/kernel/random/boot_id`` is regenerated on every boot
+        (on both transactional and normal systems), so an unchanged value
+        means the host did not actually reboot.
+
+        Args:
+            target: The rebooted target to check.
+            old_boot_id: The boot id captured before the reboot.
+
+        """
+        new_boot_id = target.boot_id()
+        if not old_boot_id or not new_boot_id:
+            logger.warning(
+                "%s: could not read boot id to confirm the reboot", target.hostname
+            )
+        elif old_boot_id == new_boot_id:
+            logger.error(
+                "%s: boot id unchanged (%s) after reboot -- the host may not "
+                "have rebooted",
+                target.hostname,
+                new_boot_id,
+            )
 
     def update_lock(self) -> None:
         """Locks all hosts in the group for an update."""

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -188,6 +188,23 @@ class Target:
         """
         self.connection.fire_and_forget(command)
 
+    def boot_id(self) -> str:
+        """Returns the host's current boot id.
+
+        Reads ``/proc/sys/kernel/random/boot_id``, which changes on every
+        boot. Used to confirm a reboot actually happened. Returns an empty
+        string if it cannot be read.
+
+        Returns:
+            The boot id, or "" if it could not be read.
+
+        """
+        try:
+            self.connection.run("cat /proc/sys/kernel/random/boot_id")
+        except Exception:
+            return ""
+        return self.connection.stdout.strip()
+
     def reconnect(self, retry, backoff) -> None:
         """Reconnects to the target host.
 

--- a/tests/test_cmd_reboot.py
+++ b/tests/test_cmd_reboot.py
@@ -1,0 +1,74 @@
+"""Tests for the `reboot` command."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mtui.commands.reboot import Reboot
+from mtui.hosts.target.hostgroup import HostsGroup
+from mtui.support.messages import NoRefhostsDefinedError
+
+
+def _target(hostname="h1", state="enabled"):
+    t = MagicMock()
+    t.hostname = hostname
+    t.state = state
+    return t
+
+
+def _prompt(targets, lock_comment=""):
+    p = MagicMock()
+    p.metadata = MagicMock()
+    p.metadata.lock_comment = lock_comment
+    p.display = MagicMock()
+    p.targets = targets
+    return p
+
+
+def test_reboot_reboots_all_connected(mock_config):
+    """No -t: reboot all connected hosts, no PI relock when not testing a PI."""
+    hg = HostsGroup([_target("h1"), _target("h2")])
+    prompt = _prompt(hg)
+    args = Namespace(hosts=None)
+
+    with patch.object(HostsGroup, "reboot") as reboot:
+        Reboot(args, mock_config, MagicMock(), prompt)()
+
+    reboot.assert_called_once_with(relock_comment="")
+
+
+def test_reboot_passes_pi_lock_comment(mock_config):
+    """An active PI testing lock is re-applied after reboot."""
+    hg = HostsGroup([_target("h1")])
+    prompt = _prompt(hg, lock_comment="testing of SUSE:PI:34556:1")
+    args = Namespace(hosts=None)
+
+    with patch.object(HostsGroup, "reboot") as reboot:
+        Reboot(args, mock_config, MagicMock(), prompt)()
+
+    reboot.assert_called_once_with(relock_comment="testing of SUSE:PI:34556:1")
+
+
+def test_reboot_selects_targets_with_t(mock_config):
+    """-t selects only the named hosts."""
+    hg = HostsGroup([_target("h1"), _target("h2")])
+    prompt = _prompt(hg)
+    args = Namespace(hosts=["h2"])
+
+    with patch.object(HostsGroup, "reboot") as reboot:
+        Reboot(args, mock_config, MagicMock(), prompt)()
+
+    # reboot() is called on the selected subgroup (which contains only h2).
+    reboot.assert_called_once_with(relock_comment="")
+
+
+def test_reboot_no_hosts_raises(mock_config):
+    """No connected hosts -> NoRefhostsDefinedError."""
+    prompt = _prompt(HostsGroup([]))
+    args = Namespace(hosts=None)
+
+    with pytest.raises(NoRefhostsDefinedError):
+        Reboot(args, mock_config, MagicMock(), prompt)()

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -50,6 +50,7 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("prepare", "mtui.commands.prepare", "Prepare"),
         ("put", "mtui.commands.sftpcmd", "SFTPPut"),
         ("quit", "mtui.commands.quit", "Quit"),
+        ("reboot", "mtui.commands.reboot", "Reboot"),
         ("reject", "mtui.commands.apicall", "Reject"),
         ("reload_openqa", "mtui.commands.reloadoqa", "ReloadOpenQA"),
         ("reload_products", "mtui.commands.reload", "ReloadProducts"),

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -454,6 +454,33 @@ def test_reboot_empty_dict_is_noop():
     t1.reconnect.assert_not_called()
 
 
+def test_reboot_all_fires_and_reconnects_each():
+    """reboot() fire-and-forgets the command then reconnects every host."""
+    t1 = _stub_target("h1")
+    t2 = _stub_target("h2")
+    hg = HostsGroup([t1, t2])
+    hg.reboot()
+    for t in (t1, t2):
+        t.reboot.assert_called_once_with("systemctl reboot")
+        t.reconnect.assert_called_once_with(retry=10, backoff=True)
+        t.lock.assert_not_called()  # no relock comment -> no relock
+
+
+def test_reboot_all_relocks_when_comment_given():
+    """A relock_comment re-applies the lock after reconnect (PI lock survives)."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg.reboot(relock_comment="testing of SUSE:PI:34556:1")
+    t1.reboot.assert_called_once_with("systemctl reboot")
+    t1.reconnect.assert_called_once_with(retry=10, backoff=True)
+    t1.lock.assert_called_once_with("testing of SUSE:PI:34556:1")
+
+
+def test_reboot_all_empty_group_is_noop():
+    hg = HostsGroup([])
+    hg.reboot()  # should not raise
+
+
 # ---------------------------------------------------------------------------
 # update_lock — comment-logging branch
 # ---------------------------------------------------------------------------

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -458,6 +458,9 @@ def test_reboot_all_fires_and_reconnects_each():
     """reboot() fire-and-forgets the command then reconnects every host."""
     t1 = _stub_target("h1")
     t2 = _stub_target("h2")
+    # boot id changes (before -> after) so the reboot is confirmed.
+    t1.boot_id.side_effect = ["id-h1-before", "id-h1-after"]
+    t2.boot_id.side_effect = ["id-h2-before", "id-h2-after"]
     hg = HostsGroup([t1, t2])
     hg.reboot()
     for t in (t1, t2):
@@ -469,11 +472,32 @@ def test_reboot_all_fires_and_reconnects_each():
 def test_reboot_all_relocks_when_comment_given():
     """A relock_comment re-applies the lock after reconnect (PI lock survives)."""
     t1 = _stub_target("h1")
+    t1.boot_id.side_effect = ["before", "after"]
     hg = HostsGroup([t1])
     hg.reboot(relock_comment="testing of SUSE:PI:34556:1")
     t1.reboot.assert_called_once_with("systemctl reboot")
     t1.reconnect.assert_called_once_with(retry=10, backoff=True)
     t1.lock.assert_called_once_with("testing of SUSE:PI:34556:1")
+
+
+def test_reboot_all_errors_when_boot_id_unchanged(caplog):
+    """An unchanged boot id after reboot is reported as an error."""
+    t1 = _stub_target("h1")
+    t1.boot_id.side_effect = ["same-boot-id", "same-boot-id"]
+    hg = HostsGroup([t1])
+    with caplog.at_level(logging.ERROR, logger="mtui.hosts.target.hostgroup"):
+        hg.reboot()
+    assert any("boot id unchanged" in r.getMessage() for r in caplog.records)
+
+
+def test_reboot_all_no_error_when_boot_id_changes(caplog):
+    """A changed boot id confirms the reboot; no error is logged."""
+    t1 = _stub_target("h1")
+    t1.boot_id.side_effect = ["before", "after"]
+    hg = HostsGroup([t1])
+    with caplog.at_level(logging.ERROR, logger="mtui.hosts.target.hostgroup"):
+        hg.reboot()
+    assert not any("boot id unchanged" in r.getMessage() for r in caplog.records)
 
 
 def test_reboot_all_empty_group_is_noop():

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -276,6 +276,25 @@ def test_target_reboot_dispatches_fire_and_forget(mock_config):
     target.connection.fire_and_forget.assert_called_once_with("systemctl reboot")
 
 
+def test_target_boot_id_reads_proc(mock_config):
+    """boot_id() reads /proc/sys/kernel/random/boot_id and strips it."""
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    target.connection = MagicMock()
+    target.connection.stdout = "cab001af-4985-41d3-ac1b-e889523076ef\n"
+
+    assert target.boot_id() == "cab001af-4985-41d3-ac1b-e889523076ef"
+    target.connection.run.assert_called_once_with("cat /proc/sys/kernel/random/boot_id")
+
+
+def test_target_boot_id_returns_empty_on_failure(mock_config):
+    """boot_id() returns '' if the command cannot be run."""
+    target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
+    target.connection = MagicMock()
+    target.connection.run.side_effect = OSError("connection lost")
+
+    assert target.boot_id() == ""
+
+
 # --- reconnect ---
 
 


### PR DESCRIPTION
## Summary

Adds an interactive **`reboot`** command that reboots reference hosts and reconnects automatically once they are back up:

```
reboot [-t HOST]
```

- No argument → reboots **all connected** reference hosts; `-t`/`--target` limits it to the named hosts (consistent with other host-acting commands).
- The reboot is dispatched **fire-and-forget** (the SSH connection is expected to drop), then mtui reconnects each host with **retries + backoff** — the same robust path the transactional update-reboot uses, now generalised to **non-transactional** hosts too.
- While testing a **Product Increment**, the per-host testing lock is **re-applied after the reboot**: a reboot clears `/var/lock` (tmpfs), which would otherwise drop the lock. (`lock_comment` is empty unless a PI assignment is active, so no relock happens otherwise.)

## Implementation

- `mtui/commands/reboot.py` — new `Reboot` command (`-t` support, no update required).
- `HostsGroup.reboot(command="systemctl reboot", relock_comment="")` — fire-and-forget the reboot on each host, reconnect each (`retry=10, backoff=True`), then re-apply the lock if `relock_comment` is set.
- Built on `Connection.fire_and_forget` / `Target.reboot` from #150.

## Tests / docs

- `tests/test_cmd_reboot.py`: all-connected default, `-t` selection, PI lock comment forwarded, no-hosts → `NoRefhostsDefinedError`.
- `tests/test_hostgroup.py`: `reboot()` fires + reconnects each; re-locks when a comment is given; empty group is a no-op.
- `tests/test_commands_registry.py`: registers `reboot`.
- `Documentation/iui.rst` + `CHANGELOG.md` (Added).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `sphinx-build -W`, `pytest` (1011 passed). Not yet verified against a live reboot.

## ⚠️ Stacked on #150

This branch is based on **#150** (transactional-reboot reconnect fix), since it reuses `Connection.fire_and_forget` / `Target.reboot` / the reconnect-with-backoff fix. The first two commits here are #150. Once #150 merges I'll rebase this onto `main` so it's just the single `feat(reboot)` commit. Please merge #150 first.
