### PR TITLE
feat(http)!: centralize timeout and TLS policy; verify certificates by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- MTUI now requires Python 3.13 or newer (previously 3.11). The
+  minimum supported interpreter, the packaging classifiers, and the
+  `ruff`/`ty` configuration were all raised to 3.13, and the
+  `typing-extensions` backport dependency was dropped now that
+  `typing.override` is available in the standard library.
 - `mtui-mcp` no longer accepts boot-time test-report or host flags
   (`-a`/`--auto-review-id`, `-k`/`--kernel-review-id`, `-s`/`--sut`);
   passing them now errors as unknown arguments. A single boot-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,20 +32,29 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - Outbound HTTP calls (Gitea PR client, QEM Dashboard client, openQA /
-  QAM Dashboard search) now share a single source of truth for the
-  `(connect, read)` timeout and TLS-certificate-verification policy in
-  `mtui.support.http`, replacing three independent, inconsistent
-  copies. A new `[mtui] ssl_verify` option globally overrides
-  verification (`true`/`false`, or a path to a CA bundle); when unset,
-  each call site keeps its previous default. The Gitea client now also
-  applies the shared request timeout (it previously had none).
+  QAM Dashboard search, and the openQA job client) now share a single
+  source of truth for the `(connect, read)` timeout and
+  TLS-certificate-verification policy in `mtui.support.http`, replacing
+  several independent, inconsistent copies. A new `[mtui] ssl_verify`
+  option controls verification globally and **defaults to `true`**, so
+  MTUI now verifies TLS certificates on every outbound connection out
+  of the box. Reaching internal hosts that present an internal-CA
+  certificate therefore requires the SUSE CA in the system trust store;
+  set `ssl_verify = false` to disable verification everywhere, or point
+  at a CA bundle with `ssl_verify = /path/to/ca.pem`. The Gitea client
+  now also applies the shared request timeout (it previously had none).
+- **Security:** previously the Gitea client and the openQA / QAM
+  Dashboard search disabled certificate verification unconditionally,
+  the QEM Dashboard client used the bare `requests` default, and the
+  install-log export silently retried unverified after a TLS error.
+  Every one of these now honors `[mtui] ssl_verify` and verifies by
+  default; the install-log export no longer falls back to an unverified
+  connection.
 - The remaining raw-`urllib` download paths now route through
   `mtui.support.http` too: the openQA install-log export, the
   result/install-log downloader, and the `refhosts.yml` fetch all use
-  the shared `(connect, read)` timeout and honor `[mtui] ssl_verify`.
-  The install-log export keeps its historical "verify, then fall back
-  to unverified on a TLS error" default when `ssl_verify` is unset; the
-  refhosts and downloader paths remain verify-on by default.
+  the shared `(connect, read)` timeout and honor `[mtui] ssl_verify`
+  (verify-on by default).
 - MTUI now requires Python 3.13 or newer (previously 3.11). The
   minimum supported interpreter, the packaging classifiers, and the
   `ruff`/`ty` configuration were all raised to 3.13, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Outbound HTTP calls (Gitea PR client, QEM Dashboard client, openQA /
+  QAM Dashboard search) now share a single source of truth for the
+  `(connect, read)` timeout and TLS-certificate-verification policy in
+  `mtui.support.http`, replacing three independent, inconsistent
+  copies. A new `[mtui] ssl_verify` option globally overrides
+  verification (`true`/`false`, or a path to a CA bundle); when unset,
+  each call site keeps its previous default. The Gitea client now also
+  applies the shared request timeout (it previously had none).
 - MTUI now requires Python 3.13 or newer (previously 3.11). The
   minimum supported interpreter, the packaging classifiers, and the
   `ruff`/`ty` configuration were all raised to 3.13, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   verification (`true`/`false`, or a path to a CA bundle); when unset,
   each call site keeps its previous default. The Gitea client now also
   applies the shared request timeout (it previously had none).
+- The remaining raw-`urllib` download paths now route through
+  `mtui.support.http` too: the openQA install-log export, the
+  result/install-log downloader, and the `refhosts.yml` fetch all use
+  the shared `(connect, read)` timeout and honor `[mtui] ssl_verify`.
+  The install-log export keeps its historical "verify, then fall back
+  to unverified on a TLS error" default when `ssl_verify` is unset; the
+  refhosts and downloader paths remain verify-on by default.
 - MTUI now requires Python 3.13 or newer (previously 3.11). The
   minimum supported interpreter, the packaging classifiers, and the
   `ruff`/`ty` configuration were all raised to 3.13, and the

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -384,6 +384,26 @@ Gitea API access token, this config has higher prio than environment
 variable. Token must have full access to the issue API.
 
 
+``mtui.ssl_verify``
+~~~~~~~~~~~~~~~~~~~
+
+  | **type**
+  |     bool or string (path)
+  | **default**
+  |     ``True``
+
+Global TLS certificate-verification policy for every outbound HTTP
+call (Gitea PR client, QEM Dashboard client, openQA job client, the
+openQA / QAM Dashboard search, the log downloads, and the
+``refhosts.yml`` fetch). Defaults to ``True``, so MTUI verifies
+certificates everywhere out of the box; reaching internal hosts that
+present an internal-CA certificate therefore requires the SUSE CA in
+the system trust store. Set ``ssl_verify = false`` to disable
+verification everywhere, or set it to a filesystem path
+(``ssl_verify = /path/to/ca-bundle.pem``) to verify against a custom CA
+bundle.
+
+
 ``lock.reap_stale``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/mtui/commands/openqa_overview.py
+++ b/mtui/commands/openqa_overview.py
@@ -23,6 +23,7 @@ from ..cli.argparse import ArgumentParser
 from ..cli.colors import blue, green, red, yellow
 from ..cli.completion import complete_choices
 from ..data_sources import oqa_search as oqa
+from ..support.http import resolve_verify
 from ..support.misc import requires_update
 from ..types import FileList, OpenQAOverviewResult
 from ..update_workflow.export.overview_inject import inject_overview
@@ -165,6 +166,11 @@ class OpenQAOverview(Command):
         Also prints colourised output to the REPL as the data arrives.
         """
         rrid = self.metadata.rrid
+
+        # Pin the global TLS verify policy on the search session before any
+        # network call so the openQA / Dashboard search honors
+        # ``[mtui] ssl_verify`` (defaulting to verify).
+        oqa.set_verify(resolve_verify(True, self.config.ssl_verify))
 
         url_openqa = self.args.url_openqa or self.config.openqa_instance
         url_dashboard_qam = self.args.url_dashboard_qam or self._derive_dashboard_url(

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -10,11 +10,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import total_ordering
 from logging import getLogger
-from typing import Any, final
+from typing import Any, final, override
 
 import requests
 import urllib3
-from typing_extensions import override
 from urllib3.exceptions import InsecureRequestWarning
 
 # The 'Config' object has dynamically generated attributes, so we must

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -108,13 +108,11 @@ class Gitea:
         self.headers = {"Authorization": f"token {config.gitea_token}"}
         self.group = group
 
-        # Resolve the TLS verification policy once: historically Gitea
-        # ran against an internal host with verification disabled, so the
-        # per-site default stays ``False``; a user can flip it on (or pass
-        # a CA bundle) globally via ``[mtui] ssl_verify``. The shared
-        # session also silences the InsecureRequestWarning when verify is
-        # off. (Resolves the long-standing "control verify from config".)
-        self._verify: VerifyPolicy = resolve_verify(False, config.ssl_verify)
+        # Resolve the TLS verification policy once: verify by default and
+        # let the global ``[mtui] ssl_verify`` policy override (disable
+        # verification or point at a CA bundle). The shared session
+        # silences the InsecureRequestWarning when verification is off.
+        self._verify: VerifyPolicy = resolve_verify(True, config.ssl_verify)
         self._session = build_session(self._verify)
 
         # Construct the necessary API endpoints from the base PR URL.

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -13,8 +13,6 @@ from logging import getLogger
 from typing import Any, final, override
 
 import requests
-import urllib3
-from urllib3.exceptions import InsecureRequestWarning
 
 # The 'Config' object has dynamically generated attributes, so we must
 # ignore type checker warnings when accessing them.
@@ -25,12 +23,10 @@ from ..support.exceptions import (
     GiteaNoReviewError,
     MissingGiteaTokenError,
 )
+from ..support.http import HTTP_TIMEOUT, VerifyPolicy, build_session, resolve_verify
 from ..types import assignment, method
 
 logger = getLogger("mtui.connector.gitea")
-
-# Suppress insecure request warnings for unverified HTTPS requests.
-urllib3.disable_warnings(category=InsecureRequestWarning)
 
 
 @dataclass
@@ -112,6 +108,15 @@ class Gitea:
         self.headers = {"Authorization": f"token {config.gitea_token}"}
         self.group = group
 
+        # Resolve the TLS verification policy once: historically Gitea
+        # ran against an internal host with verification disabled, so the
+        # per-site default stays ``False``; a user can flip it on (or pass
+        # a CA bundle) globally via ``[mtui] ssl_verify``. The shared
+        # session also silences the InsecureRequestWarning when verify is
+        # off. (Resolves the long-standing "control verify from config".)
+        self._verify: VerifyPolicy = resolve_verify(False, config.ssl_verify)
+        self._session = build_session(self._verify)
+
         # Construct the necessary API endpoints from the base PR URL.
         self.pr = giteaprapi
         self.prissues = giteaprapi.replace("pulls", "issues") + "/comments"
@@ -123,8 +128,6 @@ class Gitea:
         params: dict | None = None,
         data: dict | None = None,
         json: dict | None = None,
-        # TODO: enable control of verify from config
-        verify: bool = False,
     ) -> Any:
         """A private wrapper for making requests to the Gitea API.
 
@@ -134,7 +137,6 @@ class Gitea:
             params: URL parameters for the request.
             data: Form data for the request body.
             json: JSON data for the request body.
-            verify: If True, verifies SSL certificates.
 
         Returns:
             The JSON response from the API.
