### PR TITLE
Close MCP coverage gaps: bug titles, testreport file access, openqa_jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `list_bugs` now resolves the bug and Jira *titles* from the checkout's
+  `patchinfo.xml` instead of showing "Description not available" for
+  updates whose JSON metadata carries only ids (the git/SLFO and PI
+  workflows). A missing or malformed `patchinfo.xml` is ignored.
 - New `mtui-mcp` console script (optional `mcp` extra) ships a
   Model Context Protocol server, built on the official `mcp` Python
   SDK, that exposes every non-interactive mtui command as an MCP
-  tool, plus dedicated `testreport_read` / `testreport_patch` /
-  `testreport_write` tools, so LLM clients can drive a headless mtui
-  session over `stdio` or `http`. The `mcp` extra installs
+  tool, plus dedicated testreport tools — `testreport_read` /
+  `testreport_patch` / `testreport_write` to edit the report, and
+  `testreport_logs` / `testreport_read_file` to inspect the rest of the
+  checkout (the `build_checks/` and `install_logs/` files, `source.diff`,
+  `patchinfo.xml`) that the `log` file does not cover — so LLM clients
+  can drive a headless mtui session over `stdio` or `http`. The `mcp` extra installs
   `mcp[cli]>=1.2`; on openSUSE the SDK is packaged as
   `python3-mcp`. See `Documentation/mcp.rst` for the deny-list,
   per-client isolation model, and a `read → patch → read` worked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- New `openqa_jobs` command (auto-exposed over MCP as `mcp__mtui__openqa_jobs`)
+  lists the **individual** openQA jobs for the loaded update's incident build —
+  scenario, arch, result and job URL — so testers can see *which* jobs failed and
+  judge whether a failure relates to the package under test, rather than only the
+  per-version summary `openqa_overview` gives. `obsoleted` (superseded) jobs are
+  dropped by default; `--all` keeps them, `--failed` shows only non-passing jobs,
+  `--arch` filters by architecture.
 - `list_bugs` now resolves the bug and Jira *titles* from the checkout's
   `patchinfo.xml` instead of showing "Description not available" for
   updates whose JSON metadata carries only ids (the git/SLFO and PI

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -235,6 +235,49 @@ reuse.
   normal fetch).
 
 
+openqa_jobs
++++++++++++
+
+::
+
+  openqa_jobs [--all] [--failed] [--arch ARCH]
+              [--url-openqa URL] [--url-dashboard-qam URL]
+
+Lists the **individual** openQA jobs for the loaded update's incident build,
+so you can see *which* scenarios passed or failed (and judge whether a failure
+relates to the package under test) rather than only the per-version
+PASSED/FAILED/RUNNING summary that `openqa_overview`_ prints. Prints a per-result
+count summary followed by one colourised line per job (``result``, ``arch``,
+scenario, job URL).
+
+By default ``obsoleted`` jobs (superseded by a later retrigger) are dropped —
+only the current run matters.
+
+**Options:**
+
+.. option:: --all
+
+  Include ``obsoleted`` (superseded) jobs.
+
+.. option:: --failed
+
+  Show only non-passing jobs (``failed`` / ``parallel_failed`` / ``incomplete``;
+  ``passed``/``softfailed``/``skipped``/``obsoleted`` are hidden).
+
+.. option:: --arch ARCH
+
+  Only jobs for this architecture.
+
+.. option:: --url-openqa URL
+
+  Override the openQA host (otherwise ``config.openqa_instance``).
+
+.. option:: --url-dashboard-qam URL
+
+  Override the QAM Dashboard base URL (otherwise derived from
+  ``config.qem_dashboard_api``).
+
+
 set_workflow
 ++++++++++++
 

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -12,9 +12,11 @@ Synopsis
 
 ``mtui-mcp`` is a `Model Context Protocol`_ server that exposes a
 headless mtui session to LLM clients. Every non-interactive mtui
-command is auto-exposed as an MCP tool, and three dedicated tools
+command is auto-exposed as an MCP tool, and dedicated testreport tools
 (``testreport_read``, ``testreport_patch``, ``testreport_write``)
-replace the REPL's ``$EDITOR``-based ``edit`` flow.
+replace the REPL's ``$EDITOR``-based ``edit`` flow, with
+``testreport_logs`` and ``testreport_read_file`` exposing the rest of
+the checkout (build-check and install logs, ``source.diff``, …).
 
 Session state is isolated per client. Under ``stdio`` one process
 serves one client, so there is exactly one ``Config`` / loaded test
