### PR TITLE
Fix openqa_overview export handling and build checks parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   pick); the `UpdateError` it raises is now reported as a single concise
   `error: Prepare failed: <host>: <reason>` line instead of a stack
   trace. Genuinely unexpected errors still log a full traceback.
+- `openqa_overview --no-aggregated` now correctly omits the aggregated
+  updates section from exported logs. Previously the section appeared with
+  a "No aggregated updates builds available" message even when explicitly
+  skipped, making it look like data was missing rather than intentionally
+  excluded.
+- Test result summaries in `openqa_overview` now correctly parse the
+  `# PASS: N` / `# FAIL: N` format used in OBS build logs. Previously only
+  the `N passed` / `N failed` format was recognized, causing OBS test
+  counts to be reported as zero.
 
 ### Changed
 

--- a/mtui/commands/openqa_overview.py
+++ b/mtui/commands/openqa_overview.py
@@ -188,7 +188,7 @@ class OpenQAOverview(Command):
             incident_id if isinstance(incident_id, int) else request_id
         )
 
-        overview = OpenQAOverviewResult()
+        overview = OpenQAOverviewResult(skip_aggregated=self.args.no_aggregated)
 
         self.println(self._title("OpenQA:"))
         self.println(self._title("#######"))

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -319,8 +319,16 @@ def summarize_test_results(lines: list[str]) -> str:
     total_passed = 0
     total_failed = 0
     for line in lines[1:-1]:
+        # N passed / N failed
         passed_match = re.search(r"(\d+) pass(?:ed)?", line, re.IGNORECASE)
         failed_match = re.search(r"(\d+) fail(?:ed)?", line, re.IGNORECASE)
+        # PASS: N / FAIL: N
+        passed_match = passed_match or re.search(
+            r"#\s*pass(?:ed)?:?\s*(\d+)", line, re.IGNORECASE
+        )
+        failed_match = failed_match or re.search(
+            r"#\s*fail(?:ed)?:?\s*(\d+)", line, re.IGNORECASE
+        )
         if passed_match:
             total_passed += int(passed_match.group(1))
         if failed_match:

--- a/mtui/types/oqaresults.py
+++ b/mtui/types/oqaresults.py
@@ -52,11 +52,21 @@ class OpenQAOverviewResult:
 
     Carries the three sections the upstream oqa-search script prints so
     other consumers (e.g. exporters) can render them without re-fetching.
