### PR TITLE
fix(parser): more reliable transactional-update detection + coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   positionally into `Connection.reconnect`, whose second positional
   parameter is `timeout` — so the backoff flag was silently dropped and
   the per-attempt wait collapsed to ~1s. It is now passed by keyword.
+- Transactional-update systems are detected more reliably. Detection
+  previously only checked `/usr/etc/transactional-update.conf`, so older
+  transactional hosts (SLE Micro 5.x, openSUSE MicroOS) that keep the
+  config in `/etc/transactional-update.conf` were misdetected as
+  non-transactional. Both locations are now probed.
 
 - `downgrade` now passes `--oldpackage` to zypper (and the
   `transactional-update pkg in` variant on transactional systems), so

--- a/mtui/hosts/target/parsers/system.py
+++ b/mtui/hosts/target/parsers/system.py
@@ -72,11 +72,21 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
         if base.name == "SLES_SAP" and base.version.startswith("16"):
             addons.add(Product("sle-ha", base.version, base.arch))
 
-        try:
-            _ = sftp.open("/usr/etc/transactional-update.conf")
+        # transactional-update ships its config in /usr/etc on newer
+        # systems (SL-Micro 6.x), but older transactional systems
+        # (SLE Micro 5.x, openSUSE MicroOS) keep it in /etc. Probe both so
+        # the older layout is not misdetected as non-transactional.
+        transactional = False
+        for conf in (
+            "/usr/etc/transactional-update.conf",
+            "/etc/transactional-update.conf",
+        ):
+            try:
+                sftp.open(conf)
+            except FileNotFoundError:
+                continue
             transactional = True
             logger.info("Host: %s is transactional system", connection.hostname)
-        except FileNotFoundError:
-            transactional = False
+            break
 
     return (System(base, addons), transactional)

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -162,13 +162,12 @@ class TestParseSystem:
         # Mock the SFTP file open as context manager
         base_file = MagicMock()
         addon_file = MagicMock()
-        # sftp.open calls sequence:
-        # 1. base product file
-        # 2. addon product file
-        # 3. transactional-update.conf (FileNotFoundError)
+        # sftp.open sequence: base product, addon product, then the two
+        # transactional-update.conf probes (usr-etc then etc), both missing.
         sftp.open.side_effect = [
             base_file,
             addon_file,
+            FileNotFoundError("not found"),
             FileNotFoundError("not found"),
         ]
 
@@ -234,4 +233,35 @@ class TestParseSystem:
 
         assert system.get_base().name == "SL-Micro"
         assert system.get_base().version == "6.1"
+        assert transactional is True
+
+    @patch("mtui.hosts.target.parsers.system.product")
+    def test_parse_transactional_system_with_etc_config(self, mock_product_module):
+        """Older transactional layout: config in /etc, not /usr/etc.
+
+        SLE Micro 5.x / MicroOS keep transactional-update.conf in /etc;
+        the detector must still recognise such hosts as transactional.
+        """
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = ["SLE-Micro.prod"]
+        sftp.readlink.return_value = "SLE-Micro.prod"
+        product_file = MagicMock()
+
+        def _open(path, *args, **kwargs):
+            p = str(path)
+            if p == "/usr/etc/transactional-update.conf":
+                raise FileNotFoundError(p)  # newer location absent
+            if p == "/etc/transactional-update.conf":
+                return MagicMock()  # older location present
+            return product_file
+
+        sftp.open.side_effect = _open
+        mock_product_module.parse_product.side_effect = [
+            ("SLE-Micro", "5.5", "x86_64"),
+        ]
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        _, transactional = parse_system(conn)
+
         assert transactional is True

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -125,6 +125,28 @@ def _mock_connection_with_sftp() -> tuple[MagicMock, MagicMock]:
     return conn, sftp
 
 
+def _dispatch_open(*, transactional: bool):
+    """Build a path-aware ``sftp.open`` side effect.
+
+    Product file opens return a generic context-manager mock (the parsed
+    values come from the mocked ``product`` module). Opening a
+    ``transactional-update.conf`` path succeeds when ``transactional`` is
+    True, else raises ``FileNotFoundError``. Being path-based (not a fixed
+    call sequence) keeps the tests robust to how many config locations the
+    detector probes.
+    """
+    product_file = MagicMock()
+
+    def _open(path, *args, **kwargs):
+        if "transactional-update.conf" in str(path):
+            if transactional:
+                return MagicMock()
+            raise FileNotFoundError(path)
+        return product_file
+
+    return _open
+
+
 class TestParseSystem:
     @patch("mtui.hosts.target.parsers.system.product")
     def test_parse_suse_system(self, mock_product_module):
@@ -189,3 +211,27 @@ class TestParseSystem:
         assert system.get_base().name == "ubuntu"
         assert transactional is False
         assert conn.sftp_session.call_count == 1
+
+    @patch("mtui.hosts.target.parsers.system.product")
+    def test_parse_transactional_system(self, mock_product_module):
+        """A SL-Micro host with transactional-update.conf is transactional.
+
+        Mirrors a real SL-Micro 6.1 host: SL-Micro.prod base, one extras
+        addon, and /usr/etc/transactional-update.conf present.
+        """
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = ["SL-Micro.prod", "SL-Micro-Extras.prod"]
+        sftp.readlink.return_value = "SL-Micro.prod"
+        sftp.open.side_effect = _dispatch_open(transactional=True)
+        mock_product_module.parse_product.side_effect = [
+            ("SL-Micro", "6.1", "x86_64"),
+            ("SL-Micro-Extras", "6.1", "x86_64"),
+        ]
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        system, transactional = parse_system(conn)
+
+        assert system.get_base().name == "SL-Micro"
+        assert system.get_base().version == "6.1"
+        assert transactional is True


### PR DESCRIPTION
## Summary

Improves detection and test coverage for transactional-update systems (SL Micro / MicroOS), in two commits.

**`test(parser): cover transactional-update system detection`**
`parse_system`'s transactional branch had no test coverage. Adds a test modelled on a real SL-Micro 6.1 host (`SL-Micro.prod` base + extras addon + `transactional-update.conf` present) asserting the system is detected as transactional. Introduces a path-aware `sftp.open` test helper so detection tests don't depend on a fixed call sequence.

**`fix(parser): detect transactional config in /etc as well as /usr/etc`**
Detection previously only checked `/usr/etc/transactional-update.conf`. Newer systems (SL-Micro 6.x) ship the config there, but **older transactional systems (SLE Micro 5.x, openSUSE MicroOS) keep it in `/etc/transactional-update.conf`** — those were misdetected as non-transactional. Both locations are now probed. Includes a test for the `/etc`-only (older) layout, and updates the existing non-transactional test for the two-probe sequence.

## Context

Verified against a live SL-Micro 6.1 host: config at `/usr/etc/transactional-update.conf`, read-only btrfs-snapshot root, `/etc` overlay. (The `/var/lock → /run/lock` tmpfs detail there also confirms the PI-lock-survives-reboot handling in #151.)

## Tests / docs

- `tests/test_target_parsers.py`: transactional detection (`/usr/etc` and `/etc` layouts); existing non-transactional test updated.
- `CHANGELOG.md` (Fixed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1004 passed). Coverage of `parsers/system.py`'s transactional branch goes from uncovered to covered.

_Note: rhel-fallback and SLES_SAP addon-workaround coverage are unrelated to transactional detection and will come in a separate parser-coverage PR._
