### PR TITLE
fix(reboot): clean up reboot progress output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   registered command (split into documented and undocumented groups),
   and `help <command>` prints that command's `--help` output. Tab
   completion offers the command names.
+- Rebooting reference hosts now reads cleanly. The progress line prints a
+  sorted, comma-separated host list instead of a raw Python list repr, each
+  host logs a `… is back up` line once it reconnects, and the connection
+  attempts that fail while a host is still down (expected mid-reboot) are
+  logged at debug instead of as `No valid connection …` errors — only a
+  genuine give-up still surfaces as an error.
 - Transactional hosts no longer fail to reconnect after the post-update
   reboot. The reboot command was run through the normal command path,
   which on the (expected) dropped connection tried its own single,

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -117,8 +117,17 @@ class Connection:
         policy = self._policy if self._policy is not None else paramiko.AutoAddPolicy()
         self.client.set_missing_host_key_policy(policy)
 
-    def connect(self) -> None:
-        """Connects to the remote host using paramiko."""
+    def connect(self, quiet: bool = False) -> None:
+        """Connects to the remote host using paramiko.
+
+        Args:
+            quiet: When True, a failed connection (host unreachable) is
+                logged at debug rather than error level. Used during
+                reconnect retries -- e.g. while a host is rebooting -- where
+                a refused/timed-out connection is expected and only the
+                final give-up (a raised error) should surface to the user.
+
+        """
         cfg = SSHConfig()
         try:
             with Path("~/.ssh/config").expanduser().open() as fd:
@@ -192,7 +201,12 @@ class Connection:
             raise
 
         except OSError:
-            logger.error("No valid connection to %s:%s", self.hostname, self.port)
+            if quiet:
+                logger.debug(
+                    "No valid connection to %s:%s (yet)", self.hostname, self.port
+                )
+            else:
+                logger.error("No valid connection to %s:%s", self.hostname, self.port)
         except Exception as e:
             # general Exception
             logger.debug("%s: %s", self.hostname, e)
@@ -222,7 +236,10 @@ class Connection:
             select.select([], [], [], rtimeout)
             if backoff:
                 rtimeout = 2 * (timeout + 5 * count)
