### PR TITLE
feat(smelt): add --unassigned/--show-assignment to smelt_updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable user-visible changes to MTUI are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `smelt_updates` gains `--unassigned` and `--show-assignment` (with `--group`,
+  default `qam-sle`) to surface each SLFO update's current assignee, read from the
+  PR's mtui assign/unassign comments via Gitea. The lookup is lazy and
+  highest-priority-first, so `smelt_updates --pending qam-sle-review --unassigned
+  --limit 1` returns the top unassigned update in a few calls; without the flags
+  the listing stays a single SMELT call.
+
 ## [18.0.1] - 2026-06-18
 
 ### Added

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -308,9 +308,12 @@ smelt_updates
 ::
 
     smelt_updates [--status STATUS] [--review-group GROUP]
-                  [--pending GROUP] [--limit N]
+                  [--pending GROUP] [--group GROUP]
+                  [--unassigned] [--show-assignment] [--limit N]
 
 Enumerates the SLFO update queue (highest priority first), one line per update.
+With ``--unassigned`` / ``--show-assignment`` it also resolves each update's
+current assignee from the pull request's mtui assign/unassign comments.
 
 **Options:**
 
@@ -326,6 +329,23 @@ Enumerates the SLFO update queue (highest priority first), one line per update.
 
   Only updates whose review by ``GROUP`` is not yet ``APPROVED`` (e.g.
   ``qam-sle-review`` — the actionable queue).
+
+.. option:: --group GROUP
+
+  Review group for the assignment lookup (default ``qam-sle``); used by
+  ``--unassigned`` and ``--show-assignment``.
+
+.. option:: --unassigned
+
+  Only updates with no current assignee for ``--group``. Assignment is read from
+  the PR's mtui assign/unassign comments via Gitea — one call per row, evaluated
+  highest-priority first and short-circuited by ``--limit``, so
+  ``--pending qam-sle-review --unassigned --limit 1`` finds the top unassigned
+  update cheaply. Needs a Gitea token; ignored with a hint if none is set.
+
+.. option:: --show-assignment
+
+  Add a column with each update's current assignee (or ``unassigned``).
 
 .. option:: --limit N
 

--- a/mtui/commands/smelt.py
+++ b/mtui/commands/smelt.py
@@ -5,7 +5,9 @@
 * ``smelt_checkers`` — checker (build-check) result runs for the loaded SLFO
   update.
 * ``smelt_updates`` — enumerate the SLFO (new) update queue with filters, e.g.
-  the testing updates still pending ``qam-sle-review``.
+  the testing updates still pending ``qam-sle-review``; ``--unassigned`` /
+  ``--show-assignment`` annotate each with the current assignee (read from the
+  PR's mtui comments via Gitea).
 * ``smelt_requests`` — enumerate the classic Maintenance (old) review-request
   queue, e.g. those pending ``qam-sle``.
 
@@ -18,7 +20,9 @@ from logging import getLogger
 
 from ..cli.argparse import ArgumentParser
 from ..data_sources import Smelt
+from ..data_sources.gitea import Gitea, pr_api_url
 from ..data_sources.smelt import slfo_update_id
+from ..support.exceptions import FailedGiteaCallError, MissingGiteaTokenError
 from ..support.misc import requires_update
 from ..types import RequestKind
 from . import Command
@@ -192,7 +196,16 @@ class SmeltRequests(Command):
 
 
 class SmeltUpdates(Command):
-    """Enumerate the SLFO update queue (with filters)."""
+    """Enumerate the SLFO update queue (with filters).
+
+    ``--unassigned`` keeps only updates nobody has picked up for ``--group``
+    (default ``qam-sle``); ``--show-assignment`` adds an assignee column.
+    Both derive the assignee from the PR's mtui assign/unassign comments via
+    Gitea, so they need a Gitea token. The lookup is one Gitea call per row
+    and runs lazily, highest-priority first, so e.g. ``--pending
+    qam-sle-review --unassigned --limit 1`` finds the top unassigned update in
+    only a few calls.
+    """
 
     command = "smelt_updates"
 
@@ -212,8 +225,40 @@ class SmeltUpdates(Command):
             help="only updates whose review by this group is not yet APPROVED",
         )
         parser.add_argument(
+            "--group",
+            default="qam-sle",
+            help="review group for assignment lookup (default: qam-sle)",
+        )
+        parser.add_argument(
+            "--unassigned",
+            action="store_true",
+            help="only updates not currently assigned to anyone for --group "
+            "(assignment is read from the PR's mtui comments)",
+        )
+        parser.add_argument(
+            "--show-assignment",
+            action="store_true",
+            help="show the current assignee column (per-PR Gitea lookup)",
+        )
+        parser.add_argument(
             "--limit", type=int, default=0, help="cap the number of rows (0 = all)"
         )