@@ -145,14 +147,14 @@ class Gitea:
         """
         try:
             logger.debug("Requesting %s on %s", method, url)
-            rsp = requests.request(
+            rsp = self._session.request(
                 method,
                 url,
                 headers=self.headers,
                 params=params,
                 data=data,
                 json=json,
-                verify=verify,
+                timeout=HTTP_TIMEOUT,
             )
         except requests.exceptions.RequestException as e:
             logger.exception("API call to Gitea failed: %s", e)

--- a/mtui/data_sources/openqa/base.py
+++ b/mtui/data_sources/openqa/base.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Self
 import openqa_client.exceptions
 from openqa_client.client import OpenQA_Client as oqa
 
+from ...support.http import disable_insecure_warnings, resolve_verify
 from ...types import RequestKind, RequestReviewID, Test, URLs
 
 logger = getLogger("mtui.connector.openqa")
@@ -42,6 +43,16 @@ class OpenQA(ABC):
         )
 
         self.client = oqa(host)
+        # ``OpenQA_Client`` exposes its ``requests.Session`` but takes no
+        # verify argument; pin the global ``[mtui] ssl_verify`` policy on
+        # the session so openQA requests honor it too. ``do_request``
+        # passes ``verify=None`` per call, which falls back to this
+        # session value. Defaults to verifying; silence the insecure
+        # warning once if the user disabled verification.
+        verify = resolve_verify(True, config.ssl_verify)
+        self.client.session.verify = verify
+        if not verify:
+            disable_insecure_warnings()
         self.pp: list[str] = []
         self.results: list[URLs] | list[Test] | None = None
 

--- a/mtui/data_sources/openqa/kernel.py
+++ b/mtui/data_sources/openqa/kernel.py
@@ -1,9 +1,7 @@
 """A connector for the kernel openQA workflow."""
 
 from logging import getLogger
-from typing import Self
-
-from typing_extensions import override
+from typing import Self, override
 
 from ...types.test import Test
 from .base import OpenQA

--- a/mtui/data_sources/openqa/standard.py
+++ b/mtui/data_sources/openqa/standard.py
@@ -2,9 +2,7 @@
 
 from logging import getLogger
 from os.path import join
-from typing import Self
-
-from typing_extensions import override
+from typing import Self, override
 
 from ...types.urls import URLs
 from .base import OpenQA

--- a/mtui/data_sources/oqa_search/__init__.py
+++ b/mtui/data_sources/oqa_search/__init__.py
@@ -43,7 +43,7 @@ from .heuristics import (
     TESTSUITE_VISUAL_SEPARATORS,
     TESTSUITE_WORDS_BLOCKLIST,
 )
-from .http import _fetch_url_content, _get_json, _HTTPError, _session
+from .http import _fetch_url_content, _get_json, _HTTPError, _session, set_verify
 from .results import BuildCheckResult, GroupResult, VersionResult
 from .search import (
     OVERVIEW_BEGIN_MARKER,
@@ -122,6 +122,7 @@ __all__ = [
     "get_incident_groups",
     "get_incident_info",
     "render_overview",
+    "set_verify",
     "single_incidents",
     "summarize_test_results",
 ]

--- a/mtui/data_sources/oqa_search/__init__.py
+++ b/mtui/data_sources/oqa_search/__init__.py
@@ -43,7 +43,7 @@ from .heuristics import (
     TESTSUITE_VISUAL_SEPARATORS,
     TESTSUITE_WORDS_BLOCKLIST,
 )
-from .http import _HTTP_TIMEOUT, _fetch_url_content, _get_json, _HTTPError, _session
+from .http import _fetch_url_content, _get_json, _HTTPError, _session
 from .results import BuildCheckResult, GroupResult, VersionResult
 from .search import (
     OVERVIEW_BEGIN_MARKER,
@@ -96,7 +96,6 @@ __all__ = [
     "LogFileLinkParser",
     "VersionResult",
     "_HTTPError",
-    "_HTTP_TIMEOUT",
     "_extract_aggregated_name",
     "_extract_version",
     "_fallback_build",

--- a/mtui/data_sources/oqa_search/http.py
+++ b/mtui/data_sources/oqa_search/http.py
@@ -5,21 +5,10 @@ from logging import getLogger
 from typing import Any
 
 import requests
-import urllib3
+
+from ...support.http import HTTP_TIMEOUT, build_session
 
 logger = getLogger("mtui.connector.oqa_search")
-
-# (connect, read) timeout for every HTTP call made by this module.
-_HTTP_TIMEOUT: tuple[float, float] = (5.0, 30.0)
-
-# Most of the hosts we talk to (openqa.suse.de, dashboard.qam.suse.de,
-# qam.suse.de, internal mirrors) present self-signed or internal-CA
-# certificates that the system trust store does not know about. Mirror
-# the upstream oqa-search behaviour (which works because users typically
-# run it on a SUSE machine with the SUSE CA installed) by disabling
-# verification here, and silence the resulting per-request warning to
-# keep the REPL output readable.
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 @lru_cache(maxsize=1)
@@ -30,11 +19,10 @@ def _session() -> requests.Session:
     qam.suse.de) frequently present self-signed or internal-CA certs
     that the user's system trust store does not validate. Disable
     verification on the session so the command works out of the box;
-    the InsecureRequestWarning is silenced module-wide above.
+    :func:`mtui.support.http.build_session` silences the resulting
+    InsecureRequestWarning.
     """
-    session = requests.Session()
-    session.verify = False
-    return session
+    return build_session(verify=False)
 
 
 class _HTTPError(RuntimeError):
@@ -48,7 +36,7 @@ def _get_json(url: str) -> Any:
     so callers can convert into a user-friendly message.
     """
     try:
-        response = _session().get(url, timeout=_HTTP_TIMEOUT)
+        response = _session().get(url, timeout=HTTP_TIMEOUT)
         response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as e:
@@ -62,7 +50,7 @@ def _get_json(url: str) -> Any:
 def _fetch_url_content(url: str) -> str:
     """Fetch text from a URL with a bounded timeout."""
     try:
-        response = _session().get(url, timeout=_HTTP_TIMEOUT)
+        response = _session().get(url, timeout=HTTP_TIMEOUT)
         response.raise_for_status()
         return response.text
     except requests.exceptions.RequestException as e:

--- a/mtui/data_sources/oqa_search/http.py
+++ b/mtui/data_sources/oqa_search/http.py
@@ -6,23 +6,42 @@ from typing import Any
 
 import requests
 
-from ...support.http import HTTP_TIMEOUT, build_session
+from ...support.http import HTTP_TIMEOUT, VerifyPolicy, build_session
 
 logger = getLogger("mtui.connector.oqa_search")
+
+# Effective TLS verification policy for this module's shared session.
+# Defaults to verifying; the command layer overrides it from the global
+# ``[mtui] ssl_verify`` config via :func:`set_verify` before searching.
+_verify: VerifyPolicy = True
+
+
+def set_verify(verify: VerifyPolicy) -> None:
+    """Set the TLS verification policy for the shared search session.
+
+    Resets the cached session when the policy actually changes so the
+    next request rebuilds it with the new ``verify`` value. The command
+    layer calls this with the resolved ``[mtui] ssl_verify`` value so
+    the openQA / Dashboard search honors the global policy.
+    """
+    global _verify
+    if verify != _verify:
+        _verify = verify
+        _session.cache_clear()
 
 
 @lru_cache(maxsize=1)
 def _session() -> requests.Session:
-    """Lazy shared session with TLS verification disabled.
+    """Lazy shared session honoring the configured TLS verify policy.
 
     Internal SUSE hosts (openqa.suse.de, dashboard.qam.suse.de,
-    qam.suse.de) frequently present self-signed or internal-CA certs
-    that the user's system trust store does not validate. Disable
-    verification on the session so the command works out of the box;
-    :func:`mtui.support.http.build_session` silences the resulting
-    InsecureRequestWarning.
+    qam.suse.de) present internal-CA certs that require the SUSE CA in
+    the system trust store. Verification defaults to on; a user can
+    disable it (or point at a CA bundle) globally via ``[mtui]
+    ssl_verify`` -- :func:`mtui.support.http.build_session` silences the
+    InsecureRequestWarning when verification is off.
     """
-    return build_session(verify=False)
+    return build_session(_verify)
 
 
 class _HTTPError(RuntimeError):

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -14,10 +14,8 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from html.parser import HTMLParser
 from logging import getLogger
-from typing import Any, Final
+from typing import Any, Final, override
 from urllib.parse import quote, unquote
-
-from typing_extensions import override
 
 from .heuristics import (
     AGGREGATED_EXCLUDED_VERSIONS,

--- a/mtui/data_sources/qem_dashboard/client.py
+++ b/mtui/data_sources/qem_dashboard/client.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import requests
 
-from ...support.http import HTTP_TIMEOUT
+from ...support.http import HTTP_TIMEOUT, VerifyPolicy, build_session
 
 logger = getLogger("mtui.connector.qem_dashboard")
 
@@ -23,12 +23,25 @@ _FUTURE_TIMEOUT: float = 60.0
 class QEMDashboardClient:
     """Small read-only client for the QEM Dashboard API."""
 
-    def __init__(self, apiurl: str) -> None:
+    def __init__(self, apiurl: str, verify: VerifyPolicy = True) -> None:
+        """Initialize the client.
+
+        Args:
+            apiurl: Base URL of the QEM Dashboard API.
+            verify: TLS verification policy (the resolved ``[mtui]
+                ssl_verify`` value). Defaults to ``True`` so the client
+                verifies certificates unless the user opted out.
+
+        """
         self.apiurl = apiurl.rstrip("/")
+        # A shared session pins the verify policy (and silences the
+        # InsecureRequestWarning once when verification is disabled),
+        # so every request honors the global ssl_verify config.
+        self._session = build_session(verify)
 
     def _get(self, path: str, **params) -> Any | None:
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.apiurl}/{path.lstrip('/')}",
                 params=params or None,
                 headers={"Accept": "application/json"},

--- a/mtui/data_sources/qem_dashboard/client.py
+++ b/mtui/data_sources/qem_dashboard/client.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import requests
 
+from ...support.http import HTTP_TIMEOUT
+
 logger = getLogger("mtui.connector.qem_dashboard")
 
 # Job result statuses that should be reported individually in the exported
@@ -12,12 +14,9 @@ logger = getLogger("mtui.connector.qem_dashboard")
 # per-group summary count to keep the report short and reviewable.
 FAILED_RESULTS: frozenset[str] = frozenset({"failed", "incomplete", "timeout_exceeded"})
 
-# (connect, read) timeout for every dashboard HTTP call. Bounds a stuck
-# socket so a broken network can't hang mtui startup indefinitely.
-_HTTP_TIMEOUT: tuple[float, float] = (5.0, 30.0)
 # Wall-clock cap per future in the parallel fan-out. Defense-in-depth on
-# top of the per-request timeout above; a stuck worker won't block the
-# whole batch.
+# top of the shared per-request HTTP_TIMEOUT; a stuck worker won't block
+# the whole batch.
 _FUTURE_TIMEOUT: float = 60.0
 
 
