### PR TITLE
feat(gitea): expose current PR assignee for a review group

### DIFF
--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from functools import total_ordering
 from logging import getLogger
 from typing import Any, final, override
+from urllib.parse import urlparse
 
 import requests
 
@@ -27,6 +28,29 @@ from ..support.http import HTTP_TIMEOUT, VerifyPolicy, build_session, resolve_ve
 from ..types import assignment, method
 
 logger = getLogger("mtui.connector.gitea")
+
+
+def pr_api_url(web_url: str) -> str:
+    """Convert a Gitea PR *web* URL to its REST *API* URL.
+
+    ``https://<host>/<owner>/<repo>/pulls/<n>`` becomes
+    ``https://<host>/api/v1/repos/<owner>/<repo>/pulls/<n>`` — the form the
+    :class:`Gitea` constructor expects. The SLFO update feed only carries the
+    web form (an update's ``external_url``), so callers that build a client
+    straight from the feed need this conversion.
+
+    Raises:
+        ValueError: If ``web_url`` is not a recognisable Gitea PR URL.
+
+    """
+    parsed = urlparse(web_url)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) < 4 or parts[-2] != "pulls":
+        raise ValueError(f"not a Gitea PR URL: {web_url}")
+    owner, repo, _, number = parts[-4:]
+    return (
+        f"{parsed.scheme}://{parsed.netloc}/api/v1/repos/{owner}/{repo}/pulls/{number}"
+    )
 
 
 @dataclass
@@ -185,12 +209,42 @@ class Gitea:
             for c in cmts
         ]
 
+    @classmethod
+    def _assignee_from_comments(cls, comments: list[Comment], group: str) -> str | None:
+        """Replay assign/unassign markers and return the current assignee.
+
+        Simulates a state machine over the comments for ``group``: the last
+        valid assignment or unassignment marker wins. Returns the assignee's
+        username, or ``None`` when the group is currently unassigned.
+
+        Args:
+            comments: PR comments sorted chronologically (oldest first).
+            group: The review group whose markers to honour.
+
+        """
+        assignee: str | None = None
+        for c in comments:
+            if (match := cls.ASSIGN_RE.match(c.body)) and match.group("group") == group:
+                assignee = match.group("user")  # This user is now the assignee.
+            elif (match := cls.UNASSIGN_RE.match(c.body)) and match.group(
+                "group"
+            ) == group:
+                assignee = None  # The PR is now unassigned for this group.
+        return assignee
+
+    def assignee(self) -> str | None:
+        """Return the current assignee for this PR's group, or ``None``.
+
+        Reloads the comments and replays the assign/unassign markers (see
+        :meth:`_assignee_from_comments`). ``None`` means the group is
+        unassigned — no marker, or the last marker is an unassignment.
+        """
+        return self._assignee_from_comments(
+            sorted(self.__get_all_comments()), self.group
+        )
+
     def __check_assign(self, check_user: str | None = None) -> assignment:
         """Determines the current assignment state by parsing PR comments.
-
-        This method reads all comments, sorts them chronologically, and
-        simulates a state machine. The last valid assignment or unassignment
-        comment for the configured group determines the final state.
 
         Args:
             check_user: The user to check the assignment status for.
@@ -199,21 +253,7 @@ class Gitea:
             The assignment state.
 
         """
-        # Always reload comments to get the most up-to-date state.
-        comments = sorted(self.__get_all_comments())
-        assignee: str | None = None
-
-        # Iterate through comments chronologically to find the last state update.
-        for c in comments:
-            if match := self.ASSIGN_RE.match(c.body):
-                user, group = match.groups()
-                if group == self.group:
-                    assignee = user  # This user is now the assignee.
-            elif match := self.UNASSIGN_RE.match(c.body):
-                user, group = match.groups()
-                if group == self.group:
-                    assignee = None  # The PR is now unassigned for this group.
-
+        assignee = self.assignee()
         if assignee is None:
             return assignment.UNASSIGNED
         if assignee == check_user:

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 import responses
 
