### PR TITLE
fix(mcp): emit progress notifications during long-running tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `mtui-mcp` now emits MCP `notifications/progress` every 10 seconds
+  while a tool call is running, so spec-compliant MCP clients
+  (Inspector, Claude Desktop, opencode, …) no longer time out on
+  long-running commands such as `run`, `update`, `set_repo`, `commit`,
+  slow `add_host`, or `load_template`. The heartbeat is automatic and
+  applies to every auto-generated tool plus the three testreport
+  tools; clients that ignore progress notifications can raise their
+  own per-server timeout (see `Documentation/mcp.rst`).
 - `run`, `show_log`, and `show_diff` now return their output when
   invoked through `mtui-mcp`. The three commands routed results through
   the interactive pager (`page()`), which early-returned in

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -392,3 +392,60 @@ Concurrency and safety
 * **HTTP is single-tenant by contract.** No auth, no TLS. Bind to
   loopback (the default) and front with the operator's preferred
   reverse-proxy if external access is required.
+
+
+Long-running tool calls
+=======================
+
+Many mtui commands legitimately take minutes rather than seconds —
+``run`` against a slow refhost, ``update``, ``set_repo``, ``commit``,
+``add_host`` against an SSH endpoint that takes its time to come up,
+``load_template`` against a fresh SVN checkout, anything that drives
+``osc``/``svn`` over the network. The MCP client's default JSON-RPC
+read timeout (often 30 s, matching the SDK's
+``MCP_DEFAULT_TIMEOUT``) used to cancel those calls before the
+server's worker thread returned.
+
+To keep clients patient, every ``mtui-mcp`` tool emits
+``notifications/progress`` every 10 seconds while its underlying
+command is running. MCP-spec-compliant clients (the official
+Inspector, Claude Desktop, opencode, Cursor, …) reset their read
+deadline on each frame, so a command that takes ten minutes still
+returns its captured stdout cleanly.
+
+The heartbeat is automatic and applies to every auto-generated tool
+plus the three testreport tools; no client configuration is required
+to benefit from it.
+
+Clients that ignore progress notifications
+------------------------------------------
+
+A small number of older / non-spec-compliant clients ignore
+``notifications/progress`` and enforce their own short read timeout.
+For those, raise the timeout in the client's own configuration:
+
+* **Claude Desktop** — per-server ``timeout`` field (milliseconds) in
+  ``mcpServers.<name>``:
+
+  .. code-block:: json
+
+      {
+        "mcpServers": {
+          "mtui": {
+            "command": "mtui-mcp",
+            "args": ["--transport", "stdio"],
+            "timeout": 600000
+          }
+        }
+      }
+
+* **opencode** — per-server ``timeout`` field on the MCP entry.
+
+* **Custom Python clients built on the SDK** — pass
+  ``read_timeout_seconds`` to ``ClientSession`` or
+  ``request_read_timeout_seconds`` to ``send_request``; the SDK's
+  ``MCP_DEFAULT_TIMEOUT = 30.0`` in ``mcp.shared._httpx_utils`` is
+  the lower-bound httpx default if you do not override it.
+
+The heartbeat itself never *caps* execution time; if your client
+honours progress it will simply wait as long as the server takes.

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -24,9 +24,10 @@ from __future__ import annotations
 import asyncio
 import io
 import shlex
+import time
 from logging import Logger, getLogger
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..cli.argparse import ArgsParseFailureError
 from ..cli.display import CommandPromptDisplay
@@ -37,6 +38,17 @@ if TYPE_CHECKING:
     from ..support.config import Config
 
 logger = getLogger("mtui.mcp.session")
+
+#: Default heartbeat interval, in seconds, between
+#: ``notifications/progress`` frames emitted while a long-running tool
+#: call is in flight. The MCP SDK's client-side httpx default is 30 s
+#: (``mcp.shared._httpx_utils.MCP_DEFAULT_TIMEOUT``) and most LLM
+#: clients (Claude Desktop, opencode, Inspector) sit in the same
+#: ballpark; 10 s sits comfortably under that floor while keeping wire
+#: traffic negligible for short calls (one frame every 10 s costs
+#: nothing on the wire and stops well-behaved clients from timing out
+#: on ``run`` / ``update`` / ``set_repo`` / ``commit`` etc.).
+DEFAULT_PROGRESS_INTERVAL_SECONDS: float = 10.0
 
 
 class McpCommandError(RuntimeError):