@@ -33,7 +32,7 @@ class QEMDashboardClient:
                 f"{self.apiurl}/{path.lstrip('/')}",
                 params=params or None,
                 headers={"Accept": "application/json"},
-                timeout=_HTTP_TIMEOUT,
+                timeout=HTTP_TIMEOUT,
             )
             response.raise_for_status()
             return response.json()

--- a/mtui/data_sources/qem_dashboard/incident.py
+++ b/mtui/data_sources/qem_dashboard/incident.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from ...support.http import VerifyPolicy
 from ...types import RequestKind, RequestReviewID
 from .client import QEMDashboardClient
 
@@ -9,10 +10,22 @@ from .client import QEMDashboardClient
 class QEMIncident:
     """Incident metadata from QEM Dashboard."""
 
-    def __init__(self, rrid: RequestReviewID, apiurl: str) -> None:
+    def __init__(
+        self, rrid: RequestReviewID, apiurl: str, verify: VerifyPolicy = True
+    ) -> None:
+        """Initialize incident metadata.
+
+        Args:
+            rrid: The request/review id of the incident.
+            apiurl: Base URL of the QEM Dashboard API.
+            verify: TLS verification policy (the resolved ``[mtui]
+                ssl_verify`` value) forwarded to the dashboard client.
+                Defaults to ``True``.
+
+        """
         self.rrid = rrid
         self.incident_number = self._incident_number(rrid)
-        self.client = QEMDashboardClient(apiurl)
+        self.client = QEMDashboardClient(apiurl, verify)
         self.data: dict[str, Any] | None = self.client.incident(self.incident_number)
 
     @staticmethod

--- a/mtui/hosts/refhost/__init__.py
+++ b/mtui/hosts/refhost/__init__.py
@@ -8,20 +8,36 @@ the split (see ``tests/test_refhost.py``, which patches
 
 import os
 import time
-from urllib.request import urlopen
 
 from ...support.fileops import atomic_write_file
+from ...support.http import VerifyPolicy, get_bytes
 from ...support.paths import save_cache_path
 from .models import Addon, Attributes, Host, Product, Version
 from .resolvers import HttpsResolver, PathResolver, Resolver
 from .store import Refhosts, RefhostsResolveFailedError, _RefhostsFactory
+
+
+class _BytesResponse:
+    """Minimal ``.read()``-able wrapper so the resolver stays transport-agnostic."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def _requests_urlopener(uri: str, verify: VerifyPolicy) -> _BytesResponse:
+    """Fetch ``uri`` via the shared HTTP helper, honoring the verify policy."""
+    return _BytesResponse(get_bytes(uri, verify=verify))
+
 
 RefhostsFactory = _RefhostsFactory(
     {
         "https": HttpsResolver(
             time.time,
             os.stat,
-            urlopen,
+            _requests_urlopener,
             atomic_write_file,
             save_cache_path("refhosts.yml"),
         ),

--- a/mtui/hosts/refhost/resolvers.py
+++ b/mtui/hosts/refhost/resolvers.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from logging import getLogger
 from pathlib import Path
 
+from ...support.http import resolve_verify
 from .store import Refhosts
 
 logger = getLogger("mtui.refhost")
@@ -51,7 +52,10 @@ class HttpsResolver(Resolver):
         Args:
             time_now_getter: Callable returning the current epoch time.
             statter: Callable returning file stats (``os.stat``).
-            urlopener: Callable returning an HTTP response object.
+            urlopener: Callable ``(uri, verify) -> response`` returning an
+                object with a ``.read()`` method yielding the payload
+                bytes. ``verify`` is the :data:`~mtui.support.http.VerifyPolicy`
+                to apply to the request.
             file_writer: Callable ``(bytes, path) -> None`` to persist
                 the downloaded payload.
             cache_path: On-disk cache path for the downloaded YAML.
@@ -71,7 +75,10 @@ class HttpsResolver(Resolver):
 
     def _refresh_if_needed(self, config) -> None:
         if self._is_refresh_needed(config.refhosts_https_expiration):
-            self._refresh(config.refhosts_https_uri)
+            # refhosts.yml is served from an internal SUSE host; verify by
+            # default but let the global [mtui] ssl_verify policy override.
+            verify = resolve_verify(True, config.ssl_verify)
+            self._refresh(config.refhosts_https_uri, verify)
 
     def _is_refresh_needed(self, expiration: int) -> bool:
         try:
@@ -83,5 +90,5 @@ class HttpsResolver(Resolver):
 
         return self._time_now() - statinfo.st_mtime > expiration
 
-    def _refresh(self, uri: str) -> None:
-        self._write_file(self._urlopen(uri).read(), self.cache_path)
+    def _refresh(self, uri: str, verify) -> None:
+        self._write_file(self._urlopen(uri, verify).read(), self.cache_path)

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -59,7 +59,7 @@ def _is_clean_shutdown_group(exc: BaseException) -> bool:
     """Return True iff every leaf in ``exc`` is a shutdown sentinel.
 
     ``anyio.run`` (used by :meth:`mcp.server.fastmcp.FastMCP.run`) wraps task-group failures
-    in :class:`BaseExceptionGroup` on Python 3.11+, so a bare
+    in :class:`BaseExceptionGroup`, so a bare
     ``except KeyboardInterrupt`` does not catch Ctrl-C delivered to an
     active task group. We walk the group recursively and only treat it
     as a clean shutdown when *every* leaf is one of

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -26,6 +26,26 @@ def _identity(x: Any) -> Any:
     return x
 
 
+_TRUE_STRINGS = frozenset({"1", "yes", "true", "on"})
+_FALSE_STRINGS = frozenset({"0", "no", "false", "off"})
+
+
+def _parse_ssl_verify(raw: str) -> bool | str:
+    """Coerce the ``[mtui] ssl_verify`` value into a ``requests`` ``verify``.
+
+    Accepts the usual boolean spellings (``true``/``false``/``yes``/...)
+    and otherwise treats the value as a path to a CA bundle file, which
+    :mod:`requests` accepts directly as ``verify``.
+    """
+    token = raw.strip()
+    lowered = token.lower()
+    if lowered in _TRUE_STRINGS:
+        return True
+    if lowered in _FALSE_STRINGS:
+        return False
+    return token
+
+
 @dataclass(frozen=True, slots=True)
 class ConfigOption:
     """Declarative description of a single configuration option.
@@ -82,6 +102,7 @@ class Config:
     openqa_kernel_install_logs: str
     threshold: int
     gitea_token: str
+    ssl_verify: bool | str | None
     ssh_strict_host_key_checking: str
     lock_reap_stale: bool
     lock_stale_age: int
@@ -370,6 +391,20 @@ class Config:
                 ("gitea", "token"),
                 getenv("GITEA_TOKEN", ""),
                 getter=get,
+            ),
+            # Global override for TLS certificate verification on outbound
+            # HTTP calls (see mtui.support.http). Unset (the default) means
+            # each call site keeps its own historical default -- several
+            # internal SUSE hosts present self-signed/internal-CA certs and
+            # disable verification out of the box. Set ``ssl_verify = true``
+            # to verify everywhere (requires the SUSE CA in the trust store),
+            # ``false`` to skip everywhere, or a path to a CA bundle file.
+            ConfigOption(
+                "ssl_verify",
+                ("mtui", "ssl_verify"),
+                None,
+                _parse_ssl_verify,
+                get,
             ),
             ConfigOption(
                 "ssh_strict_host_key_checking",

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -392,17 +392,17 @@ class Config:
                 getenv("GITEA_TOKEN", ""),
                 getter=get,
             ),
-            # Global override for TLS certificate verification on outbound
-            # HTTP calls (see mtui.support.http). Unset (the default) means
-            # each call site keeps its own historical default -- several
-            # internal SUSE hosts present self-signed/internal-CA certs and
-            # disable verification out of the box. Set ``ssl_verify = true``
-            # to verify everywhere (requires the SUSE CA in the trust store),
-            # ``false`` to skip everywhere, or a path to a CA bundle file.
+            # Global policy for TLS certificate verification on every
+            # outbound HTTP call (see mtui.support.http). Defaults to
+            # ``True`` so mtui verifies certificates everywhere out of the
+            # box; this requires the SUSE CA in the system trust store to
+            # reach internal hosts that present an internal-CA certificate.
+            # Set ``ssl_verify = false`` to skip verification everywhere, or
+            # point at a CA bundle file with ``ssl_verify = /path/to/ca.pem``.
             ConfigOption(
                 "ssl_verify",
                 ("mtui", "ssl_verify"),
-                None,
+                True,
                 _parse_ssl_verify,
                 get,
             ),

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -1,0 +1,90 @@
+"""Single source of truth for outbound HTTP timeout and TLS policy.
+
+Every place in mtui that talks to an HTTP(S) service (the Gitea PR
+client, the QEM Dashboard client, the openQA / QAM Dashboard search)
+historically defined its own ``(connect, read)`` timeout constant and
+made its own, inconsistent decision about TLS certificate
+verification. This module centralises both:
+
+- :data:`HTTP_TIMEOUT` is the one ``(connect, read)`` timeout tuple
+  shared by all callers. It bounds a stuck socket so a broken network
+  cannot hang mtui indefinitely.
+- :func:`resolve_verify` turns a per-call-site default plus an optional
+  user override (``[mtui] ssl_verify`` in the config) into the
+  effective ``verify`` value passed to :mod:`requests`.
+- :func:`build_session` / :func:`disable_insecure_warnings` make the
+  ``urllib3`` ``InsecureRequestWarning`` suppression happen in exactly
+  one place, and only when verification is actually disabled.
+
+Most internal SUSE hosts (openqa.suse.de, dashboard.qam.suse.de,
+qam.suse.de, internal mirrors) present self-signed or internal-CA
+certificates that the user's system trust store does not know about,
+so several call sites disable verification by default. A user who has
+the SUSE CA installed can flip verification back on globally by setting
+``[mtui] ssl_verify = true`` (or point at a CA bundle with
+``ssl_verify = /path/to/ca.pem``).
+"""
+
+from __future__ import annotations
+
+import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+
+#: Shared ``(connect, read)`` timeout in seconds for every outbound HTTP
+#: call. Bounds a stuck socket so a broken network can't hang mtui.
+HTTP_TIMEOUT: tuple[float, float] = (5.0, 30.0)
+
+#: A ``requests``-compatible ``verify`` value: ``True`` (use the system
+#: trust store), ``False`` (skip verification), or a path to a CA
+#: bundle file.
+VerifyPolicy = bool | str
+
+_warnings_disabled = False
+
+
+def disable_insecure_warnings() -> None:
+    """Silence ``urllib3``'s per-request ``InsecureRequestWarning`` once.
+
+    Idempotent: the first call disables the warning process-wide and
+    subsequent calls are cheap no-ops. Callers invoke this only when
+    they have deliberately disabled certificate verification, so the
+    REPL output stays readable instead of emitting a warning per
+    request.
+    """
+    global _warnings_disabled
+    if not _warnings_disabled:
+        urllib3.disable_warnings(InsecureRequestWarning)
+        _warnings_disabled = True
+
+
+def resolve_verify(
+    default: VerifyPolicy, override: VerifyPolicy | None = None
+) -> VerifyPolicy:
+    """Pick the effective ``verify`` value for a request.
+
+    Args:
+        default: The call site's own default (preserves historical
+            per-host behaviour when the user has set no global policy).
+        override: The user's global ``[mtui] ssl_verify`` setting, or
+            ``None`` when unset. When not ``None`` it wins over
+            ``default``.
+
+    Returns:
+        The ``verify`` value to hand to :mod:`requests`.
+
+    """
+    return default if override is None else override
+
+
+def build_session(verify: VerifyPolicy) -> requests.Session:
+    """Create a :class:`requests.Session` with a fixed ``verify`` policy.
+
+    When ``verify`` is falsy, the module-wide insecure-request warning
+    is suppressed so callers do not have to repeat that boilerplate.
+    """
+    session = requests.Session()
+    session.verify = verify
+    if not verify:
+        disable_insecure_warnings()
+    return session

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -10,9 +10,9 @@ verification. This module centralises both:
 - :data:`HTTP_TIMEOUT` is the one ``(connect, read)`` timeout tuple
   shared by all callers. It bounds a stuck socket so a broken network
   cannot hang mtui indefinitely.
-- :func:`resolve_verify` turns a per-call-site default plus an optional
-  user override (``[mtui] ssl_verify`` in the config) into the
-  effective ``verify`` value passed to :mod:`requests`.
+- :func:`resolve_verify` turns the user's ``[mtui] ssl_verify`` config
+  value into the effective ``verify`` passed to :mod:`requests`,
+  defaulting to ``True`` (verify) when the value is unset.
 - :func:`build_session` / :func:`disable_insecure_warnings` make the
   ``urllib3`` ``InsecureRequestWarning`` suppression happen in exactly
   one place, and only when verification is actually disabled.
@@ -20,12 +20,12 @@ verification. This module centralises both:
   download sites that previously reached for raw ``urllib`` (which had
   no shared timeout and a hard-coded TLS posture).
 
-Most internal SUSE hosts (openqa.suse.de, dashboard.qam.suse.de,
-qam.suse.de, internal mirrors) present self-signed or internal-CA
-certificates that the user's system trust store does not know about,
-so several call sites disable verification by default. A user who has
-the SUSE CA installed can flip verification back on globally by setting
-``[mtui] ssl_verify = true`` (or point at a CA bundle with
+Verification is **on by default for every call site**. Several internal
+SUSE hosts (openqa.suse.de, dashboard.qam.suse.de, qam.suse.de,
+internal mirrors) present internal-CA certificates, so reaching them
+out of the box requires the SUSE CA in the system trust store. A user
+who cannot install that CA can disable verification globally with
+``[mtui] ssl_verify = false`` (or point at a CA bundle with
 ``ssl_verify = /path/to/ca.pem``).
 """
 
