### PR TITLE
fix(mcp): suppress TTY spinner for non-interactive (MCP) sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `mtui-mcp` no longer paints the interactive `|/-\` spinner to
+  stderr during long-running parallel actions (`run`, `set_repo`,
+  `sftp_*`). The spinner is a REPL-only progress channel; over MCP
+  the proper signal is `notifications/progress`. The REPL keeps its
+  spinner unchanged.
 - `mtui-mcp` now emits MCP `notifications/progress` every 10 seconds
   while a tool call is running, so spec-compliant MCP clients
   (Inspector, Claude Desktop, opencode, …) no longer time out on

--- a/mtui/hosts/target/actions.py
+++ b/mtui/hosts/target/actions.py
@@ -112,20 +112,31 @@ def run_parallel(
 class ThreadedTargetGroup(ABC):
     """An abstract base class for performing actions on a group of targets."""
 
-    def __init__(self, targets: list[Target] | ValuesView[Target]) -> None:
+    def __init__(
+        self,
+        targets: list[Target] | ValuesView[Target],
+        interactive: bool = True,
+    ) -> None:
         """Initializes the threaded target group.
 
         Args:
             targets: A list of targets to perform actions on.
+            interactive: Whether the surrounding session is interactive.
+                When False (e.g. ``mtui-mcp``), :meth:`run` passes
+                ``desc=None`` to :func:`run_parallel` so the TTY spinner
+                is skipped; MCP uses ``notifications/progress`` for
+                progress signalling instead. Defaults to True so the
+                interactive REPL keeps its spinner unchanged.
 
         """
         self.targets = targets
+        self.interactive = interactive
 
     def run(self) -> None:
         """Runs the action on every target in parallel."""
         run_parallel(
             [self.mk_cmd(t) for t in self.targets],
-            desc=type(self).__name__,
+            desc=type(self).__name__ if self.interactive else None,
         )
 
     @abstractmethod
@@ -136,15 +147,21 @@ class ThreadedTargetGroup(ABC):
 class FileDelete(ThreadedTargetGroup):
     """Deletes a file on a group of targets in parallel."""
 
-    def __init__(self, targets: list[Target] | ValuesView[Target], path: Path) -> None:
+    def __init__(
+        self,
+        targets: list[Target] | ValuesView[Target],
+        path: Path,
+        interactive: bool = True,
+    ) -> None:
         """Initializes the file delete action.
 
         Args:
             targets: A list of targets to delete the file from.
             path: The path to the file to delete.
+            interactive: See :class:`ThreadedTargetGroup`.
 
         """
-        super().__init__(targets)
+        super().__init__(targets, interactive=interactive)
         self.path = path
 
     def mk_cmd(self, t: Target) -> tuple[Callable[..., Any], tuple[Any, ...]]:
@@ -156,7 +173,11 @@ class FileUpload(ThreadedTargetGroup):
     """Uploads a file to a group of targets in parallel."""
 
     def __init__(
-        self, targets: list[Target] | ValuesView[Target], local: Path, remote: Path
+        self,
+        targets: list[Target] | ValuesView[Target],
+        local: Path,
+        remote: Path,
+        interactive: bool = True,
     ) -> None:
         """Initializes the file upload action.
 
@@ -164,9 +185,10 @@ class FileUpload(ThreadedTargetGroup):
             targets: A list of targets to upload the file to.
             local: The local path to the file to upload.
             remote: The remote path to upload the file to.
+            interactive: See :class:`ThreadedTargetGroup`.
 
         """
-        super().__init__(targets)
+        super().__init__(targets, interactive=interactive)
         self.local = local
         self.remote = remote
 
@@ -179,7 +201,11 @@ class FileDownload(ThreadedTargetGroup):
     """Downloads a file from a group of targets in parallel."""
 
     def __init__(
-        self, targets: list[Target] | ValuesView[Target], remote: Path, local: Path
+        self,
+        targets: list[Target] | ValuesView[Target],
+        remote: Path,
+        local: Path,
+        interactive: bool = True,
     ) -> None:
         """Initializes the file download action.
 
@@ -187,9 +213,10 @@ class FileDownload(ThreadedTargetGroup):
             targets: A list of targets to download the file from.
             remote: The remote path to the file to download.
             local: The local path to save the downloaded file to.
+            interactive: See :class:`ThreadedTargetGroup`.
 
         """
-        super().__init__(targets)
+        super().__init__(targets, interactive=interactive)
 
         self.remote = remote
         self.local = local
@@ -203,17 +230,26 @@ class RunCommand:
     """Runs a command on a group of targets, parallel or serial."""
 
     def __init__(
-        self, targets: dict[str, Target], command: str | dict[str, Any]
+        self,
+        targets: dict[str, Target],
+        command: str | dict[str, Any],
+        interactive: bool = True,
     ) -> None:
         """Initializes the run command action.
 
         Args:
             targets: A dictionary of targets to run the command on.
             command: The command to run.
+            interactive: Whether the surrounding session is interactive.
+                When False (e.g. ``mtui-mcp``), :meth:`run` passes
+                ``desc=None`` to :func:`run_parallel` so the TTY spinner
+                is skipped. Defaults to True so the REPL keeps its
+                spinner unchanged.
 
         """
         self.targets = targets
         self.command = command
+        self.interactive = interactive
 
     def _cmd_for(self, hostname: str) -> Any:
         """Resolve the per-host command, accepting a string or dict shape."""
@@ -234,7 +270,7 @@ class RunCommand:
         try:
             run_parallel(
                 [(t.run, (self._cmd_for(h), lock)) for h, t in parallel.items()],
-                desc="run",
+                desc="run" if self.interactive else None,
             )
 
             for h, t in serial.items():

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -46,14 +46,22 @@ class HostsGroup(UserDict[str, Target]):
 
     """
 
-    def __init__(self, hosts: list[Target]) -> None:
+    def __init__(self, hosts: list[Target], interactive: bool = True) -> None:
         """Initializes the `HostsGroup` object.
 
         Args:
             hosts: A list of `Target` objects.
+            interactive: Whether this group runs in an interactive
+                session. When False (e.g. ``mtui-mcp``), long-running
+                parallel actions skip the TTY spinner so headless
+                callers do not see ``\\r[|]`` frames bleed onto
+                stderr; MCP's ``notifications/progress`` heartbeat is
+                the proper progress channel there. Defaults to True
+                so the interactive REPL keeps its spinner unchanged.
 
         """
         super().__init__({h.hostname: h for h in hosts})
+        self.interactive = interactive
 
     def select(
         self, hosts: list[str] | None = None, enabled: bool = False
@@ -72,7 +80,8 @@ class HostsGroup(UserDict[str, Target]):
         if not hosts:
             if enabled:
                 return HostsGroup(
-                    [h for h in self.data.values() if h.state != "disabled"]
+                    [h for h in self.data.values() if h.state != "disabled"],
+                    interactive=self.interactive,
                 )
             return self
 
@@ -85,7 +94,8 @@ class HostsGroup(UserDict[str, Target]):
                 h
                 for hn, h in self.data.items()
                 if hn in hosts and ((not enabled) or h.state != "disabled")
-            ]
+            ],
+            interactive=self.interactive,
         )
 
     def unlock(self, *a, **kw) -> None:
@@ -140,7 +150,9 @@ class HostsGroup(UserDict[str, Target]):
             local: The local path to save the downloaded file to.
 
         """
-        return FileDownload(self.data.values(), remote, local).run()
+        return FileDownload(
+            self.data.values(), remote, local, interactive=self.interactive
+        ).run()
 
     def sftp_put(self, local: Path, remote: Path) -> None:
         """Uploads a file to all hosts in the group.
@@ -150,7 +162,9 @@ class HostsGroup(UserDict[str, Target]):
             remote: The remote path to upload the file to.
 
         """
-        return FileUpload(self.data.values(), local, remote).run()
+        return FileUpload(
+            self.data.values(), local, remote, interactive=self.interactive
+        ).run()
 
     def sftp_remove(self, path: Path) -> None:
         """Deletes a file from all hosts in the group.
@@ -159,7 +173,7 @@ class HostsGroup(UserDict[str, Target]):
             path: The path to the file to delete.
 
         """
-        return FileDelete(self.data.values(), path).run()
+        return FileDelete(self.data.values(), path, interactive=self.interactive).run()
 
     def run(self, cmd) -> None:
         """Runs a command on all hosts in the group.
@@ -177,7 +191,7 @@ class HostsGroup(UserDict[str, Target]):
             cmd: The command to run.
 
         """
-        return RunCommand(self.data, cmd).run()
+        return RunCommand(self.data, cmd, interactive=self.interactive).run()
 
     def _reboot(self, reboot: dict[str, str]) -> None:
         """Reboots all transactional hosts in the group.
@@ -294,7 +308,7 @@ class HostsGroup(UserDict[str, Target]):
         """Fan ``Target.repo_manager.set(operation, testreport)`` out across every host."""
         run_parallel(
             [(t.repo_manager.set, (operation, testreport)) for t in self.data.values()],
-            desc=f"set_repo {operation}",
+            desc=f"set_repo {operation}" if self.interactive else None,
         )
 
     def perform_install(self, packages: list[str]) -> None:

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -146,6 +146,10 @@ class McpSession:
 
         self.metadata = NullTestReport(config, prompter=self.prompter)
         self.targets = self.metadata.targets
+        # Mirror ``self.interactive`` onto the HostsGroup so long-running
+        # parallel actions (run, set_repo, sftp_*) skip the TTY spinner;
+        # MCP uses ``notifications/progress`` as its progress channel.
+        self.targets.interactive = False
         self.session: str | None = None
 
         # Snapshot of the registry so commands that introspect
@@ -245,6 +249,9 @@ class McpSession:
         )
         self.metadata = tr
         self.targets = tr.targets
+        # Re-apply the non-interactive flag after the testreport swap so
+        # the fresh HostsGroup inherits the session's headless mode.
+        self.targets.interactive = False
         self.set_prompt(None)
 
     # ------------------------------------------------------------------

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -170,3 +170,27 @@ def test_tty_spinner_is_silent_when_stderr_not_a_tty(capsys):
     assert captured.err == ""
     # Internal: no thread should have been spawned in non-TTY mode.
     assert s._thread is None  # noqa: SLF001
+
+
+def test_run_parallel_skips_spinner_when_desc_is_none_even_on_tty(capsys):
+    """``desc=None`` must skip the spinner unconditionally, even on a TTY.
+
+    The MCP server (and any other headless caller) declares itself
+    non-interactive so the ``HostsGroup`` layer passes ``desc=None``
+    to ``run_parallel``. If a future change ever re-enabled the
+    spinner for a ``desc=None`` call, this test would catch it: even
+    with ``sys.stderr.isatty()`` patched to True the worker must
+    finish without a single ``\\r`` frame on stderr.
+    """
+    from mtui.hosts.target.actions import run_parallel
+
+    fake_tty = MagicMock()
+    fake_tty.isatty.return_value = True
+    with patch("mtui.hosts.target.actions.sys.stderr", fake_tty):
+        run_parallel([(MagicMock(), ()), (MagicMock(), ())], desc=None)
+
+    # No spinner means no writes to the (faked) stderr at all.
+    fake_tty.write.assert_not_called()
+    # And the real captured stderr (pytest's) stays clean too.
+    captured = capsys.readouterr()
+    assert captured.err == ""

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -850,3 +850,76 @@ def test_report_log_delegates():
     hg = HostsGroup([t1])
     hg.report_log(sink, "arg")
     t1.reporter.log.assert_called_once_with(sink, "arg")
+
+
+# --- Interactive flag propagation (MCP spinner suppression) ---
+
+
+def test_hostgroup_defaults_to_interactive():
+    """The REPL path constructs ``HostsGroup`` without the kwarg."""
+    hg = HostsGroup([])
+    assert hg.interactive is True
+
+
+def test_hostgroup_non_interactive_select_inherits_flag():
+    """A sub-group from ``select`` must carry the parent's ``interactive`` bit."""
+    t1 = _stub_target("h1")
+    t2 = _stub_target("h2")
+    t1.state = "enabled"
+    t2.state = "enabled"
+    hg = HostsGroup([t1, t2], interactive=False)
+
+    sub_all = hg.select()
+    sub_named = hg.select(["h1"])
+    sub_enabled = hg.select(enabled=True)
+
+    assert sub_all.interactive is False
+    assert sub_named.interactive is False
+    assert sub_enabled.interactive is False
+
+
+def test_hostgroup_non_interactive_passes_desc_none_to_run_parallel():
+    """``_fanout_set_repo`` on a headless group must pass ``desc=None``."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1], interactive=False)
+
+    with patch("mtui.hosts.target.hostgroup.run_parallel") as mock_rp:
+        hg._fanout_set_repo("add", MagicMock())  # noqa: SLF001
+
+    assert mock_rp.call_args.kwargs["desc"] is None
+
+
+def test_hostgroup_interactive_passes_desc_label_to_run_parallel():
+    """The REPL path keeps the descriptive spinner label."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])  # interactive=True by default
+
+    with patch("mtui.hosts.target.hostgroup.run_parallel") as mock_rp:
+        hg._fanout_set_repo("add", MagicMock())  # noqa: SLF001
+
+    assert mock_rp.call_args.kwargs["desc"] == "set_repo add"
+
+
+def test_hostgroup_non_interactive_run_passes_through_to_runcommand():
+    """``HostsGroup.run`` forwards ``interactive`` into ``RunCommand``."""
+    from mtui.types import ExecutionMode
+
+    t1 = _stub_target("h1")
+    t1.mode = ExecutionMode.PARALLEL
+    hg = HostsGroup([t1], interactive=False)
+
+    with patch("mtui.hosts.target.hostgroup.RunCommand") as mock_rc:
+        hg.run("true")
+
+    assert mock_rc.call_args.kwargs["interactive"] is False
+
+
+def test_hostgroup_non_interactive_sftp_remove_forwards_flag():
+    """``sftp_remove`` constructs ``FileDelete(interactive=False)``."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1], interactive=False)
+
+    with patch("mtui.hosts.target.hostgroup.FileDelete") as mock_fd:
+        hg.sftp_remove(Path("/tmp/x"))
+
+    assert mock_fd.call_args.kwargs["interactive"] is False


### PR DESCRIPTION
## Summary

`mtui-mcp` runs headless — there is no terminal, no user watching a
spinner — so the `|/-\` frames emitted by `run_parallel` were pure
noise on stderr with no benefit to anyone. The correct progress signal
over MCP is `notifications/progress`, which is already in place from
the previous commit.

## What changed

- `ThreadedTargetGroup` gains an `interactive` flag (default `True`),
  preserving existing REPL behaviour unchanged.
- When `interactive=False`, `run()` passes `desc=None` to
  `run_parallel`, which skips the spinner unconditionally.
- The MCP session (`mtui/mcp/session.py`) wires `interactive=False`
  into `HostsGroup` construction.
- Tests verify the `desc=None` path fires even when `sys.stderr.isatty()`
  is patched to `True`.
- `CHANGELOG.md` updated under `[Unreleased] > Fixed`.

## Testing

```
uv run pytest tests/test_actions.py tests/test_hostgroup.py -v
uv run ruff format --check .
uv run ruff check .
uv run ty check
```