-            self.connect()
+            # Retries are expected to fail while the host is still down
+            # (e.g. mid-reboot); keep them quiet and let the final
+            # ConnectionError below be the single surfaced failure.
+            self.connect(quiet=True)
 
         if not self.is_active():
             raise ConnectionError(

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -187,7 +187,7 @@ class HostsGroup(UserDict[str, Target]):
 
         """
         if reboot:
-            logger.info("Rebooting transactional hosts %s", reboot.keys())
+            logger.info("Rebooting transactional hosts: %s", ", ".join(sorted(reboot)))
             # Dispatch the reboot fire-and-forget on every host first: the
             # command intentionally drops the connection, so running it
             # through the normal ``run`` path would trip its retry=0
@@ -195,8 +195,9 @@ class HostsGroup(UserDict[str, Target]):
             # host with retries + backoff while it comes back up.
             for hn, command in reboot.items():
                 self.data[hn].reboot(command)
-            for hn in reboot:
+            for hn in sorted(reboot):
                 self.data[hn].reconnect(retry=10, backoff=True)
+                logger.info("%s is back up", hn)
 
     def reboot(
         self, command: str = "systemctl reboot", relock_comment: str = ""
@@ -219,14 +220,15 @@ class HostsGroup(UserDict[str, Target]):
             logger.info("No hosts to reboot")
             return
 
-        logger.info("Rebooting %s", list(self.data))
+        logger.info("Rebooting: %s", ", ".join(sorted(self.data)))
         # Record the boot id before rebooting so we can confirm afterwards
         # that the host actually came back on a fresh boot.
         boot_ids = {hn: t.boot_id() for hn, t in self.data.items()}
         for t in self.data.values():
             t.reboot(command)
-        for t in self.data.values():
-            t.reconnect(retry=10, backoff=True)
+        for hn in sorted(self.data):
+            self.data[hn].reconnect(retry=10, backoff=True)
+            logger.info("%s is back up", hn)
 
         for hn, t in self.data.items():
             self._verify_reboot(t, boot_ids[hn])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -413,6 +413,50 @@ def test_connect_oserror_is_logged_not_raised(
     assert any("No valid connection" in r.message for r in caplog.records)
 
 
+def test_connect_oserror_quiet_logs_at_debug_not_error(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """quiet=True downgrades the unreachable-host log from error to debug."""
+    conn = Connection("h", 22, 300)
+    mock_ssh_client.connect.side_effect = OSError("network")
+    with caplog.at_level("DEBUG", logger="mtui.connection"):
+        conn.connect(quiet=True)
+    # No error-level "No valid connection" line ...
+    assert not any(
+        r.levelname == "ERROR" and "No valid connection" in r.message
+        for r in caplog.records
+    )
+    # ... but a debug breadcrumb is still emitted.
+    assert any(
+        r.levelname == "DEBUG" and "No valid connection" in r.message
+        for r in caplog.records
+    )
+
+
+def test_reconnect_retries_are_quiet(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch, caplog
+):
+    """Reconnect retries call connect(quiet=True) so failures don't log as errors."""
+    conn = Connection("h", 22, 300)
+    mock_ssh_client._transport.is_active.return_value = False
+    mock_ssh_client.connect.side_effect = OSError("still down")
+    monkeypatch.setattr(
+        "mtui.hosts.connection.connection.select.select",
+        lambda *_a, **_kw: ([], [], []),
+    )
+    with (
+        caplog.at_level("DEBUG", logger="mtui.connection"),
+        pytest.raises(ConnectionError, match="Failed to reconnect"),
+    ):
+        conn.reconnect(retry=2, timeout=0)
+    # The expected mid-reboot failures are debug, not error; only the final
+    # ConnectionError (raised above) surfaces the give-up to the user.
+    assert not any(
+        r.levelname == "ERROR" and "No valid connection" in r.message
+        for r in caplog.records
+    )
+
+
 def test_connect_unknown_exception_propagates(
     mock_ssh_client, mock_ssh_config, mock_path, caplog
 ):

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -505,6 +505,23 @@ def test_reboot_all_empty_group_is_noop():
     hg.reboot()  # should not raise
 
 
+def test_reboot_all_logs_clean_host_list_and_back_up(caplog):
+    """Reboot logs a sorted comma-joined host list (not a Python list repr)."""
+    t1 = _stub_target("h2")
+    t2 = _stub_target("h1")
+    t1.boot_id.side_effect = ["b2", "a2"]
+    t2.boot_id.side_effect = ["b1", "a1"]
+    hg = HostsGroup([t1, t2])
+    with caplog.at_level(logging.INFO, logger="mtui.target.hostgroup"):
+        hg.reboot()
+    msgs = [r.getMessage() for r in caplog.records]
+    assert "Rebooting: h1, h2" in msgs
+    assert "h1 is back up" in msgs
+    assert "h2 is back up" in msgs
+    # No raw list repr leaked into the output.
+    assert not any("['" in m for m in msgs)
+
+
 # ---------------------------------------------------------------------------
 # update_lock — comment-logging branch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Rebooting reference hosts works, but the output looked alarming:

```
info: Rebooting ['cordelia.qam.suse.cz', 'carme.qam.suse.cz', ...]
error: No valid connection to cordelia.qam.suse.cz:22
error: No valid connection to cordelia.qam.suse.cz:22
```

The hosts in fact rebooted and reconnected fine (`list_hosts` showed all Enabled), but:

1. The progress line dumped a raw Python list repr.
2. Every reconnect attempt that failed *while the host was still down* — entirely expected mid-reboot — was logged as a `No valid connection …` **error**.

## Changes

- `HostsGroup.reboot` / `_reboot`: log a sorted, comma-separated host list (`Rebooting: carme.qam.suse.cz, charon.qam.suse.cz, …`) instead of a list repr, and emit a per-host `… is back up` line after each host reconnects.
- `Connection.connect` gains a `quiet` flag; `Connection.reconnect` passes `quiet=True` for its retry loop, so the expected unreachable-host failures log at **debug**. Only the genuine give-up (the raised `ConnectionError`) still surfaces as an error.

Now the same reboot reads:

```
info: Rebooting: carme.qam.suse.cz, charon.qam.suse.cz, cordelia.qam.suse.cz, …
info: cordelia.qam.suse.cz is back up
…
```

## Tests

- `test_connect_oserror_quiet_logs_at_debug_not_error` and `test_reconnect_retries_are_quiet` cover the new quiet path.
- `test_reboot_all_logs_clean_host_list_and_back_up` asserts the clean host list + `is back up` lines and that no list repr leaks.
- Full suite: 1032 passed. ruff format/check, ty, and docs (`-W`) all clean.