+
+    def _assignee(self, item: dict) -> str | None:
+        """Current assignee for ``item``'s PR and ``--group``, or ``None``.
+
+        Best-effort: a malformed URL or a Gitea hiccup logs at debug and
+        yields ``None`` (treated as unassigned) so one bad row never aborts
+        the listing.
+        """
+        url = item.get("external_url")
+        if not url:
+            return None
+        try:
+            return Gitea(self.config, pr_api_url(url), group=self.args.group).assignee()
+        except (ValueError, FailedGiteaCallError, MissingGiteaTokenError) as e:
+            logger.debug("assignee lookup failed for %s: %s", url, e)
+            return None
 
     def __call__(self) -> None:
         """Print the filtered SLFO update queue, highest priority first."""
@@ -238,15 +283,36 @@ class SmeltUpdates(Command):
                     continue
             out.append(it)
         out.sort(key=lambda x: -(x.get("priority") or 0))
-        if self.args.limit:
-            out = out[: self.args.limit]
+
+        want_assignment = self.args.unassigned or self.args.show_assignment
+        if want_assignment and not self.config.gitea_token:
+            self.println(
+                "assignment lookup needs a Gitea token ([gitea] token); "
+                "ignoring --unassigned/--show-assignment"
+            )
+            want_assignment = False
+
+        # Compute the assignee lazily, highest priority first, and stop as soon
+        # as --limit rows are collected — so --unassigned --limit 1 is cheap.
+        rows: list[tuple[dict, str | None]] = []
         for it in out:
+            assignee = self._assignee(it) if want_assignment else None
+            if self.args.unassigned and assignee is not None:
+                continue
+            rows.append((it, assignee))
+            if self.args.limit and len(rows) >= self.args.limit:
+                break
+
+        for it, assignee in rows:
             pkgs = [
                 p.get("name") for p in (it.get("packages") or []) if isinstance(p, dict)
             ]
-            self.println(
+            line = (
                 f"{str(it.get('human_readable_id', '')):20} "
                 f"{str(it.get('status')):16} prio={it.get('priority')}  "
-                f"{','.join(pkgs)[:50]}"
             )
-        self.println(f"\n{len(out)} update(s)")
+            if want_assignment:
+                line += f"{str(assignee or 'unassigned'):16} "
+            line += f"{','.join(pkgs)[:50]}"
+            self.println(line)
+        self.println(f"\n{len(rows)} update(s)")

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from functools import total_ordering
 from logging import getLogger
 from typing import Any, final, override
+from urllib.parse import urlparse
 
 import requests
 
@@ -27,6 +28,29 @@ from ..support.http import HTTP_TIMEOUT, VerifyPolicy, build_session, resolve_ve
 from ..types import assignment, method
 
 logger = getLogger("mtui.connector.gitea")
+
+
+def pr_api_url(web_url: str) -> str:
+    """Convert a Gitea PR *web* URL to its REST *API* URL.
+
+    ``https://<host>/<owner>/<repo>/pulls/<n>`` becomes
+    ``https://<host>/api/v1/repos/<owner>/<repo>/pulls/<n>`` — the form the
+    :class:`Gitea` constructor expects. The SLFO update feed only carries the
+    web form (an update's ``external_url``), so callers that build a client
+    straight from the feed need this conversion.
+
+    Raises:
+        ValueError: If ``web_url`` is not a recognisable Gitea PR URL.
+
+    """
+    parsed = urlparse(web_url)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) < 4 or parts[-2] != "pulls":
+        raise ValueError(f"not a Gitea PR URL: {web_url}")
+    owner, repo, _, number = parts[-4:]
+    return (
+        f"{parsed.scheme}://{parsed.netloc}/api/v1/repos/{owner}/{repo}/pulls/{number}"
+    )
 
 
 @dataclass
@@ -185,12 +209,42 @@ class Gitea:
             for c in cmts
         ]
 