@@ -337,6 +339,22 @@ report is loaded.
     Full-file overwrite, same atomic-rename routine. Returns
     ``{"path", "bytes_written", "line_count"}``. Use this when line
     drift makes patching unreliable.
+
+``testreport_logs() -> dict``
+    Lists the auxiliary log files in the loaded testreport's checkout
+    that the ``log`` file does not cover: the per-package/arch
+    build-check logs (``build_checks/``) and the per-refhost install
+    logs (``install_logs/``). Returns ``{"path": str, "build_checks":
+    [{"name", "size"}], "install_logs": [{"name", "size"}]}``. Marked
+    ``readOnlyHint=True``.
+
+``testreport_read_file(relpath: str) -> dict``
+    Reads any file in the checkout by path relative to the checkout
+    directory — e.g. ``build_checks/<pkg>.<arch>.log``,
+    ``install_logs/<host>.log``, ``source.diff`` or ``patchinfo.xml``.
+    The path is resolved under the checkout and may **not** escape it
+    (``..`` traversal and absolute paths are refused). Returns
+    ``{"path", "line_count", "content"}``. Marked ``readOnlyHint=True``.
 
 .. warning::
 

--- a/mtui/commands/openqa_jobs.py
+++ b/mtui/commands/openqa_jobs.py
@@ -1,0 +1,118 @@
+"""The ``openqa_jobs`` interactive command.
+
+Lists the individual openQA jobs for the loaded update's incident build, so a
+tester (or an MCP client) can see *which* scenarios passed or failed — and judge
+whether a failure relates to the package under test — rather than only the
+per-version PASSED/FAILED/RUNNING summary that ``openqa_overview`` prints.
+
+By default ``obsoleted`` jobs (superseded by a later retrigger) are dropped; only
+the current run matters. Use ``--all`` to keep them, ``--failed`` to show only
+non-passing jobs, and ``--arch`` to filter by architecture.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from logging import getLogger
+
+from ..cli.argparse import ArgumentParser
+from ..cli.colors import green, red, yellow
+from ..data_sources import oqa_search as oqa
+from ..support.http import resolve_verify
+from ..support.misc import requires_update
+from . import Command
+
+logger = getLogger("mtui.commands.openqa_jobs")
+
+# openQA results that count as "not a failure" for the --failed filter.
+_PASSING = frozenset({"passed", "softfailed"})
+_NEUTRAL = frozenset({"obsoleted", "skipped"})
+
+
+class OpenQAJobs(Command):
+    """List the individual openQA jobs for the loaded update."""
+
+    command = "openqa_jobs"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Register the command's arguments."""
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="include obsoleted (superseded) jobs",
+        )
+        parser.add_argument(
+            "--failed",
+            action="store_true",
+            help="show only non-passing jobs (failed / parallel_failed / incomplete)",
+        )
+        parser.add_argument(
+            "--arch",
+            type=str,
+            default=None,
+            help="only jobs for this architecture",
+        )
+        parser.add_argument(
+            "--url-openqa",
+            type=str,
+            default=None,
+            help="Override openQA URL (default: config openqa_instance)",
+        )
+        parser.add_argument(
+            "--url-dashboard-qam",
+            type=str,
+            default=None,
+            help="Override QAM Dashboard base URL (default: derived from config)",
+        )
+
+    @requires_update
+    def __call__(self) -> None:
+        """Fetch and print the incident's openQA jobs."""
+        rrid = self.metadata.rrid
+        oqa.set_verify(resolve_verify(True, self.config.ssl_verify))
+
+        url_openqa = self.args.url_openqa or self.config.openqa_instance
+        url_dashboard_qam = self.args.url_dashboard_qam or (
+            self.config.qem_dashboard_api.rstrip("/").removesuffix("/api")
+        )
+
+        # incident_id is an int for Maintenance, "1.2" for SLFO; fall back to the
+        # review id (the gitea PR number) in the SLFO case -- mirrors openqa_overview.
+        incident_id = rrid.maintenance_id
+        effective_incident_id = (
+            incident_id if isinstance(incident_id, int) else rrid.review_id
+        )
+
+        try:
+            build, _ = oqa.get_incident_info(url_dashboard_qam, effective_incident_id)
+        except oqa._HTTPError as e:  # noqa: SLF001 -- module-internal exception
+            logger.error("Failed to query QEM Dashboard: %s", e)
+            return
+
+        jobs = oqa.incident_jobs(build, url_openqa, include_obsoleted=self.args.all)
+        if self.args.arch:
+            jobs = [j for j in jobs if j.arch == self.args.arch]
+        if self.args.failed:
+            jobs = [
+                j for j in jobs if j.result not in _PASSING and j.result not in _NEUTRAL
+            ]
+
+        if not jobs:
+            self.println(yellow(f"No openQA jobs for build {build!r}"))
+            return
+
+        counts = Counter(j.result for j in jobs)
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+        self.println(f"openQA jobs for build {build} ({len(jobs)}): {summary}")
+        self.println("")
+        for j in jobs:
+            if j.result in _PASSING:
+                colour = green
+            elif j.result in _NEUTRAL:
+                colour = yellow
+            else:
+                colour = red
+            self.println(
+                f"  {colour(j.result.ljust(15))} {j.arch:<8} {j.test}  {j.url}"
+            )

