### PR TITLE
fix(connection): don't prompt for SSH password in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Running under MCP (`mtui-mcp`) no longer hangs when a refhost's SSH key
+  authentication fails. Previously the connect path fell back to an interactive
+  `getpass` root-password prompt, which has no TTY in MCP mode (stdin is the
+  JSON-RPC pipe) and blocked the session indefinitely. Non-interactive sessions
+  now skip the prompt and fail fast with a single actionable WARNING naming the
+  fix (set up working SSH key auth, verify with `ssh root@<host>`); the affected
+  host is reported as unreachable instead of stalling the whole client.
 - A failed Gitea API call caused by TLS certificate verification (common when
   the SUSE root CA is not in the system trust store) now logs a single,
   actionable message naming the two remedies — install the SUSE CA or set

--- a/mtui/hosts/connection/__init__.py
+++ b/mtui/hosts/connection/__init__.py
@@ -6,6 +6,11 @@ internal leaf-module split.
 """
 
 from .connection import Connection
-from .timeout import CommandTimeoutError, policy_from_config
+from .timeout import CommandTimeoutError, NonInteractiveAuthRequired, policy_from_config
 
-__all__ = ["CommandTimeoutError", "Connection", "policy_from_config"]
+__all__ = [
+    "CommandTimeoutError",
+    "Connection",
+    "NonInteractiveAuthRequired",
+    "policy_from_config",
+]

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -24,7 +24,7 @@ from paramiko import Channel, SFTPClient, SFTPFile, SSHClient, SSHConfig
 
 from ...cli.term import termsize
 from ...support.messages import ReConnectFailed
-from .timeout import CommandTimeoutError
+from .timeout import CommandTimeoutError, NonInteractiveAuthRequired
 
 logger = getLogger("mtui.connection")
 RETRIES: int = 5
@@ -42,6 +42,7 @@ class Connection:
     """Manages SSH and SFTP connections to a remote host."""
 
     __slots__ = [
+        "_interactive",
         "_policy",
         "_timeout_prompt",
         "client",
@@ -61,6 +62,7 @@ class Connection:
         timeout: int,
         missing_host_key_policy: paramiko.MissingHostKeyPolicy | None = None,
         timeout_prompt: Callable[[str], str] | None = None,
+        interactive: bool = True,
     ) -> None:
         """Opens an SSH channel to the specified host.
 
@@ -85,9 +87,17 @@ class Connection:
                 :class:`mtui.cli.prompter.Prompter`'s ``ask`` method here
                 to surface a serialised, race-free prompt to the user
                 when multiple targets run a command in parallel.
+            interactive: Whether a TTY-backed user is available to answer
+                an SSH password prompt. ``True`` (the default) preserves
+                the legacy behaviour: if key auth fails, fall back to
+                :func:`getpass.getpass`. ``False`` (e.g. under
+                ``mtui-mcp``, which has no TTY) skips the prompt and
+                raises :class:`NonInteractiveAuthRequired` instead of
+                blocking forever on an invisible password prompt.
 
         """
         self._timeout_prompt = timeout_prompt
+        self._interactive = interactive
         self.hostname = hostname
 
         try:
@@ -163,8 +173,27 @@ class Connection:
             )
 
         except (paramiko.AuthenticationException, paramiko.BadHostKeyException):
-            # if public key auth fails, fallback to a password prompt.
-            # other than ssh, mtui asks only once for a password. this could
+            # public key auth failed. The only remaining fallback is to
+            # ask the user for the root password, which needs a TTY.
+            if not self._interactive:
+                # No TTY (e.g. under mtui-mcp): a getpass prompt would be
+                # invisible to the client and block the process forever.
+                # Fail fast with a clear, actionable message instead.
+                logger.warning(
+                    "Authentication failed on %s: key auth did not succeed and "
+                    "password prompting is unavailable in non-interactive mode. "
+                    "Set up working SSH key authentication for this host "
+                    '(verify with "ssh root@%s").',
+                    self.hostname,
+                    self.hostname,
+                )
+                raise NonInteractiveAuthRequired(
+                    f"key authentication failed on {self.hostname} and no "
+                    "interactive password prompt is available"
+                ) from None
+
+            # Interactive session: fall back to a password prompt. Other
+            # than ssh, mtui asks only once for a password. this could
             # be changed if there is demand for it.
             logger.warning(
                 "Authentication failed on %s: AuthKey missing. Make sure your system is set up correctly",

--- a/mtui/hosts/connection/timeout.py
+++ b/mtui/hosts/connection/timeout.py
@@ -29,6 +29,22 @@ class CommandTimeoutError(Exception):
         return repr(self.command)
 
 
+class NonInteractiveAuthRequired(paramiko.AuthenticationException):
+    """Raised when key auth fails but no interactive password prompt is possible.
+
+    SSH public-key authentication failed and the only remaining fallback
+    is to ask the user for the root password. In a non-interactive
+    session (e.g. ``mtui-mcp``, which has no TTY and whose stdin is the
+    JSON-RPC pipe) that prompt cannot be shown and would block forever,
+    so we raise this instead.
+
+    Subclasses :class:`paramiko.AuthenticationException` so existing
+    ``except (paramiko.)AuthenticationException`` / ``except Exception``
+    handlers in the connect path keep catching it -- the host is simply
+    reported as unreachable rather than hanging the process.
+    """
+
+
 _HOST_KEY_POLICIES: dict[str, type[paramiko.MissingHostKeyPolicy]] = {
     "auto_add": paramiko.AutoAddPolicy,
     "warn": paramiko.WarningPolicy,

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -85,6 +85,7 @@ class Target:
         lock: type[TargetLock] = TargetLock,
         connection: type[Connection] = Connection,
         prompter: "Prompter | None" = None,
+        interactive: bool = True,
     ) -> None:
         """Initializes the `Target` object.
 
