### PR TITLE
docs(docs): improve readability of configuration directives via consistent alignment

### DIFF
--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -15,6 +15,8 @@ overriding those from the former.
 
 Values found in configuration files can be overridden using command line options.
 
+.. _`INI-formatted`: https://docs.python.org/3/library/configparser.html
+
 Directives
 ==========
 
@@ -33,7 +35,7 @@ Gitea API access token, this config has higher prio than environment
 variable. Token must have full access to the issue API.
 
 ``lock.lock.pi_autolock``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
   | **type**
   |     bool
   | **default**


### PR DESCRIPTION
The configuration directives in `cfg.rst` had inconsistent indentation/alignment, which can make the documentation harder to scan. This change corrects the alignment of the `lock.lock.pi_autolock` directive to ensure a consistent and professional appearance.