@@ -239,7 +251,14 @@ class McpSession:
     # Command dispatch
     # ------------------------------------------------------------------
 
-    async def run_command(self, cmd_cls: type[Command], argv: list[str]) -> str:
+    async def run_command(
+        self,
+        cmd_cls: type[Command],
+        argv: list[str],
+        ctx: Any | None = None,
+        *,
+        progress_interval: float = DEFAULT_PROGRESS_INTERVAL_SECONDS,
+    ) -> str:
         """Runs a registered command and returns its captured stdout.
 
         The lock makes the call sequentially consistent with every
@@ -247,10 +266,27 @@ class McpSession:
         :func:`asyncio.to_thread` hop keeps blocking command bodies
         off the event loop.
 
+        When ``ctx`` is supplied (the synthesised tool wrappers in
+        :mod:`mtui.mcp.tools` and the testreport tools pass it through
+        from FastMCP), a heartbeat coroutine emits
+        ``notifications/progress`` every ``progress_interval`` seconds
+        while the worker thread runs, so MCP clients that honour the
+        protocol's progress contract do not time out on long-running
+        commands (``run``, ``update``, ``set_repo``, ``commit``, slow
+        ``add_host``, ``load_template``, ...). The notification is
+        addressed at the request's ``progressToken``; if the client
+        did not supply one the SDK's :meth:`Context.report_progress`
+        is a no-op, so the heartbeat costs nothing in that case.
+
         Args:
             cmd_cls: The :class:`Command` subclass to invoke.
             argv: The command-line tokens (already split, no shell
                 quoting required from the caller).
+            ctx: Optional FastMCP :class:`Context` for the in-flight
+                tool call. ``None`` skips the heartbeat (used by the
+                autoconnect path in :mod:`mtui.mcp.main` and by tests).
+            progress_interval: Seconds between heartbeat frames.
+                Defaults to :data:`DEFAULT_PROGRESS_INTERVAL_SECONDS`.
 
         Returns:
             The text the command wrote to stdout during the call.
@@ -262,7 +298,57 @@ class McpSession:
 
         """
         async with self._lock:
-            return await asyncio.to_thread(self._run_sync, cmd_cls, argv)
+            if ctx is None:
+                return await asyncio.to_thread(self._run_sync, cmd_cls, argv)
+            return await self._run_with_heartbeat(
+                ctx, cmd_cls, argv, interval=progress_interval
+            )
+
+    async def _run_with_heartbeat(
+        self,
+        ctx: Any,
+        cmd_cls: type[Command],
+        argv: list[str],
+        *,
+        interval: float,
+    ) -> str:
+        """Drive ``_run_sync`` in a worker thread while emitting heartbeats.
+
+        The worker task is created with :func:`asyncio.create_task` and
+        we wait on it with :func:`asyncio.wait` so the heartbeat loop
+        wakes every ``interval`` seconds regardless of how long the
+        underlying blocking body takes. ``ctx.report_progress`` is
+        ``await``-ed inside the loop; a notification-send failure is
+        logged at ``DEBUG`` and swallowed so a flaky transport never
+        masks the actual command outcome.
+        """
+        worker = asyncio.create_task(asyncio.to_thread(self._run_sync, cmd_cls, argv))
+        started = time.monotonic()
+        try:
+            while True:
+                done, _pending = await asyncio.wait({worker}, timeout=interval)
+                if worker in done:
+                    break
+                elapsed = time.monotonic() - started
+                try:
+                    await ctx.report_progress(
+                        progress=elapsed,
+                        total=None,
+                        message=f"{cmd_cls.command} running ({elapsed:.0f}s)…",
+                    )
+                except Exception as exc:  # noqa: BLE001 - never mask the command result
+                    logger.debug(
+                        "progress notification failed for %s: %s",
+                        cmd_cls.command,
+                        exc,
+                    )
+        except BaseException:
+            # The caller (or the surrounding task group) cancelled us.
+            # Cancel the worker too so we do not leak a background
+            # thread future; then re-raise.
+            worker.cancel()
+            raise
+        return worker.result()
 
     def _run_sync(self, cmd_cls: type[Command], argv: list[str]) -> str:
         """Synchronous core of :meth:`run_command`; runs in a worker thread."""

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -38,7 +38,7 @@ from ..test_reports.null_report import NullTestReport
 from .session import McpCommandError
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.fastmcp import Context, FastMCP
 
     from .session import McpSession
 
