### PR TITLE
fix(openqa_overview): show build checks for all packages in multi-package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,11 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- `openqa_overview` now shows build check logs for all packages in a
+  multi-package update, not just one. Previously only logs matching a
+  single package name extracted from the build string were displayed,
+  causing build check results for other packages in the update to be
+  silently omitted.

--- a/mtui/commands/openqa_overview.py
+++ b/mtui/commands/openqa_overview.py
@@ -236,11 +236,14 @@ class OpenQAOverview(Command):
         self.println("-------")
         self.println(self._title("\nBuild checks:"))
         self.println(self._title("#############"))
+        packages = self.metadata.get_package_list() if self.metadata else []
+        if not packages and build:
+            packages = [build.split(":")[-1]]
         overview.build_checks = oqa.build_checks(
             product,
             effective_incident_id,
             request_id,
-            build,
+            packages,
             url_qam,
             self.args.test_pattern,
         )

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -465,12 +465,24 @@ def build_checks(
     product: str,
     incident_id: int | str,
     request_id: int,
-    build: str,
+    packages: list[str],
     url_qam: str,
     test_pattern: str | None = None,
 ) -> list[BuildCheckResult]:
-    """Parse the qam.suse.de build_checks index and extract summaries."""
-    package_name = build.split(":")[-1]
+    """Parse the qam.suse.de build_checks index and extract summaries.
+
+    Args:
+        product: The product kind (e.g., "Maintenance", "SLFO").
+        incident_id: The incident/maintenance ID.
+        request_id: The request/review ID.
+        packages: List of package names to filter logs by.
+        url_qam: Base URL for the QAM service.
+        test_pattern: Optional regex pattern to extract test results.
+
+    Returns:
+        List of BuildCheckResult objects, one per matching .log file.
+
+    """
     base_url = (
         f"{url_qam}/testreports/SUSE:{product}:{incident_id}:{request_id}/build_checks"
     )
@@ -484,10 +496,17 @@ def build_checks(
     parser = LogFileLinkParser()
     parser.feed(html_text)
 
-    logfiles = [
-        log for log in parser.log_files if package_name in log and ".log" in log
-    ]
+    # Filter .log files to those matching any package in this update
+    logfiles = [log for log in parser.log_files if any(pkg in log for pkg in packages)]
+
+    logger.debug(
+        "Found %d .log files in build_checks index, %d match packages %r",
+        len(parser.log_files),
+        len(logfiles),
+        packages,
+    )
     if not logfiles:
+        logger.warning("No build check logs found for packages %r", packages)
         return []
 
     out: list[BuildCheckResult] = []

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -288,9 +288,7 @@ def test_build_checks_filters_logs_by_package_and_parses():
             body=_LOG_SHORT,
             status=200,
         )
-    out = oqa_search.build_checks(
-        "Maintenance", 12358, 199773, ":12358:bash", QAM, None
-    )
+    out = oqa_search.build_checks("Maintenance", 12358, 199773, ["bash"], QAM, None)
 
     # Two .log files in the index match the package "bash"
     assert len(out) == 2
@@ -316,9 +314,7 @@ def test_build_checks_folds_long_match_lists():
         status=200,
     )
 
-    out = oqa_search.build_checks(
-        "Maintenance", 12358, 199773, ":12358:bash", QAM, None
-    )
+    out = oqa_search.build_checks("Maintenance", 12358, 199773, ["bash"], QAM, None)
     assert len(out) == 1
     entry = out[0]
     assert entry.summary  # non-empty
@@ -334,10 +330,42 @@ def test_build_checks_index_404_returns_empty():
         f"{QAM}/testreports/SUSE:Maintenance:12358:199773/build_checks",
         status=404,
     )
-    out = oqa_search.build_checks(
-        "Maintenance", 12358, 199773, ":12358:bash", QAM, None
-    )
+    out = oqa_search.build_checks("Maintenance", 12358, 199773, ["bash"], QAM, None)
     assert out == []
+
+
+@responses.activate
+def test_build_checks_filters_multiple_packages():
+    """Logs matching any package in the list are included."""
+    responses.add(
+        responses.GET,
+        f"{QAM}/testreports/SUSE:Maintenance:12358:199773/build_checks",
+        body=_HTML_INDEX,
+        status=200,
+        content_type="text/html",
+    )
+    for arch in ("x86_64", "aarch64"):
+        responses.add(
+            responses.GET,
+            url=(
+                f"{QAM}/testreports/SUSE:Maintenance:12358:199773/build_checks/"
+                f"bash.SUSE_SLE-15-SP5_Update.{arch}.log"
+            ),
+            body=_LOG_SHORT,
+            status=200,
+        )
+    responses.add(
+        responses.GET,
+        f"{QAM}/testreports/SUSE:Maintenance:12358:199773/build_checks/other-package.log",
+        body=_LOG_SHORT,
+        status=200,
+    )
+
+    out = oqa_search.build_checks(
+        "Maintenance", 12358, 199773, ["bash", "other-package"], QAM, None
+    )
+
+    assert len(out) == 3
 
 
 def test_extract_test_results_custom_pattern_overrides_heuristics():


### PR DESCRIPTION
<!--
Thanks for contributing! Please make sure your PR follows the
checklist below. See CONTRIBUTING.md for the full workflow.
-->

## Summary

Previously `openqa_overview` only displayed build check logs for a single package extracted from the build string, silently omitting logs for other packages in multi-package updates. Now it shows build checks for all packages in the update.

## Changes

- Refactored `build_checks()` to accept a list of package names instead of a build string
- Filters build check logs against all packages in the update when metadata is available
- Falls back to extracting package name from build string when metadata is unavailable
- Added test coverage for multi-package filtering
- Updated CHANGELOG.md with user-facing fix description

-

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean.
- [x] `uv run pytest` passes.
- [x] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
- [ ] Documentation under `Documentation/` updated where relevant.