@@ -68,8 +68,9 @@ def resolve_verify(
     """Pick the effective ``verify`` value for a request.
 
     Args:
-        default: The call site's own default (preserves historical
-            per-host behaviour when the user has set no global policy).
+        default: The fallback used when ``override`` is ``None``. Call
+            sites pass ``True`` so verification is on whenever the user
+            has expressed no preference.
         override: The user's global ``[mtui] ssl_verify`` setting, or
             ``None`` when unset. When not ``None`` it wins over
             ``default``.

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -1,9 +1,10 @@
 """Single source of truth for outbound HTTP timeout and TLS policy.
 
 Every place in mtui that talks to an HTTP(S) service (the Gitea PR
-client, the QEM Dashboard client, the openQA / QAM Dashboard search)
-historically defined its own ``(connect, read)`` timeout constant and
-made its own, inconsistent decision about TLS certificate
+client, the QEM Dashboard client, the openQA / QAM Dashboard search,
+the openQA install/result-log downloads, and the ``refhosts.yml``
+fetch) historically defined its own ``(connect, read)`` timeout
+constant and made its own, inconsistent decision about TLS certificate
 verification. This module centralises both:
 
 - :data:`HTTP_TIMEOUT` is the one ``(connect, read)`` timeout tuple
@@ -15,6 +16,9 @@ verification. This module centralises both:
 - :func:`build_session` / :func:`disable_insecure_warnings` make the
   ``urllib3`` ``InsecureRequestWarning`` suppression happen in exactly
   one place, and only when verification is actually disabled.
+- :func:`get_bytes` is the shared GET-to-bytes path used by the
+  download sites that previously reached for raw ``urllib`` (which had
+  no shared timeout and a hard-coded TLS posture).
 
 Most internal SUSE hosts (openqa.suse.de, dashboard.qam.suse.de,
 qam.suse.de, internal mirrors) present self-signed or internal-CA
@@ -88,3 +92,37 @@ def build_session(verify: VerifyPolicy) -> requests.Session:
     if not verify:
         disable_insecure_warnings()
     return session
+
+
+def get_bytes(
+    url: str,
+    *,
+    verify: VerifyPolicy,
+    timeout: tuple[float, float] = HTTP_TIMEOUT,
+) -> bytes:
+    """GET ``url`` and return the raw response body as bytes.
+
+    The single GET-to-bytes path for callers that just want a payload
+    (a log file, a YAML document) rather than a streaming response.
+    Applies the shared :data:`HTTP_TIMEOUT` and the given ``verify``
+    policy, and raises for any non-2xx status.
+
+    Args:
+        url: The URL to fetch.
+        verify: The :data:`VerifyPolicy` to apply (resolve it from the
+            call site default and config via :func:`resolve_verify`).
+        timeout: The ``(connect, read)`` timeout; defaults to the
+            shared :data:`HTTP_TIMEOUT`.
+
+    Returns:
+        The response body as ``bytes``.
+
+    Raises:
+        requests.exceptions.RequestException: On any transport failure
+            or non-2xx HTTP status.
+
+    """
+    session = build_session(verify)
+    response = session.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.content

--- a/mtui/types/hostlog.py
+++ b/mtui/types/hostlog.py
@@ -1,6 +1,6 @@
 """A list-like object for storing command log entries."""
 
-from typing_extensions import override
+from typing import override
 
 from . import CommandLog
 

--- a/mtui/types/package.py
+++ b/mtui/types/package.py
@@ -1,8 +1,6 @@
 """A class for representing a software package and its versions."""
 
-from typing import final
-
-from typing_extensions import override
+from typing import final, override
 
 from .rpmver import RPMVersion
 

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -1,8 +1,6 @@
 """A class for comparing RPM version strings."""
 
-from typing import ClassVar, final
-
-from typing_extensions import override
+from typing import ClassVar, final, override
 
 try:
     import rpm  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]

--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -2,9 +2,7 @@
 
 from collections.abc import Callable, Sequence
 from itertools import zip_longest
-from typing import Any, final
-
-from typing_extensions import override
+from typing import Any, final, override
 
 from .enums import RequestKind
 

--- a/mtui/types/systems.py
+++ b/mtui/types/systems.py
@@ -1,6 +1,6 @@
 """A class for representing the system information of a target host."""
 
-from typing_extensions import override
+from typing import override
 
 from . import Product
 

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -6,9 +6,7 @@ from collections.abc import Callable
 from errno import ENOENT
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, final
-
-from typing_extensions import override
+from typing import TYPE_CHECKING, final, override
 
 if TYPE_CHECKING:
     from ..cli.prompter import Prompter

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -20,6 +20,7 @@ from ..support.exceptions import (
     InvalidGiteaHashError,
     MissingGiteaTokenError,
 )