@@ -141,17 +141,39 @@ def _count_lines(text: str) -> int:
     return len(text.splitlines())
 
 
+async def _heartbeat(ctx: Context | None, message: str) -> None:
+    """Best-effort single progress frame for the testreport tools.
+
+    Disk I/O on these tools is typically sub-second so a heartbeat
+    loop would be overkill; we emit one frame *before* the I/O so
+    queued clients can see the call has been picked up. ``ctx`` is
+    optional (tests and direct coroutine callers pass ``None``); a
+    notification-send failure is swallowed so a flaky transport never
+    masks the actual tool outcome.
+    """
+    if ctx is None:
+        return
+    try:
+        await ctx.report_progress(progress=0.0, total=None, message=message)
+    except Exception as exc:  # noqa: BLE001 - never mask the tool result
+        logger.debug("progress notification failed: %s", exc)
+
+
 # --------------------------------------------------------------------------- #
 # Tools                                                                       #
 # --------------------------------------------------------------------------- #
 
 
-async def testreport_read(session: McpSession) -> dict[str, Any]:
+async def testreport_read(
+    session: McpSession,
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+) -> dict[str, Any]:
     """Return the loaded testreport file's content and line count.
 
     Acquires ``session._lock`` so the snapshot is coherent with any
     in-flight command dispatch (e.g. a concurrent ``commit``).
     """
+    await _heartbeat(ctx, "testreport_read: waiting for session lock")
     async with session._lock:
         path = _resolve_testreport_path(session)
         content = path.read_text(encoding="utf-8", errors="replace")
