### PR TITLE
fix(gitea): allow --force to reassign a PR held by another user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   transactional hosts (SLE Micro 5.x, openSUSE MicroOS) that keep the
   config in `/etc/transactional-update.conf` were misdetected as
   non-transactional. Both locations are now probed.
+- `assign --force` now reassigns a Gitea PR that is already assigned to a
+  different user. Previously `--force` only bypassed the "no review
+  requested" check, so force-assigning a PR held by someone else still
+  failed with `Gitea PR has assigned different user than <you>`; it now
+  posts the assignment comment regardless of the current assignee (an
+  already approved/rejected PR is still refused). Approval continues to
+  respect only the last assignee.
 
 - `downgrade` now passes `--oldpackage` to zypper (and the
   `transactional-update pkg in` variant on transactional systems), so

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -292,20 +292,27 @@ class Gitea:
             force: If True, bypasses the check for an existing review request.
 
         Raises:
-            GiteaNoReviewError: If a review has not been requested and `force` is False.
-            GiteaAssignInvalidError: If the PR is not in an unassigned state.
+            GiteaNoReviewError: If a review has not been requested and `force`
+                is False, or if the PR was already approved/rejected.
+            GiteaAssignInvalidError: If the PR is not in an unassigned state
+                and `force` is False.
 
         """
         a_user = other or self.user
-        if not self.__has_review() and not force:
+        # `force` skips the "review requested" and "already assigned" guards
+        # and simply posts the assignment comment -- e.g. to (re)assign a PR
+        # that is currently assigned to a different user. An approved/rejected
+        # PR is still refused.
+        if not force and not self.__has_review():
             raise GiteaNoReviewError(f"There is no review for {self.group}-review")
 
         if self.__is_done():
             raise GiteaNoReviewError("PR was already approved/rejected")
 
-        assign_state = self.__check_assign(a_user)
-        if assign_state != assignment.UNASSIGNED:
-            raise GiteaAssignInvalidError(assign_state, a_user)
+        if not force:
+            assign_state = self.__check_assign(a_user)
+            if assign_state != assignment.UNASSIGNED:
+                raise GiteaAssignInvalidError(assign_state, a_user)
 
         logger.info("Assigning PR to %s for group %s", a_user, self.group)
         msg = self.ASSIGN_TEMPLATE % (a_user, self.group)

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -156,6 +156,65 @@ class TestGiteaOperations:
         gitea.assign()
 
     @responses.activate
+    def test_assign_force_posts_comment_when_assigned_to_other(self, gitea):
+        """assign(force=True) posts the assignment even if assigned to someone else."""
+        other = self._make_comment(1, gitea.ASSIGN_TEMPLATE % ("alice", gitea.group))
+        # is_done -> an assignment comment, not an approval -> not done
+        responses.add(responses.GET, gitea.prissues, json=[other], status=200)
+        # POST the (forced) assignment comment
+        responses.add(responses.POST, gitea.prissues, json={"id": 2}, status=201)
+
+        gitea.assign(force=True)
+
+        posts = [c for c in responses.calls if c.request.method == "POST"]
+        assert len(posts) == 1
+        assert f"assigned to user: {gitea.user}" in str(posts[0].request.body)
+
+    @responses.activate
+    def test_assign_without_force_raises_when_assigned_to_other(self, gitea):
+        """Without --force, assigning a PR held by another user is refused."""
+        other = self._make_comment(1, gitea.ASSIGN_TEMPLATE % ("alice", gitea.group))
+        # has_review -> the review is requested
+        responses.add(
+            responses.GET,
+            gitea.pr,
+            json={"requested_reviewers": [{"login": f"{gitea.group}-review"}]},
+            status=200,
+        )
+        # is_done -> not done
+        responses.add(responses.GET, gitea.prissues, json=[other], status=200)
+        # check_assign -> assigned to alice (ASSIGNED_OTHER)
+        responses.add(responses.GET, gitea.prissues, json=[other], status=200)
+
+        with pytest.raises(GiteaAssignInvalidError):
+            gitea.assign()
+
+    @responses.activate
+    def test_approve_uses_last_assignee(self, gitea):
+        """approve() respects only the last assignee, ignoring an earlier one."""
+        alice = self._make_comment(
+            1,
+            gitea.ASSIGN_TEMPLATE % ("alice", gitea.group),
+            "2024-01-01T00:00:00+00:00",
+        )
+        me = self._make_comment(
+            2,
+            gitea.ASSIGN_TEMPLATE % (gitea.user, gitea.group),
+            "2024-01-02T00:00:00+00:00",
+        )
+        # check_assign -> last assignee is the session user
+        responses.add(responses.GET, gitea.prissues, json=[alice, me], status=200)
+        # is_done -> not done
+        responses.add(responses.GET, gitea.prissues, json=[alice, me], status=200)
+        responses.add(responses.POST, gitea.prissues, json={"id": 3}, status=201)
+
+        gitea.approve()
+
+        posts = [c for c in responses.calls if c.request.method == "POST"]
+        assert len(posts) == 1
+        assert "LGTM" in str(posts[0].request.body)
+
+    @responses.activate
     def test_assign_no_review_raises(self, gitea):
         """Test assign raises GiteaNoReviewError when no review exists."""
         responses.add(


### PR DESCRIPTION
## Problem

`assign --force` on an SLFO update already assigned to someone else fails:

```
mtui> assign --force
info: Assign PR SUSE:SLFO:1.2:4527
error: Gitea PR has assigned different user than mpluskal
```

`--force` was only wired to bypass the "no review requested" check, not an existing assignment, so reassigning a PR held by another user was impossible.

## Fix

In `Gitea.assign`, `--force` now also skips the assignment-state check and posts the assignment comment regardless of the current assignee (reassigning over another user). An already approved/rejected PR is still refused (`__is_done`). The "review requested" probe is also skipped under `--force` (no longer queried).

Approval is unchanged and already respects **only the last assignee** (the comment state machine is last-wins) — now covered by a test.

## Tests / docs

- `tests/test_gitea.py`: `assign(force=True)` posts the comment when assigned to another user; without `--force` it still raises; `approve()` works when the session user is the last assignee despite an earlier different assignee.
- `CHANGELOG.md` (Fixed).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1005 passed).
