### PR TITLE
fix(cli): show RRID in bottom toolbar instead of always 'empty'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The interactive REPL's bottom toolbar no longer reports
+  `session: empty` after a test report has been loaded. The toolbar now
+  shows, in precedence order, an explicit name set via
+  `set_session_name`, the loaded report's RRID, or the literal `empty`
+  before any report is loaded. Previously the toolbar only reflected the
+  manual `set_session_name` value and stayed on `empty` for every other
+  case, even with a fully loaded template.
 - Interactive prompts triggered from inside a command no longer hang
   or echo literal `^M` after the answer is typed, then drop the user
   back to the shell. Both the yes/no confirmation helper used by

--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -235,9 +235,12 @@ class CommandPrompt:
         * ``mode`` — ``kernel`` when :attr:`config.kernel` is set
           (kernel-update workflow), ``auto`` when only :attr:`config.auto`
           is set (automatic-update workflow), ``manual`` otherwise.
-        * ``session`` — the session name passed to :meth:`set_prompt`
-          (typically the test report's session id), or the literal
-          ``"empty"`` before any test report is loaded.
+        * ``session`` — resolved in precedence order: an explicit name
+          set via ``set_session_name`` (:attr:`self.session`) wins; else
+          the loaded test report's :attr:`id` (its RRID); else the
+          literal ``"empty"`` when no test report is loaded.
+          :class:`NullTestReport` returns ``""`` from ``id``, so the
+          fallback to ``"empty"`` covers the pre-load state.
         * ``hosts`` — count of connected refhosts. Falls back to ``"?"``
           if ``self.targets`` does not expose ``__len__`` (defensive
           guard for the brief construction window between ``__init__``
@@ -261,7 +264,10 @@ class CommandPrompt:
         else:
             mode = "manual"
 
-        sess = self.session if getattr(self, "session", None) else "empty"
+        sess = self.session if getattr(self, "session", None) else ""
+        if not sess:
+            metadata = getattr(self, "metadata", None)
+            sess = getattr(metadata, "id", "") or "empty"
 
         try:
             n_hosts: int | str = len(self.targets)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -592,6 +592,34 @@ def test_bottom_toolbar_before_set_prompt_uses_literal_empty():
     assert " session: empty " in out
 
 
+def test_bottom_toolbar_falls_back_to_metadata_id_when_no_session():
+    """A loaded test report surfaces its RRID via ``metadata.id``."""
+    p = _make_prompt()
+    # No explicit session set; metadata is a real (non-null) report with an id.
+    assert not hasattr(p, "session")
+    p.metadata = MagicMock()
+    p.metadata.id = "SUSE:Maintenance:12345:67890"
+    assert " session: SUSE:Maintenance:12345:67890 " in p._bottom_toolbar()
+
+
+def test_bottom_toolbar_manual_session_overrides_metadata_id():
+    """``set_session_name`` wins over the loaded report's RRID."""
+    p = _make_prompt()
+    p.metadata = MagicMock()
+    p.metadata.id = "SUSE:Maintenance:12345:67890"
+    p.session = "my-debug-session"
+    assert " session: my-debug-session " in p._bottom_toolbar()
+
+
+def test_bottom_toolbar_empty_metadata_id_falls_back_to_empty():
+    """A ``NullTestReport``-style empty id collapses to the ``empty`` literal."""
+    p = _make_prompt()
+    # NullTestReport.id returns ""; the default p.metadata is already that.
+    assert isinstance(p.metadata, NullTestReport)
+    assert p.metadata.id == ""
+    assert " session: empty " in p._bottom_toolbar()
+
+
 def test_load_update_swaps_metadata_and_targets():
     """``load_update`` installs the new test report and resets the prompt."""
     p = _make_prompt()


### PR DESCRIPTION
## Problem

The bottom toolbar's `session` field read `self.session`, which is only ever populated by the optional `set_session_name` command. Loading a test report did not touch it, so the toolbar reported `session: empty` even with a fully loaded template — defeating its purpose of helping users tell parallel mtui sessions apart.

## Fix

Resolve the toolbar's `session` field in precedence order:

1. An explicit `set_session_name` value (`self.session`), if set, wins.
2. Otherwise the loaded test report's RRID (`metadata.id`).
3. Otherwise the literal `empty` — `NullTestReport.id` returns `""`, so the pre-load state still renders correctly.

The lookup is guarded with `getattr` for both `self.session` and `self.metadata` to keep the toolbar safe during the brief construction window before `__init__` finishes, mirroring the existing defensive guard around `len(self.targets)`.

## Tests

Adds three focused tests in `tests/test_prompt.py` covering the new precedence chain:

- `test_bottom_toolbar_falls_back_to_metadata_id_when_no_session` — loaded report's RRID surfaces in the toolbar
- `test_bottom_toolbar_manual_session_overrides_metadata_id` — `set_session_name` wins
- `test_bottom_toolbar_empty_metadata_id_falls_back_to_empty` — NullTestReport pre-load state still says `empty`

## Verification

- `uv run ruff format --check .` — 262 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run ty check` — All checks passed
- `uv run pytest` — 1113 passed

## Changelog

Added a `### Fixed` entry under `[Unreleased]`.