@@ -167,6 +189,7 @@ async def testreport_patch(
     start_line: int,
     end_line: int,
     replacement: str,
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Replace an inclusive 1-indexed line range with ``replacement``.
 
@@ -177,6 +200,7 @@ async def testreport_patch(
     of the surrounding lines (which come from
     :meth:`str.splitlines` with ``keepends=True``).
     """
+    await _heartbeat(ctx, "testreport_patch: waiting for session lock")
     async with session._lock:
         path = _resolve_testreport_path(session)
         content = path.read_text(encoding="utf-8", errors="replace")
@@ -215,13 +239,18 @@ async def testreport_patch(
     }
 
 
-async def testreport_write(session: McpSession, content: str) -> dict[str, Any]:
+async def testreport_write(
+    session: McpSession,
+    content: str,
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+) -> dict[str, Any]:
     """Overwrite the loaded testreport file with ``content`` atomically.
 
     Fallback for the case where line drift across patches makes
     :func:`testreport_patch` unreliable; the LLM resends the whole
     file in one shot.
     """
+    await _heartbeat(ctx, "testreport_write: waiting for session lock")
     async with session._lock:
         path = _resolve_testreport_path(session)
         bytes_written = _atomic_write_text(path, content)
@@ -252,18 +281,36 @@ def register_testreport_tools(mcp: FastMCP, session: McpSession) -> list[str]:
         and asserted in tests.
 
     """
+    # The trailing ``ctx: Context | None = None`` parameter is what
+    # FastMCP's ``find_context_parameter`` picks up via
+    # :func:`typing.get_type_hints` to (a) strip ``ctx`` from the
+    # tool's JSON schema and (b) inject the live per-request Context
+    # at call time. ``get_type_hints`` resolves the string annotation
+    # ``"Context | None"`` against the *module* globals (not the
+    # enclosing function's locals), so we inject ``Context`` into
+    # this module's globals lazily here rather than importing it at
+    # module top — keeping ``mtui.mcp.testreport_tools`` importable
+    # without the ``[mcp]`` extra.
+    from mcp.server.fastmcp import Context as _Context
     from mcp.types import ToolAnnotations
 
-    async def _read() -> dict[str, Any]:
-        return await testreport_read(session)
+    globals().setdefault("Context", _Context)
+
+    async def _read(ctx: Context | None = None) -> dict[str, Any]:
+        return await testreport_read(session, ctx=ctx)
 
     async def _patch(
-        start_line: int, end_line: int, replacement: str
+        start_line: int,
+        end_line: int,
+        replacement: str,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
-        return await testreport_patch(session, start_line, end_line, replacement)
+        return await testreport_patch(
+            session, start_line, end_line, replacement, ctx=ctx
+        )
 
-    async def _write(content: str) -> dict[str, Any]:
-        return await testreport_write(session, content)
+    async def _write(content: str, ctx: Context | None = None) -> dict[str, Any]:
+        return await testreport_write(session, content, ctx=ctx)
 
     read_desc = (
         "Read the currently loaded testreport file. Returns the path, "

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -41,7 +41,10 @@ from .session import McpCommandError
 if TYPE_CHECKING:
     import argparse
 
-    from mcp.server.fastmcp import FastMCP
+    # ``Context`` is imported lazily inside ``_make_wrapper`` (it requires
+    # the optional ``mcp`` extra); the TYPE_CHECKING re-export is kept for
+    # editors/type-checkers, hence the ``noqa: F401``.
+    from mcp.server.fastmcp import Context, FastMCP  # noqa: F401
 
     from .session import McpSession
 
@@ -80,13 +83,42 @@ def _make_wrapper(
     prepended to the argv produced from kwargs; used by the subparser
     fan-out to inject the subcommand name (``["show"]`` for
     ``config_show``).
+
+    The synthesised signature also carries a trailing keyword-only
+    ``ctx`` parameter annotated as :class:`mcp.server.fastmcp.Context`.
+    FastMCP detects the ``Context`` annotation via
+    :func:`mcp.server.fastmcp.utilities.context_injection.find_context_parameter`
+    (which reads :func:`typing.get_type_hints`), strips the parameter
+    from the JSON schema via ``skip_names``, and injects the live
+    per-request :class:`Context` at call time. We forward it into
+    :meth:`McpSession.run_command` so the session can heartbeat
+    ``notifications/progress`` while the worker thread runs, which
+    keeps MCP clients from timing out on long-running commands.
     """
+    # Import lazily and only when actually building wrappers: callers
+    # outside the ``mtui[mcp]`` extra never reach this function (the
+    # MCP entrypoint already errored out with a friendly hint), but
+    # the lazy import keeps ``mtui.mcp.tools`` importable in
+    # documentation builds and unit tests that monkey-patch around
+    # the SDK.
+    from mcp.server.fastmcp import Context
+
     params = build_parameters(parser)
+    # Append the Context-typed parameter LAST so the existing required-
+    # before-optional ordering is preserved (``ctx`` has a default of
+    # ``None`` and is keyword-only).
+    ctx_param = inspect.Parameter(
+        "ctx",
+        inspect.Parameter.KEYWORD_ONLY,
+        default=None,
+        annotation=Context,
+    )
+    all_params = [*params, ctx_param]
     signature = inspect.Signature(
-        parameters=params,
+        parameters=all_params,
         return_annotation=str,
     )
-    annotations = {p.name: p.annotation for p in params}
+    annotations = {p.name: p.annotation for p in all_params}
     annotations["return"] = str
 
     # Synthetic-name mutex groups (load_template -a/-k) need a runtime
@@ -108,6 +140,11 @@ def _make_wrapper(
     )
 
     async def wrapper(**kwargs: Any) -> str:
+        # FastMCP injects ``ctx`` only when the client request carries
+        # a progress token (and even then, only because we annotated
+        # the parameter as Context); strip it before kwargs_to_argv so
+        # the encoder does not try to render it as a CLI flag.
+        ctx = kwargs.pop("ctx", None)
         if synthetic_required:
             supplied = [n for n in synthetic_names if kwargs.get(n) is not None]
             if len(supplied) != 1:
@@ -117,7 +154,7 @@ def _make_wrapper(
                 )
                 raise McpCommandError("", msg, 2)
         argv = list(argv_prefix) + kwargs_to_argv(parser, kwargs)
-        return await session.run_command(cls, argv)
+        return await session.run_command(cls, argv, ctx=ctx)
 
     # ``inspect.Signature`` lives on a dunder slot; ty does not model it
     # for nested ``async def``, hence the suppression.

--- a/tests/test_mcp_session_progress.py
+++ b/tests/test_mcp_session_progress.py
@@ -1,0 +1,221 @@
+"""Tests for the heartbeat path in :meth:`McpSession.run_command`.
+
+When the synthesised tool wrappers in :mod:`mtui.mcp.tools` (and the
+hand-written testreport tools) pass a FastMCP ``Context`` through to
+:meth:`McpSession.run_command`, the session is expected to emit
+``notifications/progress`` every ``progress_interval`` seconds while
+the underlying blocking command runs in a worker thread. This module
+exercises that contract without spinning up the real MCP transport:
+
+* ``ctx=None`` (the autoconnect path and most legacy callers) must
+  take the original ``asyncio.to_thread`` shortcut and emit no
+  progress frames.
+* ``ctx`` supplied + a command that runs longer than the interval
+  must produce one or more ``report_progress`` calls and still return
+  the command's captured stdout.
+* A command that finishes faster than the interval must produce zero
+  progress frames (the heartbeat loop exits on the first
+  ``asyncio.wait`` that sees the worker complete).
+* Exceptions raised by the command must propagate unchanged through
+  the heartbeat path.
+* A ``report_progress`` failure must NOT mask the command's result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.commands import Command
+from mtui.commands.whoami import Whoami
+from mtui.mcp.session import McpCommandError, McpSession
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.template_dir = tmp_path
+    cfg.target_tempdir = tmp_path / "target"
+    cfg.chdir_to_template_dir = False
+    cfg.connection_timeout = 30
+    cfg.session_user = "testuser"
+    return cfg
+
+
+def _make_session(tmp_path: Path) -> McpSession:
+    return McpSession(_config(tmp_path), logging.getLogger("test.mcp.progress"))
+
+
+class _RecordingCtx:
+    """Minimal stand-in for :class:`mcp.server.fastmcp.Context`.
+
+    Only the ``report_progress`` coroutine is consumed by the
+    heartbeat path; the real Context carries far more, but
+    construction of one requires a live request scope. Tests pass
+    this object as ``ctx`` and inspect ``calls`` afterwards.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, float | None, str | None]] = []
+
+    async def report_progress(
+        self,
+        progress: float,
+        total: float | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.calls.append((progress, total, message))
+
+
+class _FailingCtx(_RecordingCtx):
+    """Variant whose ``report_progress`` always raises.
+
+    Used to assert the heartbeat loop swallows notification-send
+    failures so a flaky transport never masks the command's result.
+    """
+
+    async def report_progress(
+        self,
+        progress: float,
+        total: float | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.calls.append((progress, total, message))
+        raise RuntimeError("transport gone")
+
+
+class _SleepyCommand(Command):
+    """Test-only command that sleeps for ``_hold_seconds`` then prints OK."""
+
+    command = "_mcp_test_sleepy_command"
+    _hold_seconds: ClassVar[float] = 0.25
+
+    def __call__(self) -> None:  # pragma: no cover - exercised by tests
+        time.sleep(self._hold_seconds)
+        self.println("ok")
+
+
+class _ExplodingCommand(Command):
+    """Test-only command that always raises."""
+
+    command = "_mcp_test_exploding_command"
+
+    def __call__(self) -> None:  # pragma: no cover - exercised by tests
+        raise RuntimeError("kaboom from command body")
+
+
+# --------------------------------------------------------------------------- #
+# ctx=None preserves the legacy zero-overhead path                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_ctx_none_emits_no_progress_and_returns_stdout(tmp_path: Path) -> None:
+    """``ctx=None`` must take the ``asyncio.to_thread`` shortcut unchanged."""
+    sess = _make_session(tmp_path)
+    ctx = _RecordingCtx()
+
+    out = asyncio.run(sess.run_command(Whoami, [], ctx=None, progress_interval=0.01))
+    assert out.startswith("User: testuser")
+    # The Context we built was never passed to run_command, so it must
+    # carry no recorded calls.
+    assert ctx.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# ctx supplied + slow command -> heartbeat fires                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_heartbeat_fires_for_slow_command(tmp_path: Path) -> None:
+    """A 0.25 s command with a 0.05 s heartbeat must record >= 1 frame."""
+    sess = _make_session(tmp_path)
+    ctx = _RecordingCtx()
+
+    out = asyncio.run(
+        sess.run_command(_SleepyCommand, [], ctx=ctx, progress_interval=0.05)
+    )
+    assert out == "ok\n"
+    # At least one heartbeat must have landed; with hold=0.25 and
+    # interval=0.05 we expect roughly 4 but assert loosely to keep
+    # the test stable under slow CI.
+    assert len(ctx.calls) >= 1, f"no heartbeat fired: {ctx.calls!r}"
+    # Each frame must carry the command name in the message and a
+    # non-negative progress value.
+    for progress, total, message in ctx.calls:
+        assert progress >= 0.0
+        assert total is None
+        assert message is not None
+        assert "_mcp_test_sleepy_command" in message
+
+
+def test_heartbeat_progress_values_are_monotonic(tmp_path: Path) -> None:
+    """Heartbeat ``progress`` values record elapsed seconds; must not regress."""
+    sess = _make_session(tmp_path)
+    ctx = _RecordingCtx()
+
+    asyncio.run(sess.run_command(_SleepyCommand, [], ctx=ctx, progress_interval=0.05))
+    values = [p for p, _t, _m in ctx.calls]
+    if len(values) >= 2:
+        assert values == sorted(values), f"non-monotonic progress: {values!r}"
+
+
+# --------------------------------------------------------------------------- #
+# ctx supplied + fast command -> no heartbeat                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_no_heartbeat_for_fast_command(tmp_path: Path) -> None:
+    """``whoami`` is sub-millisecond; with 1 s interval we expect zero frames."""
+    sess = _make_session(tmp_path)
+    ctx = _RecordingCtx()
+
+    out = asyncio.run(sess.run_command(Whoami, [], ctx=ctx, progress_interval=1.0))
+    assert out.startswith("User: testuser")
+    assert ctx.calls == [], f"unexpected heartbeat: {ctx.calls!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Exception propagation through the heartbeat path                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_command_exception_propagates_through_heartbeat(tmp_path: Path) -> None:
+    """A failing command must surface :class:`McpCommandError` unchanged."""
+    sess = _make_session(tmp_path)
+    ctx = _RecordingCtx()
+
+    with pytest.raises(McpCommandError) as ei:
+        asyncio.run(
+            sess.run_command(_ExplodingCommand, [], ctx=ctx, progress_interval=0.05)
+        )
+    assert ei.value.exit_code == 1
+    assert "kaboom" in ei.value.stderr
+
+
+# --------------------------------------------------------------------------- #
+# report_progress failure must not mask the command result                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_progress_send_failure_is_swallowed(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If ``ctx.report_progress`` raises, the command result still surfaces."""
+    sess = _make_session(tmp_path)
+    ctx = _FailingCtx()
+
+    with caplog.at_level(logging.DEBUG, logger="mtui.mcp.session"):
+        out = asyncio.run(
+            sess.run_command(_SleepyCommand, [], ctx=ctx, progress_interval=0.05)
+        )
+    assert out == "ok\n"
+    # We attempted at least one heartbeat (FailingCtx records the
+    # attempt before raising).
+    assert len(ctx.calls) >= 1
+    # And the swallowed failure was logged at DEBUG.
+    assert any("progress notification failed" in r.message for r in caplog.records)

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -309,3 +309,88 @@ def test_register_testreport_tools_exposes_three_tools(tmp_path: Path) -> None:
     # The read-first warning is glued onto each description.
     for tool in (read_tool, patch_tool, write_tool):
         assert "testreport_read" in tool.description
+
+
+# --------------------------------------------------------------------------- #
+# Progress-notification heartbeat                                             #
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingCtx:
+    """Stand-in for :class:`mcp.server.fastmcp.Context`.
+
+    Mirrors the one in ``tests/test_mcp_session_progress.py`` but
+    duplicated locally to keep the two test modules independent.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, float | None, str | None]] = []
+
+    async def report_progress(
+        self,
+        progress: float,
+        total: float | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.calls.append((progress, total, message))
+
+
+def test_testreport_read_emits_heartbeat_when_ctx_supplied(tmp_path: Path) -> None:
+    """When called with a Context, ``testreport_read`` fires one progress frame."""
+    file = tmp_path / "report.txt"
+    file.write_text("x\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    ctx = _RecordingCtx()
+
+    result = asyncio.run(tt.testreport_read(sess, ctx=ctx))  # ty: ignore[invalid-argument-type]
+
+    assert result["content"] == "x\n"
+    assert len(ctx.calls) == 1
+    _progress, _total, message = ctx.calls[0]
+    assert message is not None
+    assert "testreport_read" in message
+
+
+def test_testreport_write_emits_heartbeat_when_ctx_supplied(tmp_path: Path) -> None:
+    """``testreport_write`` also fires one progress frame for client patience."""
+    file = tmp_path / "report.txt"
+    file.write_text("orig\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    ctx = _RecordingCtx()
+
+    asyncio.run(tt.testreport_write(sess, "new\n", ctx=ctx))  # ty: ignore[invalid-argument-type]
+
+    assert file.read_text(encoding="utf-8") == "new\n"
+    assert len(ctx.calls) == 1
+
+
+def test_testreport_patch_emits_heartbeat_when_ctx_supplied(tmp_path: Path) -> None:
+    """``testreport_patch`` fires one progress frame before the splice."""
+    file = tmp_path / "report.txt"
+    file.write_text("a\nb\nc\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    ctx = _RecordingCtx()
+
+    asyncio.run(tt.testreport_patch(sess, 2, 2, "B\n", ctx=ctx))  # ty: ignore[invalid-argument-type]
+
+    assert file.read_text(encoding="utf-8") == "a\nB\nc\n"
+    assert len(ctx.calls) == 1
+
+
+def test_testreport_tools_strip_ctx_from_json_schema(tmp_path: Path) -> None:
+    """``ctx`` must not leak into the JSON schema of any testreport tool."""
+    pytest.importorskip("mcp")
+    from mcp.server.fastmcp import FastMCP
+
+    sess = _null_session(tmp_path)
+    mcp: FastMCP = FastMCP(name="test-mtui-mcp-schema")
+    tt.register_testreport_tools(mcp, sess)
+
+    for name in ("testreport_read", "testreport_patch", "testreport_write"):
+        tool = mcp._tool_manager.get_tool(name)  # noqa: SLF001
+        assert tool is not None
+        props = tool.parameters.get("properties", {})
+        assert "ctx" not in props, (
+            f"tool {name!r} leaked ctx into its JSON schema: {list(props)!r}"
+        )
+        assert "ctx" not in tool.parameters.get("required", [])

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -232,6 +232,67 @@ def test_config_set_schema_requires_attribute_and_value(
 # --------------------------------------------------------------------------- #
 
 
+def test_synthesised_wrapper_carries_context_parameter() -> None:
+    """The synthesised wrapper must expose a ``ctx: Context`` parameter.
+
+    FastMCP's :func:`find_context_parameter` reads
+    :func:`typing.get_type_hints` to locate the parameter to inject
+    the per-request :class:`Context` into; we therefore need both the
+    synthesised :class:`inspect.Signature` AND the ``__annotations__``
+    map to advertise ``ctx`` with the real ``Context`` annotation.
+    """
+    import inspect
+
+    from mcp.server.fastmcp import Context
+
+    from mtui.mcp.tools import _make_wrapper
+
+    session_stub = MagicMock()
+    parser = Command.registry["whoami"].argparser(__import__("sys"))
+    wrapper = _make_wrapper(Command.registry["whoami"], parser, session_stub)
+
+    sig = inspect.signature(wrapper)
+    assert "ctx" in sig.parameters
+    ctx_param = sig.parameters["ctx"]
+    assert ctx_param.kind is inspect.Parameter.KEYWORD_ONLY
+    assert ctx_param.default is None
+    assert ctx_param.annotation is Context
+    # Annotations map must also resolve to the real class (not a
+    # string) so ``typing.get_type_hints`` succeeds without a
+    # ForwardRef lookup.
+    assert wrapper.__annotations__["ctx"] is Context
+
+
+def test_tool_schema_does_not_advertise_ctx(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """``ctx`` must be stripped from every tool's JSON schema.
+
+    FastMCP's tool registration calls ``func_metadata(fn,
+    skip_names=[context_kwarg])`` which excludes the Context-typed
+    parameter from the pydantic model used to build the JSON schema.
+    Asserted for a representative cross-section so a regression in
+    the SDK contract (e.g. a future version that no longer skips
+    Context params) surfaces loudly.
+    """
+    for name in (
+        "whoami",
+        "run",
+        "update",
+        "load_template",
+        "config_set",
+        "config_show",
+    ):
+        params = _params_of(mcp, name)
+        props = params.get("properties", {})
+        assert "ctx" not in props, (
+            f"tool {name!r} leaked a Context parameter into its JSON schema: "
+            f"{list(props)!r}"
+        )
+        required = params.get("required", [])
+        assert "ctx" not in required
+
+
 def test_read_only_heuristic_matches_allow_list() -> None:
     """The internal helper honours the prefix + exact allow-list."""
     assert _is_read_only("whoami")


### PR DESCRIPTION
## Why

In practice, MCP clients time out on the mtui commands that legitimately take minutes rather than seconds — `run` against a slow refhost, `update`, `set_repo`, `commit`, slow `add_host`, `load_template` against a fresh SVN checkout, anything that drives `osc`/`svn` over the network. The mtui side never enforced a timeout itself; the deadline came from the client's JSON-RPC read timeout (often 30 s, matching the SDK's `MCP_DEFAULT_TIMEOUT = 30.0` in `mcp.shared._httpx_utils`). Worker threads kept running and finished correctly, but the reply landed after the client had already cancelled, so the LLM saw an empty timeout error instead of the command's output.

## What

`mtui-mcp` now emits `notifications/progress` every 10 s while a tool call is in flight, addressed at the request's `progressToken`. Spec-compliant clients (the official Inspector, Claude Desktop, opencode, Cursor, ...) reset their read deadline on each frame, so a ten-minute command still returns its captured stdout cleanly with no client-side configuration change. The heartbeat is uniform across every auto-generated tool plus the three testreport tools; the SDK's `Context.report_progress` is a no-op when the client did not request progress, so the path costs nothing for clients that opt out.

### Diff shape

- **`mtui/mcp/session.py`** — `run_command` accepts an optional `ctx` and a `progress_interval` knob (default 10 s via new `DEFAULT_PROGRESS_INTERVAL_SECONDS`). When `ctx` is supplied, a new `_run_with_heartbeat` helper races the worker thread against a heartbeat loop; `ctx=None` preserves the legacy zero-overhead `asyncio.to_thread` path used by autoconnect and tests.
- **`mtui/mcp/tools.py`** — `_make_wrapper` appends a keyword-only `ctx: Context` parameter to every synthesised wrapper. FastMCP detects the `Context` annotation via `find_context_parameter`, strips `ctx` from the tool's JSON schema, and injects the live per-request Context at call time. The wrapper pops `ctx` before re-serialising kwargs to argv and forwards it into `run_command`.
- **`mtui/mcp/testreport_tools.py`** — `testreport_read`/`_patch`/`_write` accept an optional `ctx` and emit one frame before disk I/O so queued clients see the call has been picked up. `Context` is lazily injected into the module globals inside `register_testreport_tools` so `typing.get_type_hints` resolves the closure's string annotations without forcing a hard module-level dependency on the optional `[mcp]` extra.
- **`Documentation/mcp.rst`** — new "Long-running tool calls" section covering the heartbeat plus per-client timeout knobs (Claude Desktop, opencode, custom SDK clients) for the rare clients that ignore progress notifications.
- **`CHANGELOG.md`** — `[Unreleased] / Fixed` bullet.

### Tests

New `tests/test_mcp_session_progress.py` and extensions to `test_mcp_tools.py` / `test_mcp_testreport_tools.py` pin:

- heartbeat fires for slow commands, zero frames for fast ones,
- `ctx=None` preserves the legacy path,
- command exceptions propagate through the heartbeat,
- `ctx.report_progress` failures are swallowed (never mask the command's result),
- progress values are monotonic,
- synthesised wrapper signature carries `ctx: Context`,
- `ctx` does not leak into any tool's JSON schema (auto-generated or testreport).

## Gates

- `uv run ruff format --check .` — 278 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run ty check` — All checks passed
- `uv run pytest` — **1201 passed in 4.92 s**
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html` — build succeeded

## Risk

- **Older / non-spec-compliant MCP clients** may ignore `notifications/progress` and keep their own short timeout. The change is strictly additive — no client breaks; the new doc section points them at their per-server `timeout` knob.
- **FastMCP `Context` injection contract.** The change relies on FastMCP recognising a `Context`-annotated parameter and excluding it from the JSON schema via `skip_names`. Pinned by `test_synthesised_wrapper_carries_context_parameter` and `test_tool_schema_does_not_advertise_ctx` so a future SDK regression surfaces loudly.
- **Heartbeat starts only after lock acquisition.** Clients queued behind a long-running call still see no progress until they reach the lock. This matches the existing single-tenant contract; out of scope here.