### PR TITLE
feat(mcp): per-client session isolation, idle reaping, and concurrency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   session over `stdio` or `http`. The `mcp` extra installs
   `mcp[cli]>=1.2`; on openSUSE the SDK is packaged as
   `python3-mcp`. See `Documentation/mcp.rst` for the deny-list,
-  single-session caveat, and a `read → patch → read` worked example.
+  per-client isolation model, and a `read → patch → read` worked
+  example.
+- `mtui-mcp`'s `http` transport now isolates session state **per
+  client**: each connected client gets its own loaded test report and
+  set of SSH hosts, keyed on the MCP session, so concurrent clients no
+  longer share (or clobber) one another's `load_template` / `add_host`
+  state and run without cross-session serialisation. The number of
+  concurrent sessions is bounded by `[mcp] session_cap` (default 32)
+  and idle sessions are reaped after `[mcp] session_idle_timeout`
+  seconds (default 1800), disconnecting their hosts. `stdio` is
+  unchanged (one process, one session).
+
+### Changed
+
+- `mtui-mcp` no longer accepts boot-time test-report or host flags
+  (`-a`/`--auto-review-id`, `-k`/`--kernel-review-id`, `-s`/`--sut`);
+  passing them now errors as unknown arguments. A single boot-time
+  seed cannot belong to any one client under the new per-client
+  isolation, so each client loads its own state at runtime via the
+  `load_template` and `add_host` tools instead. (The REPL `mtui`
+  keeps these flags.)
 
 ### Fixed
 

--- a/Documentation/developer.rst
+++ b/Documentation/developer.rst
@@ -309,9 +309,9 @@ the response envelope. From a fresh server:
     > whoami()
     User: <username>, Session PID: <pid>
 
-If a test report was preloaded with ``-a`` / ``-k``,
-``testreport_read`` returns its current contents. Otherwise the
-editing tools refuse cleanly with
+Once a test report has been loaded for the session (via the
+``load_template`` tool), ``testreport_read`` returns its current
+contents. Before that the editing tools refuse cleanly with
 ``no testreport loaded; run `load_template` first`` — that is the
 correct refusal path and exercises
 :class:`~mtui.support.messages.UserError` handling.
@@ -329,10 +329,10 @@ Troubleshooting
   URL the client is configured with.
 * **Tool calls time out under HTTP.** mtui's network-bound commands
   (``update``, ``prepare``, ``checkout``) can run for minutes against
-  real refhosts. Raise the client's per-tool timeout. The
-  process-wide ``asyncio.Lock`` serialises invocations, so a long
-  tool call blocks every concurrent client on the same server — that
-  is by design, not a bug.
+  real refhosts. Raise the client's per-tool timeout. Each HTTP client
+  has its own isolated session and lock, so a long tool call blocks
+  only that client's own subsequent calls — other clients run
+  concurrently against their own sessions.
 * **Need to see the wire protocol.** Pass ``--debug`` to ``mtui-mcp``;
   both the server logger and the ``mcp.server.fastmcp`` logger drop
   to ``DEBUG``, surfacing JSON-RPC frames and MCP-server routing

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -16,11 +16,13 @@ command is auto-exposed as an MCP tool, and three dedicated tools
 (``testreport_read``, ``testreport_patch``, ``testreport_write``)
 replace the REPL's ``$EDITOR``-based ``edit`` flow.
 
-The server is **single-session** and **single-tenant** by contract:
-one process holds one ``Config``, one loaded test report, and one set
-of connected hosts. A process-wide ``asyncio.Lock`` serialises every
-tool invocation so the HTTP transport can accept concurrent clients
-without interleaving mutations of ``metadata`` / ``targets``.
+Session state is isolated per client. Under ``stdio`` one process
+serves one client, so there is exactly one ``Config`` / loaded test
+report / set of connected hosts. Under ``http`` each connected client
+gets its **own** isolated session — its own ``metadata`` and
+``targets`` — so concurrent clients never see each other's loaded
+template or hosts (see :ref:`mcp-concurrency`). Clients load their own
+state at runtime via the ``load_template`` and ``add_host`` tools.
 
 .. _Model Context Protocol: https://modelcontextprotocol.io
 
@@ -98,20 +100,19 @@ Flags mirror :doc:`cli` for the configuration surface that
 ``-l, --location``, ``-t, --template_dir``, ``-g, --gitea_token``, ``-w, --connection_timeout``
     Configuration overrides identical to ``mtui``.
 
-``-s, --sut HOST[,HOST...]``
-    Cumulative list of refhosts to autoconnect on boot. Failures are
-    logged and the server keeps running (a long-lived MCP session
-    has its own recovery paths via the ``add_host`` tool).
-
-``-a, --auto-review-id ID`` / ``-k, --kernel-review-id ID``
-    Preload an auto- or kernel-update test report on boot.
-    Mutually exclusive. Failures are logged and the server keeps
-    running with a :class:`NullTestReport`; the LLM can recover by
-    calling the ``load_template`` tool.
-
 ``-V, --version``
     Print mtui, Python, paramiko and openqa-client versions, then
     exit.
+
+.. note::
+
+   ``mtui-mcp`` takes **no** boot-time test-report or host flags.
+   Earlier versions accepted ``-a``/``-k`` (preload an RRID) and
+   ``-s``/``--sut`` (autoconnect hosts); these were removed when the
+   HTTP transport gained per-client isolation, because a single
+   boot-time seed cannot belong to any one client. Each client loads
+   its own state at runtime with the ``load_template`` and
+   ``add_host`` tools.
 
 
 Connecting an LLM client
@@ -167,9 +168,10 @@ is not on the client's ``PATH``, give the absolute path
       }
     }
 
-Preload a test report on boot by appending the matching CLI flag to
-``args`` — ``-a``/``-k`` for the RRID, ``-s`` for autoconnect hosts,
-``-c`` for a custom config:
+Point the server at a custom config with ``-c`` if needed; the test
+report and hosts are **not** seeded from CLI flags — the client loads
+them at runtime by calling the ``load_template`` and ``add_host``
+tools:
 
 .. code-block:: json
 
@@ -179,8 +181,7 @@ Preload a test report on boot by appending the matching CLI flag to
           "command": "mtui-mcp",
           "args": [
             "--transport", "stdio",
-            "-a", "SUSE:Maintenance:12345:67890",
-            "-s", "host1.example.com,host2.example.com"
+            "-c", "/etc/mtui/qam.cfg"
           ]
         }
       }
@@ -231,11 +232,11 @@ which avoids the long-lived server process entirely:
       }
     }
 
-The HTTP transport is single-tenant by contract (see
-:ref:`mcp-concurrency`). Bind to loopback (the default) and front
-with the operator's reverse-proxy of choice if remote access is
-required — ``mtui-mcp`` itself does not terminate TLS or authenticate
-callers.
+The HTTP transport isolates state per client but does **not**
+authenticate them (see :ref:`mcp-concurrency`). Bind to loopback (the
+default) and front with the operator's reverse-proxy of choice if
+remote access is required — ``mtui-mcp`` itself does not terminate TLS
+or authenticate callers.
 
 
 Tool coverage
@@ -374,24 +375,55 @@ re-read to confirm the new line count:
 Concurrency and safety
 ======================
 
-* **Single session per process.** The HTTP transport accepts
-  concurrent clients, but they all share the same ``McpSession`` and
-  therefore the same ``Config``, ``metadata``, and ``targets``.
-* **Process-wide ``asyncio.Lock``.** Every tool invocation —
-  auto-generated and testreport-editing alike — acquires the same
-  lock, so mutations of ``metadata`` / ``targets`` cannot interleave.
-* **Atomic file writes.** ``testreport_patch`` and
-  ``testreport_write`` swap via ``os.replace`` after ``fsync``; the
-  on-disk file is always either fully old or fully new, never torn.
-* **Concurrent writers are not detected.** The lock prevents
-  interleaving within one process, but two MCP clients reading the
-  file, computing patches against the same line numbers, then
-  applying them sequentially will still cause the second one to
-  land at stale offsets. A future ``expected_sha256`` round-trip
-  field on ``patch``/``write`` is the planned mitigation.
-* **HTTP is single-tenant by contract.** No auth, no TLS. Bind to
-  loopback (the default) and front with the operator's preferred
-  reverse-proxy if external access is required.
+* **One isolated session per client (HTTP).** Under ``--transport
+  http`` each connected client gets its own :class:`McpSession` — its
+  own ``Config`` view, ``metadata``, and ``targets``. One client's
+  ``load_template`` / ``add_host`` is invisible to every other client,
+  so concurrent reviewers never collide. Under ``stdio`` there is one
+  client and therefore one session.
+* **Sessions are keyed on the MCP session.** The registry keys each
+  session on the identity of the request's ``ServerSession`` object
+  (``id(ctx.session)``), which the SDK keeps 1:1 with the MCP session
+  for the connection's lifetime. The ``Mcp-Session-Id`` header is used
+  for log lines only, never to route state.
+* **Per-session ``asyncio.Lock``.** Within a single session every tool
+  invocation — auto-generated and testreport-editing alike — acquires
+  *that session's* lock, so one client's calls cannot interleave
+  mutations of its own ``metadata`` / ``targets``. Calls from different
+  clients hold different locks and run concurrently.
+* **Bounded session count.** The HTTP registry refuses to create more
+  than ``[mcp] session_cap`` concurrent sessions (default ``32``),
+  failing the offending tool call with a clear error rather than
+  spawning unbounded SSH connections and worker threads. Raise the cap
+  in config if you genuinely need more simultaneous clients.
+* **Idle sessions are reaped.** A session that receives no tool calls
+  for ``[mcp] session_idle_timeout`` seconds (default ``1800``) is
+  evicted and its hosts disconnected. Because the MCP SDK gives the
+  application no per-session teardown callback, this sweep is what
+  releases the SSH connections of a client that simply disconnected;
+  set the timeout to ``0`` to disable it. (A client that reconnects
+  after eviction simply re-loads its template and hosts.)
+* **Atomic file writes.** ``testreport_patch`` and ``testreport_write``
+  swap via ``os.replace`` after ``fsync``; the on-disk file is always
+  either fully old or fully new, never torn.
+* **Concurrent writers within one session are not detected.** The
+  per-session lock prevents interleaving, but if one client reads the
+  file, computes two patches against the same line numbers, then
+  applies them sequentially, the second still lands at stale offsets.
+  A future ``expected_sha256`` round-trip field on ``patch`` /
+  ``write`` is the planned mitigation.
+* **No auth, no TLS.** Isolation is not authentication: ``mtui-mcp``
+  does not identify callers. Bind to loopback (the default) and front
+  with the operator's preferred reverse-proxy if external access is
+  required.
+
+These knobs live in the ``[mcp]`` section of the mtui config file:
+
+.. code-block:: ini
+
+    [mcp]
+    session_cap = 32
+    session_idle_timeout = 1800
 
 
 Long-running tool calls

