### PR TITLE
config/docs: remove unused template.smelt_threshold; document smelt.url; fix dev-setup --extra mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - Config is INI from `MTUI_CONF`, explicit `--config`, or `/etc/mtui.cfg` plus `~/.mtuirc`; `TEMPLATE_DIR`, `TMPDIR`, and `GITEA_TOKEN` are also read.
 
 ## Development Commands
-- Setup: `uv sync --extra norpm --group dev`. The `norpm` extra avoids requiring system `rpm` Python bindings by using `version_utils`.
+- Setup: `uv sync --extra norpm --extra mcp --group dev` (matches CI). The `norpm` extra avoids requiring system `rpm` Python bindings by using `version_utils`; the `mcp` extra provides `mcp`/`pydantic`, without which the `test_mcp_*` suites fail to import.
 - Full local gates matching CI: `uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check`, `uv run pytest`.
 - Auto-fix style: `uv run ruff format .` then `uv run ruff check --fix .`.
 - Coverage run: `uv run pytest -v --cov=./mtui --cov-report=xml --cov-report=term`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `connection_timeout` is now read from the `[connection]` section (falling
   back to the legacy `[mtui]` section), matching where it is documented to live.
 
+### Removed
+
+- Removed the `template.smelt_threshold` config option. It was parsed and
+  documented but never consumed by any command (intended to limit smelt-checkers
+  output in the template, never wired up).
+
 ## [18.0.1] - 2026-06-18
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,14 @@ The project uses [`uv`](https://docs.astral.sh/uv/) for environment and
 dependency management.
 
 ```sh
-uv sync --extra norpm --group dev
+uv sync --extra norpm --extra mcp --group dev
 ```
 
 This creates a virtualenv under `.venv/` containing mtui in editable
 mode plus the test and lint tooling. The `norpm` extra pulls in
 `version_utils` so the test suite runs without the system `rpm` Python
-bindings.
+bindings. The `mcp` extra pulls in `mcp`/`pydantic`, without which the
+`test_mcp_*` suites fail to import.
 
 To run mtui from the checkout:
 

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -339,6 +339,19 @@ This property takes a comma-separated list of resolver types.
 Resolvers are tried left-to-right.
 
 
+``smelt.url``
+~~~~~~~~~~~~~
+  | **type**
+  |     URL
+  | **default**
+  |     none (unset)
+
+Base URL of the SMELT instance used by the ``smelt_*`` commands and by
+``assign`` to show an update's priority and deadline. There is no built-in
+default: when it is unset the SMELT-backed features are silently skipped. Set it
+to ``https://smelt.suse.de`` to enable them.
+
+
 ``svn.path``
 ~~~~~~~~~~~~
   | **type**

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -381,17 +381,6 @@ MTUI checks out the testreport from, and commits it to,
 MTUI uses testsuites in this directory in refhosts.
 
 
-``template.smelt_threshold``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  | **type**
-  |     int 
-  | **default**
-  |     10 
-
-Set text wrapping for smelt checkers results.
-Default is first 10 lines in template.
-
-
 ``url.bugzilla``
 ~~~~~~~~~~~~~~~~
   | **type**

--- a/Documentation/developer.rst
+++ b/Documentation/developer.rst
@@ -86,11 +86,13 @@ dependency management.
 
 .. code-block:: sh
 
-    uv sync --extra norpm --group dev
+    uv sync --extra norpm --extra mcp --group dev
 
 This creates ``.venv/`` with mtui in editable mode plus the test and
 lint tooling. The ``norpm`` extra pulls in ``version_utils`` so the
-test suite runs without the system ``rpm`` Python bindings.
+test suite runs without the system ``rpm`` Python bindings. The ``mcp``
+extra pulls in ``mcp``/``pydantic``, without which the ``test_mcp_*``
+suites fail to import.
 
 To run mtui from the checkout:
 

--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -48,7 +48,7 @@ and pins dependencies via ``uv.lock``.
 
     git clone https://github.com/openSUSE/mtui.git
     cd mtui
-    uv sync --extra norpm --group dev
+    uv sync --extra norpm --extra mcp --group dev
     uv run mtui --help
 
 With pip

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -288,7 +288,7 @@ smelt_update
 Prints the loaded update's SMELT detail — priority, deadline, status, category,
 rating and packages. SLFO updates are read from SMELT's REST v2 API; classic
 Maintenance updates from its GraphQL API. Requires the SMELT base URL in
-``[smelt] url``.
+``[smelt] url`` (see :doc:`cfg`).
 
 
 smelt_checkers
@@ -299,7 +299,8 @@ smelt_checkers
     smelt_checkers
 
 Prints the checker (build-check) result runs for the loaded SLFO update — per run
-the checker type and pass/fail/warn/error/running counts. SLFO only.
+the checker type and pass/fail/warn/error/running counts. SLFO only. Requires the
+SMELT base URL in ``[smelt] url`` (see :doc:`cfg`).
 
 
 smelt_updates
@@ -313,7 +314,8 @@ smelt_updates
 
 Enumerates the SLFO update queue (highest priority first), one line per update.
 With ``--unassigned`` / ``--show-assignment`` it also resolves each update's
-current assignee from the pull request's mtui assign/unassign comments.
+current assignee from the pull request's mtui assign/unassign comments. Requires
+the SMELT base URL in ``[smelt] url`` (see :doc:`cfg`).
 
 **Options:**
 
@@ -361,7 +363,8 @@ smelt_requests
 
 Enumerates the classic Maintenance review-request queue (GraphQL) — the
 old-SMELT counterpart of `smelt_updates`_. Unlike the SLFO feed it shows the
-per-request assignee.
+per-request assignee. Requires the SMELT base URL in ``[smelt] url`` (see
+:doc:`cfg`).
 
 **Options:**
 

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -100,7 +100,6 @@ class Config:
     openqa_install_distri: str
     openqa_install_logs: str
     openqa_kernel_install_logs: str
-    threshold: int
     gitea_token: str
     ssl_verify: bool | str | None
     ssh_strict_host_key_checking: str
@@ -380,14 +379,6 @@ class Config:
                 ("openqa", "kernel_install_logfile"),
                 "update_kernel-zypper.log",
                 getter=get,
-            ),
-            # config for template export
-            ConfigOption(
-                "threshold",
-                ("template", "smelt_threshold"),
-                10,
-                int,
-                getint,
             ),
             # process location last as that needs to access
             # RefhostsFactory which need access to parts of config.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,7 +222,6 @@ def test_fixup_failure_logs_and_falls_back_to_default(
         # ``getint`` raises inside ``_get_option`` → caught in ``_parse_config``
         # → ERROR logged → default applied.
         ("refhosts", "https_expiration", "xyz", "refhosts_https_expiration", 3600 * 12),