+
+    Attributes:
+        single_incidents: results for the single-incidents section
+        aggregated_updates: results for the aggregated-updates section
+        build_checks: results for the build-checks section.
+        skip_aggregated: whether the user requested to skip the aggregated-updates section
+            When ``True`` the aggregated section should be omitted from
+            exported output entirely because the absence is intentional
+
     """
 
     single_incidents: list["VersionResult"] = field(default_factory=list)
     aggregated_updates: list["GroupResult"] = field(default_factory=list)
     build_checks: list["BuildCheckResult"] = field(default_factory=list)
+    skip_aggregated: bool = False
 
     def __bool__(self) -> bool:
         """True if any of the three sections has content."""

--- a/mtui/update_workflow/export/base.py
+++ b/mtui/update_workflow/export/base.py
@@ -165,6 +165,7 @@ class BaseExport(ABC):
             overview.single_incidents,
             overview.aggregated_updates,
             overview.build_checks,
+            skip_aggregated=overview.skip_aggregated,
         ):
             logger.info("Injected openqa_overview block into template")
 

--- a/tests/test_export_openqa.py
+++ b/tests/test_export_openqa.py
@@ -3,7 +3,18 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.export import Export
-from mtui.types import FileList, OpenQAResults, RequestReviewID, URLs
+from mtui.data_sources.oqa_search import (
+    OVERVIEW_BEGIN_MARKER,
+    OVERVIEW_END_MARKER,
+    VersionResult,
+)
+from mtui.types import (
+    FileList,
+    OpenQAOverviewResult,
+    OpenQAResults,
+    RequestReviewID,
+    URLs,
+)
 from mtui.update_workflow.export.auto import AutoExport
 from mtui.update_workflow.export.base import BaseExport
 
@@ -189,13 +200,6 @@ def test_install_status_failed_when_any_result_fails(mock_config):
 
 def test_inject_overview_writes_block_into_template(mock_config):
     """BaseExport.inject_overview inserts the marker-bounded block."""
-    from mtui.data_sources.oqa_search import (
-        OVERVIEW_BEGIN_MARKER,
-        OVERVIEW_END_MARKER,
-        VersionResult,
-    )
-    from mtui.types import OpenQAOverviewResult
-
     template = FileList(
         [
             "regression tests:\n",
@@ -252,3 +256,36 @@ def test_inject_overview_is_noop_when_overview_unset(mock_config):
     exporter.inject_overview()
 
     assert list(exporter.template) == original
+
+
+def test_inject_overview_skip_aggregated_omits_aggregated_section(mock_config):
+    """skip_aggregated=True suppresses the aggregated section entirely."""
+    template = FileList(
+        [
+            "regression tests:\n",
+            "-----------------\n",
+            "(put your details here)\n",
+            "build log review:\n",
+        ]
+    )
+    overview = OpenQAOverviewResult(
+        single_incidents=[VersionResult("15-SP5", "u1", "passed")],
+        aggregated_updates=[],
+        skip_aggregated=True,
+    )
+
+    exporter = ExportProbe(
+        mock_config,
+        OpenQAResults(overview=overview),
+        template,
+        False,
+        "SUSE:Maintenance:1:1",
+        False,
+    )
+
+    exporter.inject_overview()
+
+    body = "".join(exporter.template)
+    assert "No aggregated updates" not in body
+    assert "Aggregated Updates" not in body
+    assert "15-SP5" in body

--- a/tests/test_openqa_overview_command.py
+++ b/tests/test_openqa_overview_command.py
@@ -101,6 +101,7 @@ def test_openqa_overview_runs_all_three_sections_and_stores_payload(mock_config)
     assert overview.single_incidents == single_rows
     assert overview.aggregated_updates == aggregated_rows
     assert overview.build_checks == build_check_rows
+    assert overview.skip_aggregated is False
 
 
 def test_openqa_overview_no_aggregated_flag_skips_aggregated_section(mock_config):
@@ -126,6 +127,7 @@ def test_openqa_overview_no_aggregated_flag_skips_aggregated_section(mock_config
 
     au.assert_not_called()
     assert prompt.metadata.openqa.overview.aggregated_updates == []
+    assert prompt.metadata.openqa.overview.skip_aggregated is True
 
 
 def test_openqa_overview_no_versions_skips_openqa_sections(mock_config):

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -600,21 +600,18 @@ def test_filter_openqa_groups(
             ],
             "(4 more results, 30 passed, 8 failed)",
         ),
-        # OBS-style block: only rows with explicit "N passed / N failed"
-        # tokens count; the "# PASS:" / "# FAIL:" cells do not match
-        # the regex and stay at zero.
         (
             [
-                "[  204s] ======================= 437 passed, 5 skipped in 22.51s ========================",
-                "[  204s] # TOTAL: 0",
-                "[  204s] # PASS:  0",
-                "[  204s] # SKIP:  0",
-                "[  204s] # XFAIL: 0",
-                "[  204s] # FAIL:  0",
-                "[  204s] # XPASS: 0",
-                "[  204s] # ERROR: 0",
+                "[  949s] # TOTAL: 2901",
+                "[  949s] # PASS:  2709",
+                "[  949s] # SKIP:  151",
+                "[  949s] # XFAIL: 0",
+                "[  949s] # FAIL:  2",
+                "[  949s] # XPASS: 0",
+                "[  949s] # ERROR: 0",
+                "[  949s] make[1]: Leaving directory '/usr/src/packages/BUILD/automake-1.16.5'",
             ],
-            "(6 more results, 0 passed, 0 failed)",
+            "(6 more results, 2709 passed, 2 failed)",
         ),
     ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing! Please make sure your PR follows the
checklist below. See CONTRIBUTING.md for the full workflow.
-->

## Summary

Fixes two issues with openqa_overview:
  
  1. When running `openqa_overview  --no-aggregated`, the exported log was still showing "No aggregated updates builds available". Now the skip_aggregated flag is properly threaded through to the export formatter so the section is omitted entirely when requested as the absence is intentional, not a data gap.
  
  2. Some build checks logs use "# PASS: 1234" format instead of "1234 passed", which wasn't being  parsed. Extended the regex to match both formats so test result summaries are counted correctly.

## Changes

  - Add `skip_aggregated` field to `OpenQAOverviewResult` to track user intent
  - Thread `skip_aggregated` flag from command through to export formatter
  - Extend test result parsing regex to handle "# PASS: N" / "# FAIL: N" format from OBS
  logs

-

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean.
- [x] `uv run pytest` passes.
- [x] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
- [ ] Documentation under `Documentation/` updated where relevant.

