### PR TITLE
docs(installation): add missing svn runtime dependency

### DIFF
--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -112,3 +112,8 @@ must be installed separately from the Python dependencies.
 ``ssh`` / ``scp``
     Required by paramiko's underlying configuration parsing and by
     several mtui helper scripts. Any modern OpenSSH client suffices.
+
+``svn``
+    Required for the ``svn`` connector. The command-line client must be
+    installed, but it does not need to be configured with any repositories
+    since mtui shells out to it with explicit repository URLs.


### PR DESCRIPTION
Why this change was needed:
The installation documentation listed required system packages but omitted
`svn`, which is needed by the svn connector. Users installing mtui from
the docs had no guidance that a command-line SVN client must also be
available.

Problem solved:
New installations now have a complete list of runtime dependencies,
preventing confusion when the svn connector is encountered.

What changed:
- Added `svn` entry to the runtime dependencies section in
  Documentation/installation.rst with a brief note that no repository
  configuration is needed since mtui passes explicit URLs.