+    @classmethod
+    def _assignee_from_comments(cls, comments: list[Comment], group: str) -> str | None:
+        """Replay assign/unassign markers and return the current assignee.
+
+        Simulates a state machine over the comments for ``group``: the last
+        valid assignment or unassignment marker wins. Returns the assignee's
+        username, or ``None`` when the group is currently unassigned.
+
+        Args:
+            comments: PR comments sorted chronologically (oldest first).
+            group: The review group whose markers to honour.
+
+        """
+        assignee: str | None = None
+        for c in comments:
+            if (match := cls.ASSIGN_RE.match(c.body)) and match.group("group") == group:
+                assignee = match.group("user")  # This user is now the assignee.
+            elif (match := cls.UNASSIGN_RE.match(c.body)) and match.group(
+                "group"
+            ) == group:
+                assignee = None  # The PR is now unassigned for this group.
+        return assignee
+
+    def assignee(self) -> str | None:
+        """Return the current assignee for this PR's group, or ``None``.
+
+        Reloads the comments and replays the assign/unassign markers (see
+        :meth:`_assignee_from_comments`). ``None`` means the group is
+        unassigned — no marker, or the last marker is an unassignment.
+        """
+        return self._assignee_from_comments(
+            sorted(self.__get_all_comments()), self.group
+        )
+
     def __check_assign(self, check_user: str | None = None) -> assignment:
         """Determines the current assignment state by parsing PR comments.
-
-        This method reads all comments, sorts them chronologically, and
-        simulates a state machine. The last valid assignment or unassignment
-        comment for the configured group determines the final state.
 
         Args:
             check_user: The user to check the assignment status for.
@@ -199,21 +253,7 @@ class Gitea:
             The assignment state.
 
         """
-        # Always reload comments to get the most up-to-date state.
-        comments = sorted(self.__get_all_comments())
-        assignee: str | None = None
-
-        # Iterate through comments chronologically to find the last state update.
-        for c in comments:
-            if match := self.ASSIGN_RE.match(c.body):
-                user, group = match.groups()
-                if group == self.group:
-                    assignee = user  # This user is now the assignee.
-            elif match := self.UNASSIGN_RE.match(c.body):
-                user, group = match.groups()
-                if group == self.group:
-                    assignee = None  # The PR is now unassigned for this group.
-
+        assignee = self.assignee()
         if assignee is None:
             return assignment.UNASSIGNED
         if assignee == check_user:

