### PR TITLE
fix(refhosts): resilient refhosts.yml resolution and clearer TLS errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   tempdir`) is now expanded to the user's home directory instead of being used
   as a literal relative path, so a home-relative `refhosts.yml` location loads
   correctly.
+- Setting `[mtui] location` no longer breaks refhosts resolution during config
+  parsing with `'Config' object has no attribute 'ssl_verify'`. The `location`
+  option is now parsed after the `ssl_verify` and `refhosts_*` options it
+  depends on, so the validation resolve triggered by setting a location reads a
+  fully-populated config.
 - A failed `update` no longer crashes with `KeyError(<hostname>)` during its
   automatic rollback. The downgrade builds a command only for hosts with a
   recorded previous version, but `RunCommand` ran it against the whole group;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A failed Gitea API call caused by TLS certificate verification (common when
+  the SUSE root CA is not in the system trust store) now logs a single,
+  actionable message naming the two remedies — install the SUSE CA or set
+  `ssl_verify = false` (or a CA-bundle path) under `[mtui]` — instead of dumping
+  a multi-frame `SSLCertVerificationError` traceback. The full traceback is
+  still available at debug level.
 - The HTTPS refhosts resolver no longer fails silently when its on-disk cache
   directory (e.g. `~/.cache/mtui`) does not exist: the cache write now creates
   the destination directory. Previously the download succeeded but persisting it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A `~`-prefixed `[refhosts] path` (and `[mtui] install_logs`, `[target]