-from mtui.data_sources.gitea import Comment, Gitea
+from mtui.data_sources.gitea import Comment, Gitea, pr_api_url
 from mtui.support.exceptions import (
     FailedGiteaCallError,
     GiteaAssignInvalidError,
@@ -389,3 +389,91 @@ class TestAssignmentStateMachine:
 
         result = gitea._Gitea__check_assign("testuser")
         assert result == assignment.UNASSIGNED
+
+
+# --- PR web URL -> API URL conversion ---
+
+
+class TestPrApiUrl:
+    def test_converts_web_to_api(self):
+        """A Gitea PR web URL is rewritten to the REST API form."""
+        assert (
+            pr_api_url("https://src.example.de/products/SLFO/pulls/4919")
+            == "https://src.example.de/api/v1/repos/products/SLFO/pulls/4919"
+        )
+
+    def test_trailing_slash_ok(self):
+        """A trailing slash does not break parsing."""
+        assert (
+            pr_api_url("https://h.example/owner/repo/pulls/1/")
+            == "https://h.example/api/v1/repos/owner/repo/pulls/1"
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "https://h.example/owner/repo/issues/1",  # not a pulls URL
+            "https://h.example/owner/repo",  # too short
+            "not a url",
+        ],
+    )
+    def test_invalid_raises(self, bad):
+        """A non-PR URL raises ValueError."""
+        with pytest.raises(ValueError, match="not a Gitea PR URL"):
+            pr_api_url(bad)
+
+
+# --- Public assignee() and the static comment parser ---
+
+
+class TestAssignee:
+    @pytest.fixture
+    def gitea(self, mock_config):
+        api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
+        return Gitea(mock_config, api_url)  # type: ignore[arg-type]
+
+    def _c(self, serial, body, date):
+        return Comment(serial, body, datetime(2024, 1, date))
+
+    def test_parser_last_marker_wins(self):
+        """The last assign/unassign marker for the group decides the assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"), 1),
+            self._c(2, Gitea.ASSIGN_TEMPLATE % ("bob", "qam-sle"), 2),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") == "bob"
+
+    def test_parser_unassign_clears(self):
+        """An unassign marker after an assign clears the assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"), 1),
+            self._c(2, Gitea.UNASSIGN_TEMPLATE % ("alice", "qam-sle"), 2),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") is None
+
+    def test_parser_is_group_scoped(self):
+        """Markers for another group do not affect this group's assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("bob", "qam-openqa"), 1),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") is None
+        assert Gitea._assignee_from_comments(comments, "qam-openqa") == "bob"
+
+    @responses.activate
+    def test_assignee_returns_user(self, gitea):
+        """assignee() reads comments and returns the current assignee."""
+        comments = [
+            {
+                "id": 1,
+                "body": Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"),
+                "updated_at": "2024-01-01T00:00:00+00:00",
+            },
+        ]
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        assert gitea.assignee() == "alice"
+
+    @responses.activate
+    def test_assignee_none_when_unassigned(self, gitea):
+        """assignee() returns None when there is no marker."""
+        responses.add(responses.GET, gitea.prissues, json=[], status=200)
+        assert gitea.assignee() is None


### PR DESCRIPTION
## What

- Add `Gitea.assignee()` — returns the current assignee for the client's review group (or `None` when unassigned).
- Refactor the comment state-machine out of the private `__check_assign` into a reusable static `Gitea._assignee_from_comments(comments, group)`; `__check_assign` now delegates to it (behaviour unchanged).
- Add a module-level `pr_api_url(web_url)` that converts a PR **web** URL (e.g. an SLFO update's `external_url`, `https://<host>/<owner>/<repo>/pulls/<n>`) into the REST **API** URL the `Gitea` constructor expects.

## Why

Lets callers read per-PR assignment straight from mtui's assign/unassign comment markers without driving an `assign`/`approve` action. Needed by the follow-up that annotates the SLFO update queue with assignment state.

## Testing

`tests/test_gitea.py` gains coverage for `pr_api_url()` (valid + invalid URLs), the static parser (last-marker-wins, unassign clears, group-scoped), and `assignee()` (assigned / unassigned). Full suite green; ruff clean.