--- a/tests/test_cmd_smelt.py
+++ b/tests/test_cmd_smelt.py
@@ -59,7 +59,13 @@ def test_smelt_update_not_configured(mock_config):
 def test_smelt_updates_pending_filter(mock_config):
     sysmock = _sysmock()
     args = Namespace(
-        status="testing", review_group=None, pending="qam-sle-review", limit=0
+        status="testing",
+        review_group=None,
+        pending="qam-sle-review",
+        group="qam-sle",
+        unassigned=False,
+        show_assignment=False,
+        limit=0,
     )
     items = [
         {  # kept: testing + qam-sle-review not approved
@@ -147,3 +153,165 @@ def test_smelt_requests_pending_filter(mock_config):
     assert "libarchive" in out
     assert "req 2" not in out
     assert "1 request(s)" in out
+
+
+# --- smelt_updates assignment filtering (--unassigned / --show-assignment) ---
+
+
+def _uargs(**kw) -> Namespace:
+    base = {
+        "status": None,
+        "review_group": None,
+        "pending": None,
+        "group": "qam-sle",
+        "unassigned": False,
+        "show_assignment": False,
+        "limit": 0,
+    }
+    base.update(kw)
+    return Namespace(**base)
+
+
+def _assign_items() -> list[dict]:
+    return [
+        {
+            "human_readable_id": "p #1",
+            "status": "testing",
+            "priority": 100,
+            "external_url": "https://h/o/r/pulls/1",
+            "packages": [{"name": "a"}],
+        },
+        {
+            "human_readable_id": "p #2",
+            "status": "testing",
+            "priority": 90,
+            "external_url": "https://h/o/r/pulls/2",
+            "packages": [{"name": "b"}],
+        },
+        {
+            "human_readable_id": "p #3",
+            "status": "testing",
+            "priority": 80,
+            "external_url": "https://h/o/r/pulls/3",
+            "packages": [{"name": "c"}],
+        },
+    ]
+
+
+def _run_updates(cfg, args, assignees=None) -> str:
+    """Run SmeltUpdates with Smelt.unreleased mocked; return the printed output.
+
+    ``assignees`` maps external_url -> assignee (None = unassigned); when given,
+    ``_assignee`` is stubbed to consult it instead of hitting Gitea.
+    """
+    sysmock = _sysmock()
+    with patch("mtui.commands.smelt.Smelt") as cls:
+        smelt = cls.return_value
+        smelt.configured = True
+        smelt.unreleased.return_value = _assign_items()
+        if assignees is None:
+            SmeltUpdates(args, cfg, sysmock, MagicMock())()
+        else:
+
+            def _fake_assignee(self, item):
+                return assignees.get(item["external_url"])
+
+            with patch.object(SmeltUpdates, "_assignee", _fake_assignee):
+                SmeltUpdates(args, cfg, sysmock, MagicMock())()
+    return sysmock.stdout.getvalue()
+
+
+def test_plain_listing_has_no_assignee_column(mock_config):
+    """Without the flags, no assignment work happens and no column is shown."""
+    out = _run_updates(mock_config, _uargs())
+    assert "#1" in out
+    assert "#2" in out
+    assert "#3" in out
+    assert "unassigned" not in out
+    assert "3 update(s)" in out
+
+
+def test_unassigned_filters_out_assigned(mock_config):
+    assignees = {
+        "https://h/o/r/pulls/1": "alice",
+        "https://h/o/r/pulls/2": None,
+        "https://h/o/r/pulls/3": None,
+    }
+    out = _run_updates(mock_config, _uargs(unassigned=True), assignees)
+    assert "#1" not in out
+    assert "#2" in out
+    assert "#3" in out
+    assert "2 update(s)" in out
+
+
+def test_unassigned_limit_one_is_lazy(mock_config):
+    """--unassigned --limit 1 returns the top unassigned and stops probing."""
+    assignees = {
+        "https://h/o/r/pulls/1": "alice",
+        "https://h/o/r/pulls/2": None,
+        "https://h/o/r/pulls/3": None,
+    }
+    calls: list[str] = []
+    sysmock = _sysmock()
+
+    def _fake_assignee(self, item):
+        calls.append(item["external_url"])
+        return assignees.get(item["external_url"])
+
+    with (
+        patch("mtui.commands.smelt.Smelt") as cls,
+        patch.object(SmeltUpdates, "_assignee", _fake_assignee),
+    ):
+        cls.return_value.configured = True
+        cls.return_value.unreleased.return_value = _assign_items()
+        SmeltUpdates(
+            _uargs(unassigned=True, limit=1), mock_config, sysmock, MagicMock()
+        )()
+    out = sysmock.stdout.getvalue()
+    assert "#2" in out
+    assert "#1" not in out
+    assert "#3" not in out
+    assert "1 update(s)" in out
+    # Stopped after the first unassigned: #3 was never probed.
+    assert calls == ["https://h/o/r/pulls/1", "https://h/o/r/pulls/2"]
+
+
+def test_show_assignment_adds_column(mock_config):
+    assignees = {
+        "https://h/o/r/pulls/1": "alice",
+        "https://h/o/r/pulls/2": None,
+        "https://h/o/r/pulls/3": "bob",
+    }
+    out = _run_updates(mock_config, _uargs(show_assignment=True), assignees)
+    assert "alice" in out
+    assert "bob" in out
+    assert "unassigned" in out
+    assert "3 update(s)" in out
+
+
+def test_missing_token_skips_assignment(mock_config):
+    """Without a Gitea token, --unassigned is ignored with a hint."""
+    mock_config.gitea_token = ""
+    out = _run_updates(mock_config, _uargs(unassigned=True), assignees={})
+    assert "Gitea token" in out
+    assert "3 update(s)" in out  # filter ignored, all rows shown
+
+
+def test_assignee_uses_gitea_client(mock_config):
+    """_assignee builds a Gitea client from external_url and returns assignee()."""
+    sysmock = _sysmock()
+    with (
+        patch("mtui.commands.smelt.Smelt") as smelt_cls,
+        patch("mtui.commands.smelt.Gitea") as gitea_cls,
+    ):
+        smelt_cls.return_value.configured = True
+        smelt_cls.return_value.unreleased.return_value = _assign_items()
+        gitea_cls.return_value.assignee.return_value = "carol"
+        SmeltUpdates(
+            _uargs(show_assignment=True, limit=1), mock_config, sysmock, MagicMock()
+        )()
+    out = sysmock.stdout.getvalue()
+    assert "carol" in out
+    # The client is constructed with the API URL derived from external_url.
+    assert gitea_cls.call_args.args[1] == "https://h/api/v1/repos/o/r/pulls/1"
+    assert gitea_cls.call_args.kwargs["group"] == "qam-sle"

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 import responses
 
-from mtui.data_sources.gitea import Comment, Gitea
+from mtui.data_sources.gitea import Comment, Gitea, pr_api_url
 from mtui.support.exceptions import (
     FailedGiteaCallError,
     GiteaAssignInvalidError,
@@ -389,3 +389,91 @@ class TestAssignmentStateMachine:
 
         result = gitea._Gitea__check_assign("testuser")
         assert result == assignment.UNASSIGNED
+
+
+# --- PR web URL -> API URL conversion ---
+
+
+class TestPrApiUrl:
+    def test_converts_web_to_api(self):
+        """A Gitea PR web URL is rewritten to the REST API form."""
+        assert (
+            pr_api_url("https://src.example.de/products/SLFO/pulls/4919")
+            == "https://src.example.de/api/v1/repos/products/SLFO/pulls/4919"
+        )
+
+    def test_trailing_slash_ok(self):
+        """A trailing slash does not break parsing."""
+        assert (
+            pr_api_url("https://h.example/owner/repo/pulls/1/")
+            == "https://h.example/api/v1/repos/owner/repo/pulls/1"
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "https://h.example/owner/repo/issues/1",  # not a pulls URL
+            "https://h.example/owner/repo",  # too short
+            "not a url",
+        ],
+    )
+    def test_invalid_raises(self, bad):
+        """A non-PR URL raises ValueError."""
+        with pytest.raises(ValueError, match="not a Gitea PR URL"):
+            pr_api_url(bad)
+
+
+# --- Public assignee() and the static comment parser ---
+
+
+class TestAssignee:
+    @pytest.fixture
+    def gitea(self, mock_config):
+        api_url = "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
+        return Gitea(mock_config, api_url)  # type: ignore[arg-type]
+
+    def _c(self, serial, body, date):
+        return Comment(serial, body, datetime(2024, 1, date))
+
+    def test_parser_last_marker_wins(self):
+        """The last assign/unassign marker for the group decides the assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"), 1),
+            self._c(2, Gitea.ASSIGN_TEMPLATE % ("bob", "qam-sle"), 2),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") == "bob"
+
+    def test_parser_unassign_clears(self):
+        """An unassign marker after an assign clears the assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"), 1),
+            self._c(2, Gitea.UNASSIGN_TEMPLATE % ("alice", "qam-sle"), 2),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") is None
+
+    def test_parser_is_group_scoped(self):
+        """Markers for another group do not affect this group's assignee."""
+        comments = [
+            self._c(1, Gitea.ASSIGN_TEMPLATE % ("bob", "qam-openqa"), 1),
+        ]
+        assert Gitea._assignee_from_comments(comments, "qam-sle") is None
+        assert Gitea._assignee_from_comments(comments, "qam-openqa") == "bob"
+
+    @responses.activate
+    def test_assignee_returns_user(self, gitea):
+        """assignee() reads comments and returns the current assignee."""
+        comments = [
+            {
+                "id": 1,
+                "body": Gitea.ASSIGN_TEMPLATE % ("alice", "qam-sle"),
+                "updated_at": "2024-01-01T00:00:00+00:00",
+            },
+        ]
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        assert gitea.assignee() == "alice"
+
+    @responses.activate
+    def test_assignee_none_when_unassigned(self, gitea):
+        """assignee() returns None when there is no marker."""
+        responses.add(responses.GET, gitea.prissues, json=[], status=200)
+        assert gitea.assignee() is None


### PR DESCRIPTION
## What

Annotate the SLFO update queue (`smelt_updates`) with the current assignee:

- `--unassigned` — keep only updates nobody has picked up for `--group`.
- `--show-assignment` — add an assignee column.
- `--group` — review group for the lookup (default `qam-sle`).

Assignment is read from each PR's mtui assign/unassign comments via Gitea (`Gitea.assignee()`). The lookup is one Gitea call per row, computed **lazily** highest-priority-first and short-circuited by `--limit`, so the default listing (no flags) stays a single SMELT call, while:

```
smelt_updates --pending qam-sle-review --unassigned --limit 1
```

finds the top unassigned update in only a few calls. Without a Gitea token the flags are ignored with a hint instead of failing.

## Why

The SLFO feed has no per-tester assignment field — it lives in the PR's mtui comments. This makes "find the first unassigned update by priority" a single command instead of an out-of-tree script + custom Gitea comment walk.

## Depends on

Builds on #182 (`Gitea.assignee()` + `pr_api_url()`). Until #182 merges this PR's diff includes that commit; it will reduce to just the `smelt`/test changes once #182 lands.

## Testing

`tests/test_cmd_smelt.py` covers the plain listing (no assignment work), `--unassigned` filtering, lazy `--limit 1` (asserts probing stops at the first hit), `--show-assignment` column, the missing-token hint, and that `_assignee` builds the client from `external_url`. Full suite green; ruff clean.