### PR TITLE
feat(add_host): switch to manual workflow when run in automatic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   host did not actually reboot. While testing a Product Increment, the
   per-host testing lock is re-applied after the reboot (a reboot clears
   `/var/lock`), so it is not lost.
+- `add_host` now switches the session from automatic to manual workflow.
+  Running `add_host` is a manual action, so when a session that was
+  started in automatic mode adds a host it is taken as the intent to test
+  manually — `mtui` drops `config.auto`/`config.kernel`, updates the
+  prompt (the `-auto` marker disappears), and continues adding the host.
+  In manual mode the workflow is left untouched. Pass `-k`/`--keep-mode`
+  to add a host without switching the workflow.
 
 ### Fixed
 

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -47,10 +47,15 @@ add_host
 
 ::
 
-  add_host [-t HOST]
+  add_host [-t HOST] [-k]
 
 Adds another machine to the target host list.
 Without parameter adds all hosts from testplatform based on location
+
+If the session is in automatic mode, running ``add_host`` switches it to
+the manual workflow (adding hosts by hand is a manual action), updating
+the prompt accordingly. Pass ``-k``/``--keep-mode`` to add a host without
+switching the workflow.
 
 
 remove_host

--- a/mtui/commands/addhost.py
+++ b/mtui/commands/addhost.py
@@ -1,9 +1,12 @@
 """The `add_host` command."""
 
 import concurrent.futures
+from logging import getLogger
 
 from ..cli.completion import complete_choices
 from . import Command
+
+logger = getLogger("mtui.commands.addhost")
 
 
 class AddHost(Command):
@@ -23,9 +26,25 @@ class AddHost(Command):
             action="append",
             help="address of the target host (should be the FQDN)",
         )
+        parser.add_argument(
+            "-k",
+            "--keep-mode",
+            action="store_true",
+            help="do not switch to the manual workflow when in automatic mode",
+        )
 
     def __call__(self) -> None:
         """Executes the `add_host` command."""
+        # Running add_host is a manual action. If the session is still in
+        # automatic mode the user almost certainly meant to test manually
+        # (and just forgot to switch), so move to the manual workflow --
+        # unless --keep-mode was given.
+        if self.config.auto and not self.args.keep_mode:
+            logger.info("add_host: switching from automatic to manual workflow")
+            self.config.auto = False
+            self.config.kernel = False
+            self.prompt.set_prompt(self.prompt.session)
+
         if not self.args.target:
             for tp in self.metadata.testplatforms:
                 self.metadata.refhosts_from_tp(tp)
@@ -41,4 +60,4 @@ class AddHost(Command):
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
-        return complete_choices([("-t", "--target")], line, text)
+        return complete_choices([("-t", "--target"), ("-k", "--keep-mode")], line, text)

--- a/tests/test_cmd_addhost.py
+++ b/tests/test_cmd_addhost.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
@@ -17,9 +18,27 @@ def _prompt() -> MagicMock:
     return p
 
 
+def test_add_host_argparser_accepts_target_and_keep_mode():
+    """The argument parser wires up -t/--target and -k/--keep-mode."""
+    ns = AddHost.parse_args("-t h1 -t h2 -k", sys)
+    assert ns.target == ["h1", "h2"]
+    assert ns.keep_mode is True
+
+    default = AddHost.parse_args("", sys)
+    assert default.target is None
+    assert default.keep_mode is False
+
+
+def test_add_host_complete_offers_flags():
+    """Tab completion offers -t and the new -k/--keep-mode flag."""
+    out = AddHost.complete({"hosts": []}, "", "add_host ", 9, 9)
+    assert "--keep-mode" in out
+    assert "--target" in out
+
+
 def test_add_host_with_explicit_targets_submits_per_host(mock_config):
     prompt = _prompt()
-    args = Namespace(target=["h1", "h2"])
+    args = Namespace(target=["h1", "h2"], keep_mode=False)
 
     with (
         patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor") as tpe,
@@ -40,7 +59,7 @@ def test_add_host_with_explicit_targets_submits_per_host(mock_config):
 
 def test_add_host_without_targets_uses_testplatforms(mock_config):
     prompt = _prompt()
-    args = Namespace(target=None)
+    args = Namespace(target=None, keep_mode=False)
 
     AddHost(args, mock_config, MagicMock(), prompt)()
 
@@ -48,3 +67,46 @@ def test_add_host_without_targets_uses_testplatforms(mock_config):
         "base=sles(major=15);arch=[x86_64]"
     )
     prompt.metadata.connect_targets.assert_called_once_with()
+
+
+def test_add_host_in_automatic_mode_switches_to_manual(mock_config):
+    """Running add_host while in automatic mode switches to the manual workflow."""
+    mock_config.auto = True
+    mock_config.kernel = False
+    prompt = _prompt()
+    args = Namespace(target=None, keep_mode=False)
+
+    AddHost(args, mock_config, MagicMock(), prompt)()
+
+    assert mock_config.auto is False
+    assert mock_config.kernel is False
+    # Prompt indicator refreshed (drops the "-auto" marker).
+    prompt.set_prompt.assert_called_once_with(prompt.session)
+    # The hosts are still added.
+    prompt.metadata.connect_targets.assert_called_once_with()
+
+
+def test_add_host_keep_mode_stays_automatic(mock_config):
+    """--keep-mode leaves automatic mode untouched even though a host is added."""
+    mock_config.auto = True
+    mock_config.kernel = False
+    prompt = _prompt()
+    args = Namespace(target=None, keep_mode=True)
+
+    AddHost(args, mock_config, MagicMock(), prompt)()
+
+    assert mock_config.auto is True  # still automatic
+    prompt.set_prompt.assert_not_called()
+    # The hosts are still added.
+    prompt.metadata.connect_targets.assert_called_once_with()
+
+
+def test_add_host_in_manual_mode_does_not_switch(mock_config):
+    """In manual mode add_host leaves the workflow untouched."""
+    mock_config.auto = False
+    prompt = _prompt()
+    args = Namespace(target=None, keep_mode=False)
+
+    AddHost(args, mock_config, MagicMock(), prompt)()
+
+    prompt.set_prompt.assert_not_called()


### PR DESCRIPTION
## Summary

mtui is usually started in **automatic mode**. When a tester decides to test manually they sometimes forget to switch workflow, but they do run `add_host`. Adding a host by hand is a clear signal of manual testing, so `add_host` now switches the session to the manual workflow automatically.

When `add_host` runs and the session is in automatic mode:
- `config.auto` and `config.kernel` are cleared (manual = neither),
- the prompt is refreshed so the `-auto` marker disappears (`mtui-auto>` → `mtui>`),
- the host is then added as usual.

In manual mode the workflow is left untouched.

## Implementation

- `mtui/commands/addhost.py` — at the top of `__call__`, if `self.config.auto` is set, log the switch, clear the mode flags, and call `self.prompt.set_prompt(self.prompt.session)`.

## Tests / docs

- `tests/test_cmd_addhost.py`: switches to manual (flags cleared, prompt refreshed, host still added) when in automatic mode; no switch in manual mode.
- `Documentation/iui.rst` (add_host) + `CHANGELOG.md` (Added).

All gates pass locally: `ruff format --check`, `ruff check`, `ty check`, `sphinx-build -W`, `pytest` (1007 passed).