--- a/mtui/mcp/args.py
+++ b/mtui/mcp/args.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 from ..cli.argparse import ArgumentParser
 from ..cli.args import _VerboseVersionAction
-from ..support.misc import SUTParse
-from ..types.updateid import AutoOBSUpdateID, KernelOBSUpdateID
 
 
 def get_parser(sys) -> ArgumentParser:
@@ -13,11 +11,14 @@ def get_parser(sys) -> ArgumentParser:
 
     The parser intentionally mirrors :func:`mtui.cli.args.get_parser` for
     the flags that ``Config.merge_args`` and the testreport-loading code
-    care about (``-l``, ``-t``, ``-c``, ``-g``, ``-s``, ``-a``, ``-k``,
-    ``--color``, ``--debug``, ``-V``) so the same ``Namespace`` shape can
-    be reused. REPL-only flags (``-p/--prerun``, ``-n/--noninteractive``)
-    are dropped, and three MCP-server flags (``--transport``, ``--host``,
-    ``--port``) are added.
+    care about (``-l``, ``-t``, ``-c``, ``-g``, ``--color``, ``--debug``,
+    ``-V``) so the same ``Namespace`` shape can be reused. REPL-only flags
+    (``-p/--prerun``, ``-n/--noninteractive``) are dropped, and three
+    MCP-server flags (``--transport``, ``--host``, ``--port``) are added.
+
+    Templates and hosts are loaded per session at runtime via the
+    ``load_template`` and ``add_host`` tools, so the server takes no
+    boot-time update/SUT flags.
 
     Args:
         sys: The ``sys`` module, used for stdout/stderr.
@@ -32,14 +33,6 @@ def get_parser(sys) -> ArgumentParser:
     )
     parser.add_argument(
         "-t", "--template_dir", type=Path, help="override config mtui.template_dir"
-    )
-    parser.add_argument(
-        "-s",
-        "--sut",
-        type=SUTParse,
-        action="append",
-        help="cumulatively override default hosts from template "
-        "(format: hostname,hostname2)",
     )
     parser.add_argument(
         "-w",
@@ -88,23 +81,6 @@ def get_parser(sys) -> ArgumentParser:
         type=int,
         default=8000,
         help="bind port for --transport http (default: 8000)",
-    )
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "-a",
-        "--auto-review-id",
-        metavar="RequestReviewID",
-        type=AutoOBSUpdateID,
-        help="OBS request review id (example: SUSE:Maintenance:1:1)",
-        dest="update",
-    )
-    group.add_argument(
-        "-k",
-        "--kernel-review-id",
-        metavar="RequestReviewID",
-        type=KernelOBSUpdateID,
-        help="OBS kernel/live-patch request review id (example: SUSE:Maintenance:1:1)",
-        dest="update",
     )
 
     return parser

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -3,34 +3,26 @@
 Parses CLI args, builds the same :class:`Config` the REPL does, runs
 :func:`detect_system`, lazily imports :mod:`mcp.server.fastmcp` so a
 missing ``[mcp]`` extra produces a friendly hint instead of a
-traceback, then constructs an :class:`McpSession`, optionally preloads
-an update and autoconnects SUTs, registers every non-denied command
-plus the three testreport tools, and dispatches on the chosen
-transport.
+traceback, then constructs an :class:`McpSession`, registers every
+non-denied command plus the three testreport tools, and dispatches on
+the chosen transport.
 
-Preload and autoconnect both **log-and-continue** on failure: an MCP
-session is long-lived, the LLM has its own recovery paths
-(``load_template``, ``add_host``), and refusing to boot would force a
-manual restart for a single typo. The REPL's stricter "exit 1 on
-preload failure" contract does not translate cleanly to a server.
+Templates and hosts are loaded per session at runtime via the
+``load_template`` and ``add_host`` tools; the server performs no
+boot-time preload or SUT autoconnect.
 """
 
 import asyncio
 import logging
-import shlex
 import sys
-from subprocess import CalledProcessError
 
 from ..cli.argparse import ArgsParseFailureError
 from ..cli.colors import create_logger
 from ..cli.colors import set_mode as set_color_mode
-from ..commands import Command
 from ..support.config import Config
-from ..support.exceptions import MissingGiteaTokenError
-from ..support.messages import MetadataNotLoadedError, SvnCheckoutInterruptedError
 from ..support.systemcheck import detect_system
 from .args import get_parser
-from .session import McpCommandError, McpSession
+from .session import McpSession
 from .testreport_tools import register_testreport_tools
 from .tools import build_tools
 
@@ -96,62 +88,9 @@ def main() -> int:
 
     cfg = Config(args.config)
     cfg.merge_args(args)
-    cfg.kernel = False
-    cfg.auto = False
     cfg.distro, cfg.distro_ver, cfg.distro_kernel = detect_system()
 
     session = McpSession(cfg, logger)
-
-    # Preload an explicitly requested update. Log-and-continue: a
-    # failure here leaves `session.metadata` as the NullTestReport the
-    # constructor already installed, so testreport_* tools refuse with
-    # their well-defined "no testreport loaded" message instead of
-    # tearing the server down.
-    if args.update:
-        if args.update.kind == "kernel":
-            cfg.kernel = True
-            cfg.auto = False
-        elif args.update.kind == "auto":
-            cfg.auto = True
-            cfg.kernel = False
-        try:
-            session.load_update(args.update, autoconnect=not bool(args.sut))
-        except KeyboardInterrupt:
-            logger.info("mtui-mcp: shutting down")
-            return 0
-        except (
-            SvnCheckoutInterruptedError,
-            CalledProcessError,
-            MetadataNotLoadedError,
-            MissingGiteaTokenError,
-        ) as e:
-            logger.warning(
-                "failed to preload update %s: %s; continuing without a "
-                "loaded testreport",
-                args.update,
-                e,
-            )
-
-    # Autoconnect SUTs by dispatching through the registered `add_host`
-    # command, exactly like the REPL does. We are pre-server here so
-    # the asyncio loop has not started yet; calling the synchronous
-    # core directly avoids spinning up and tearing down a loop just to
-    # invoke code that the lock would not even contend on (single
-    # thread, no concurrent caller exists yet).
-    if args.sut:
-        add_host_cls = Command.registry.get("add_host")
-        if add_host_cls is None:
-            logger.error("add_host command missing from registry; cannot autoconnect")
-        else:
-            try:
-                for x in args.sut:
-                    try:
-                        session._run_sync(add_host_cls, shlex.split(x.print_args()))  # noqa: SLF001
-                    except McpCommandError as e:
-                        logger.error("failed to add host %s: %s", x, e)
-            except KeyboardInterrupt:
-                logger.info("mtui-mcp: shutting down")
-                return 0
 
     # ``host``/``port`` are constructor-time settings in the SDK and
     # only consulted under the ``streamable-http`` transport; passing

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -3,18 +3,29 @@
 Parses CLI args, builds the same :class:`Config` the REPL does, runs
 :func:`detect_system`, lazily imports :mod:`mcp.server.fastmcp` so a
 missing ``[mcp]`` extra produces a friendly hint instead of a
-traceback, then constructs an :class:`McpSession`, registers every
-non-denied command plus the three testreport tools, and dispatches on
-the chosen transport.
+traceback, then selects a session provider, registers every non-denied
+command plus the three testreport tools, and dispatches on the chosen
+transport.
+
+The provider choice is the per-client isolation contract: under
+``--transport http`` a :class:`mtui.mcp.registry.SessionRegistry` mints
+one fully isolated :class:`McpSession` per client (keyed on the request
+session), so concurrent clients never share ``metadata`` / ``targets``;
+under stdio (one process == one session) a single eagerly-built
+:class:`McpSession` doubles as the degenerate single-entry provider.
 
 Templates and hosts are loaded per session at runtime via the
 ``load_template`` and ``add_host`` tools; the server performs no
 boot-time preload or SUT autoconnect.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import sys
+from logging import Logger
+from typing import TYPE_CHECKING
 
 from ..cli.argparse import ArgsParseFailureError
 from ..cli.colors import create_logger
@@ -22,9 +33,14 @@ from ..cli.colors import set_mode as set_color_mode
 from ..support.config import Config
 from ..support.systemcheck import detect_system
 from .args import get_parser
+from .registry import SessionRegistry
 from .session import McpSession
 from .testreport_tools import register_testreport_tools
 from .tools import build_tools
+
+if TYPE_CHECKING:
+    from .registry import SessionProvider
+
 
 # Exception types that we treat as "user asked us to stop" rather than
 # as crashes. ``CancelledError`` shows up because the MCP server runs
@@ -52,6 +68,31 @@ def _is_clean_shutdown_group(exc: BaseException) -> bool:
     if isinstance(exc, BaseExceptionGroup):
         return all(_is_clean_shutdown_group(e) for e in exc.exceptions)
     return isinstance(exc, _SHUTDOWN_LEAVES)
+
+
+def build_session(cfg: Config, log: Logger) -> McpSession:
+    """Construct a fresh :class:`McpSession` from ``cfg`` and ``log``.
+
+    A deliberately thin factory: with boot-time preload/autoconnect
+    gone (Phase A), minting a session is just calling the constructor.
+    It exists so the http :class:`mtui.mcp.registry.SessionRegistry`
+    can lazily mint a fresh, fully isolated session per client and the
+    stdio path can mint one eagerly — both through the same call — so
+    every session is born identically regardless of transport.
+
+    Args:
+        cfg: The application configuration (already merged with CLI
+            args and populated with ``detect_system`` results by
+            :func:`main`).
+        log: The configured server logger, reused by commands that
+            touch ``self.prompt.log``.
+
+    Returns:
+        A new :class:`McpSession` with its own ``metadata`` /
+        ``targets`` / lock.
+
+    """
+    return McpSession(cfg, log)
 
 
 def main() -> int:
@@ -90,14 +131,26 @@ def main() -> int:
     cfg.merge_args(args)
     cfg.distro, cfg.distro_ver, cfg.distro_kernel = detect_system()
 
-    session = McpSession(cfg, logger)
+    # Provider selection is the whole of the per-client isolation
+    # contract: under http each client gets its own isolated
+    # ``McpSession`` minted lazily by the registry (keyed on the
+    # request session); under stdio one process == one session, so a
+    # single eagerly-built session doubles as the degenerate
+    # single-entry provider (its ``get_or_create`` returns ``self``).
+    # ``build_tools`` / ``register_testreport_tools`` only see the
+    # ``get_or_create`` shape, so they stay transport-agnostic.
+    if args.transport == "http":
+        provider: SessionProvider = SessionRegistry(build_session, cfg, logger)
+        logger.info("mtui-mcp: http transport — per-client session isolation enabled")
+    else:
+        provider = build_session(cfg, logger)
 
     # ``host``/``port`` are constructor-time settings in the SDK and
     # only consulted under the ``streamable-http`` transport; passing
     # them under stdio is a harmless no-op.
     mcp = FastMCP(name="mtui", host=args.host, port=args.port)
-    build_tools(mcp, session)
-    register_testreport_tools(mcp, session)
+    build_tools(mcp, provider)
+    register_testreport_tools(mcp, provider)
 
     try:
         if args.transport == "http":

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -140,8 +140,19 @@ def main() -> int:
     # ``build_tools`` / ``register_testreport_tools`` only see the
     # ``get_or_create`` shape, so they stay transport-agnostic.
     if args.transport == "http":
-        provider: SessionProvider = SessionRegistry(build_session, cfg, logger)
-        logger.info("mtui-mcp: http transport — per-client session isolation enabled")
+        provider: SessionProvider = SessionRegistry(
+            build_session,
+            cfg,
+            logger,
+            max_sessions=cfg.mcp_session_cap,
+            idle_timeout=cfg.mcp_session_idle_timeout,
+        )
+        logger.info(
+            "mtui-mcp: http transport — per-client session isolation "
+            "(cap=%d, idle_timeout=%ss)",
+            cfg.mcp_session_cap,
+            cfg.mcp_session_idle_timeout,
+        )
     else:
         provider = build_session(cfg, logger)
 

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -22,6 +22,7 @@ boot-time preload or SUT autoconnect.
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import sys
 from logging import Logger
@@ -73,26 +74,39 @@ def _is_clean_shutdown_group(exc: BaseException) -> bool:
 def build_session(cfg: Config, log: Logger) -> McpSession:
     """Construct a fresh :class:`McpSession` from ``cfg`` and ``log``.
 