+  tempdir`) is now expanded to the user's home directory instead of being used
+  as a literal relative path, so a home-relative `refhosts.yml` location loads
+  correctly.
 - A failed `update` no longer crashes with `KeyError(<hostname>)` during its
   automatic rollback. The downgrade builds a command only for hosts with a
   recorded previous version, but `RunCommand` ran it against the whole group;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The HTTPS refhosts resolver no longer fails silently when its on-disk cache
+  directory (e.g. `~/.cache/mtui`) does not exist: the cache write now creates
+  the destination directory. Previously the download succeeded but persisting it
+  raised a `FileNotFoundError` that the resolver chain swallowed, making the
+  fetch appear to fail regardless of the `ssl_verify` setting.
+- A failing refhosts resolver now logs the real reason for the failure (e.g. the
+  underlying connection, file, or TLS error) at WARNING instead of only a
+  generic "resolver X failed" line, so refhosts download problems are
+  diagnosable without enabling debug logging.
 - A `~`-prefixed `[refhosts] path` (and `[mtui] install_logs`, `[target]
   tempdir`) is now expanded to the user's home directory instead of being used
   as a literal relative path, so a home-relative `refhosts.yml` location loads

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -24,7 +24,14 @@ from ..support.exceptions import (
     GiteaNoReviewError,
     MissingGiteaTokenError,
 )
-from ..support.http import HTTP_TIMEOUT, VerifyPolicy, build_session, resolve_verify
+from ..support.http import (
+    HTTP_TIMEOUT,
+    VerifyPolicy,
+    build_session,
+    is_ssl_verification_error,
+    resolve_verify,
+    ssl_verification_hint,
+)
 from ..types import assignment, method
 
 logger = getLogger("mtui.connector.gitea")
@@ -179,7 +186,14 @@ class Gitea:
                 timeout=HTTP_TIMEOUT,
             )
         except requests.exceptions.RequestException as e:
-            logger.exception("API call to Gitea failed: %s", e)
+            if is_ssl_verification_error(e):
+                # Non-technical users hit this against internal-CA hosts
+                # without the SUSE CA installed. Surface the actionable
+                # remedy at ERROR instead of a multi-frame traceback.
+                logger.error(ssl_verification_hint(urlparse(url).hostname))
+                logger.debug("Gitea TLS error detail: %s", e)
+            else:
+                logger.exception("API call to Gitea failed: %s", e)
             raise FailedGiteaCallError(f"{method} - {url}") from e
 
         if not rsp.ok:

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -181,8 +181,8 @@ class _RefhostsFactory:
                 continue
             try:
                 return resolver.resolve(config)
-            except Exception:
-                logger.warning("Refhosts: resolver %s failed", name)
+            except Exception as e:
+                logger.warning("Refhosts: resolver %s failed: %s", name, e)
                 logger.debug(format_exc())
 
         raise RefhostsResolveFailedError()

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -380,14 +380,6 @@ class Config:
                 "update_kernel-zypper.log",
                 getter=get,
             ),
-            # process location last as that needs to access
-            # RefhostsFactory which need access to parts of config.
-            ConfigOption(
-                "location",
-                ("mtui", "location"),
-                "default",
-                getter=get,
-            ),
             ConfigOption(
                 "gitea_token",
                 ("gitea", "token"),
@@ -463,6 +455,19 @@ class Config:
                 1800,
                 int,
                 getint,
+            ),
+            # ``location`` MUST be parsed last. Assigning it goes through the
+            # ``location`` property setter, which resolves refhosts to validate
+            # the location -- and the resolve reads ``ssl_verify`` and the
+            # ``refhosts_*`` options. Those must already be set on ``self``, so
+            # this option stays at the end of the list. Reordering it earlier
+            # reintroduces ``AttributeError: 'Config' object has no attribute
+            # 'ssl_verify'`` during config parsing.
+            ConfigOption(
+                "location",
+                ("mtui", "location"),
+                "default",
+                getter=get,
             ),
         ]
 

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -251,7 +251,7 @@ class Config:
                 "install_logs",
                 ("mtui", "install_logs"),
                 Path("install_logs"),
-                Path,
+                expanduser,
                 get,
             ),
             # Seconds. Bounds both establishing the SSH connection (TCP
@@ -307,7 +307,7 @@ class Config:
                 "target_tempdir",
                 ("target", "tempdir"),
                 Path("/tmp"),
-                Path,
+                expanduser,
                 get,
             ),
             ConfigOption(
@@ -339,7 +339,7 @@ class Config:
                 "refhosts_path",
                 ("refhosts", "path"),
                 Path("/usr/share/qam-metadata/refhosts.yml"),
-                Path,
+                expanduser,
                 get,
             ),
             ConfigOption(

--- a/mtui/support/fileops.py
+++ b/mtui/support/fileops.py
@@ -67,6 +67,12 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
     """
     if isinstance(data, bytes):
         data = data.decode("utf-8")
+    # Ensure the destination directory exists; ``mkstemp(dir=...)`` and the
+    # final ``move`` both require it. Cache locations such as
+    # ``~/.cache/mtui`` may be absent on a fresh checkout, which otherwise
+    # makes the write (e.g. the refhosts.yml HTTPS download) fail with a
+    # ``FileNotFoundError`` that masks the real reason for the resolve.
+    path.parent.mkdir(parents=True, exist_ok=True)
     fd, fname = mkstemp(dir=path.parent)
 
     with os.fdopen(fd, "w") as f:

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -31,6 +31,8 @@ who cannot install that CA can disable verification globally with
 
 from __future__ import annotations
 
+import ssl
+
 import requests
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
@@ -127,3 +129,43 @@ def get_bytes(
     response = session.get(url, timeout=timeout)
     response.raise_for_status()
     return response.content
+
+
+def is_ssl_verification_error(exc: BaseException) -> bool:
+    """Return ``True`` if ``exc`` is (or was caused by) a TLS cert failure.
+
+    ``requests`` wraps the underlying :class:`ssl.SSLCertVerificationError`
+    several layers deep (``requests.exceptions.SSLError`` ->
+    ``urllib3`` ``MaxRetryError`` -> ``ssl`` error), so this walks the
+    ``__cause__``/``__context__`` chain and also matches by message as a
+    last resort for transports that stringify the cause.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+        if isinstance(current, requests.exceptions.SSLError):
+            return True
+        current = current.__cause__ or current.__context__
+    return "CERTIFICATE_VERIFY_FAILED" in str(exc)
+
+
+def ssl_verification_hint(host: str | None = None) -> str:
+    """A short, actionable message for a TLS certificate-verification failure.
+
+    Aimed at non-technical users who hit an internal-CA host without the
+    SUSE CA installed: it names the two concrete remedies instead of
+    dumping a multi-frame traceback.
+    """
+    where = f" to {host}" if host else ""
+    return (
+        f"TLS certificate verification failed{where}. The server's "
+        "certificate could not be verified against your system's trust "
+        "store. To fix this, either install the SUSE root CA in your "
+        "system trust store, or disable verification by setting "
+        "'ssl_verify = false' under the [mtui] section of your mtui config "
+        "(e.g. ~/.mtuirc). You can also point 'ssl_verify' at a CA bundle "
+        "file: 'ssl_verify = /path/to/ca.pem'."
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,26 @@ def test_smelt_url_defaults_empty_and_overrides(tmpdir):
     )
 
 
+def test_path_options_expand_tilde(tmpdir):
+    """``~``-prefixed path options expand to the user's home directory."""
+    config_file = Path(tmpdir.join("test.cfg"))
+    config_file.write_text(
+        "[refhosts]\npath = ~/qam/refhosts.yml\n"
+        "[mtui]\ninstall_logs = ~/logs\n"
+        "[target]\ntempdir = ~/scratch\n"
+    )
+    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    assert cfg.refhosts_path == Path.home() / "qam/refhosts.yml"
+    assert cfg.install_logs == Path.home() / "logs"
+    assert cfg.target_tempdir == Path.home() / "scratch"
+    # An absolute path is passed through unchanged.
+    abs_cfg = Path(tmpdir.join("abs.cfg"))
+    abs_cfg.write_text("[refhosts]\npath = /usr/share/refhosts.yml\n")
+    assert config.Config(abs_cfg, refhosts=MockRefhosts).refhosts_path == Path(
+        "/usr/share/refhosts.yml"
+    )
+
+
 def test_merge_args(tmpdir):
     """Test merge_args."""
     config_file = Path(tmpdir.join("test.cfg"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,36 @@ def test_path_options_expand_tilde(tmpdir):
     )
 
 
+def test_ssl_verify_available_when_location_resolves_during_parse(tmpdir):
+    """Parsing ``location`` triggers the resolve, which reads ``ssl_verify``.
+
+    Regression: ``location`` was parsed before ``ssl_verify``, so the resolve
+    fired by the ``location`` setter raised ``AttributeError: 'Config' object
+    has no attribute 'ssl_verify'``. ``location`` must be parsed last so every
+    option the resolve depends on is already set.
+    """
+    seen: dict[str, object] = {}
+
+    class SslReadingRefhosts:
+        def __init__(self, cfg):
+            self._cfg = cfg
+
+        def check_location_sanity(self, location):
+            # Reading these must not raise during config parsing.
+            seen["ssl_verify"] = self._cfg.ssl_verify
+            seen["refhosts_resolvers"] = self._cfg.refhosts_resolvers
+
+        def __call__(self, cfg):
+            return SslReadingRefhosts(cfg)
+
+    cfg_file = Path(tmpdir.join("test.cfg"))
+    cfg_file.write_text("[mtui]\nlocation = nuremberg\nssl_verify = false\n")
+    cfg = config.Config(cfg_file, refhosts=SslReadingRefhosts(None))
+    assert cfg.location == "nuremberg"
+    assert cfg.ssl_verify is False
+    assert seen["ssl_verify"] is False
+
+
 def test_merge_args(tmpdir):
     """Test merge_args."""
     config_file = Path(tmpdir.join("test.cfg"))

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -78,6 +78,15 @@ def test_atomic_write(create_temp):
     atomic_write_file(data.encode(), Path(path) / "bytes")
 
 
+def test_atomic_write_creates_missing_parent(create_temp):
+    """The destination directory is created if absent (e.g. ~/.cache/mtui)."""
+    target = Path(create_temp) / "missing" / "nested" / "refhosts.yml"
+    assert not target.parent.exists()
+    atomic_write_file(b"data: 1\n", target)
+    assert target.exists()
+    assert target.read_text() == "data: 1\n"
+
+
 def test_timestamp():
     """Test timestamp."""
     assert isinstance(int(timestamp()), int)

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -298,6 +298,34 @@ class TestGiteaOperations:
         with pytest.raises(FailedGiteaCallError):
             gitea.get_hash()
 
+    @responses.activate
+    def test_ssl_error_logs_actionable_hint_without_traceback(self, gitea, caplog):
+        """A TLS cert failure logs a concise remedy at ERROR, no traceback."""
+        import ssl
+
+        import requests
+
+        cause = ssl.SSLCertVerificationError(
+            1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+        )
+        exc = requests.exceptions.SSLError("verify failed")
+        exc.__cause__ = cause
+        responses.add(responses.GET, gitea.pr, body=exc)
+
+        with (
+            caplog.at_level("ERROR", logger="mtui.connector.gitea"),
+            pytest.raises(FailedGiteaCallError),
+        ):
+            gitea.get_hash()
+
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert error_records, "expected an ERROR log for the SSL failure"
+        msg = error_records[0].getMessage()
+        assert "ssl_verify = false" in msg
+        assert "certificate" in msg.lower()
+        # The actionable ERROR must not carry a traceback (that stays at DEBUG).
+        assert all(r.exc_info is None for r in error_records)
+
     def test_repr(self, gitea):
         """Test Gitea repr."""
         result = repr(gitea)

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -568,6 +568,26 @@ class TestRefhostsFactory:
         assert rh is working.resolve.return_value
         assert any("resolver https failed" in r.message for r in caplog.records)
 
+    def test_call_logs_real_exception_cause(self, caplog):
+        """The resolver's actual exception message is surfaced, not just a
+        generic 'failed' line, so HTTPS failures are debuggable."""
+        failing = MagicMock(spec=refhost.Resolver)
+        failing.resolve.side_effect = FileNotFoundError(
+            2, "No such file or directory", "/home/u/.cache/mtui/refhosts.yml"
+        )
+        factory = refhost._RefhostsFactory({"https": failing})
+        cfg = _make_config(refhosts_resolvers="https")
+        with (
+            caplog.at_level("WARNING", logger="mtui.refhost"),
+            pytest.raises(refhost.RefhostsResolveFailedError),
+        ):
+            factory(cfg)
+        assert any(
+            "resolver https failed" in r.message
+            and "No such file or directory" in r.message
+            for r in caplog.records
+        )
+
     def test_call_raises_when_all_resolvers_fail(self):
         failing = MagicMock(spec=refhost.Resolver)
         failing.resolve.side_effect = RuntimeError("boom")

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -1,5 +1,7 @@
 """Tests for the centralized HTTP timeout / TLS-verification helper."""
 
+import ssl
+
 import pytest
 
 from mtui.support import http as _http
@@ -172,3 +174,65 @@ def test_get_bytes_raises_on_http_error_status(monkeypatch):
 
     with pytest.raises(_http.requests.exceptions.HTTPError):
         _http.get_bytes("https://h/file", verify=True)
+
+
+# ---------------------------------------------------------------------------
+# is_ssl_verification_error / ssl_verification_hint
+# ---------------------------------------------------------------------------
+
+
+def test_is_ssl_verification_error_detects_wrapped_cert_error():
+    inner = ssl.SSLCertVerificationError(
+        1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+    )
+    outer = _http.requests.exceptions.SSLError("wrapped")
+    outer.__cause__ = inner
+    assert _http.is_ssl_verification_error(outer) is True
+
+
+def test_is_ssl_verification_error_detects_requests_sslerror():
+    assert (
+        _http.is_ssl_verification_error(_http.requests.exceptions.SSLError("boom"))
+        is True
+    )
+
+
+def test_is_ssl_verification_error_matches_message_fallback():
+    # A generic error whose text mentions the cert failure still matches.
+    assert (
+        _http.is_ssl_verification_error(
+            RuntimeError("... CERTIFICATE_VERIFY_FAILED ...")
+        )
+        is True
+    )
+
+
+def test_is_ssl_verification_error_false_for_other_errors():
+    assert (
+        _http.is_ssl_verification_error(
+            _http.requests.exceptions.ConnectTimeout("timed out")
+        )
+        is False
+    )
+    assert _http.is_ssl_verification_error(ValueError("nope")) is False
+
+
+def test_is_ssl_verification_error_handles_cause_cycle():
+    # A self-referential cause must not loop forever.
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert _http.is_ssl_verification_error(a) is False
+
+
+def test_ssl_verification_hint_mentions_remedies():
+    msg = _http.ssl_verification_hint("src.suse.de")
+    assert "src.suse.de" in msg
+    assert "ssl_verify = false" in msg
+    assert "CA" in msg
+
+
+def test_ssl_verification_hint_without_host():
+    msg = _http.ssl_verification_hint()
+    assert "ssl_verify = false" in msg


### PR DESCRIPTION
## Summary

Fixes several rough edges around `refhosts.yml` resolution and TLS-verification UX that surface badly for users without the SUSE internal CA installed.

Each fix is a self-contained commit with tests and a CHANGELOG entry.

## Fixes

1. **`fix(config): expand ~ in refhosts path and other path options`**
   `refhosts_path`, `install_logs`, and `target_tempdir` used a bare `Path()`
   fixup, so a `~`-prefixed value (e.g. `[refhosts] path = ~/qam/refhosts.yml`)
   became a literal relative path and failed to load. They now use the existing
   `expanduser` fixup; absolute paths are unaffected.

2. **`fix(refhosts): make HTTPS resolver robust and surface real failures`**
   Two compounding bugs made the HTTPS resolver appear to fail regardless of
   `ssl_verify`:
   - `atomic_write_file` did not create the destination directory, so writing
     the download into a missing cache dir (e.g. `~/.cache/mtui` on a fresh
     checkout) raised `FileNotFoundError` after a successful fetch. It now
     creates `path.parent` first.
   - The resolver chain swallowed the real exception, logging only a generic
     `resolver X failed` at WARNING. It now includes the underlying cause.

3. **`fix(config): parse location last so ssl_verify is available during resolve`**
   Assigning `location` goes through its property setter, which resolves
   refhosts and reads `config.ssl_verify`. Because `location` was declared
   before `ssl_verify`, parsing it first raised
   `'Config' object has no attribute 'ssl_verify'`. `location` is now parsed
   last, after every option its validation resolve depends on.

4. **`fix(gitea): show actionable hint on TLS cert failure instead of traceback`**
   A Gitea API call failing on certificate verification dumped a multi-frame
   `SSLCertVerificationError` traceback with no guidance. New shared helpers
   `is_ssl_verification_error()` / `ssl_verification_hint()` in
   `mtui.support.http` detect the wrapped cert failure and render a concise
   remedy (install the SUSE CA, set `ssl_verify = false`, or point at a CA
   bundle). The Gitea client logs that hint at ERROR and keeps the full
   traceback at DEBUG.

## Testing

- Added focused tests in `test_config.py`, `test_refhost.py`, `test_fileops.py`,
  `test_support_http.py`, and `test_gitea.py`.
- Local CI gates all green: `ruff format --check`, `ruff check`, `ty check`,
  and `pytest` (1339 passed).