@@ -103,6 +104,11 @@ class Target:
                 cross-thread serialisation. ``None`` means "no prompt,
                 silently wait on timeout" — see
                 :class:`mtui.connection.Connection`.
+            interactive: Whether a TTY-backed user can answer an SSH
+                password prompt if key auth fails. Forwarded to
+                :class:`mtui.connection.Connection`; ``False`` (headless,
+                e.g. ``mtui-mcp``) makes a key-auth failure raise rather
+                than block on an invisible password prompt.
 
         """
         self.config = config
@@ -114,6 +120,7 @@ class Target:
         self.TargetLock = lock
         self.Connection = connection
         self._prompter = prompter
+        self._interactive = interactive
 
         self.state: TargetState | str = TargetState(state)
         # default timeout for target, used only on connecting/reconnecting Target
@@ -160,6 +167,7 @@ class Target:
                 self._timeout,
                 missing_host_key_policy=policy_from_config(policy_name),
                 timeout_prompt=self._prompter.ask if self._prompter else None,
+                interactive=self._interactive,
             )
         except Exception as e:
             logger.critical(messages.ConnectingTargetFailedMessage(self.hostname, e))

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -497,6 +497,7 @@ class TestReport(ABC):
                 self.packages,
                 timeout=self.config.connection_timeout,
                 prompter=self._prompter,
+                interactive=self._prompter is not None,
             )
             target.connect()
             new_system = str(target.system)
@@ -577,6 +578,7 @@ class TestReport(ABC):
                 hostname,
                 self.packages,
                 prompter=self._prompter,
+                interactive=self._prompter is not None,
             )
             self.targets[hostname].connect()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 import paramiko
 import pytest
 
-from mtui.hosts.connection import CommandTimeoutError, Connection, policy_from_config
+from mtui.hosts.connection import (
+    CommandTimeoutError,
+    Connection,
+    NonInteractiveAuthRequired,
+    policy_from_config,
+)
 
 
 @pytest.fixture
@@ -100,6 +105,47 @@ def test_connection_init_auth_fallback(mock_ssh_client, mock_ssh_config, mock_pa
             banner_timeout=300,
             auth_timeout=300,
         )
+
+
+def test_connection_noninteractive_auth_fail_raises_without_getpass(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """Non-interactive: a key-auth failure must NOT prompt for a password.
+
+    Under ``mtui-mcp`` there is no TTY, so ``getpass.getpass`` would block
+    forever on an invisible prompt. With ``interactive=False`` the
+    fallback is skipped entirely and ``NonInteractiveAuthRequired`` is
+    raised instead (the original hang reported against homer.qam.suse.cz).
+    """
+    mock_ssh_client.connect.side_effect = paramiko.AuthenticationException
+
+    with patch("getpass.getpass") as mock_getpass:
+        with pytest.raises(NonInteractiveAuthRequired):
+            Connection("test_host", 22, 300, interactive=False)
+
+        mock_getpass.assert_not_called()
+        # Only the initial key-auth attempt happened; no password retry.
+        assert mock_ssh_client.connect.call_count == 1
+
+
+def test_connection_noninteractive_bad_host_key_raises_without_getpass(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """A BadHostKeyException is treated the same as auth failure when headless."""
+    mock_ssh_client.connect.side_effect = paramiko.BadHostKeyException(
+        "test_host", MagicMock(), MagicMock()
+    )
+
+    with patch("getpass.getpass") as mock_getpass:
+        with pytest.raises(NonInteractiveAuthRequired):
+            Connection("test_host", 22, 300, interactive=False)
+
+        mock_getpass.assert_not_called()
+
+
+def test_connection_noninteractive_auth_fail_is_paramiko_auth_subclass():
+    """The raised error stays catchable by existing AuthenticationException handlers."""
+    assert issubclass(NonInteractiveAuthRequired, paramiko.AuthenticationException)
 
 
 def test_run_command_success(mock_ssh_client, mock_ssh_config, mock_path):

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -325,6 +325,36 @@ def test_connect_target_exception_returns_false_false(tmp_path: Path) -> None:
     assert out == (False, False)
 
 
+def test_connect_target_noninteractive_when_no_prompter(tmp_path: Path) -> None:
+    """No prompter (MCP / headless) -> Target built with interactive=False.
+
+    This is the ``add_host`` path that previously hung: a key-auth failure
+    must not drop into an invisible ``getpass`` prompt under MCP.
+    """
+    r = _make(tmp_path)
+    assert r._prompter is None
+    fake_target = MagicMock()
+    fake_target.system = "sles15"
+    with patch(
+        "mtui.test_reports.testreport.Target", return_value=fake_target
+    ) as target_cls:
+        r.connect_target("h1")
+    assert target_cls.call_args.kwargs["interactive"] is False
+
+
+def test_connect_target_interactive_when_prompter_present(tmp_path: Path) -> None:
+    """A real prompter (REPL) -> Target built with interactive=True."""
+    r = _make(tmp_path)
+    r._prompter = MagicMock()
+    fake_target = MagicMock()
+    fake_target.system = "sles15"
+    with patch(
+        "mtui.test_reports.testreport.Target", return_value=fake_target
+    ) as target_cls:
+        r.connect_target("h1")
+    assert target_cls.call_args.kwargs["interactive"] is True
+
+
 # ---------------------------------------------------------------------------
 # add_target
 # ---------------------------------------------------------------------------
@@ -338,6 +368,24 @@ def test_add_target_already_connected_warns_and_returns(tmp_path: Path, caplog) 
     with caplog.at_level(logging.WARNING, logger="mtui.template.testreport"):
         r.add_target("h1")
     assert any("already connected" in rec.message for rec in caplog.records)
+
+
+def test_add_target_noninteractive_when_no_prompter(tmp_path: Path) -> None:
+    """``add_host -t <host>`` under MCP builds the Target with interactive=False.
+
+    ``AddHost.__call__`` dispatches to ``TestReport.add_target`` for each
+    ``--target``; with no prompter the connection must skip the password
+    prompt instead of blocking (the homer.qam.suse.cz hang).
+    """
+    r = _make(tmp_path)
+    assert r._prompter is None
+    fake_target = MagicMock()
+    fake_target.system = "sles15"
+    with patch(
+        "mtui.test_reports.testreport.Target", return_value=fake_target
+    ) as target_cls:
+        r.add_target("h1")
+    assert target_cls.call_args.kwargs["interactive"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When SSH public-key authentication fails, `Connection.connect()` falls back to `getpass.getpass()` to ask for the root password. Under `mtui-mcp` there is no TTY and stdin is the JSON-RPC pipe, so the prompt is **invisible to the client and blocks the session indefinitely**.

Reported when a client (Claude) ran `add_host` against a refhost (`homer.qam.suse.cz`) that had no working key auth — mtui hung waiting for a password that could never be entered.

## Fix

- Add an `interactive: bool = True` parameter to `Connection.__init__`. When `False`, the key-auth-failure branch skips the password prompt and raises a new `NonInteractiveAuthRequired` instead of calling `getpass`, after logging a single actionable WARNING (set up working SSH key auth, verify with `ssh root@<host>`).
- `NonInteractiveAuthRequired` subclasses `paramiko.AuthenticationException`, so existing `except (paramiko.)AuthenticationException` / `except Exception` handlers in the connect path keep catching it — the host is cleanly reported unreachable rather than hanging.
- Thread `interactive` from `Target` into `Connection`. The two `Target(...)` construction sites in `TestReport` derive it from the prompter (`interactive=self._prompter is not None`): MCP sets `prompter=None` → non-interactive; the REPL always supplies a real `Prompter` → interactive.
- This covers **both** `add_host` paths: `connect_targets()` → `connect_target()` and `add_target()`.

Interactive REPL behaviour is unchanged (default `interactive=True` preserves the legacy `getpass` fallback).

## Tests

- `tests/test_connection.py`: non-interactive auth failure and bad-host-key both raise `NonInteractiveAuthRequired` **without** calling `getpass`; subclass-contract check.
- `tests/test_testreport.py`: `connect_target` / `add_target` build `Target` with `interactive=False` when no prompter (MCP) and `interactive=True` when a prompter is present (REPL).

## Verification

- `uv run ruff format --check .` — clean
- `uv run ruff check .` — clean
- `uv run ty check` — clean
- `uv run pytest` — 1345 passed