-    A deliberately thin factory: with boot-time preload/autoconnect
-    gone (Phase A), minting a session is just calling the constructor.
-    It exists so the http :class:`mtui.mcp.registry.SessionRegistry`
-    can lazily mint a fresh, fully isolated session per client and the
-    stdio path can mint one eagerly — both through the same call — so
-    every session is born identically regardless of transport.
+    Each session gets its **own** shallow copy of ``cfg`` so the
+    per-client isolation extends to the mutable workflow flags that
+    commands flip in place — ``config.auto`` / ``config.kernel`` (set
+    by ``load_template`` / ``add_host`` / ``set_mode``) and
+    ``config.location`` (``set_location``). A shallow copy is the right
+    tool: those attributes are scalars, so each session rebinds its own
+    while the heavy read-only members (the parsed ``ConfigParser``, the
+    refhosts factory) stay shared. Without the copy, every http client
+    would share one ``Config`` and clobber each other's workflow mode.
+
+    The workflow flags are seeded to ``False`` here, matching the REPL's
+    boot defaults in :func:`mtui.main.main`: ``add_host`` (and other
+    commands) read ``config.auto`` *before* any ``load_template`` runs,
+    so an unset attribute would raise ``AttributeError``.
 
     Args:
-        cfg: The application configuration (already merged with CLI
-            args and populated with ``detect_system`` results by
-            :func:`main`).
+        cfg: The base application configuration (already merged with
+            CLI args and populated with ``detect_system`` results by
+            :func:`main`); copied, never mutated.
         log: The configured server logger, reused by commands that
             touch ``self.prompt.log``.
 
     Returns:
-        A new :class:`McpSession` with its own ``metadata`` /
-        ``targets`` / lock.
+        A new :class:`McpSession` with its own ``config`` copy,
+        ``metadata`` / ``targets`` / lock.
 
     """
-    return McpSession(cfg, log)
+    session_cfg = copy.copy(cfg)
+    # Match the REPL boot defaults (mtui.main.main); commands read these
+    # before any template is loaded.
+    session_cfg.kernel = False
+    session_cfg.auto = False
+    return McpSession(session_cfg, log)
 
 
 def main() -> int:

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -21,14 +21,21 @@ provider used by stdio), so :mod:`mtui.mcp.tools` and
 :mod:`mtui.mcp.testreport_tools` resolve a session per call without
 caring which transport they run under.
 
-Lifecycle (idle-TTL eviction, session cap) and :meth:`McpSession.close`
-land in Phase C; :meth:`evict` is already best-effort
-``close()``-aware so wiring it in is additive.
+Lifecycle is registry-owned because the MCP SDK gives no per-session
+teardown callback we can reach through :meth:`FastMCP.run` (its
+``streamable-http`` path exposes no ``session_idle_timeout``, and a
+``ServerSession`` has no close hook): a background idle-TTL sweeper
+evicts sessions that have gone quiet for ``idle_timeout`` seconds and
+:meth:`McpSession.close`-es their hosts, and a ``max_sessions`` cap
+refuses new-session creation past the bound (DoS guard) rather than
+spawning unbounded ``targets`` / threads.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import time
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -48,6 +55,25 @@ logger = getLogger("mtui.mcp.registry")
 #: ignores the key) and yields one shared fallback session under the
 #: http :class:`SessionRegistry`.
 DEFAULT_SESSION_KEY: str = "<default>"
+
+#: Default ceiling on concurrent client sessions (DoS guard). Overridden
+#: from ``[mcp] session_cap`` via :func:`mtui.mcp.main.main`.
+DEFAULT_MAX_SESSIONS: int = 32
+
+#: Default idle-TTL, in seconds, after which a quiet session is swept.
+#: Overridden from ``[mcp] session_idle_timeout``. ``0`` disables the
+#: sweeper.
+DEFAULT_IDLE_TIMEOUT_SECONDS: float = 1800.0
+
+
+class SessionRegistryFullError(RuntimeError):
+    """Raised when creating a new session would exceed ``max_sessions``.
+
+    Surfaced to the client as the failing tool call's error so a
+    misbehaving or runaway fleet of clients gets a clear, bounded
+    refusal instead of silently exhausting the server's SSH/thread
+    budget.
+    """
 
 
 class SessionProvider(Protocol):
@@ -158,6 +184,14 @@ class SessionRegistry:
     the per-session lock. Creation is guarded by a registry-wide
     :class:`asyncio.Lock` with a double-checked read so a burst of
     concurrent first-calls for the same key mints exactly one session.
+
+    Two safety bounds:
+
+    * ``max_sessions`` caps how many sessions may coexist; creating one
+      past the cap raises :class:`SessionRegistryFullError` (DoS guard).
+    * ``idle_timeout`` drives a lazily-started background sweeper that
+      evicts (and :meth:`McpSession.close`-es) any session untouched
+      for that many seconds. A non-positive timeout disables sweeping.
     """
 
     def __init__(
@@ -165,21 +199,32 @@ class SessionRegistry:
         factory: Callable[[Config, Logger], McpSession],
         cfg: Config,
         log: Logger,
+        *,
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
+        idle_timeout: float = DEFAULT_IDLE_TIMEOUT_SECONDS,
     ) -> None:
-        """Store the session factory and the base ``cfg`` / ``log``.
+        """Store the session factory, base ``cfg`` / ``log``, and bounds.
 
         Args:
             factory: Callable that mints a fresh session from
                 ``(cfg, log)`` — :func:`mtui.mcp.main.build_session`.
             cfg: The base configuration handed to every minted session.
             log: The server logger handed to every minted session.
+            max_sessions: Ceiling on concurrent sessions; exceeding it
+                raises :class:`SessionRegistryFullError`.
+            idle_timeout: Seconds of inactivity before a session is
+                swept; ``<= 0`` disables the sweeper.
 
         """
         self._factory = factory
         self._cfg = cfg
         self._log = log
+        self._max_sessions = max_sessions
+        self._idle_timeout = idle_timeout
         self._sessions: dict[str, McpSession] = {}
+        self._last_touch: dict[str, float] = {}
         self._lock = asyncio.Lock()
+        self._sweeper: asyncio.Task[None] | None = None
 
     async def get_or_create(self, key: str) -> McpSession:
         """Return the session for ``key``, minting one on first use.
@@ -188,7 +233,10 @@ class SessionRegistry:
         present) reads the dict without contending on the registry
         lock; only a miss takes the lock, re-checks, and creates. So a
         flurry of concurrent first-calls for one key produces exactly
-        one session.
+        one session. Every call refreshes the key's last-touch
+        timestamp so the idle sweeper only reaps genuinely quiet
+        sessions, and the first call lazily starts the sweeper (we are
+        guaranteed to be inside the event loop here).
 
         Args:
             key: The per-client session key from :func:`_session_key`.
@@ -196,13 +244,25 @@ class SessionRegistry:
         Returns:
             The :class:`McpSession` bound to ``key``.
 
+        Raises:
+            SessionRegistryFullError: If a new session is required but the
+                registry already holds ``max_sessions`` sessions.
+
         """
+        self._ensure_sweeper()
         session = self._sessions.get(key)
         if session is not None:
+            self._last_touch[key] = time.monotonic()
             return session
         async with self._lock:
             session = self._sessions.get(key)
             if session is None:
+                if len(self._sessions) >= self._max_sessions:
+                    raise SessionRegistryFullError(
+                        f"session registry full: {self._max_sessions} concurrent "
+                        "client sessions already active; retry once a session is "
+                        "released or raise [mcp] session_cap"
+                    )
                 session = self._factory(self._cfg, self._log)
                 self._sessions[key] = session
                 logger.info(
@@ -210,13 +270,14 @@ class SessionRegistry:
                     key,
                     len(self._sessions),
                 )
+            self._last_touch[key] = time.monotonic()
             return session
 
     async def evict(self, key: str) -> None:
         """Drop ``key`` from the registry and best-effort close it.
 
-        Pops the session (no-op if absent) and, when it carries a
-        ``close`` coroutine (added in Phase C), awaits it under
+        Pops the session (no-op if absent), drops its last-touch
+        bookkeeping, and awaits :meth:`McpSession.close` under
         suppression so a teardown error never propagates. Safe to call
         more than once for the same key.
 
