### PR TITLE
fix(connection): bound SSH connect with connection_timeout; read it from [connection]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   --limit 1` returns the top unassigned update in a few calls; without the flags
   the listing stays a single SMELT call.
 
+### Fixed
+
+- The SSH connection setup now honours `connection_timeout` for the TCP
+  connect, SSH banner, and authentication (previously only remote command
+  execution was bounded, so a dead/firewalled refhost stalled on the OS TCP
+  timeout — making a bulk `add_host` appear to hang for minutes).
+- `connection_timeout` is now read from the `[connection]` section (falling
+  back to the legacy `[mtui]` section), matching where it is documented to live.
+
 ## [18.0.1] - 2026-06-18
 
 ### Added

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -70,7 +70,8 @@ class Connection:
         Args:
             hostname: The hostname or IP address of the remote host.
             port: The port number to connect to.
-            timeout: The timeout for remote commands.
+            timeout: Timeout in seconds for both establishing the connection
+                (TCP connect, SSH banner, auth) and remote command execution.
             missing_host_key_policy: paramiko policy applied to unknown
                 host keys. ``None`` (the default) preserves the legacy
                 behaviour of ``AutoAddPolicy``.
@@ -156,6 +157,9 @@ class Connection:
                     if "proxycommand" in opts
                     else None
                 ),
+                timeout=self.timeout,
+                banner_timeout=self.timeout,
+                auth_timeout=self.timeout,
             )
 
         except (paramiko.AuthenticationException, paramiko.BadHostKeyException):
@@ -185,6 +189,9 @@ class Connection:
                         if "proxycommand" in opts
                         else None
                     ),
+                    timeout=self.timeout,
+                    banner_timeout=self.timeout,
+                    auth_timeout=self.timeout,
                 )
             except paramiko.AuthenticationException:
                 # if a wrong password was set, don't connect to the host and

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -219,6 +219,14 @@ class Config:
         getint = self.config.getint
         getboolean = self.config.getboolean
 
+        def get_connection_timeout(section: str, option: str) -> str:
+            # Read from the [connection] section, falling back to the legacy
+            # [mtui] location so existing configs keep working.
+            try:
+                return self.config.get(section, option)
+            except (configparser.NoSectionError, configparser.NoOptionError):
+                return self.config.get("mtui", option)
+
         self.data: list[ConfigOption] = [
             ConfigOption(
                 "template_dir",
@@ -247,15 +255,15 @@ class Config:
                 Path,
                 get,
             ),
-            # connection.timeout appears to be in units of seconds as
-            # indicated by
-            # http://www.lag.net/paramiko/docs/paramiko.Channel-class.html#gettimeout
+            # Seconds. Bounds both establishing the SSH connection (TCP
+            # connect / banner / auth) and remote command execution. Read
+            # from [connection], falling back to the legacy [mtui] section.
             ConfigOption(
                 "connection_timeout",
-                ("mtui", "connection_timeout"),
+                ("connection", "connection_timeout"),
                 300,
                 int,
-                get,
+                get_connection_timeout,
             ),
             ConfigOption(
                 "svn_path",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,24 @@ def test_override_default_config(tmpdir):
     assert cfg.connection_timeout == 600
 
 
+def test_connection_timeout_from_connection_section(tmpdir):
+    """connection_timeout is read from the [connection] section."""
+    config_file = Path(tmpdir.join("test.cfg"))
+    config_file.write_text("[connection]\nconnection_timeout = 45\n")
+    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    assert cfg.connection_timeout == 45
+
+
+def test_connection_timeout_connection_section_wins(tmpdir):
+    """[connection] takes precedence over the legacy [mtui] location."""
+    config_file = Path(tmpdir.join("test.cfg"))
+    config_file.write_text(
+        "[mtui]\nconnection_timeout = 600\n[connection]\nconnection_timeout = 45\n"
+    )
+    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    assert cfg.connection_timeout == 45
+
+
 def test_smelt_url_defaults_empty_and_overrides(tmpdir):
     """smelt_url has no default (off unless configured) and reads [smelt] url."""
     empty = Path(tmpdir.join("empty.cfg"))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -55,7 +55,14 @@ def test_connection_init_success(mock_ssh_client, mock_ssh_config, mock_path):
     mock_ssh_client.load_system_host_keys.assert_called_once()
     mock_ssh_client.set_missing_host_key_policy.assert_called_once()
     mock_ssh_client.connect.assert_called_once_with(
-        hostname="test_host", port=22, username="root", key_filename=None, sock=None
+        hostname="test_host",
+        port=22,
+        username="root",
+        key_filename=None,
+        sock=None,
+        timeout=300,
+        banner_timeout=300,
+        auth_timeout=300,
     )
     assert conn.hostname == "test_host"
     assert conn.port == 22
@@ -74,7 +81,14 @@ def test_connection_init_auth_fallback(mock_ssh_client, mock_ssh_config, mock_pa
         assert mock_getpass.call_count == 1
         assert mock_ssh_client.connect.call_count == 2
         mock_ssh_client.connect.assert_any_call(
-            hostname="test_host", port=22, username="root", key_filename=None, sock=None
+            hostname="test_host",
+            port=22,
+            username="root",
+            key_filename=None,
+            sock=None,
+            timeout=300,
+            banner_timeout=300,
+            auth_timeout=300,
         )
         mock_ssh_client.connect.assert_any_call(
             hostname="test_host",
@@ -82,6 +96,9 @@ def test_connection_init_auth_fallback(mock_ssh_client, mock_ssh_config, mock_pa
             username="root",
             password="password",
             sock=None,
+            timeout=300,
+            banner_timeout=300,
+            auth_timeout=300,
         )
 
 


### PR DESCRIPTION
## Problem

`add_host` (especially with no `-t`, which connects the whole testplatform) could appear to hang for minutes. The connect phase is already parallel (`ThreadPoolExecutor` in `addhost.py` / `connect_targets`), but paramiko's `client.connect()` was called with **no timeout**, so a dead/firewalled refhost stalled on the OS TCP timeout and `concurrent.futures.wait()` blocked on that thread. `connection_timeout` only bounded *remote command execution*, never the connect.

There was also a latent config bug: `connection_timeout` was read from the `[mtui]` section, but it's documented/used under `[connection]`, so a value placed there was silently ignored.

## Fix

- Pass `connection_timeout` as paramiko's `timeout`, `banner_timeout` and `auth_timeout` on both `client.connect()` calls, so the TCP connect, SSH banner and auth phases are bounded by the same knob that already bounds command execution.
- Read `connection_timeout` from the `[connection]` section, falling back to the legacy `[mtui]` location for backward compatibility.
- Default unchanged (300s).

## Tests

- `tests/test_connection.py`: assert the connect kwargs now include `timeout`/`banner_timeout`/`auth_timeout`.
- `tests/test_config.py`: `connection_timeout` read from `[connection]`, and `[connection]` taking precedence over `[mtui]` (the `[mtui]` fallback is covered by the existing override test).
- Full suite green; ruff + ty clean.