### PR TITLE
ci(workflows): narrow Python matrix and upgrade codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: MTUI tests + coverage
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.13', '3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
@@ -45,13 +45,13 @@ jobs:
       - name: Test run ${{ matrix.python-version }}
         run: uv run pytest -v --cov=./mtui --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v5
-        if: ${{ matrix.python-version == '3.13' }} 
+        uses: codecov/codecov-action@v7
+        if: ${{ matrix.python-version == '3.14' }} 
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to CodeCov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: ${{ !cancelled() }} 
         with:
           files: junit.xml


### PR DESCRIPTION
## What changed

- Removed Python 3.11 and 3.12 from CI test matrix (`.github/workflows/ci.yml`)
- Bumped `codecov/codecov-action` from v5 to v7 (both coverage and test result uploads)
- Shifted coverage upload trigger from 3.13 to 3.14 (new matrix minimum)

## Why

- **CI cost reduction:** Running all four Python versions adds unnecessary time and cost to every PR. Narrowing to 3.13/3.14 keeps coverage meaningful while speeding up feedback.
- **Codecov reliability:** codecov-action v5 had known issues causing unreliable uploads. Upgrading to v7 uses the actively maintained version.