@@ -225,6 +286,7 @@ class SessionRegistry:
 
         """
         session = self._sessions.pop(key, None)
+        self._last_touch.pop(key, None)
         if session is None:
             return
         close = getattr(session, "close", None)
@@ -234,3 +296,55 @@ class SessionRegistry:
             except Exception as exc:  # noqa: BLE001 - teardown is best-effort
                 logger.warning("error closing session %s: %s", key, exc)
         logger.info("evicted MCP session (key=%s, live=%d)", key, len(self._sessions))
+
+    def _ensure_sweeper(self) -> None:
+        """Lazily start the idle-TTL sweeper task on first use.
+
+        Started from :meth:`get_or_create` (always inside the running
+        loop) rather than ``__init__`` (which runs before
+        :meth:`FastMCP.run` enters the loop). A non-positive
+        ``idle_timeout`` disables sweeping entirely.
+        """
+        if self._idle_timeout <= 0 or self._sweeper is not None:
+            return
+        self._sweeper = asyncio.create_task(self._sweep_loop())
+
+    async def _sweep_loop(self) -> None:
+        """Periodically evict sessions idle past ``idle_timeout``.
+
+        Wakes every ``idle_timeout / 2`` seconds (bounded to a sane
+        floor), collects keys whose last-touch is older than the
+        timeout, and evicts each outside the registry lock (so a slow
+        :meth:`McpSession.close` cannot stall fresh
+        :meth:`get_or_create` calls). Runs until cancelled by
+        :meth:`aclose`.
+        """
+        interval = max(1.0, self._idle_timeout / 2)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                now = time.monotonic()
+                stale = [
+                    key
+                    for key, touched in self._last_touch.items()
+                    if now - touched >= self._idle_timeout
+                ]
+                for key in stale:
+                    logger.info("sweeping idle MCP session (key=%s)", key)
+                    await self.evict(key)
+        except asyncio.CancelledError:
+            raise
+
+    async def aclose(self) -> None:
+        """Cancel the sweeper and close every live session.
+
+        Used for graceful shutdown and by tests to avoid leaking a
+        background task. Idempotent.
+        """
+        if self._sweeper is not None:
+            self._sweeper.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._sweeper
+            self._sweeper = None
+        for key in list(self._sessions):
+            await self.evict(key)

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -1,0 +1,236 @@
+"""Per-client :class:`McpSession` registry for the http transport.
+
+Under ``--transport http`` a single ``mtui-mcp`` process serves many
+concurrent MCP clients. Each client must see **only its own** loaded
+template and SSH ``targets`` — sharing one global session would let one
+client's ``load_template`` clobber another's. The MCP SDK keys its own
+connection bookkeeping by ``Mcp-Session-Id`` internally but exposes no
+per-session application-state hook, so this registry is
+application-owned.
+
+:class:`SessionRegistry` maps a per-client key to a lazily-minted,
+fully isolated :class:`McpSession` (own ``metadata`` / ``targets`` /
+lock). The key is :func:`id` of the request's ``ServerSession`` object
+(``ctx.session``), which is 1:1 with the MCP session and present in
+every tool call; the ``Mcp-Session-Id`` header is read for log lines
+only (never load-bearing — see :func:`_log_label`).
+
+The registry exposes the same ``async get_or_create(key) -> McpSession``
+shape as :meth:`McpSession.get_or_create` (the degenerate single-entry
+provider used by stdio), so :mod:`mtui.mcp.tools` and
+:mod:`mtui.mcp.testreport_tools` resolve a session per call without
+caring which transport they run under.
+
+Lifecycle (idle-TTL eviction, session cap) and :meth:`McpSession.close`
+land in Phase C; :meth:`evict` is already best-effort
+``close()``-aware so wiring it in is additive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Protocol
+
+from .session import McpSession
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from logging import Logger
+
+    from ..support.config import Config
+
+logger = getLogger("mtui.mcp.registry")
+
+#: Registry key used when a tool is invoked without a request Context
+#: (direct-call tests, non-request paths). It collides harmlessly under
+#: the static single-entry provider (:meth:`McpSession.get_or_create`
+#: ignores the key) and yields one shared fallback session under the
+#: http :class:`SessionRegistry`.
+DEFAULT_SESSION_KEY: str = "<default>"
+
+
+class SessionProvider(Protocol):
+    """The minimal surface :mod:`mtui.mcp.tools` resolves a session through.
+
+    Implemented by both :class:`SessionRegistry` (http: lazy
+    per-client sessions) and :class:`mtui.mcp.session.McpSession` (the
+    degenerate single-entry provider for stdio + direct tests), so the
+    tool layer is transport-agnostic.
+    """
+
+    async def get_or_create(self, key: str) -> McpSession:
+        """Return the session bound to ``key`` (minting one if needed)."""
+        ...
+
+
+async def resolve_session(provider: SessionProvider, ctx: Any | None) -> McpSession:
+    """Resolve the per-call session from ``provider`` for request ``ctx``.
+
+    Routes the ``ctx is None`` case (direct-call tests, non-request
+    invocation) to :data:`DEFAULT_SESSION_KEY` instead of computing a
+    key off a missing context, so the existing direct-call tests keep
+    working unchanged. Otherwise keys on :func:`_session_key`.
+
+    Args:
+        provider: The session provider (registry or static session).
+        ctx: The FastMCP :class:`~mcp.server.fastmcp.Context`, or
+            ``None``.
+
+    Returns:
+        The :class:`McpSession` to dispatch this call through.
+
+    """
+    key = DEFAULT_SESSION_KEY if ctx is None else _session_key(ctx)
+    return await provider.get_or_create(key)
+
+
+def _session_key(ctx: Any | None) -> str:
+    """Return the registry key for the request carried by ``ctx``.
+
+    The key is the identity of the request's ``ServerSession`` object
+    (``ctx.session`` → ``ctx.request_context.session``), which the SDK
+    keeps 1:1 with the MCP session for the connection's whole lifetime
+    and supplies on every tool call. Stringified so the registry dict
+    key type is uniform and log-friendly.
+
+    Args:
+        ctx: The FastMCP :class:`~mcp.server.fastmcp.Context` for the
+            in-flight tool call, or ``None``.
+
+    Returns:
+        ``str(id(ctx.session))``.
+
+    Raises:
+        ValueError: If ``ctx`` is ``None`` — callers must route the
+            ``ctx is None`` case (direct tests, non-request invocation)
+            to a static provider *before* reaching here.
+
+    """
+    if ctx is None:
+        raise ValueError("cannot derive a session key without a request Context")
+    return str(id(ctx.session))
+
+
+def _log_label(ctx: Any | None) -> str:
+    """Best-effort human-readable session label for log lines only.
+
+    Tries the ``Mcp-Session-Id`` request header (present under the
+    streamable-http transport), falling back to the SDK ``request_id``
+    and finally the :func:`_session_key`. Every lookup is wrapped so a
+    missing/renamed attribute or a header-less stdio request can never
+    raise — this string is purely cosmetic and must never gate
+    dispatch.
+
+    Args:
+        ctx: The FastMCP :class:`~mcp.server.fastmcp.Context`, or
+            ``None``.
+
+    Returns:
+        A short label such as the ``Mcp-Session-Id`` value, ``req=<id>``,
+        or ``id=<key>``; ``"<no-ctx>"`` when ``ctx`` is ``None``.
+
+    """
+    if ctx is None:
+        return "<no-ctx>"
+    try:
+        headers = ctx.request_context.request.headers  # type: ignore[union-attr]
+        sid = headers.get("mcp-session-id")
+        if sid:
+            return str(sid)
+    except Exception:  # noqa: BLE001 - cosmetic only, never load-bearing
+        pass
+    try:
+        return f"req={ctx.request_context.request_id}"
+    except Exception:  # noqa: BLE001 - cosmetic only
+        pass
+    try:
+        return f"id={_session_key(ctx)}"
+    except Exception:  # noqa: BLE001 - cosmetic only
+        return "<unknown>"
+
+
+class SessionRegistry:
+    """Maps a per-client key to an isolated :class:`McpSession`.
+
+    Each distinct key gets its own session minted through ``factory``,
+    so concurrent http clients never share ``metadata`` / ``targets`` /
+    the per-session lock. Creation is guarded by a registry-wide
+    :class:`asyncio.Lock` with a double-checked read so a burst of
+    concurrent first-calls for the same key mints exactly one session.
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[Config, Logger], McpSession],
+        cfg: Config,
+        log: Logger,
+    ) -> None:
+        """Store the session factory and the base ``cfg`` / ``log``.
+
+        Args:
+            factory: Callable that mints a fresh session from
+                ``(cfg, log)`` — :func:`mtui.mcp.main.build_session`.
+            cfg: The base configuration handed to every minted session.
+            log: The server logger handed to every minted session.
+
+        """
+        self._factory = factory
+        self._cfg = cfg
+        self._log = log
+        self._sessions: dict[str, McpSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_or_create(self, key: str) -> McpSession:
+        """Return the session for ``key``, minting one on first use.
+
+        Double-checked locking: the common hot path (key already
+        present) reads the dict without contending on the registry
+        lock; only a miss takes the lock, re-checks, and creates. So a
+        flurry of concurrent first-calls for one key produces exactly
+        one session.
+
+        Args:
+            key: The per-client session key from :func:`_session_key`.
+
+        Returns:
+            The :class:`McpSession` bound to ``key``.
+
+        """
+        session = self._sessions.get(key)
+        if session is not None:
+            return session
+        async with self._lock:
+            session = self._sessions.get(key)
+            if session is None:
+                session = self._factory(self._cfg, self._log)
+                self._sessions[key] = session
+                logger.info(
+                    "minted new MCP session (key=%s, live=%d)",
+                    key,
+                    len(self._sessions),
+                )
+            return session
+
+    async def evict(self, key: str) -> None:
+        """Drop ``key`` from the registry and best-effort close it.
+
+        Pops the session (no-op if absent) and, when it carries a
+        ``close`` coroutine (added in Phase C), awaits it under
+        suppression so a teardown error never propagates. Safe to call
+        more than once for the same key.
+
+        Args:
+            key: The per-client session key to evict.
+
+        """
+        session = self._sessions.pop(key, None)
+        if session is None:
+            return
+        close = getattr(session, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+                logger.warning("error closing session %s: %s", key, exc)
+        logger.info("evicted MCP session (key=%s, live=%d)", key, len(self._sessions))

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -258,6 +258,27 @@ class McpSession:
     # Command dispatch
     # ------------------------------------------------------------------
 
+    async def get_or_create(self, key: str) -> McpSession:
+        """Return ``self`` regardless of ``key`` (single-entry provider).
+
+        :class:`McpSession` doubles as the degenerate one-session
+        "provider" used by the stdio transport (one process == one
+        session) and by direct-call tests. It exposes the same
+        ``async get_or_create(key) -> McpSession`` shape as
+        :class:`mtui.mcp.registry.SessionRegistry` so
+        :mod:`mtui.mcp.tools` and :mod:`mtui.mcp.testreport_tools` can
+        resolve a session per call without caring which transport they
+        run under. The ``key`` is accepted and ignored.
+
+        Args:
+            key: The per-client session key (ignored here).
+
+        Returns:
+            This session instance.
+
+        """
+        return self
+
     async def run_command(
         self,
         cmd_cls: type[Command],

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -6,12 +6,24 @@ surface :class:`mtui.commands._command.Command` instances read from
 ``self.prompt``. There is no :mod:`prompt_toolkit`, no history file, no
 bottom toolbar, no ``do_<name>`` setattr loop.
 
-One :class:`McpSession` lives per ``mtui-mcp`` server process; every
-:meth:`McpSession.run_command` call is serialised through a single
-:class:`asyncio.Lock` so HTTP-transport concurrency cannot interleave
-mutations of ``metadata`` / ``targets``. Blocking command bodies (SSH,
-subprocess) run inside :func:`asyncio.to_thread` so they do not stall
-the event loop.
+Session lifetime depends on transport. Under **stdio** one process
+serves one client, so a single :class:`McpSession` lives per process.
+Under **http** :class:`mtui.mcp.registry.SessionRegistry` mints one
+isolated :class:`McpSession` **per client** — keyed on
+``id(ctx.session)`` (the request's ``ServerSession``, 1:1 with the MCP
+session) — so concurrent clients never share ``metadata`` / ``targets``
+and each has its own lock. Idle http sessions are swept after a
+configurable TTL (``[mcp] session_idle_timeout``) and their hosts
+disconnected via :meth:`McpSession.close`; the number of concurrent
+sessions is bounded by ``[mcp] session_cap``.
+
+Within a single session, every :meth:`McpSession.run_command` call is
+serialised through that session's :class:`asyncio.Lock`, so two
+concurrent tool calls from the *same* client cannot interleave
+mutations of its ``metadata`` / ``targets``; calls from *different*
+clients run concurrently against their own sessions. Blocking command
+bodies (SSH, subprocess) run inside :func:`asyncio.to_thread` so they
+do not stall the event loop.
 
 Stdout / stderr produced by a command are captured per-call via a
 fresh :class:`io.StringIO`; stdout is returned to the caller, stderr
@@ -22,6 +34,7 @@ WARNING on a clean return.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import io
 import shlex
 import time
@@ -114,13 +127,19 @@ class _FakeSys(SimpleNamespace):
 
 
 class McpSession:
-    """Headless mtui session shared by every ``mtui-mcp`` tool call.
+    """Headless mtui session backing one ``mtui-mcp`` client.
 
     Holds the same mutable state as :class:`CommandPrompt` — ``config``,
     ``metadata``, ``targets``, ``session`` — so that the existing
     ``Command`` ABI works unchanged. Stateless per-call concerns
     (``display``, ``sys``) are constructed inside :meth:`run_command`
     and torn down after the call returns.
+
+    Under stdio one instance serves the single client; under http
+    :class:`mtui.mcp.registry.SessionRegistry` owns one instance per
+    client and reaps it (via :meth:`close`) on idle-TTL or eviction.
+    It also doubles as the degenerate single-entry session provider —
+    see :meth:`get_or_create`.
     """
 
     def __init__(self, config: Config, log: Logger) -> None:
@@ -162,11 +181,13 @@ class McpSession:
         # silently misbehaving.
         self._history = None
 
-        # Single process-wide serialiser. Concurrent HTTP-transport
-        # clients queue here; the lock is held across the
-        # ``to_thread`` worker so re-entrant calls (a Command's body
-        # touching ``self.prompt.load_update``) execute on the same
-        # thread without re-acquiring.
+        # Per-session serialiser. Concurrent tool calls from the *same*
+        # client queue here so they cannot interleave mutations of this
+        # session's ``metadata`` / ``targets``; calls from *other* http
+        # clients hold their own session's lock and run concurrently.
+        # The lock is held across the ``to_thread`` worker so re-entrant
+        # calls (a Command's body touching ``self.prompt.load_update``)
+        # execute on the same thread without re-acquiring.
         self._lock = asyncio.Lock()
 
         # Per-call stdout pointer. ``println`` falls back to ``log``
@@ -278,6 +299,52 @@ class McpSession:
 
         """
         return self
+
+    async def close(self) -> None:
+        """Disconnect every connected host; safe to call more than once.
+
+        Owned by the http :class:`mtui.mcp.registry.SessionRegistry`,
+        which calls this when it evicts a session (idle-TTL sweep or
+        explicit eviction). Mirrors the REPL ``quit`` disconnect path —
+        ``Target.close()`` per host, in parallel — but **without** the
+        ``sys.exit`` / history-flush tail, since the process keeps
+        serving other clients.
+
+        The blocking paramiko closes run in a worker thread (via
+        :func:`asyncio.to_thread`) so the event loop is never stalled,
+        matching :meth:`run_command`'s threading discipline. The whole
+        teardown is best-effort: a per-host close failure is logged and
+        swallowed so one wedged connection cannot block reaping the
+        rest, and ``targets`` is emptied either way so a second call is
+        a cheap no-op.
+        """
+        targets = self.targets
+        if not targets:
+            return
+        await asyncio.to_thread(self._disconnect_targets)
+
+    def _disconnect_targets(self) -> None:
+        """Synchronous parallel host-disconnect core for :meth:`close`.
+
+        Runs in a worker thread. Closes each :class:`Target` on its own
+        pool thread (paramiko teardown is blocking) with a bounded
+        wait, then clears ``targets`` regardless of individual
+        outcomes. Per-host errors are logged at WARNING, never raised.
+        """
+        targets = self.targets
+        hostnames = list(targets)
+
+        def _close_one(name: str) -> None:
+            try:
+                targets[name].close()
+            except Exception as exc:  # noqa: BLE001 - best-effort teardown
+                self.log.warning("error disconnecting host %s: %s", name, exc)
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [executor.submit(_close_one, name) for name in hostnames]
+            concurrent.futures.wait(futures, timeout=45)
+
+        targets.clear()
 
     async def run_command(
         self,

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -12,10 +12,13 @@ directly on the file path tracked by ``session.metadata.path``:
   written atomically via ``NamedTemporaryFile`` + :func:`os.replace`.
 * :func:`testreport_write` — full-file overwrite, also atomic.
 
-All three are ``async def`` and acquire ``session._lock`` so they are
-serialised against concurrent :meth:`McpSession.run_command` calls
-under the http transport (matches the risk-section commitment in
-PLAN.md).
+All three are ``async def``. The registered tool closures resolve the
+caller's own :class:`McpSession` from the
+:class:`mtui.mcp.registry.SessionProvider` (keyed on the request
+session under http, a single session under stdio) and then acquire
+*that session's* ``_lock``, so each client serialises only against its
+own concurrent :meth:`McpSession.run_command` calls and patches **only
+its own** loaded testreport file — no cross-client interference.
 
 Refusal is uniform: when ``session.metadata`` is a
 :class:`NullTestReport` or ``metadata.path`` is ``None``, every tool
@@ -35,11 +38,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..test_reports.null_report import NullTestReport
+from .registry import resolve_session
 from .session import McpCommandError
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import Context, FastMCP
 
+    from .registry import SessionProvider
     from .session import McpSession
 
 logger = getLogger("mtui.mcp.testreport_tools")
@@ -266,7 +271,7 @@ async def testreport_write(
 # --------------------------------------------------------------------------- #
 
 
-def register_testreport_tools(mcp: FastMCP, session: McpSession) -> list[str]:
+def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     """Register the three testreport tools on ``mcp``.
 
     Mirrors the registration shape used by :func:`mtui.mcp.tools.build_tools`
@@ -274,7 +279,11 @@ def register_testreport_tools(mcp: FastMCP, session: McpSession) -> list[str]:
 
     Args:
         mcp: The :class:`mcp.server.fastmcp.FastMCP` server.
-        session: The shared :class:`McpSession` bound into each closure.
+        provider: The :class:`mtui.mcp.registry.SessionProvider` each
+            tool resolves its per-call :class:`McpSession` through, so
+            under http every client patches **only its own** loaded
+            testreport file. Under stdio this is a single
+            :class:`McpSession`.
 
     Returns:
         Sorted list of registered tool names — used by the boot log