-        ("template", "smelt_threshold", "nope", "threshold", 10),
         # ``getboolean`` raises inside ``_get_option`` → same path.
         ("mtui", "chdir_to_template_dir", "maybe", "chdir_to_template_dir", False),
         ("mtui", "use_keyring", "perhaps", "use_keyring", False),


### PR DESCRIPTION
## Summary

Three changes (config cleanup + docs):

1. **`docs(cfg)`: document `smelt.url`**
   The `[smelt] url` option was read by the code but absent from
   `cfg.rst`, the canonical config reference. Adds its section (type,
   default-unset behaviour, the `https://smelt.suse.de` value to set)
   and makes every `smelt_*` command section self-contained by linking
   to it.

2. **`refactor(config)!`: remove unused `template.smelt_threshold`**
   The option (exposed as `config.threshold`, default `10`) was parsed,
   typed, documented, and covered by one test, but **never read by any
   command**. It was intended to limit smelt-checkers output in the
   template, but that wiring was never added. Removes the dataclass
   annotation, the `ConfigOption`, the `cfg.rst` section, and the lone
   test parametrize row (the typed-getter fallback test keeps three
   other cases). Recorded in the changelog as it was a documented,
   user-facing config key.

3. **`docs`: include `--extra mcp` in dev-setup commands**
   The documented setup (`uv sync --extra norpm --group dev`) omitted
   the `mcp` extra, so the `test_mcp_*` suites fail to import
   `mcp`/`pydantic` on a fresh checkout. Aligns `AGENTS.md`,
   `CONTRIBUTING.md`, `Documentation/installation.rst`, and
   `Documentation/developer.rst` with CI
   (`uv sync --extra norpm --extra mcp --group dev`).

## Verification

Full CI-matching gate run locally, all green:

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 1327 passed
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html`

## Notes

The `template.smelt_threshold` removal is marked breaking (`!`) because
it drops a documented config key, though no functionality relied on it.