### PR TITLE
fix(update): don't crash rollback on partial host set; surface UpdateError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A failed `update` no longer crashes with `KeyError(<hostname>)` during its
+  automatic rollback. The downgrade builds a command only for hosts with a
+  recorded previous version, but `RunCommand` ran it against the whole group;
+  it now acts only on the hosts a per-host command dict actually covers.
+- A failed `update` now surfaces the original `UpdateError` (e.g. a dependency
+  error) to the caller even when the rollback itself raises — previously a
+  rollback error masked the real reason the update failed, and a clean rollback
+  silently swallowed it.
 - The SSH connection setup now honours `connection_timeout` for the TCP
   connect, SSH banner, and authentication (previously only remote command
   execution was bounded, so a dead/firewalled refhost stalled on the OS TCP

--- a/mtui/hosts/target/actions.py
+++ b/mtui/hosts/target/actions.py
@@ -259,12 +259,19 @@ class RunCommand:
 
     def run(self) -> None:
         """Runs the command: parallel hosts in a pool, serial hosts one at a time."""
+        # When the command is a per-host dict, act only on the hosts it
+        # actually covers. Some callers build a command for a subset of the
+        # group (e.g. the downgrade rollback only targets hosts with a
+        # recorded previous version); running it against the rest would
+        # KeyError in ``_cmd_for``. A plain string command applies to all.
+        if isinstance(self.command, dict):
+            targets = {h: t for h, t in self.targets.items() if h in self.command}
+        else:
+            targets = self.targets
         parallel = {
-            h: t for h, t in self.targets.items() if t.mode is not ExecutionMode.SERIAL
+            h: t for h, t in targets.items() if t.mode is not ExecutionMode.SERIAL
         }
-        serial = {
-            h: t for h, t in self.targets.items() if t.mode is ExecutionMode.SERIAL
-        }
+        serial = {h: t for h, t in targets.items() if t.mode is ExecutionMode.SERIAL}
         lock = Lock()
 
         try:

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -354,7 +354,19 @@ class TestReport(ABC):
         except UpdateError:
             logger.error("Update failed")
             logger.warning("Error while updating. Rolling back changes")
-            self.perform_downgrade(targets)
+            try:
+                self.perform_downgrade(targets)
+            except Exception:
+                # A failure during rollback must not bury the original update
+                # error: log it and still re-raise the UpdateError below so the
+                # real reason (e.g. a dependency error) is what the user sees.
+                logger.error(
+                    "Rollback after the failed update did not complete cleanly"
+                )
+                logger.debug(format_exc())
+            # Surface the original update failure to the caller — the update did
+            # not apply, even though we attempted to roll back.
+            raise
 
     def perform_downgrade(self, targets):
         """Performs a `downgrade` operation.

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -51,6 +51,31 @@ def test_run_command_run_propagates_worker_exception():
         cmd.run()
 
 
+def test_run_command_dict_skips_targets_without_a_command():
+    """A per-host command dict missing a host must not KeyError on it.
+
+    The downgrade rollback builds a command for only the hosts that have a
+    recorded previous version; ``run`` must act on the covered hosts and skip
+    the rest rather than raising ``KeyError`` in ``_cmd_for``.
+    """
+    from mtui.hosts.target.actions import RunCommand
+    from mtui.types import ExecutionMode
+
+    covered = MagicMock()
+    covered.hostname = "h1"
+    covered.mode = ExecutionMode.PARALLEL
+    uncovered = MagicMock()
+    uncovered.hostname = "h2"
+    uncovered.mode = ExecutionMode.PARALLEL
+
+    # command dict covers only h1; h2 is in the group but has no command.
+    cmd = RunCommand({"h1": covered, "h2": uncovered}, {"h1": "true"})  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+    cmd.run()  # must not raise KeyError("h2")
+
+    covered.run.assert_called_once()
+    uncovered.run.assert_not_called()
+
+
 def test_run_parallel_no_work_is_noop():
     """``run_parallel([])`` must not allocate an executor."""
     from mtui.hosts.target.actions import run_parallel

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -251,14 +251,34 @@ def test_perform_update_happy_path(tmp_path: Path) -> None:
     targets.perform_update.assert_called_once_with(r, ["--quiet"])
 
 
-def test_perform_update_rolls_back_on_update_error(tmp_path: Path) -> None:
+def test_perform_update_rolls_back_then_reraises_on_update_error(
+    tmp_path: Path,
+) -> None:
     r = _make(tmp_path)
     r.packages = {"v": ["bash"]}
     targets = MagicMock()
     targets.perform_update.side_effect = UpdateError("boom", "h")
-    r.perform_update(targets, [])  # ty: ignore[invalid-argument-type]
+    # The update error is surfaced to the caller even though we roll back.
+    with pytest.raises(UpdateError, match="boom"):
+        r.perform_update(targets, [])  # ty: ignore[invalid-argument-type]
     # add_history called twice: once for update, once for the rollback
     assert targets.add_history.call_count == 2
+    targets.perform_downgrade.assert_called_once()
+
+
+def test_perform_update_reraises_update_error_even_if_rollback_fails(
+    tmp_path: Path,
+) -> None:
+    """A failed rollback must not mask the original update error."""
+    r = _make(tmp_path)
+    r.packages = {"v": ["bash"]}
+    targets = MagicMock()
+    targets.perform_update.side_effect = UpdateError("dependency error", "h1")
+    # Rollback blows up (e.g. the historical KeyError) — the caller must still
+    # see the original UpdateError, not the rollback exception.
+    targets.perform_downgrade.side_effect = KeyError("h2")
+    with pytest.raises(UpdateError, match="dependency error"):
+        r.perform_update(targets, [])  # ty: ignore[invalid-argument-type]
     targets.perform_downgrade.assert_called_once()
 
 


### PR DESCRIPTION
## Problem

A failed `update` could crash with `KeyError(<hostname>)` instead of reporting why it failed.

When `perform_update` hits an `UpdateError`, it rolls back via `perform_downgrade`. The downgrade builds a per-package command **only for hosts that have a recorded previous version**:
```python
cmd = {h: ... for h, t in self.data.items() if package in versions[h]}
self.run(cmd)
```
But `RunCommand.run()` executed that dict against the **whole** group and did `self.command[hostname]` for every host (`_cmd_for`), so any host the dict didn't cover raised `KeyError(<hostname>)`.

Found while testing a python313 update whose real problem was a zypper **dependency error** on install — the rollback then died with `KeyError('charon.qam.suse.cz')`, hiding the actual cause.

## Fix

- **`RunCommand.run`** now acts only on the hosts a per-host command **dict** covers (a plain string command still applies to every target). Partial-coverage commands (the downgrade case) no longer `KeyError`.
- **`perform_update`** guards the rollback and **re-raises the original `UpdateError`**, so the real reason (e.g. the dependency error) is surfaced even if the rollback itself raises — and a failed-but-rolled-back update is no longer silently swallowed.

## Tests

- `test_actions.py`: a command dict missing a host runs the covered host and skips the rest (no `KeyError`).
- `test_testreport.py`: `perform_update` re-raises `UpdateError` after rollback, and still re-raises it even when `perform_downgrade` itself raises.
- Full suite green; ruff + ty clean.