--- a/mtui/data_sources/oqa_search/__init__.py
+++ b/mtui/data_sources/oqa_search/__init__.py
@@ -44,7 +44,7 @@ from .heuristics import (
     TESTSUITE_WORDS_BLOCKLIST,
 )
 from .http import _fetch_url_content, _get_json, _HTTPError, _session, set_verify
-from .results import BuildCheckResult, GroupResult, VersionResult
+from .results import BuildCheckResult, GroupResult, JobResult, VersionResult
 from .search import (
     OVERVIEW_BEGIN_MARKER,
     OVERVIEW_END_MARKER,
@@ -71,6 +71,7 @@ from .search import (
     get_aggregated_groups,
     get_incident_groups,
     get_incident_info,
+    incident_jobs,
     log_matches_package,
     render_overview,
     single_incidents,
@@ -94,6 +95,7 @@ __all__ = [
     "TESTSUITE_WORDS_BLOCKLIST",
     "BuildCheckResult",
     "GroupResult",
+    "JobResult",
     "LogFileLinkParser",
     "VersionResult",
     "_HTTPError",
@@ -122,6 +124,7 @@ __all__ = [
     "get_aggregated_groups",
     "get_incident_groups",
     "get_incident_info",
+    "incident_jobs",
     "log_matches_package",
     "render_overview",
     "set_verify",

--- a/mtui/data_sources/oqa_search/results.py
+++ b/mtui/data_sources/oqa_search/results.py
@@ -35,3 +35,22 @@ class BuildCheckResult:
     url: str
     matches: list[str] = field(default_factory=list)
     summary: str = ""
+
+
+@dataclass
+class JobResult:
+    """One openQA job for an incident build.
+
+    ``result`` is openQA's job result: ``passed``, ``softfailed``,
+    ``failed``, ``parallel_failed``, ``incomplete``, ``skipped`` or
+    ``obsoleted`` (superseded by a retrigger). ``test`` is the scenario
+    name (the meaningful field for judging relevance — unlike the full
+    job name it does not embed the build string).
+    """
+
+    job_id: int
+    test: str
+    arch: str
+    result: str
+    group: str = ""
+    url: str = ""

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -33,7 +33,7 @@ from .heuristics import (
     TESTSUITE_WORDS_BLOCKLIST,
 )
 from .http import _fetch_url_content, _get_json, _HTTPError
-from .results import BuildCheckResult, GroupResult, VersionResult
+from .results import BuildCheckResult, GroupResult, JobResult, VersionResult
 
 logger = getLogger("mtui.connector.oqa_search")
 
@@ -75,6 +75,53 @@ def get_incident_info(
     versions = sorted(raw_versions)
 
     return build, versions or None
+
+
+def incident_jobs(
+    build: str, url_openqa: str, *, include_obsoleted: bool = False
+) -> list[JobResult]:
+    """List the individual openQA jobs for an incident ``build``.
+
+    Complements :func:`single_incidents` (which collapses jobs into a
+    per-version PASSED/FAILED/RUNNING summary) by returning one
+    :class:`JobResult` per job, so callers can judge *which* scenarios
+    failed and whether they relate to the package under test.
+
+    ``obsoleted`` jobs (superseded by a later retrigger) are dropped
+    unless ``include_obsoleted`` is set — only the current run matters.
+
+    Args:
+        build: The incident build name (from :func:`get_incident_info`).
+        url_openqa: Base openQA URL.
+        include_obsoleted: Keep superseded jobs in the result.
+
+    Returns:
+        The jobs, sorted by result then arch then scenario. Empty when
+        ``build`` is falsy or no jobs exist.
+
+    """
+    if not build:
+        return []
+    data = _get_json(f"{url_openqa}/api/v1/jobs?build={quote(build, safe='')}")
+    jobs = data.get("jobs", []) if isinstance(data, dict) else []
+    rows: list[JobResult] = []
+    for job in jobs:
+        result = job.get("result", "")
+        if result == "obsoleted" and not include_obsoleted:
+            continue
+        settings = job.get("settings") or {}
+        rows.append(
+            JobResult(
+                job_id=job.get("id", 0),
+                test=job.get("test") or job.get("name", ""),
+                arch=settings.get("ARCH") or job.get("arch", ""),
+                result=result,
+                group=job.get("group", ""),
+                url=f"{url_openqa.rstrip('/')}/t{job.get('id', '')}",
+            )
+        )
+    rows.sort(key=lambda r: (r.result, r.arch, r.test))
+    return rows
 
 
 def _fallback_build(url_dashboard_qam: str, incident_id: int | str) -> str:

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -12,6 +12,14 @@ directly on the file path tracked by ``session.metadata.path``:
   written atomically via ``NamedTemporaryFile`` + :func:`os.replace`.
 * :func:`testreport_write` — full-file overwrite, also atomic.
 
+Two further read-only tools expose the rest of the checkout that the
+``log`` file does not cover:
+
+* :func:`testreport_logs` — list the ``build_checks/`` and
+  ``install_logs/`` files (name + size).
+* :func:`testreport_read_file` — read any file under the checkout
+  directory by relative path (traversal-guarded).
+
 All three are ``async def``. The registered tool closures resolve the
 caller's own :class:`McpSession` from the
 :class:`mtui.mcp.registry.SessionProvider` (keyed on the request
@@ -90,6 +98,34 @@ def _resolve_testreport_path(session: McpSession) -> Path:
             1,
         )
     return Path(metadata.path)
+
+
+def _resolve_template_dir(session: McpSession) -> Path:
+    """Return the loaded testreport's checkout directory.
+
+    This is the parent of the ``log`` file (``metadata.path``) — the directory
+    holding ``metadata.json``, ``source.diff``, ``patchinfo.xml`` and the
+    ``build_checks/`` and ``install_logs/`` subdirectories. Raises the same
+    refusal as :func:`_resolve_testreport_path` when nothing is loaded.
+    """
+    return _resolve_testreport_path(session).parent
+
+
+def _safe_template_file(base: Path, relpath: str) -> Path:
+    """Resolve ``relpath`` under ``base``, refusing anything that escapes it.
+
+    Guards against ``..`` traversal and absolute paths so a tool call can only
+    read files inside the loaded checkout directory.
+    """
+    base_resolved = base.resolve()
+    target = (base_resolved / relpath).resolve()
+    if target != base_resolved and base_resolved not in target.parents:
+        raise McpCommandError(
+            "",
+            f"path {relpath!r} escapes the testreport directory",
+            1,
+        )
+    return target
 
 
 def _atomic_write_text(path: Path, text: str) -> int:
@@ -189,6 +225,69 @@ async def testreport_read(
     }
 
 
+async def testreport_logs(
+    session: McpSession,
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+) -> dict[str, Any]:
+    """List the auxiliary log files in the loaded testreport's checkout.
+
+    The build-check logs (per source package and arch) and the per-refhost
+    install logs live in ``build_checks/`` and ``install_logs/`` next to the
+    testreport, but are not part of the ``log`` file. This returns their
+    names (and byte sizes) so a caller can then fetch one with
+    :func:`testreport_read_file`.
+    """
+    await _heartbeat(ctx, "testreport_logs: waiting for session lock")
+    async with session._lock:
+        base = _resolve_template_dir(session)
+
+        def listing(sub: str) -> list[dict[str, Any]]:
+            d = base / sub
+            if not d.is_dir():
+                return []
+            return [
+                {"name": p.name, "size": p.stat().st_size}
+                for p in sorted(d.iterdir())
+                if p.is_file()
+            ]
+
+        return {
+            "path": str(base),
+            "build_checks": listing("build_checks"),
+            "install_logs": listing("install_logs"),
+        }
+
+
+async def testreport_read_file(
+    session: McpSession,
+    relpath: str,
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+) -> dict[str, Any]:
+    """Read a file from the loaded testreport's checkout by relative path.
+
+    Complements :func:`testreport_read` (which only returns the ``log``):
+    use this for ``build_checks/<pkg>.<arch>.log``, ``install_logs/<host>.log``,
+    ``source.diff``, ``patchinfo.xml`` and the like. ``relpath`` is resolved
+    under the checkout directory and may not escape it.
+    """
+    await _heartbeat(ctx, "testreport_read_file: waiting for session lock")
+    async with session._lock:
+        base = _resolve_template_dir(session)
+        target = _safe_template_file(base, relpath)
+        if not target.is_file():
+            raise McpCommandError(
+                "",
+                f"no such file in testreport checkout: {relpath}",
+                1,
+            )
+        content = target.read_text(encoding="utf-8", errors="replace")
+    return {
+        "path": str(target),
+        "line_count": _count_lines(content),
+        "content": content,
+    }
+
+
 async def testreport_patch(
     session: McpSession,
     start_line: int,
@@ -272,7 +371,7 @@ async def testreport_write(
 
 
 def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
-    """Register the three testreport tools on ``mcp``.
+    """Register the testreport tools on ``mcp``.
 
     Mirrors the registration shape used by :func:`mtui.mcp.tools.build_tools`
     so the boot log entries look uniform.
@@ -309,6 +408,14 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         session = await resolve_session(provider, ctx)
         return await testreport_read(session, ctx=ctx)
 
+    async def _logs(ctx: Context | None = None) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
+        return await testreport_logs(session, ctx=ctx)
+
+    async def _read_file(relpath: str, ctx: Context | None = None) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
+        return await testreport_read_file(session, relpath, ctx=ctx)
+
     async def _patch(
         start_line: int,
         end_line: int,
@@ -340,12 +447,36 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         "content. Atomic. Use this as the fallback when patching would "
         f"require tracking line-number drift across many edits. {_READ_FIRST_WARNING}"
     )
+    logs_desc = (
+        "List the auxiliary log files in the loaded testreport's checkout: the "
+        "per-package/arch build-check logs (build_checks/) and the per-refhost "
+        "install logs (install_logs/). Returns each file's name and size; fetch "
+        "one with testreport_read_file."
+    )
+    read_file_desc = (
+        "Read a file from the loaded testreport's checkout by relative path, "
+        "e.g. 'build_checks/<pkg>.<arch>.log', 'install_logs/<host>.log', "
+        "'source.diff' or 'patchinfo.xml'. The path may not escape the checkout "
+        "directory. Returns path, line count and full content."
+    )
 
     specs = (
         (
             "testreport_read",
             _read,
             read_desc,
+            ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        ),
+        (
+            "testreport_logs",
+            _logs,
+            logs_desc,
+            ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        ),
+        (
+            "testreport_read_file",
+            _read_file,
+            read_file_desc,
             ToolAnnotations(readOnlyHint=True, idempotentHint=True),
         ),
         (

--- a/mtui/test_reports/metadata_parsers.py
+++ b/mtui/test_reports/metadata_parsers.py
@@ -102,6 +102,43 @@ class JSONParser:
         results.packages = packages
 
 
+def patchinfo_titles(directory: Path) -> dict[str, str]:
+    """Map issue id -> title from a checkout's ``patchinfo.xml``.
+
+    The JSON metadata envelope only carries bare bug/jira *ids*, so
+    :class:`JSONParser` fills their descriptions with a placeholder. The
+    human-readable titles do exist in the checkout's ``patchinfo.xml``
+    (the same source the server uses to build the report's ``BUGS SUMMARY``),
+    as ``<issue tracker="bnc" id="123">title</issue>`` elements. This reads
+    them so callers can enrich the ids with real titles.
+
+    Best-effort: a missing or unparseable ``patchinfo.xml`` yields ``{}`` —
+    not every report kind ships one, and a malformed file must never break
+    loading.
+
+    Args:
+        directory: The checkout directory (where ``patchinfo.xml`` lives).
+
+    Returns:
+        A mapping of issue id to its title, empty when none are available.
+
+    """
+    pi = directory / "patchinfo.xml"
+    if not pi.is_file():
+        return {}
+    try:
+        root = ET.fromstring(pi.read_text(errors="replace"))
+    except ET.ParseError:
+        return {}
+    titles: dict[str, str] = {}
+    for issue in root.findall("issue"):
+        iid = (issue.get("id") or "").strip()
+        title = (issue.text or "").strip()
+        if iid and title:
+            titles[iid] = title
+    return titles
+
+
 # ---------------------------------------------------------------------------
 # Repository-information parsers (was mtui/repoparse.py).
 # ---------------------------------------------------------------------------

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -26,6 +26,7 @@ from ..support.fileops import ensure_dir_exists
 from ..support.messages import MetadataNotLoadedError
 from ..support.paths import scripts_path
 from ..types import OpenQAResults, Product, TargetMeta
+from .metadata_parsers import patchinfo_titles
 from .svn_io import (
     TemplateFormatError,
     TemplateIOError,
@@ -177,6 +178,24 @@ class TestReport(ABC):
             raise MetadataNotLoadedError
 
         self._parse_json(data, tpl)
+        self._enrich_issue_titles(path.parent)
+
+    def _enrich_issue_titles(self, directory: Path) -> None:
+        """Fill in real bug/jira titles from the checkout's ``patchinfo.xml``.
+
+        The JSON metadata only carries ids, so :class:`JSONParser` leaves a
+        placeholder description. ``patchinfo.xml`` (in the same checkout) has
+        the titles; here we overlay them onto the ids we already know about,
+        leaving the id set authoritative and untouched when no title is found.
+        """
+        titles = patchinfo_titles(directory)
+        if not titles:
+            return
+        for iid, title in titles.items():
+            if iid in self.bugs:
+                self.bugs[iid] = title
+            elif iid in self.jira:
+                self.jira[iid] = title
 
     def read(self, path: Path) -> None:
         """Reads a test report file.

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -47,6 +47,7 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("load_template", "mtui.commands.loadtemplate", "LoadTemplate"),
         ("lock", "mtui.commands.hostslock", "HostLock"),
         ("lrun", "mtui.commands.localrun", "LocalRun"),
+        ("openqa_jobs", "mtui.commands.openqa_jobs", "OpenQAJobs"),
         ("openqa_overview", "mtui.commands.openqa_overview", "OpenQAOverview"),
         ("prepare", "mtui.commands.prepare", "Prepare"),
         ("put", "mtui.commands.sftpcmd", "SFTPPut"),

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -271,8 +271,8 @@ def test_atomic_write_text_unlinks_tmp_on_failure(
 # --------------------------------------------------------------------------- #
 
 
-def test_register_testreport_tools_exposes_three_tools(tmp_path: Path) -> None:
-    """Smoke-test: three tools registered, ``readOnlyHint`` set as expected."""
+def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
+    """Smoke-test: all tools registered, ``readOnlyHint`` set as expected."""
     pytest.importorskip("mcp")
     from mcp.server.fastmcp import FastMCP
 
@@ -282,8 +282,10 @@ def test_register_testreport_tools_exposes_three_tools(tmp_path: Path) -> None:
     names = tt.register_testreport_tools(mcp, sess)
 
     assert names == [
+        "testreport_logs",
         "testreport_patch",
         "testreport_read",
+        "testreport_read_file",
         "testreport_write",
     ]
 
@@ -293,22 +295,71 @@ def test_register_testreport_tools_exposes_three_tools(tmp_path: Path) -> None:
         assert tool is not None, f"tool {n!r} missing after registration"
         tools[n] = tool
 
-    read_tool = tools["testreport_read"]
-    patch_tool = tools["testreport_patch"]
-    write_tool = tools["testreport_write"]
+    # The read-only tools advertise it; the mutating ones must not.
+    for n in ("testreport_read", "testreport_logs", "testreport_read_file"):
+        assert tools[n].annotations is not None
+        assert tools[n].annotations.readOnlyHint is True
+        assert tools[n].annotations.idempotentHint is True
+    for n in ("testreport_patch", "testreport_write"):
+        if tools[n].annotations is not None:
+            assert tools[n].annotations.readOnlyHint is not True
 
-    assert read_tool.annotations is not None
-    assert read_tool.annotations.readOnlyHint is True
-    assert read_tool.annotations.idempotentHint is True
+    # The read-first warning is glued onto each edit-flow description.
+    for n in ("testreport_read", "testreport_patch", "testreport_write"):
+        assert "testreport_read" in tools[n].description
 
-    # Patch/write must NOT be marked read-only.
-    for tool in (patch_tool, write_tool):
-        if tool.annotations is not None:
-            assert tool.annotations.readOnlyHint is not True
 
-    # The read-first warning is glued onto each description.
-    for tool in (read_tool, patch_tool, write_tool):
-        assert "testreport_read" in tool.description
+# --------------------------------------------------------------------------- #
+# Auxiliary checkout files: testreport_logs / testreport_read_file            #
+# --------------------------------------------------------------------------- #
+
+
+def test_logs_and_read_file_roundtrip(tmp_path: Path) -> None:
+    """``testreport_logs`` inventories the subdirs; ``read_file`` returns one."""
+    (tmp_path / "build_checks").mkdir()
+    (tmp_path / "install_logs").mkdir()
+    (tmp_path / "build_checks" / "libica.s390x.log").write_text("ok\nfine\n")
+    (tmp_path / "install_logs" / "host1.log").write_text("zypper\n")
+    sess = _loaded_session(tmp_path, tmp_path / "log")
+
+    logs = asyncio.run(tt.testreport_logs(sess))  # ty: ignore[invalid-argument-type]
+    assert [f["name"] for f in logs["build_checks"]] == ["libica.s390x.log"]
+    assert [f["name"] for f in logs["install_logs"]] == ["host1.log"]
+
+    out = asyncio.run(
+        tt.testreport_read_file(sess, "build_checks/libica.s390x.log")  # ty: ignore[invalid-argument-type]
+    )
+    assert out["content"] == "ok\nfine\n"
+    assert out["line_count"] == 2
+
+
+def test_logs_empty_when_subdirs_absent(tmp_path: Path) -> None:
+    sess = _loaded_session(tmp_path, tmp_path / "log")
+    logs = asyncio.run(tt.testreport_logs(sess))  # ty: ignore[invalid-argument-type]
+    assert logs["build_checks"] == []
+    assert logs["install_logs"] == []
+
+
+def test_read_file_missing_raises(tmp_path: Path) -> None:
+    sess = _loaded_session(tmp_path, tmp_path / "log")
+    with pytest.raises(McpCommandError, match="no such file"):
+        asyncio.run(tt.testreport_read_file(sess, "build_checks/nope.log"))  # ty: ignore[invalid-argument-type]
+
+
+def test_read_file_rejects_traversal(tmp_path: Path) -> None:
+    """A relative path escaping the checkout dir is refused."""
+    (tmp_path.parent / "secret.txt").write_text("nope\n")
+    sess = _loaded_session(tmp_path, tmp_path / "log")
+    with pytest.raises(McpCommandError, match="escapes"):
+        asyncio.run(tt.testreport_read_file(sess, "../secret.txt"))  # ty: ignore[invalid-argument-type]
+
+
+def test_logs_and_read_file_refuse_without_loaded_report(tmp_path: Path) -> None:
+    sess = _null_session(tmp_path)
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_logs(sess))
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_read_file(sess, "source.diff"))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_metadata_parsers.py
+++ b/tests/test_metadata_parsers.py
@@ -193,3 +193,29 @@ def test_obsrepoparse(tmpdir):
     # we except repos has product key with exact value
     product = Product("SLES", "15", "x86_64")
     assert repos[product] == "https://example.com/SLE-15-x86_64"
+
+
+def test_patchinfo_titles(tmp_path):
+    """patchinfo_titles maps issue ids to their titles from patchinfo.xml."""
+    (tmp_path / "patchinfo.xml").write_text(
+        """<patchinfo>
+          <issue tracker="bnc" id="1260938">Deprecate SHA1</issue>
+          <issue tracker="bnc" id="1265607">All-Zero HMAC Key Detected</issue>
+          <issue tracker="jsc" id="PED-1">A feature</issue>
+        </patchinfo>"""
+    )
+    titles = metadata_parsers.patchinfo_titles(tmp_path)
+    assert titles["1260938"] == "Deprecate SHA1"
+    assert titles["1265607"] == "All-Zero HMAC Key Detected"
+    assert titles["PED-1"] == "A feature"
+
+
+def test_patchinfo_titles_absent(tmp_path):
+    """No patchinfo.xml -> empty mapping (best effort, never raises)."""
+    assert metadata_parsers.patchinfo_titles(tmp_path) == {}
+
+
+def test_patchinfo_titles_malformed(tmp_path):
+    """Unparseable patchinfo.xml -> empty mapping rather than an exception."""
+    (tmp_path / "patchinfo.xml").write_text("<patchinfo><issue ")
+    assert metadata_parsers.patchinfo_titles(tmp_path) == {}

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -815,3 +815,70 @@ def test_set_verify_same_value_keeps_cached_session(oqa_http_module):
     first = _oqa_http._session()
     _oqa_http.set_verify(True)
     assert _oqa_http._session() is first
+
+
+@responses.activate
+def test_incident_jobs_drops_obsoleted_by_default():
+    """obsoleted jobs are dropped unless include_obsoleted is set."""
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                {
+                    "id": 1,
+                    "test": "fips_smoke",
+                    "result": "passed",
+                    "settings": {"ARCH": "s390x"},
+                },
+                {
+                    "id": 2,
+                    "test": "ha_2nodes",
+                    "result": "failed",
+                    "settings": {"ARCH": "s390x"},
+                },
+                {
+                    "id": 3,
+                    "test": "old_run",
+                    "result": "obsoleted",
+                    "settings": {"ARCH": "x86_64"},
+                },
+            ]
+        },
+        status=200,
+    )
+
+    rows = oqa_search.incident_jobs(":git:5137:libica", OPENQA)
+
+    assert [r.result for r in rows] == ["failed", "passed"]  # sorted, no obsoleted
+    failed = next(r for r in rows if r.result == "failed")
+    assert failed.test == "ha_2nodes"
+    assert failed.arch == "s390x"
+    assert failed.url == f"{OPENQA}/t2"
+
+
+@responses.activate
+def test_incident_jobs_include_obsoleted():
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                {
+                    "id": 3,
+                    "test": "x",
+                    "result": "obsoleted",
+                    "settings": {"ARCH": "x86_64"},
+                }
+            ]
+        },
+        status=200,
+    )
+    rows = oqa_search.incident_jobs(":b", OPENQA, include_obsoleted=True)
+    assert len(rows) == 1
+    assert rows[0].result == "obsoleted"
+
+
+def test_incident_jobs_empty_build_makes_no_request():
+    """A falsy build short-circuits with no HTTP call."""
+    assert oqa_search.incident_jobs("", OPENQA) == []


### PR DESCRIPTION
Three read-only improvements found while driving updates through `mtui-mcp`, where data that exists in the checkout / openQA wasn't reachable through mtui itself.

## `list_bugs`: resolve bug/Jira titles from `patchinfo.xml`

For updates whose JSON metadata carries only bug/Jira **ids** (git/SLFO, PI), `JSONParser` filled descriptions with `"Description not available"`. The titles already exist in the checkout's `patchinfo.xml` (the source the server uses for `BUGS SUMMARY`). New `metadata_parsers.patchinfo_titles()` reads them and `_open_and_parse` overlays them onto the known ids.

Before: `Bug #1260938: Description not available`
After: `Bug #1260938: [Security][FIPS 140-3][SLES16][SLM6.2][Libica] Deprecate SHA1`

## MCP: `testreport_logs` and `testreport_read_file`

`testreport_read` only exposed the loaded `log`. Added two read-only tools: `testreport_logs()` (lists `build_checks/` + `install_logs/` with sizes) and `testreport_read_file(relpath)` (reads any file under the checkout dir; traversal-guarded).

## `openqa_jobs` command (`mcp__mtui__openqa_jobs`)

`openqa_overview` only gives a per-version PASSED/FAILED/RUNNING summary, so judging *which* scenarios failed (and whether they relate to the package under test) meant hitting the openQA API by hand. New `openqa_jobs` lists the individual jobs (scenario / arch / result / URL) for the incident build, dropping `obsoleted` (superseded) runs by default; `--all`, `--failed`, `--arch` filters. Backed by `oqa_search.incident_jobs()` + a `JobResult` dataclass.

## Testing

`ruff format --check`, `ruff check`, `ty check` clean; `pytest -m 'not slow and not network'` green (new unit tests for all three); `sphinx-build -W` clean. `CHANGELOG.md` and `Documentation/{iui,mcp}.rst` updated.