@@ -297,6 +306,7 @@ def register_testreport_tools(mcp: FastMCP, session: McpSession) -> list[str]:
     globals().setdefault("Context", _Context)
 
     async def _read(ctx: Context | None = None) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
         return await testreport_read(session, ctx=ctx)
 
     async def _patch(
@@ -305,11 +315,13 @@ def register_testreport_tools(mcp: FastMCP, session: McpSession) -> list[str]:
         replacement: str,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
         return await testreport_patch(
             session, start_line, end_line, replacement, ctx=ctx
         )
 
     async def _write(content: str, ctx: Context | None = None) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
         return await testreport_write(session, content, ctx=ctx)
 
     read_desc = (

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -36,6 +36,7 @@ from ..commands import Command
 from ._argv import kwargs_to_argv
 from ._schema import build_parameters
 from .deny import REPL_ONLY
+from .registry import resolve_session
 from .session import McpCommandError
 
 if TYPE_CHECKING:
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
     # editors/type-checkers, hence the ``noqa: F401``.
     from mcp.server.fastmcp import Context, FastMCP  # noqa: F401
 
-    from .session import McpSession
+    from .registry import SessionProvider
 
 logger = getLogger("mtui.mcp.tools")
 
@@ -73,7 +74,7 @@ def _is_read_only(name: str) -> bool:
 def _make_wrapper(
     cls: type[Command],
     parser: argparse.ArgumentParser,
-    session: McpSession,
+    provider: SessionProvider,
     argv_prefix: tuple[str, ...] = (),
 ):
     """Build the async tool handler for ``cls``.
@@ -90,10 +91,13 @@ def _make_wrapper(
     :func:`mcp.server.fastmcp.utilities.context_injection.find_context_parameter`
     (which reads :func:`typing.get_type_hints`), strips the parameter
     from the JSON schema via ``skip_names``, and injects the live
-    per-request :class:`Context` at call time. We forward it into
-    :meth:`McpSession.run_command` so the session can heartbeat
-    ``notifications/progress`` while the worker thread runs, which
-    keeps MCP clients from timing out on long-running commands.
+    per-request :class:`Context` at call time. We use it twice: to
+    resolve the caller's isolated :class:`McpSession` from ``provider``
+    (keyed on the request session — see
+    :func:`mtui.mcp.registry.resolve_session`) and to let
+    :meth:`McpSession.run_command` heartbeat ``notifications/progress``
+    while the worker thread runs, which keeps MCP clients from timing
+    out on long-running commands.
     """
     # Import lazily and only when actually building wrappers: callers
     # outside the ``mtui[mcp]`` extra never reach this function (the
@@ -154,6 +158,7 @@ def _make_wrapper(
                 )
                 raise McpCommandError("", msg, 2)
         argv = list(argv_prefix) + kwargs_to_argv(parser, kwargs)
+        session = await resolve_session(provider, ctx)
         return await session.run_command(cls, argv, ctx=ctx)
 
     # ``inspect.Signature`` lives on a dunder slot; ty does not model it
@@ -171,7 +176,7 @@ def _register_tool(
     name: str,
     cls: type[Command],
     parser: argparse.ArgumentParser,
-    session: McpSession,
+    provider: SessionProvider,
     argv_prefix: tuple[str, ...] = (),
     description: str | None = None,
 ) -> None:
@@ -183,7 +188,7 @@ def _register_tool(
     """
     from mcp.types import ToolAnnotations
 
-    wrapper = _make_wrapper(cls, parser, session, argv_prefix=argv_prefix)
+    wrapper = _make_wrapper(cls, parser, provider, argv_prefix=argv_prefix)
     desc = (description or cls.__doc__ or name).strip()
     mcp.add_tool(
         wrapper,
@@ -196,7 +201,7 @@ def _register_tool(
 def _fan_out_subparser(
     mcp: FastMCP,
     cls: type[Command],
-    session: McpSession,
+    provider: SessionProvider,
 ) -> list[str]:
     """Register one tool per subcommand of a parser using ``add_subparsers``.
 
@@ -229,7 +234,7 @@ def _fan_out_subparser(
             name=tool_name,
             cls=cls,
             parser=sub_parser,
-            session=session,
+            provider=provider,
             argv_prefix=(subname,),
             description=desc.splitlines()[0] if desc else tool_name,
         )
@@ -237,7 +242,7 @@ def _fan_out_subparser(
     return names
 
 
-def build_tools(mcp: FastMCP, session: McpSession) -> list[str]:
+def build_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     """Register one MCP tool per non-denied :class:`Command` subclass.
 
     Subparser commands (``config`` today) are fanned out into one tool
@@ -248,8 +253,11 @@ def build_tools(mcp: FastMCP, session: McpSession) -> list[str]:
     Args:
         mcp: The :class:`mcp.server.fastmcp.FastMCP` server instance
             to register tools on.
-        session: The shared :class:`McpSession` every tool dispatches
-            through.
+        provider: The :class:`mtui.mcp.registry.SessionProvider` every
+            tool resolves its per-call :class:`McpSession` through —
+            a :class:`mtui.mcp.registry.SessionRegistry` under http
+            (one isolated session per client) or a single
+            :class:`McpSession` under stdio.
 
     Returns:
         Sorted list of registered tool names (used by the boot log and
@@ -272,7 +280,7 @@ def build_tools(mcp: FastMCP, session: McpSession) -> list[str]:
         if name in REPL_ONLY:
             continue
         if name in SUBPARSER_COMMANDS:
-            registered.extend(_fan_out_subparser(mcp, cls, session))
+            registered.extend(_fan_out_subparser(mcp, cls, provider))
             continue
         parser = cls.argparser(__import__("sys"))
         _register_tool(
@@ -280,7 +288,7 @@ def build_tools(mcp: FastMCP, session: McpSession) -> list[str]:
             name=name,
             cls=cls,
             parser=parser,
-            session=session,
+            provider=provider,
         )
         registered.append(name)
 

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -87,6 +87,10 @@ class Config:
     lock_stale_age: int
     lock_pi_autolock: bool
 
+    # -- mtui-mcp server (http transport) per-client session registry --
+    mcp_session_cap: int
+    mcp_session_idle_timeout: int
+
     # -- Attributes set externally in main.py --
     kernel: bool
     auto: bool
@@ -401,6 +405,27 @@ class Config:
                 True,
                 bool,
                 getboolean,
+            ),
+            # ``mtui-mcp`` http transport isolates state per client in a
+            # session registry (see mtui.mcp.registry). ``session_cap``
+            # bounds how many concurrent client sessions may exist at
+            # once (DoS guard against unbounded targets/threads);
+            # ``session_idle_timeout`` is the seconds of inactivity
+            # after which an idle session is swept and its hosts
+            # disconnected. Both are ignored under the stdio transport.
+            ConfigOption(
+                "mcp_session_cap",
+                ("mcp", "session_cap"),
+                32,
+                int,
+                getint,
+            ),
+            ConfigOption(
+                "mcp_session_idle_timeout",
+                ("mcp", "session_idle_timeout"),
+                1800,
+                int,
+                getint,
             ),
         ]
 

--- a/tests/test_mcp_main.py
+++ b/tests/test_mcp_main.py
@@ -11,9 +11,7 @@ Focused on the Ctrl-C / graceful shutdown contract:
   an active task group this way, so a bare ``except KeyboardInterrupt``
   would miss it;
 * a :class:`BaseExceptionGroup` containing a real error still hits the
-  crash path (``return 1``, ``mtui-mcp crashed`` logged);
-* a ``KeyboardInterrupt`` during preload (``session.load_update``) is
-  caught before the server is reached and exits ``0`` cleanly.
+  crash path (``return 1``, ``mtui-mcp crashed`` logged).
 
 The tests stub out :class:`Config`, :func:`detect_system`, the
 :class:`McpSession` constructor, and ``build_tools`` /
@@ -46,8 +44,6 @@ def stub_environment(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
     or swap in side effects (e.g. make ``load_update`` raise).
     """
     cfg = MagicMock(name="Config")
-    cfg.kernel = False
-    cfg.auto = False
     config_cls = MagicMock(name="Config_cls", return_value=cfg)
     detect = MagicMock(name="detect_system", return_value=("sles", "15", "5.14"))
     session = MagicMock(name="McpSession")
@@ -227,98 +223,6 @@ def test_main_returns_one_on_plain_exception(
     rc, _ = _run_with_fake_fastmcp(monkeypatch, RuntimeError("kaboom"))
     assert rc == 1
     assert any("crashed" in r.message for r in caplog.records)
-
-
-# --------------------------------------------------------------------------- #
-# Pre-server Ctrl-C (preload)                                                 #
-# --------------------------------------------------------------------------- #
-
-
-def test_main_returns_zero_on_keyboardinterrupt_during_preload(
-    monkeypatch: pytest.MonkeyPatch,
-    stub_environment: dict[str, MagicMock],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Ctrl-C while ``load_update`` is running exits 0 without starting the server."""
-    caplog.set_level(logging.INFO, logger="mtui-mcp")
-
-    stub_environment["session"].load_update.side_effect = KeyboardInterrupt
-
-    # Build a Namespace-like object so we can bypass argparse (the real
-    # parser would need a valid OBS review id for ``-a``).
-    fake_args = MagicMock(
-        config=None,
-        color="never",
-        debug=False,
-        sut=None,
-        transport="stdio",
-        host="127.0.0.1",
-        port=8000,
-    )
-    # ``update`` has to walk the ``kind`` branch; give it a stub.
-    fake_update = MagicMock()
-    fake_update.kind = "auto"
-    fake_args.update = fake_update
-
-    parser = MagicMock(name="parser")
-    parser.parse_args.return_value = fake_args
-    monkeypatch.setattr(mcp_main, "get_parser", lambda _sys: parser)
-
-    fastmcp_cls, fastmcp_instance = _install_fake_fastmcp(monkeypatch)
-
-    rc = mcp_main.main()
-
-    assert rc == 0
-    assert any("shutting down" in r.message for r in caplog.records)
-    # Server must never have been constructed or run.
-    assert not fastmcp_cls.called
-    assert not fastmcp_instance.run.called
-
-
-def test_main_returns_zero_on_keyboardinterrupt_during_autoconnect(
-    monkeypatch: pytest.MonkeyPatch,
-    stub_environment: dict[str, MagicMock],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Ctrl-C while iterating the autoconnect SUT list exits 0 cleanly."""
-    caplog.set_level(logging.INFO, logger="mtui-mcp")
-
-    # Force the add_host command lookup to succeed with a stub, then
-    # make session._run_sync raise KI on the first invocation.
-    fake_add_host_cls = MagicMock(name="add_host_cls")
-    monkeypatch.setattr(
-        mcp_main.Command,
-        "registry",
-        {"add_host": fake_add_host_cls},
-    )
-    stub_environment["session"]._run_sync.side_effect = KeyboardInterrupt
-
-    fake_sut = MagicMock()
-    fake_sut.print_args.return_value = "host1.example.com"
-
-    fake_args = MagicMock(
-        config=None,
-        color="never",
-        debug=False,
-        sut=[fake_sut],
-        update=None,
-        transport="stdio",
-        host="127.0.0.1",
-        port=8000,
-    )
-
-    parser = MagicMock(name="parser")
-    parser.parse_args.return_value = fake_args
-    monkeypatch.setattr(mcp_main, "get_parser", lambda _sys: parser)
-
-    fastmcp_cls, fastmcp_instance = _install_fake_fastmcp(monkeypatch)
-
-    rc = mcp_main.main()
-
-    assert rc == 0
-    assert any("shutting down" in r.message for r in caplog.records)
-    assert not fastmcp_cls.called
-    assert not fastmcp_instance.run.called
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -31,7 +31,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from mtui.mcp.main import build_session
-from mtui.mcp.registry import SessionRegistry, _log_label, _session_key
+from mtui.mcp.registry import (
+    SessionRegistry,
+    SessionRegistryFullError,
+    _log_label,
+    _session_key,
+)
 from mtui.mcp.session import McpSession
 
 if TYPE_CHECKING:
@@ -58,9 +63,22 @@ def _config(tmp_path: Path) -> MagicMock:
     return cfg
 
 
-def _registry(tmp_path: Path) -> SessionRegistry:
-    """A registry wired to the real :func:`build_session` factory."""
-    return SessionRegistry(build_session, _config(tmp_path), _LOG)
+def _registry(
+    tmp_path: Path, *, idle_timeout: float = 0.0, max_sessions: int = 32
+) -> SessionRegistry:
+    """A registry wired to the real :func:`build_session` factory.
+
+    ``idle_timeout`` defaults to ``0`` (sweeper disabled) so the common
+    keying/isolation tests do not spawn a background task; the
+    sweeper-specific tests opt in with a small positive value.
+    """
+    return SessionRegistry(
+        build_session,
+        _config(tmp_path),
+        _LOG,
+        max_sessions=max_sessions,
+        idle_timeout=idle_timeout,
+    )
 
 
 def _ctx_with_session(obj: object) -> SimpleNamespace:
@@ -176,7 +194,7 @@ def test_get_or_create_concurrent_first_calls_mint_one(tmp_path: Path) -> None:
         calls["n"] += 1
         return build_session(cfg, log)
 
-    reg = SessionRegistry(counting_factory, _config(tmp_path), _LOG)
+    reg = SessionRegistry(counting_factory, _config(tmp_path), _LOG, idle_timeout=0.0)
 
     async def driver() -> list[McpSession]:
         return await asyncio.gather(*(reg.get_or_create("dup") for _ in range(25)))
@@ -217,7 +235,7 @@ def test_evict_awaits_close_when_present(tmp_path: Path) -> None:
         async def _close() -> None:
             closed["n"] += 1
 
-        session.close = _close  # ty: ignore[unresolved-attribute]
+        session.close = _close  # ty: ignore[invalid-assignment]
         await reg.evict("k1")
 
     asyncio.run(driver())
@@ -234,7 +252,167 @@ def test_evict_swallows_close_errors(tmp_path: Path) -> None:
         async def _close() -> None:
             raise RuntimeError("boom")
 
-        session.close = _close  # ty: ignore[unresolved-attribute]
+        session.close = _close  # ty: ignore[invalid-assignment]
         await reg.evict("k1")  # must not raise
 
     asyncio.run(driver())
+
+
+def test_evict_calls_real_session_close_and_removes_key(tmp_path: Path) -> None:
+    """``evict`` invokes the real :meth:`McpSession.close` and drops the key.
+
+    Spies on the minted session's ``close`` (a real coroutine on
+    McpSession now) to prove eviction both tears the session down and
+    removes it from the registry.
+    """
+    reg = _registry(tmp_path)
+    closed = {"n": 0}
+
+    async def driver() -> bool:
+        session = await reg.get_or_create("k1")
+        real_close = session.close
+
+        async def _spy() -> None:
+            closed["n"] += 1
+            await real_close()
+
+        session.close = _spy  # ty: ignore[invalid-assignment]
+        await reg.evict("k1")
+        # Key gone -> a refetch mints a brand-new session.
+        again = await reg.get_or_create("k1")
+        return again is session
+
+    refetch_is_same = asyncio.run(driver())
+    assert closed["n"] == 1
+    assert refetch_is_same is False
+
+
+# --------------------------------------------------------------------------- #
+# Session cap (DoS guard)                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_cap_refuses_creation_past_limit(tmp_path: Path) -> None:
+    """Creating one session past ``max_sessions`` raises the documented error."""
+    reg = _registry(tmp_path, max_sessions=2)
+
+    async def driver() -> None:
+        await reg.get_or_create("k1")
+        await reg.get_or_create("k2")
+        # Third distinct key would exceed the cap of 2.
+        await reg.get_or_create("k3")
+
+    with pytest.raises(SessionRegistryFullError, match="session registry full"):
+        asyncio.run(driver())
+
+
+def test_cap_does_not_count_existing_keys(tmp_path: Path) -> None:
+    """Re-requesting an existing key never trips the cap."""
+    reg = _registry(tmp_path, max_sessions=1)
+
+    async def driver() -> McpSession:
+        first = await reg.get_or_create("k1")
+        # Same key, many times: must not raise even at cap == 1.
+        for _ in range(5):
+            again = await reg.get_or_create("k1")
+            assert again is first
+        return first
+
+    assert isinstance(asyncio.run(driver()), McpSession)
+
+
+def test_cap_frees_a_slot_after_evict(tmp_path: Path) -> None:
+    """Evicting a session frees a slot so a new key can be created."""
+    reg = _registry(tmp_path, max_sessions=1)
+
+    async def driver() -> McpSession:
+        await reg.get_or_create("k1")
+        await reg.evict("k1")
+        # Slot freed -> a different key now fits.
+        return await reg.get_or_create("k2")
+
+    assert isinstance(asyncio.run(driver()), McpSession)
+
+
+# --------------------------------------------------------------------------- #
+# Idle-TTL sweeper                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_idle_sweeper_evicts_stale_session(tmp_path: Path) -> None:
+    """A session untouched past a short TTL is swept and closed automatically.
+
+    Uses a tiny ``idle_timeout`` so the sweeper (wake interval = ttl/2,
+    floored at 1s) reaps within a couple of seconds. We spy on the
+    session's ``close`` to confirm teardown fired, then assert the key
+    is gone.
+    """
+    reg = _registry(tmp_path, idle_timeout=1.0)
+    closed = {"n": 0}
+
+    async def driver() -> int:
+        session = await reg.get_or_create("k1")
+        real_close = session.close
+
+        async def _spy() -> None:
+            closed["n"] += 1
+            await real_close()
+
+        session.close = _spy  # ty: ignore[invalid-assignment]
+
+        # Wait long enough for one sweep cycle (interval == max(1, ttl/2)
+        # == 1s) plus the ttl to elapse with margin.
+        for _ in range(40):
+            await asyncio.sleep(0.1)
+            if "k1" not in reg._sessions:  # noqa: SLF001
+                break
+        await reg.aclose()
+        return closed["n"]
+
+    n_closed = asyncio.run(driver())
+    assert n_closed == 1
+
+
+def test_fresh_activity_keeps_session_alive(tmp_path: Path) -> None:
+    """Touching a session within the TTL prevents it from being swept."""
+    reg = _registry(tmp_path, idle_timeout=1.0)
+
+    async def driver() -> bool:
+        first = await reg.get_or_create("k1")
+        # Keep touching it under the TTL for ~1.5s of wall time.
+        for _ in range(15):
+            await asyncio.sleep(0.1)
+            again = await reg.get_or_create("k1")
+            assert again is first
+        alive = "k1" in reg._sessions  # noqa: SLF001
+        await reg.aclose()
+        return alive
+
+    assert asyncio.run(driver()) is True
+
+
+def test_sweeper_disabled_when_idle_timeout_zero(tmp_path: Path) -> None:
+    """``idle_timeout <= 0`` starts no sweeper task."""
+    reg = _registry(tmp_path, idle_timeout=0.0)
+
+    async def driver() -> object:
+        await reg.get_or_create("k1")
+        return reg._sweeper  # noqa: SLF001
+
+    assert asyncio.run(driver()) is None
+
+
+def test_aclose_cancels_sweeper_and_closes_all(tmp_path: Path) -> None:
+    """``aclose`` cancels the sweeper task and evicts every live session."""
+    reg = _registry(tmp_path, idle_timeout=30.0)
+
+    async def driver() -> tuple[bool, int]:
+        await reg.get_or_create("k1")
+        await reg.get_or_create("k2")
+        sweeper_running = reg._sweeper is not None  # noqa: SLF001
+        await reg.aclose()
+        return sweeper_running, len(reg._sessions)
+
+    sweeper_running, live_after = asyncio.run(driver())
+    assert sweeper_running is True
+    assert live_after == 0

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -1,0 +1,240 @@
+"""Tests for :mod:`mtui.mcp.registry`.
+
+Covers the per-client isolation contract Phase B introduces:
+
+* :func:`_session_key` returns ``str(id(ctx.session))`` and refuses a
+  ``None`` context;
+* :func:`_log_label` prefers the ``Mcp-Session-Id`` header, degrades to
+  ``request_id`` / key, and never raises on a malformed context;
+* :meth:`SessionRegistry.get_or_create` returns the *same* instance for
+  one key and *independent* sessions (own ``metadata`` / ``targets`` /
+  lock) for different keys;
+* a burst of concurrent first-calls for one key mints exactly one
+  session (double-checked locking);
+* :meth:`SessionRegistry.evict` drops the key, awaits a ``close``
+  coroutine when present, and is idempotent.
+
+No ``[mcp]`` extra is required: the registry only touches
+:class:`McpSession` and plain objects, so a tiny stand-in stands in for
+:class:`mcp.server.fastmcp.Context`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.mcp.main import build_session
+from mtui.mcp.registry import SessionRegistry, _log_label, _session_key
+from mtui.mcp.session import McpSession
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from mtui.support.config import Config
+
+_LOG = logging.getLogger("test.mcp.registry")
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    """The minimal Config shape McpSession's constructor touches."""
+    cfg = MagicMock()
+    cfg.template_dir = tmp_path
+    cfg.target_tempdir = tmp_path / "target"
+    cfg.chdir_to_template_dir = False
+    cfg.connection_timeout = 30
+    cfg.session_user = "testuser"
+    return cfg
+
+
+def _registry(tmp_path: Path) -> SessionRegistry:
+    """A registry wired to the real :func:`build_session` factory."""
+    return SessionRegistry(build_session, _config(tmp_path), _LOG)
+
+
+def _ctx_with_session(obj: object) -> SimpleNamespace:
+    """A fake Context whose ``.session`` is ``obj`` (for keying)."""
+    return SimpleNamespace(session=obj)
+
+
+# --------------------------------------------------------------------------- #
+# _session_key                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_session_key_is_id_of_ctx_session() -> None:
+    """The key is the stringified identity of ``ctx.session``."""
+    sentinel = object()
+    ctx = _ctx_with_session(sentinel)
+    assert _session_key(ctx) == str(id(sentinel))
+
+
+def test_session_key_stable_across_calls_for_same_session() -> None:
+    """Two reads of the same context yield the same key."""
+    ctx = _ctx_with_session(object())
+    assert _session_key(ctx) == _session_key(ctx)
+
+
+def test_session_key_differs_for_distinct_sessions() -> None:
+    """Distinct ``ServerSession`` objects produce distinct keys."""
+    assert _session_key(_ctx_with_session(object())) != _session_key(
+        _ctx_with_session(object())
+    )
+
+
+def test_session_key_raises_on_none_ctx() -> None:
+    """``None`` context must raise so callers route it to a static provider."""
+    with pytest.raises(ValueError, match="without a request Context"):
+        _session_key(None)
+
+
+# --------------------------------------------------------------------------- #
+# _log_label                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_log_label_none_ctx() -> None:
+    assert _log_label(None) == "<no-ctx>"
+
+
+def test_log_label_prefers_mcp_session_id_header() -> None:
+    """A present ``Mcp-Session-Id`` header wins (case-insensitive get)."""
+    headers = {"mcp-session-id": "abc-123"}
+    request = SimpleNamespace(headers=headers)
+    ctx = SimpleNamespace(request_context=SimpleNamespace(request=request))
+    assert _log_label(ctx) == "abc-123"
+
+
+def test_log_label_falls_back_to_request_id() -> None:
+    """No header → ``req=<request_id>``."""
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(request=None, request_id="rid-7")
+    )
+    assert _log_label(ctx) == "req=rid-7"
+
+
+def test_log_label_never_raises_on_garbage_ctx() -> None:
+    """A context missing every attribute degrades, never raises."""
+    label = _log_label(SimpleNamespace())
+    assert isinstance(label, str)
+    assert label  # non-empty
+
+
+# --------------------------------------------------------------------------- #
+# get_or_create                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_or_create_same_key_returns_same_instance(tmp_path: Path) -> None:
+    """One key → one cached session across repeated calls."""
+    reg = _registry(tmp_path)
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        a = await reg.get_or_create("k1")
+        b = await reg.get_or_create("k1")
+        return a, b
+
+    a, b = asyncio.run(driver())
+    assert a is b
+    assert isinstance(a, McpSession)
+
+
+def test_get_or_create_distinct_keys_are_isolated(tmp_path: Path) -> None:
+    """Different keys get independent sessions, metadata, targets and locks."""
+    reg = _registry(tmp_path)
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        return await reg.get_or_create("k1"), await reg.get_or_create("k2")
+
+    a, b = asyncio.run(driver())
+    assert a is not b
+    assert a.metadata is not b.metadata
+    assert a.targets is not b.targets
+    assert a._lock is not b._lock  # noqa: SLF001
+
+
+def test_get_or_create_concurrent_first_calls_mint_one(tmp_path: Path) -> None:
+    """A burst of concurrent first-calls for one key creates exactly one session.
+
+    The factory is wrapped so we can count constructions; the registry
+    lock + double-checked read must collapse the race to a single mint.
+    """
+    calls = {"n": 0}
+
+    def counting_factory(cfg: Config, log: Logger) -> McpSession:
+        calls["n"] += 1
+        return build_session(cfg, log)
+
+    reg = SessionRegistry(counting_factory, _config(tmp_path), _LOG)
+
+    async def driver() -> list[McpSession]:
+        return await asyncio.gather(*(reg.get_or_create("dup") for _ in range(25)))
+
+    sessions = asyncio.run(driver())
+    assert calls["n"] == 1
+    assert all(s is sessions[0] for s in sessions)
+
+
+# --------------------------------------------------------------------------- #
+# evict                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_evict_removes_key_and_is_idempotent(tmp_path: Path) -> None:
+    """Evicting drops the key; a second evict is a no-op and a refetch mints anew."""
+    reg = _registry(tmp_path)
+
+    async def driver() -> bool:
+        a = await reg.get_or_create("k1")
+        await reg.evict("k1")
+        await reg.evict("k1")  # must not raise
+        b = await reg.get_or_create("k1")
+        return a is b
+
+    # A fresh get_or_create after eviction mints a *new* session.
+    assert asyncio.run(driver()) is False
+
+
+def test_evict_awaits_close_when_present(tmp_path: Path) -> None:
+    """When a session exposes ``close``, eviction awaits it once."""
+    reg = _registry(tmp_path)
+    closed = {"n": 0}
+
+    async def driver() -> None:
+        session = await reg.get_or_create("k1")
+
+        async def _close() -> None:
+            closed["n"] += 1
+
+        session.close = _close  # ty: ignore[unresolved-attribute]
+        await reg.evict("k1")
+
+    asyncio.run(driver())
+    assert closed["n"] == 1
+
+
+def test_evict_swallows_close_errors(tmp_path: Path) -> None:
+    """A failing ``close`` during eviction must not propagate."""
+    reg = _registry(tmp_path)
+
+    async def driver() -> None:
+        session = await reg.get_or_create("k1")
+
+        async def _close() -> None:
+            raise RuntimeError("boom")
+
+        session.close = _close  # ty: ignore[unresolved-attribute]
+        await reg.evict("k1")  # must not raise
+
+    asyncio.run(driver())

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -63,6 +63,25 @@ def _config(tmp_path: Path) -> MagicMock:
     return cfg
 
 
+class _RealishConfig:
+    """Minimal plain-object config that ``copy.copy`` duplicates faithfully.
+
+    A ``MagicMock`` cannot stand in here: ``copy.copy(MagicMock())``
+    yields another mock whose ``.auto`` attribute is a truthy ``Mock``,
+    masking the ``False`` seeding :func:`build_session` performs. This
+    plain class behaves like the real :class:`mtui.support.config.Config`
+    for the handful of attributes the session constructor and
+    ``build_session`` touch, while staying cheap to instantiate.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.template_dir = tmp_path
+        self.target_tempdir = tmp_path / "target"
+        self.chdir_to_template_dir = False
+        self.connection_timeout = 30
+        self.session_user = "testuser"
+
+
 def _registry(
     tmp_path: Path, *, idle_timeout: float = 0.0, max_sessions: int = 32
 ) -> SessionRegistry:
@@ -416,3 +435,64 @@ def test_aclose_cancels_sweeper_and_closes_all(tmp_path: Path) -> None:
     sweeper_running, live_after = asyncio.run(driver())
     assert sweeper_running is True
     assert live_after == 0
+
+
+# --------------------------------------------------------------------------- #
+# build_session: workflow-flag seeding + per-session config isolation         #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_session_seeds_workflow_flags_false(tmp_path: Path) -> None:
+    """A fresh session must expose ``config.auto`` / ``config.kernel`` as False.
+
+    Regression guard: ``add_host`` (and other commands) read
+    ``config.auto`` *before* any ``load_template`` runs. Phase A removed
+    the boot-time defaults, which made ``add_host`` on a fresh MCP
+    session raise ``AttributeError: 'Config' object has no attribute
+    'auto'``. ``build_session`` now seeds both flags.
+    """
+    session = build_session(_RealishConfig(tmp_path), _LOG)  # ty: ignore[invalid-argument-type]
+    assert session.config.auto is False
+    assert session.config.kernel is False
+
+
+def test_build_session_copies_config_per_session(tmp_path: Path) -> None:
+    """Each session gets its own config copy; workflow flips don't leak.
+
+    Under http every session is minted from one base ``cfg``; a shallow
+    copy per session keeps the mutable workflow flags
+    (``auto``/``kernel``/``location``) independent so one client's
+    ``load_template`` cannot flip another client's workflow mode.
+    """
+    base = _RealishConfig(tmp_path)
+    a = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
+    b = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
+
+    assert a.config is not b.config
+    # Simulate client A loading a kernel template.
+    a.config.auto = True
+    a.config.kernel = True
+    # Client B must be unaffected.
+    assert b.config.auto is False
+    assert b.config.kernel is False
+    # And the shared base config must never have been mutated.
+    assert not hasattr(base, "auto")
+    assert not hasattr(base, "kernel")
+
+
+def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
+    """Two registry-minted sessions for distinct keys carry independent configs."""
+    reg = SessionRegistry(
+        build_session,
+        _RealishConfig(tmp_path),  # ty: ignore[invalid-argument-type]
+        _LOG,
+        idle_timeout=0.0,
+    )
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        return await reg.get_or_create("k1"), await reg.get_or_create("k2")
+
+    a, b = asyncio.run(driver())
+    assert a.config is not b.config
+    a.config.kernel = True
+    assert b.config.kernel is False

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -394,3 +394,71 @@ def test_testreport_tools_strip_ctx_from_json_schema(tmp_path: Path) -> None:
             f"tool {name!r} leaked ctx into its JSON schema: {list(props)!r}"
         )
         assert "ctx" not in tool.parameters.get("required", [])
+
+
+# --------------------------------------------------------------------------- #
+# Per-client isolation (http): two ctx keys -> two templates                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_two_ctx_keys_read_their_own_template(tmp_path: Path) -> None:
+    """Distinct request sessions must each ``testreport_read`` only their own file.
+
+    The registered ``testreport_read`` closure resolves the per-call
+    session from the provider keyed on ``id(ctx.session)``. We drive it
+    with two contexts whose ``.session`` objects differ; a real
+    :class:`SessionRegistry` mints one isolated session per key, and we
+    seed each with its own loaded testreport path. If the closure
+    leaked a shared session, both reads would return the same file.
+    """
+    pytest.importorskip("mcp")
+    from mcp.server.fastmcp import FastMCP
+
+    from mtui.mcp.registry import SessionRegistry
+
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("alpha\n", encoding="utf-8")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("beta\nbeta2\n", encoding="utf-8")
+
+    # Each minted session is a real McpSession, then re-pointed at its
+    # own loaded testreport (NullTestReport -> a SimpleNamespace path).
+    seeds = [file_a, file_b]
+
+    def seeding_factory(cfg: object, log: object) -> McpSession:
+        session = _null_session(tmp_path)
+        session.metadata = SimpleNamespace(path=str(seeds.pop(0)))
+        return session
+
+    registry = SessionRegistry(
+        seeding_factory,
+        _config(tmp_path),
+        logging.getLogger("test.mcp.testreport"),
+    )
+    mcp: FastMCP = FastMCP(name="test-mtui-mcp-isolation")
+    tt.register_testreport_tools(mcp, registry)
+
+    read_tool = mcp._tool_manager.get_tool("testreport_read")  # noqa: SLF001
+    assert read_tool is not None
+    read = read_tool.fn
+
+    # Two distinct request sessions -> two distinct registry keys.
+    ctx_a = SimpleNamespace(session=object())
+    ctx_b = SimpleNamespace(session=object())
+
+    async def driver() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        # Interleave to prove the resolution is per-ctx, not first-wins.
+        first = await read(ctx=ctx_a)
+        second = await read(ctx=ctx_b)
+        third = await read(ctx=ctx_a)  # ctx_a again -> still its own file
+        return first, second, third
+
+    first, second, third = asyncio.run(driver())
+
+    assert first["content"] == "alpha\n"
+    assert first["path"] == str(file_a)
+    assert second["content"] == "beta\nbeta2\n"
+    assert second["path"] == str(file_b)
+    # Re-reading ctx_a must still hit file_a (cached session, not file_b).
+    assert third["content"] == "alpha\n"
+    assert third["path"] == str(file_a)


### PR DESCRIPTION
## Summary

Overhauls the `mtui-mcp` server to support multiple concurrent MCP clients safely under the `http` transport. Each client now gets fully isolated session state (loaded test report, SSH hosts, workflow flags), idle sessions are reaped automatically, and a suite of crash and correctness bugs discovered during real MCP usage are fixed.

## Changes

### Added
- **Per-client session isolation** for `http` transport: each connected client gets its own `McpSession` (loaded template, hosts, config, workflow flags). Concurrent clients no longer share or clobber one another's `load_template` / `add_host` state and run without cross-session serialisation.
- **Session registry with bounded capacity and idle reaping** (`mtui/mcp/registry.py`): `[mcp] session_cap` (default 32) caps concurrent sessions; `[mcp] session_idle_timeout` (default 1800 s) evicts idle sessions and disconnects their SSH hosts. `stdio` is unchanged (one process, one session).
- New config keys `session_cap` and `session_idle_timeout` in the `[mcp]` INI section (`mtui/support/config.py`).
- 498-line test module `tests/test_mcp_registry.py` covering session lifecycle, idle reaping, capacity enforcement, and activity-touch behaviour.
- 68-line `tests/test_mcp_testreport_tools.py` covering testreport tool edge cases.

### Changed
- `mtui-mcp` drops boot-time `-a`/`-k`/`-s` flags (auto-review-id, kernel-review-id, SUT); passing them now errors. A single boot-time seed cannot belong to any one client under per-client isolation — clients load their own state at runtime via `load_template` and `add_host`.
- Non-interactive `prompt_user` now returns the `default` argument instead of always `False`, so `load_template` and `updateid` auto-confirm when called over MCP.

### Fixed
- `add_host` no longer crashes when per-session config workflow flags are absent (seed them in `McpSession.__init__`).
- Long-running tools now send `notifications/progress` heartbeats every 10 s so spec-compliant clients (Inspector, Claude Desktop, opencode) do not time out.
- `run`, `show_log`, `show_diff` now return output over MCP (were routing through the interactive pager, which early-returned in non-interactive mode).
- `lrun` now captures child stdout/stderr and propagates the real exit code over MCP.
- `mtui-mcp` no longer paints the interactive `|/-\` spinner to stderr in MCP mode.
- `set_repo`, `load_template`, `openqa_overview`, single-token positional tools, and `config show` schema/crash fixes.
- Clean shutdown on Ctrl-C (catches `BaseExceptionGroup` leaves wrapping `KeyboardInterrupt`/`SystemExit`/`CancelledError` on Python 3.11+).

## Breaking Changes

- `mtui-mcp` CLI: `-a`, `-k`, `-s` flags are **removed**. Scripts or invocations using them must be updated to call `load_template` / `add_host` tools at runtime instead.

## Testing

- `uv run ruff format --check .` — 280 files already formatted
- `uv run ruff check .` — all checks passed
- `uv run ty check` — all checks passed
- `uv run pytest` — 1232 passed

New test coverage: `tests/test_mcp_registry.py` (session lifecycle, reaping, cap) and `tests/test_mcp_testreport_tools.py`.

## Related

Continues the MCP server work started in previous phases. Addresses multi-client safety concerns identified during real opencode/Claude Desktop usage.

## Reviewer notes

- The registry (`mtui/mcp/registry.py`) is the main new module; start there.
- The session-key extraction and per-request dispatch wiring is in `mtui/mcp/main.py`.
- Breaking change (removed CLI flags) is documented in CHANGELOG under `[Unreleased] → Changed`.