+from ..support.http import resolve_verify
 from ..support.messages import (
     SvnCheckoutFailed,
     SvnCheckoutInterruptedError,
@@ -221,7 +222,11 @@ class AutoOBSUpdateID(UpdateID):
             return NullTestReport(config, prompter=prompter)
 
         self._create_installogs_dir(config)
-        tr.incident = QEMIncident(self.id, config.qem_dashboard_api)
+        tr.incident = QEMIncident(
+            self.id,
+            config.qem_dashboard_api,
+            resolve_verify(True, config.ssl_verify),
+        )
 
         logger.info("Getting data from QEM Dashboard")
         tr.openqa.auto = DashboardAutoOpenQA(
@@ -306,7 +311,11 @@ class KernelOBSUpdateID(UpdateID):
 
         self._create_installogs_dir(config)
         self.create_results_dir(config)
-        tr.incident = QEMIncident(self.id, config.qem_dashboard_api)
+        tr.incident = QEMIncident(
+            self.id,
+            config.qem_dashboard_api,
+            resolve_verify(True, config.ssl_verify),
+        )
         tr.openqa.auto = DashboardAutoOpenQA(
             config,
             config.openqa_instance,

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -1,22 +1,16 @@
 """An exporter for the automatic workflow."""
 
-import ssl
-from http.client import RemoteDisconnected
 from itertools import zip_longest
 from logging import getLogger
 from pathlib import Path
-from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
 
+import requests
+
+from ...support.http import HTTP_TIMEOUT, build_session, resolve_verify
 from ...types import FileList
 from .base import BaseExport
 
 logger = getLogger("mtui.export.auto")
-
-# TODO: migrate this raw-urllib log download to the shared requests-based
-# helper in mtui.support.http so TLS verification follows the global
-# [mtui] ssl_verify policy instead of this hard-coded unverified context.
-no_verify = ssl._create_unverified_context()  # noqa: SLF001
 
 
 class AutoExport(BaseExport):
@@ -117,33 +111,52 @@ class AutoExport(BaseExport):
 
         return filenames
 
-    @staticmethod
-    def _openqa_installog_to_template(url) -> list[str]:
-        """Converts an openQA install log to a template.
+    def _openqa_installog_to_template(self, url) -> list[str]:
+        """Download an openQA install log and return its lines.
 
         Args:
-            url: The URL of the log to convert.
+            url: A ``URLs`` instance whose ``url`` attribute points at the
+                install log to fetch.
 
         Returns:
-            A list of strings representing the log content.
+            The log content as a list of lines (with trailing newlines),
+            or an empty list if the download failed.
+
+        TLS verification follows the global ``[mtui] ssl_verify`` policy.
+        When that policy is unset this preserves the historical
+        behaviour of trying verified first and falling back to an
+        unverified retry on a certificate error -- most openQA hosts use
+        an internal CA the system trust store may not know about. When
+        ``ssl_verify`` is set explicitly the user's choice is honoured
+        with no insecure fallback.
 
         """
-        # input is URLs instance
+        verify = resolve_verify(True, self.config.ssl_verify)
         try:
-            with urlopen(url.url) as log:
-                t = log.readlines()
-            return [x.decode() for x in t]
-        except (RemoteDisconnected, HTTPError):
-            logger.error("log %s failed to download", url.url)
-            return []
-        except URLError:
-            try:
-                with urlopen(url.url, context=no_verify) as log:
-                    t = log.readlines()
-                return [x.decode() for x in t]
-            except (RemoteDisconnected, HTTPError, URLError):
+            response = build_session(verify).get(url.url, timeout=HTTP_TIMEOUT)
+            response.raise_for_status()
+            return response.text.splitlines(keepends=True)
+        except requests.exceptions.SSLError:
+            if self.config.ssl_verify is not None:
+                # User explicitly chose a verification policy; do not
+                # silently downgrade to an unverified connection.
                 logger.error("log %s failed to download", url.url)
                 return []
+            logger.debug(
+                "verified fetch of %s failed on TLS; retrying unverified", url.url
+            )
+            try:
+                response = build_session(verify=False).get(
+                    url.url, timeout=HTTP_TIMEOUT
+                )
+                response.raise_for_status()
+                return response.text.splitlines(keepends=True)
+            except requests.exceptions.RequestException:
+                logger.error("log %s failed to download", url.url)
+                return []
+        except requests.exceptions.RequestException:
+            logger.error("log %s failed to download", url.url)
+            return []
 
     def run(self, *args, **kwds) -> FileList | list[str]:
         """Runs the exporter.

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -13,6 +13,9 @@ from .base import BaseExport
 
 logger = getLogger("mtui.export.auto")
 
+# TODO: migrate this raw-urllib log download to the shared requests-based
+# helper in mtui.support.http so TLS verification follows the global
+# [mtui] ssl_verify policy instead of this hard-coded unverified context.
 no_verify = ssl._create_unverified_context()  # noqa: SLF001
 
 

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -122,13 +122,11 @@ class AutoExport(BaseExport):
             The log content as a list of lines (with trailing newlines),
             or an empty list if the download failed.
 
-        TLS verification follows the global ``[mtui] ssl_verify`` policy.
-        When that policy is unset this preserves the historical
-        behaviour of trying verified first and falling back to an
-        unverified retry on a certificate error -- most openQA hosts use
-        an internal CA the system trust store may not know about. When
-        ``ssl_verify`` is set explicitly the user's choice is honoured
-        with no insecure fallback.
+        TLS verification follows the global ``[mtui] ssl_verify`` policy,
+        which defaults to verifying. Reaching openQA hosts that present
+        an internal-CA certificate therefore requires the SUSE CA in the
+        system trust store, or ``ssl_verify`` set to ``false`` / a CA
+        bundle path.
 
         """
         verify = resolve_verify(True, self.config.ssl_verify)
@@ -136,24 +134,6 @@ class AutoExport(BaseExport):
             response = build_session(verify).get(url.url, timeout=HTTP_TIMEOUT)
             response.raise_for_status()
             return response.text.splitlines(keepends=True)
-        except requests.exceptions.SSLError:
-            if self.config.ssl_verify is not None:
-                # User explicitly chose a verification policy; do not
-                # silently downgrade to an unverified connection.
-                logger.error("log %s failed to download", url.url)
-                return []
-            logger.debug(
-                "verified fetch of %s failed on TLS; retrying unverified", url.url
-            )
-            try:
-                response = build_session(verify=False).get(
-                    url.url, timeout=HTTP_TIMEOUT
-                )
-                response.raise_for_status()
-                return response.text.splitlines(keepends=True)
-            except requests.exceptions.RequestException:
-                logger.error("log %s failed to download", url.url)
-                return []
         except requests.exceptions.RequestException:
             logger.error("log %s failed to download", url.url)
             return []

--- a/mtui/update_workflow/export/downloader.py
+++ b/mtui/update_workflow/export/downloader.py
@@ -2,17 +2,22 @@
 
 import concurrent.futures
 import os.path
-import urllib.error
 from collections.abc import Callable
 from logging import getLogger
-from urllib.request import urlretrieve
+from pathlib import Path
 
+import requests
+
+from ...support.fileops import atomic_write_file
+from ...support.http import VerifyPolicy, get_bytes
 from ...support.messages import ResultsMissingError
 
 logger = getLogger("mtui.export.downloader")
 
 
-def _subdl(oqa_path: str, l_path: str, test: dict, errormode: str) -> None:
+def _subdl(
+    oqa_path: str, l_path: str, test: dict, errormode: str, verify: VerifyPolicy = True
+) -> None:
     """A helper function for downloading a single log file.
 
     Args:
@@ -20,12 +25,14 @@ def _subdl(oqa_path: str, l_path: str, test: dict, errormode: str) -> None:
         l_path: The local path to save the log file to.
         test: A dictionary containing information about the test.
         errormode: The error mode to use if the download fails.
+        verify: The TLS verification policy (see ``mtui.support.http``).
 
     """
     try:
         logger.info("Downloading log %s", oqa_path)
-        urlretrieve(oqa_path, l_path)
-    except urllib.error.HTTPError:
+        data = get_bytes(oqa_path, verify=verify)
+        atomic_write_file(data, Path(l_path))
+    except requests.exceptions.RequestException:
         logger.error("Download from %s failed", oqa_path)
         if errormode == "full":
             raise ResultsMissingError(test["name"], test["arch"]) from None
@@ -44,7 +51,9 @@ def _emptylog(host, test, *args, **kwds) -> None:
     logger.debug("No log to download for test: %s on %s", test["name"], host)
 
 
-def _resultlog(host, test, resultsdir, _, errormode) -> None:
+def _resultlog(
+    host, test, resultsdir, _, errormode, verify: VerifyPolicy = True
+) -> None:
     """A downloader function for result logs.
 
     Args:
@@ -53,6 +62,7 @@ def _resultlog(host, test, resultsdir, _, errormode) -> None:
         resultsdir: The directory to save the results to.
         _: An unused argument.
         errormode: The error mode to use if the download fails.
+        verify: The TLS verification policy (see ``mtui.support.http``).
 
     """
     oqa_path = os.path.join(
@@ -63,10 +73,12 @@ def _resultlog(host, test, resultsdir, _, errormode) -> None:
     )
     logger.debug("Download from %s ", oqa_path)
     logger.debug("Store in %s", l_path)
-    _subdl(oqa_path, l_path, test, errormode)
+    _subdl(oqa_path, l_path, test, errormode, verify)
 
 
-def _installlog(host, test, _, installlogsdir, errormode) -> None:
+def _installlog(
+    host, test, _, installlogsdir, errormode, verify: VerifyPolicy = True
+) -> None:
     """A downloader function for install logs.
 
     Args:
@@ -75,6 +87,7 @@ def _installlog(host, test, _, installlogsdir, errormode) -> None:
         _: An unused argument.
         installlogsdir: The directory to save the install logs to.
         errormode: The error mode to use if the download fails.
+        verify: The TLS verification policy (see ``mtui.support.http``).
 
     """
     oqa_path = os.path.join(
@@ -85,17 +98,19 @@ def _installlog(host, test, _, installlogsdir, errormode) -> None:
     )
     logger.debug("Download from %s ", oqa_path)
     logger.debug("Store in %s", l_path)
-    _subdl(oqa_path, l_path, test, errormode)
+    _subdl(oqa_path, l_path, test, errormode, verify)
 
 
 #: A dictionary that maps log types to downloader functions.
-downloader: dict[str, Callable[[str, dict, str, str, str], None]] = {
+downloader: dict[str, Callable[..., None]] = {
     "install": _installlog,
     "ltp": _resultlog,
 }
 
 
-def download_logs(oqa, resultsdir, installogsdir, errormode: str) -> None:
+def download_logs(
+    oqa, resultsdir, installogsdir, errormode: str, verify: VerifyPolicy = True
+) -> None:
     """Downloads logs from openQA.
 
     Args:
@@ -103,6 +118,7 @@ def download_logs(oqa, resultsdir, installogsdir, errormode: str) -> None:
         resultsdir: The directory to save the results to.
         installogsdir: The directory to save the install logs to.
         errormode: The error mode to use if a download fails.
+        verify: The TLS verification policy (see ``mtui.support.http``).
 
     """
     results_matrix: list[tuple[str, str, str, str]] = []
@@ -116,4 +132,4 @@ def download_logs(oqa, resultsdir, installogsdir, errormode: str) -> None:
         for host, name, test_id, arch in results_matrix:
             test = {"name": name, "test_id": test_id, "arch": arch}
             dl = downloader.get(name.split("_")[0], _emptylog)
-            e.submit(dl, host, test, resultsdir, installogsdir, errormode)
+            e.submit(dl, host, test, resultsdir, installogsdir, errormode, verify)

--- a/mtui/update_workflow/export/kernel.py
+++ b/mtui/update_workflow/export/kernel.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from pathlib import Path
 
 from ...support.fileops import ensure_dir_exists
+from ...support.http import resolve_verify
 from ...types import FileList
 from .base import BaseExport
 from .downloader import download_logs
@@ -31,7 +32,8 @@ class KernelExport(BaseExport):
         ensure_dir_exists(res_path)
         oqa = (result for result in self.openqa.kernel)
         # TODO: configurable errormode
-        download_logs(oqa, res_path, in_path, "tolerant")
+        verify = resolve_verify(True, self.config.ssl_verify)
+        download_logs(oqa, res_path, in_path, "tolerant", verify)
 
         return [fn.name for fn in in_path.glob("*.log")]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,17 @@ classifiers = [
   "Environment :: Console",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14"
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
   "openqa-client",
   "paramiko",
   "prompt_toolkit",
   "pyxdg",
   "requests",
-  "ruamel.yaml",
-  "typing-extensions>=4.5"
+  "ruamel.yaml"
 ]
 dynamic = ["version"]
 
@@ -69,7 +66,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = [
@@ -127,8 +124,8 @@ ignore = [
 [tool.ty.environment]
 # Pin to the lowest version we support so we catch features that
 # would only work on newer interpreters; the CI matrix exercises
-# 3.11-3.14 separately.
-python-version = "3.11"
+# 3.13-3.14 separately.
+python-version = "3.13"
 
 [tool.ty.terminal]
 # Promote warnings to errors so 'ty check' is a hard gate.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def mock_config():
     config.template_dir = Path("/tmp/templates")
     config.qem_dashboard_api = "https://dashboard.example.com/api"
     config.gitea_token = "test-token-123"
+    config.ssl_verify = None
     config.location = "nuremberg"
     config.auto = False
     config.chdir_to_template_dir = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,9 @@ def mock_config():
     config.template_dir = Path("/tmp/templates")
     config.qem_dashboard_api = "https://dashboard.example.com/api"
     config.gitea_token = "test-token-123"
-    config.ssl_verify = None
+    # Matches the production default: verify TLS certificates everywhere
+    # unless the user opts out via [mtui] ssl_verify.
+    config.ssl_verify = True
     config.location = "nuremberg"
     config.auto = False
     config.chdir_to_template_dir = False

--- a/tests/test_export_auto_download.py
+++ b/tests/test_export_auto_download.py
@@ -1,0 +1,129 @@
+"""Tests for ``AutoExport._openqa_installog_to_template`` log download.
+
+This is the first coverage for the install-log download path, added
+when it migrated from raw ``urllib`` to ``mtui.support.http``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from mtui.support.http import HTTP_TIMEOUT
+from mtui.types import FileList, URLs
+from mtui.update_workflow.export.auto import AutoExport
+
+
+def _make_exporter(mock_config) -> AutoExport:
+    """Build an AutoExport whose openQA results are irrelevant here."""
+    return AutoExport(
+        mock_config,
+        MagicMock(),
+        FileList([]),
+        False,
+        "SUSE:Maintenance:1:1",
+        False,
+    )
+
+
+def _url(u: str = "https://openqa.example.com/tests/1/file/log") -> URLs:
+    return URLs("sle", "x86_64", "15-SP7", u)
+
+
+def _fake_session(get_return=None, get_side_effect=None) -> MagicMock:
+    session = MagicMock()
+    if get_side_effect is not None:
+        session.get.side_effect = get_side_effect
+    else:
+        session.get.return_value = get_return
+    return session
+
+
+def _ok_response(text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.text = text
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_download_success_returns_decoded_lines(mock_config):
+    exporter = _make_exporter(mock_config)
+    resp = _ok_response("line1\nline2\n")
+    session = _fake_session(get_return=resp)
+
+    with patch(
+        "mtui.update_workflow.export.auto.build_session", return_value=session
+    ) as bs:
+        out = exporter._openqa_installog_to_template(_url())
+
+    assert out == ["line1\n", "line2\n"]
+    # ssl_verify is None in mock_config -> per-site default True.
+    bs.assert_called_once_with(True)
+    assert session.get.call_args.kwargs["timeout"] == HTTP_TIMEOUT
+
+
+def test_download_default_falls_back_to_unverified_on_sslerror(mock_config):
+    exporter = _make_exporter(mock_config)
+    good = _fake_session(get_return=_ok_response("recovered\n"))
+    bad = _fake_session(get_side_effect=requests.exceptions.SSLError("cert"))
+
+    # First build_session() (verify=True) yields the failing session;
+    # the fallback build_session(verify=False) yields the good one.
+    with patch(
+        "mtui.update_workflow.export.auto.build_session",
+        side_effect=[bad, good],
+    ) as bs:
+        out = exporter._openqa_installog_to_template(_url())
+
+    assert out == ["recovered\n"]
+    assert bs.call_count == 2
+    assert bs.call_args_list[0].args == (True,)
+    assert bs.call_args_list[1].kwargs == {"verify": False}
+
+
+def test_download_ssl_verify_true_does_not_fall_back(mock_config, caplog):
+    mock_config.ssl_verify = True
+    exporter = _make_exporter(mock_config)
+    bad = _fake_session(get_side_effect=requests.exceptions.SSLError("cert"))
+
+    with (
+        patch("mtui.update_workflow.export.auto.build_session", return_value=bad) as bs,
+        caplog.at_level("ERROR", logger="mtui.export.auto"),
+    ):
+        out = exporter._openqa_installog_to_template(_url())
+
+    assert out == []
+    # Only the single verified attempt -- no insecure retry.
+    bs.assert_called_once_with(True)
+    assert any("failed to download" in r.message for r in caplog.records)
+
+
+def test_download_request_exception_returns_empty_and_logs(mock_config, caplog):
+    exporter = _make_exporter(mock_config)
+    session = _fake_session(
+        get_side_effect=requests.exceptions.ConnectionError("refused")
+    )
+
+    with (
+        patch("mtui.update_workflow.export.auto.build_session", return_value=session),
+        caplog.at_level("ERROR", logger="mtui.export.auto"),
+    ):
+        out = exporter._openqa_installog_to_template(_url())
+
+    assert out == []
+    assert any("failed to download" in r.message for r in caplog.records)
+
+
+def test_download_ssl_verify_false_skips_verification(mock_config):
+    mock_config.ssl_verify = False
+    exporter = _make_exporter(mock_config)
+    session = _fake_session(get_return=_ok_response("x\n"))
+
+    with patch(
+        "mtui.update_workflow.export.auto.build_session", return_value=session
+    ) as bs:
+        out = exporter._openqa_installog_to_template(_url())
+
+    assert out == ["x\n"]
+    bs.assert_called_once_with(False)

--- a/tests/test_export_auto_download.py
+++ b/tests/test_export_auto_download.py
@@ -58,28 +58,31 @@ def test_download_success_returns_decoded_lines(mock_config):
         out = exporter._openqa_installog_to_template(_url())
 
     assert out == ["line1\n", "line2\n"]
-    # ssl_verify is None in mock_config -> per-site default True.
+    # ssl_verify unset in mock_config resolves to the default: verify=True.
     bs.assert_called_once_with(True)
     assert session.get.call_args.kwargs["timeout"] == HTTP_TIMEOUT
 
 
-def test_download_default_falls_back_to_unverified_on_sslerror(mock_config):
+def test_download_sslerror_returns_empty_no_insecure_retry(mock_config, caplog):
+    """An SSL error is a hard failure: no silent downgrade to unverified.
+
+    ``ssl_verify`` defaults to ``True``; a certificate failure returns an
+    empty result and logs an error instead of retrying without
+    verification.
+    """
     exporter = _make_exporter(mock_config)
-    good = _fake_session(get_return=_ok_response("recovered\n"))
     bad = _fake_session(get_side_effect=requests.exceptions.SSLError("cert"))
 
-    # First build_session() (verify=True) yields the failing session;
-    # the fallback build_session(verify=False) yields the good one.
-    with patch(
-        "mtui.update_workflow.export.auto.build_session",
-        side_effect=[bad, good],
-    ) as bs:
+    with (
+        patch("mtui.update_workflow.export.auto.build_session", return_value=bad) as bs,
+        caplog.at_level("ERROR", logger="mtui.export.auto"),
+    ):
         out = exporter._openqa_installog_to_template(_url())
 
-    assert out == ["recovered\n"]
-    assert bs.call_count == 2
-    assert bs.call_args_list[0].args == (True,)
-    assert bs.call_args_list[1].kwargs == {"verify": False}
+    assert out == []
+    # Exactly one attempt with the default verify=True -- no insecure retry.
+    bs.assert_called_once_with(True)
+    assert any("failed to download" in r.message for r in caplog.records)
 
 
 def test_download_ssl_verify_true_does_not_fall_back(mock_config, caplog):

--- a/tests/test_export_downloader.py
+++ b/tests/test_export_downloader.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from mtui.support.messages import ResultsMissingError
 from mtui.update_workflow.export.downloader import (
@@ -23,15 +23,43 @@ from mtui.update_workflow.export.downloader import (
 
 
 def test_subdl_success() -> None:
-    with patch("mtui.update_workflow.export.downloader.urlretrieve") as urlretrieve:
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes",
+            return_value=b"log-bytes",
+        ) as get_bytes,
+        patch("mtui.update_workflow.export.downloader.atomic_write_file") as write_file,
+    ):
         _subdl("http://h/file", "/tmp/x", {"name": "t", "arch": "x"}, "tolerant")
-    urlretrieve.assert_called_once_with("http://h/file", "/tmp/x")
+    get_bytes.assert_called_once_with("http://h/file", verify=True)
+    # The downloaded bytes are written to the requested local path.
+    args, _ = write_file.call_args
+    assert args[0] == b"log-bytes"
+    assert str(args[1]) == "/tmp/x"
+
+
+def test_subdl_passes_verify_policy() -> None:
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes",
+            return_value=b"",
+        ) as get_bytes,
+        patch("mtui.update_workflow.export.downloader.atomic_write_file"),
+    ):
+        _subdl(
+            "http://h/file",
+            "/tmp/x",
+            {"name": "t", "arch": "x"},
+            "tolerant",
+            verify=False,
+        )
+    get_bytes.assert_called_once_with("http://h/file", verify=False)
 
 
 def test_subdl_http_error_tolerant_logs_no_raise(caplog) -> None:
-    err = urllib.error.HTTPError("http://h", 404, "no", {}, None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    err = requests.exceptions.HTTPError("404")
     with (
-        patch("mtui.update_workflow.export.downloader.urlretrieve", side_effect=err),
+        patch("mtui.update_workflow.export.downloader.get_bytes", side_effect=err),
         caplog.at_level("ERROR", logger="mtui.export.downloader"),
     ):
         _subdl("http://h/file", "/tmp/x", {"name": "t", "arch": "x"}, "tolerant")
@@ -39,9 +67,9 @@ def test_subdl_http_error_tolerant_logs_no_raise(caplog) -> None:
 
 
 def test_subdl_http_error_full_raises_results_missing() -> None:
-    err = urllib.error.HTTPError("http://h", 404, "no", {}, None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    err = requests.exceptions.HTTPError("404")
     with (
-        patch("mtui.update_workflow.export.downloader.urlretrieve", side_effect=err),
+        patch("mtui.update_workflow.export.downloader.get_bytes", side_effect=err),
         pytest.raises(ResultsMissingError),
     ):
         _subdl("http://h/file", "/tmp/x", {"name": "t", "arch": "x"}, "full")

--- a/tests/test_openqa_connector.py
+++ b/tests/test_openqa_connector.py
@@ -1,5 +1,6 @@
 """Tests for the mtui connector openqa modules."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -240,3 +241,44 @@ class TestAutoOpenQABool:
         auto_oqa.results = [MagicMock()]
         auto_oqa.pp = []
         assert bool(auto_oqa) is True
+
+
+# --- OpenQA client honors the global ssl_verify policy ---
+
+
+class TestOpenQAClientVerifyPolicy:
+    """The third-party OpenQA_Client session must carry the ssl_verify policy."""
+
+    @staticmethod
+    def _build(mock_config, mock_rrid, mock_incident):
+        # Give the patched client a plain object as its session so we can
+        # read back the verify attribute the connector sets on it.
+        with patch("mtui.data_sources.openqa.base.oqa") as oqa_cls:
+            client = MagicMock()
+            client.session = SimpleNamespace()
+            oqa_cls.return_value = client
+            return AutoOpenQA(
+                mock_config, "https://openqa.example.com", mock_incident, mock_rrid
+            )
+
+    def test_defaults_to_verify_true(self, mock_config, mock_rrid, mock_incident):
+        mock_config.ssl_verify = True
+        oqa = self._build(mock_config, mock_rrid, mock_incident)
+        assert oqa.client.session.verify is True
+
+    def test_unset_resolves_to_verify_true(self, mock_config, mock_rrid, mock_incident):
+        mock_config.ssl_verify = None
+        oqa = self._build(mock_config, mock_rrid, mock_incident)
+        assert oqa.client.session.verify is True
+
+    def test_disabled_when_config_false(self, mock_config, mock_rrid, mock_incident):
+        mock_config.ssl_verify = False
+        oqa = self._build(mock_config, mock_rrid, mock_incident)
+        assert oqa.client.session.verify is False
+
+    def test_ca_bundle_path_is_passed_through(
+        self, mock_config, mock_rrid, mock_incident
+    ):
+        mock_config.ssl_verify = "/etc/ssl/ca.pem"
+        oqa = self._build(mock_config, mock_rrid, mock_incident)
+        assert oqa.client.session.verify == "/etc/ssl/ca.pem"

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -711,3 +711,52 @@ def test_extract_test_results_rust_folds_via_summarize():
     # the totals must be > 0 for passed.
     assert "0 passed" not in summary
     assert "0 failed" in summary
+
+
+# --- set_verify: TLS policy for the shared search session ---
+
+
+@pytest.fixture
+def oqa_http_module():
+    """Yield the oqa_search http module, restoring its verify policy after."""
+    from mtui.data_sources.oqa_search import http as _oqa_http
+
+    original = _oqa_http._verify
+    yield _oqa_http
+    _oqa_http._verify = original
+    _oqa_http._session.cache_clear()
+
+
+def test_session_verifies_by_default(oqa_http_module):
+    """The shared search session verifies TLS unless told otherwise."""
+    _oqa_http = oqa_http_module
+    _oqa_http.set_verify(True)
+    assert _oqa_http._session().verify is True
+
+
+def test_set_verify_rebuilds_session_with_new_policy(oqa_http_module):
+    """Changing the policy clears the cache so the session is rebuilt."""
+    _oqa_http = oqa_http_module
+
+    _oqa_http.set_verify(True)
+    first = _oqa_http._session()
+    assert first.verify is True
+
+    _oqa_http.set_verify(False)
+    second = _oqa_http._session()
+    # A new session object with the new policy (cache was cleared).
+    assert second is not first
+    assert second.verify is False
+
+    # A CA-bundle path is honored verbatim.
+    _oqa_http.set_verify("/etc/ssl/ca.pem")
+    assert _oqa_http._session().verify == "/etc/ssl/ca.pem"
+
+
+def test_set_verify_same_value_keeps_cached_session(oqa_http_module):
+    """Setting the same policy does not rebuild the cached session."""
+    _oqa_http = oqa_http_module
+    _oqa_http.set_verify(True)
+    first = _oqa_http._session()
+    _oqa_http.set_verify(True)
+    assert _oqa_http._session() is first

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -583,9 +583,10 @@ def test_get_passes_timeout_to_requests(monkeypatch):
         captured["kwargs"] = kwargs
         return _FakeResponse()
 
-    monkeypatch.setattr(_qem_client.requests, "get", _fake_get)
-
     client = QEMDashboardClient("https://dashboard.example.com/api")
+    # The client routes every request through its shared session so the
+    # configured ssl_verify policy is applied; patch that session's get.
+    monkeypatch.setattr(client._session, "get", _fake_get)
     assert client.incident(123) == {"ok": True}
 
     assert captured["kwargs"]["timeout"] == _qem_client.HTTP_TIMEOUT
@@ -593,6 +594,16 @@ def test_get_passes_timeout_to_requests(monkeypatch):
     connect, read = _qem_client.HTTP_TIMEOUT
     assert connect > 0
     assert read > 0
+
+
+def test_client_session_honors_verify_policy():
+    """QEMDashboardClient pins the verify policy on its shared session."""
+    assert QEMDashboardClient("https://d/api")._session.verify is True
+    assert QEMDashboardClient("https://d/api", verify=False)._session.verify is False
+    assert (
+        QEMDashboardClient("https://d/api", verify="/ca.pem")._session.verify
+        == "/ca.pem"
+    )
 
 
 def test_load_jobs_skips_timed_out_per_setting_future(monkeypatch, mock_config, caplog):

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -588,9 +588,9 @@ def test_get_passes_timeout_to_requests(monkeypatch):
     client = QEMDashboardClient("https://dashboard.example.com/api")
     assert client.incident(123) == {"ok": True}
 
-    assert captured["kwargs"]["timeout"] == _qem_client._HTTP_TIMEOUT
+    assert captured["kwargs"]["timeout"] == _qem_client.HTTP_TIMEOUT
     # Sanity: the constant is a (connect, read) tuple of positive floats.
-    connect, read = _qem_client._HTTP_TIMEOUT
+    connect, read = _qem_client.HTTP_TIMEOUT
     assert connect > 0
     assert read > 0
 

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -419,6 +419,7 @@ def _make_config(**overrides):
         "refhosts_https_uri": "https://example.invalid/refhosts.yml",
         "refhosts_https_expiration": 3600,
         "location": "default",
+        "ssl_verify": None,
     }
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -498,8 +499,8 @@ class TestHttpsResolver:
             file_writer=file_writer,
             cache_path=Path("/dst"),
         )
-        resolver._refresh("https://x/refhosts.yml")
-        urlopener.assert_called_once_with("https://x/refhosts.yml")
+        resolver._refresh("https://x/refhosts.yml", True)
+        urlopener.assert_called_once_with("https://x/refhosts.yml", True)
         file_writer.assert_called_once_with(b"yaml-bytes", Path("/dst"))
 
     def test_refresh_if_needed_skips_when_fresh(self):
@@ -524,8 +525,24 @@ class TestHttpsResolver:
             cache_path=Path("/x"),
         )
         resolver._refresh_if_needed(_make_config())
-        urlopener.assert_called_once()
+        # ssl_verify unset -> per-site default True flows to the opener.
+        urlopener.assert_called_once_with("https://example.invalid/refhosts.yml", True)
         file_writer.assert_called_once_with(b"payload", Path("/x"))
+
+    def test_refresh_if_needed_honors_ssl_verify_override(self):
+        statter = MagicMock(return_value=SimpleNamespace(st_mtime=0))
+        url_resp = MagicMock()
+        url_resp.read.return_value = b"payload"
+        urlopener = MagicMock(return_value=url_resp)
+        resolver = _make_https_resolver(
+            statter=statter,
+            time_now_getter=MagicMock(return_value=1_000_000),
+            urlopener=urlopener,
+            file_writer=MagicMock(),
+            cache_path=Path("/x"),
+        )
+        resolver._refresh_if_needed(_make_config(ssl_verify=False))
+        urlopener.assert_called_once_with("https://example.invalid/refhosts.yml", False)
 
 
 class TestRefhostsFactory:

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -1,0 +1,108 @@
+"""Tests for the centralized HTTP timeout / TLS-verification helper."""
+
+import pytest
+
+from mtui.support import http as _http
+from mtui.support.config import _parse_ssl_verify
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_flag():
+    """Reset the module-level idempotency flag around each test."""
+    original = _http._warnings_disabled
+    _http._warnings_disabled = False
+    yield
+    _http._warnings_disabled = original
+
+
+def test_http_timeout_is_positive_connect_read_tuple():
+    connect, read = _http.HTTP_TIMEOUT
+    assert connect > 0
+    assert read > 0
+
+
+@pytest.mark.parametrize(
+    ("default", "override", "expected"),
+    [
+        (False, None, False),  # unset override -> keep per-site default
+        (True, None, True),
+        (False, True, True),  # override wins over default
+        (True, False, False),
+        (False, "/etc/ssl/ca.pem", "/etc/ssl/ca.pem"),  # CA bundle path
+    ],
+)
+def test_resolve_verify_precedence(default, override, expected):
+    assert _http.resolve_verify(default, override) == expected
+
+
+def test_build_session_sets_verify_true_and_keeps_warnings(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        _http.urllib3, "disable_warnings", lambda *a, **k: calls.append(a)
+    )
+
+    session = _http.build_session(verify=True)
+
+    assert session.verify is True
+    # Verification is on, so the insecure-request warning must stay active.
+    assert calls == []
+    assert _http._warnings_disabled is False
+
+
+def test_build_session_disables_warnings_when_verify_off(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        _http.urllib3, "disable_warnings", lambda *a, **k: calls.append(a)
+    )
+
+    session = _http.build_session(verify=False)
+
+    assert session.verify is False
+    assert len(calls) == 1
+    assert _http._warnings_disabled is True
+
+
+def test_build_session_with_ca_bundle_path_keeps_warnings(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        _http.urllib3, "disable_warnings", lambda *a, **k: calls.append(a)
+    )
+
+    session = _http.build_session(verify="/etc/ssl/ca.pem")
+
+    assert session.verify == "/etc/ssl/ca.pem"
+    # A truthy CA-bundle path is still "verifying", so no suppression.
+    assert calls == []
+
+
+def test_disable_insecure_warnings_is_idempotent(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        _http.urllib3, "disable_warnings", lambda *a, **k: calls.append(a)
+    )
+
+    _http.disable_insecure_warnings()
+    _http.disable_insecure_warnings()
+    _http.disable_insecure_warnings()
+
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("1", True),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("0", False),
+        ("  true  ", True),
+        ("/etc/ssl/ca-bundle.pem", "/etc/ssl/ca-bundle.pem"),
+    ],
+)
+def test_parse_ssl_verify(raw, expected):
+    assert _parse_ssl_verify(raw) == expected

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -106,3 +106,69 @@ def test_disable_insecure_warnings_is_idempotent(monkeypatch):
 )
 def test_parse_ssl_verify(raw, expected):
     assert _parse_ssl_verify(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_bytes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes, *, raise_exc: Exception | None = None) -> None:
+        self.content = content
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self) -> None:
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.get_calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self._response
+
+
+def test_get_bytes_returns_response_content(monkeypatch):
+    session = _FakeSession(_FakeResponse(b"payload-bytes"))
+    monkeypatch.setattr(_http, "build_session", lambda verify: session)
+
+    out = _http.get_bytes("https://h/file", verify=True)
+
+    assert out == b"payload-bytes"
+
+
+def test_get_bytes_passes_shared_timeout_by_default(monkeypatch):
+    session = _FakeSession(_FakeResponse(b""))
+    monkeypatch.setattr(_http, "build_session", lambda verify: session)
+
+    _http.get_bytes("https://h/file", verify=False)
+
+    assert session.get_calls[0][1]["timeout"] == _http.HTTP_TIMEOUT
+
+
+def test_get_bytes_honors_verify_argument(monkeypatch):
+    captured = {}
+
+    def fake_build_session(verify):
+        captured["verify"] = verify
+        return _FakeSession(_FakeResponse(b""))
+
+    monkeypatch.setattr(_http, "build_session", fake_build_session)
+
+    _http.get_bytes("https://h/file", verify="/etc/ssl/ca.pem")
+
+    assert captured["verify"] == "/etc/ssl/ca.pem"
+
+
+def test_get_bytes_raises_on_http_error_status(monkeypatch):
+    err = _http.requests.exceptions.HTTPError("404")
+    session = _FakeSession(_FakeResponse(b"", raise_exc=err))
+    monkeypatch.setattr(_http, "build_session", lambda verify: session)
+
+    with pytest.raises(_http.requests.exceptions.HTTPError):
+        _http.get_bytes("https://h/file", verify=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version < '3.12'",
-]
+requires-python = ">=3.13"
 
 [[package]]
 name = "alabaster"
@@ -39,7 +35,6 @@ version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -80,15 +75,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -155,10 +141,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
-    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
 ]
 
 [[package]]
@@ -179,31 +161,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
     { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
     { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
@@ -246,38 +203,6 @@ version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
-    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
-    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
-    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
     { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
     { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
     { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
@@ -356,36 +281,6 @@ version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
-    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
-    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
-    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
-    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
-    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
-    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
-    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
     { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
     { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
     { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
@@ -449,11 +344,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
 ]
 
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
 [[package]]
 name = "cryptography"
 version = "48.0.0"
@@ -505,12 +395,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
     { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
     { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
-    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -587,18 +471,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -632,9 +504,6 @@ wheels = [
 name = "jaraco-context"
 version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
@@ -705,7 +574,6 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
     { name = "jaraco-functools" },
@@ -736,28 +604,6 @@ version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
-    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
-    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
-    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
     { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
     { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
     { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
@@ -875,7 +721,6 @@ dependencies = [
     { name = "pyxdg" },
     { name = "requests" },
     { name = "ruamel-yaml" },
-    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -909,8 +754,7 @@ dev = [
 ]
 doc = [
     { name = "myst-parser" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx" },
 ]
 
 [package.metadata]
@@ -926,7 +770,6 @@ requires-dist = [
     { name = "requests" },
     { name = "rpm", marker = "extra == 'rpm'" },
     { name = "ruamel-yaml" },
-    { name = "typing-extensions", specifier = ">=4.5" },
     { name = "version-utils", marker = "extra == 'norpm'" },
 ]
 provides-extras = ["keyring", "mcp", "norpm", "notify", "rpm", "completion"]
@@ -955,8 +798,7 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
     { name = "pyyaml" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
@@ -1064,36 +906,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
-    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
-    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
-    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
-    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
-    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
-    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
-    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
-    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
     { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
     { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
     { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
@@ -1139,22 +951,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
-    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
-    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
-    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -1250,7 +1046,7 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", extra = ["toml"] },
+    { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -1282,12 +1078,6 @@ name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
     { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
     { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
     { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
@@ -1323,25 +1113,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
     { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
     { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
     { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
@@ -1379,7 +1150,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -1443,36 +1213,6 @@ version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
-    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
-    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
-    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
-    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
-    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
     { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
     { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
     { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
@@ -1560,18 +1300,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
     { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
-    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
-    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
-    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
-    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
-    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
 ]
 
 [[package]]
@@ -1650,60 +1378,26 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "9.0.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.12'",
-]
-dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
-]
-
-[[package]]
-name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -1783,65 +1477,10 @@ version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
-    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
-    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
-    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
-    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
-    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]
@@ -1949,13 +1588,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/44/c833e6b746ffb654e9abacf7ad6c2480a9c8c42e9637c1ae849964fb4dde/wcwidth-0.8.0.tar.gz", hash = "sha256:68a882ff6d14e3d14e0cae590b96a0551be64ce4905408112a8254434a1bdf69", size = 1305357, upload-time = "2026-06-05T21:19:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/17/c68b6cbcfeadbf420b3c3edaf8fda51335bc9c38732adb2d3ba8984dc607/wcwidth-0.8.0-py3-none-any.whl", hash = "sha256:8c75e6099cefd197c4bcc67a486f70b5dbc68f997c05f34a811d853910450d64", size = 324935, upload-time = "2026-06-05T21:19:33.999Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Why

Every place in mtui that makes outbound HTTP calls (Gitea client, QEM Dashboard, openQA/QAM search, the openQA job client, log download, refhosts.yml fetch) defined its own `(connect, read)` timeout constant and made its own inconsistent decision about TLS certificate verification. This meant:

- **No shared timeout:** a broken network could hang mtui indefinitely (the Gitea client had no timeout at all).
- **Inconsistent — and silent — TLS posture:** some call sites disabled verification unconditionally (`verify=False`), some used the bare `requests` default, and one retried unverified after a TLS error. There was no single, authoritative way for a user to control verification, and several paths skipped it behind the user's back.

This PR centralizes the timeout/TLS policy **and** makes `[mtui] ssl_verify` the one authoritative knob honored on every outbound connection, defaulting to verifying.

## What

Introduces `mtui.support.http` as the single source of truth for **both** timeout and TLS verification policy:

- **`HTTP_TIMEOUT`** — a `(connect, read)` tuple shared by all callers, bounding stuck sockets.
- **`resolve_verify(True, config.ssl_verify)`** — every call site resolves the global `[mtui] ssl_verify` config, defaulting to `True` (verify) when unset.
- **`build_session()` / `get_bytes()`** — shared session and GET-to-bytes helpers that apply the policy and suppress `InsecureRequestWarning` exactly once (only when verification is off).

### ssl_verify is now authoritative everywhere

`[mtui] ssl_verify` (`true` / `false` / a path to a CA bundle) **defaults to `true`** and is honored on every HTTP path:

- `mtui.data_sources.gitea` — per-site default flipped from `False` to verify-on; also gains the shared timeout (previously had none).
- `mtui.data_sources.oqa_search.http` — replaced the hardcoded `verify=False` cached session with a `set_verify()` policy the `openqa_overview` command sets from config.
- `mtui.data_sources.qem_dashboard.client` — previously used the bare `requests` default with no `verify`; now routes through a shared session pinned to the resolved policy, threaded through `QEMIncident` and the `updateid` call sites.
- `mtui.data_sources.openqa.base` — the third-party `OpenQA_Client` takes no `verify` argument; the resolved policy is now pinned on its `session.verify`.
- `mtui.update_workflow.export.auto` — dropped the "verify, then silently fall back to unverified on TLS error" behavior; an SSL failure is now a hard failure.
- `mtui.update_workflow.export.downloader` / `.kernel` — replaced raw `urllib` with `get_bytes()`, honoring the policy (already verify-on).
- `mtui.hosts.refhost` — fetches `refhosts.yml` via `get_bytes()` honoring `ssl_verify` (already verify-on).

Also raises the minimum supported Python version to 3.13 (dropping the `typing-extensions` backport).

## :warning: Breaking change

Outbound HTTP now **verifies TLS certificates by default** (`ssl_verify` defaults to `true`). Reaching internal hosts that present an internal-CA certificate (e.g. `openqa.suse.de`, `dashboard.qam.suse.de`) requires the SUSE CA in the system trust store, or:

- `ssl_verify = false` to disable verification everywhere, or
- `ssl_verify = /path/to/ca-bundle.pem` to verify against a custom CA bundle.

Previously these internal hosts worked out of the box because several call sites disabled verification by default.

## Changes

- `mtui/support/http.py` — central timeout + TLS policy; docs state verify-on-by-default.
- `mtui/support/config.py` — `ssl_verify` default `None` → `True`.
- `mtui/data_sources/gitea.py` — per-site default `False` → `True`.
- `mtui/data_sources/oqa_search/http.py` + `__init__.py` — `set_verify()` policy, no hardcoded `verify=False`.
- `mtui/data_sources/qem_dashboard/client.py` + `incident.py` — thread verify through a shared session.
- `mtui/data_sources/openqa/base.py` — pin policy on `OpenQA_Client.session.verify`.
- `mtui/commands/openqa_overview.py` — set the search verify policy from config.
- `mtui/types/updateid.py` — pass the resolved policy to `QEMIncident`.
- `mtui/update_workflow/export/auto.py` — drop the insecure unverified fallback.
- `mtui/update_workflow/export/downloader.py` / `kernel.py` — `get_bytes()` honoring verify.
- `mtui/hosts/refhost/__init__.py` — fetch `refhosts.yml` via `support.http`.
- `pyproject.toml` — minimum Python 3.13.
- `Documentation/cfg.rst` — document `[mtui] ssl_verify`.
- `CHANGELOG.md` — user-facing entries under Changed (incl. the breaking default).

## Testing

- `tests/test_support_http.py` — timeout, verify resolution, session building, warning suppression, `get_bytes`.
- `tests/test_export_downloader.py` — success, verify policy, request exceptions.
- `tests/test_export_auto_download.py` — reworked: an SSL error now returns empty with no insecure retry.
- New coverage for the previously-unguarded paths: `oqa_search.set_verify`, the openQA-client `session.verify`, and the QEM-client `session.verify`.
- `tests/test_refhost.py`, `tests/conftest.py` — updated for the verify-on default.

Local gates: `ruff format --check`, `ruff check`, `ty check`, `pytest` (1272 passed), and the docs build (`sphinx-build -W`) all pass.
