### PR TITLE
feat(refhost): verify connected hosts' products against refhosts.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable user-visible changes to MTUI are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Connecting a reference host now verifies that its installed products matchV
+  what `refhosts.yml` records for that host. On any drift — wrong or
+  wrong-version base product, wrong architecture, addons that are missing,
+  unexpected, or at a different version, or a dangling
+  `/etc/products.d/baseproduct` symlink — `add_host` prints a `WARNING` per
+  drift class and keeps the host (the check never aborts a connect). `qa` is
+  ignored on both sides to match the products mtui already skips. This catches
+  validating an update on a host that is not the system its metadata claims;
+  hosts absent from `refhosts.yml` are skipped silently.
+
 ## 18.1.0 - 2026-06-19
 
 ### Added

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -64,6 +64,15 @@ the manual workflow (adding hosts by hand is a manual action), updating
 the prompt accordingly. Pass ``-k``/``--keep-mode`` to add a host without
 switching the workflow.
 
+When a host connects, mtui checks that the products actually installed on
+it (from ``/etc/products.d``) match what ``refhosts.yml`` records for that
+host. Any drift — a wrong or wrong-version base product, a wrong
+architecture, addons that are missing, unexpected, or at a different
+version, or a dangling ``/etc/products.d/baseproduct`` symlink — is printed
+as a ``WARNING`` and the host is kept (the check never aborts a connect).
+The ``qa`` product is ignored, and hosts not listed in ``refhosts.yml`` are
+skipped silently.
+
 
 remove_host
 +++++++++++

--- a/mtui/commands/addhost.py
+++ b/mtui/commands/addhost.py
@@ -45,6 +45,8 @@ class AddHost(Command):
             self.config.kernel = False
             self.prompt.set_prompt(self.prompt.session)
 
+        before = set(self.metadata.targets)
+
         if not self.args.target:
             for tp in self.metadata.testplatforms:
                 self.metadata.refhosts_from_tp(tp)
@@ -56,6 +58,21 @@ class AddHost(Command):
                     for hostname in self.args.target
                 ]
                 concurrent.futures.wait(connections)
+
+        self._report_product_warnings(before)
+
+    def _report_product_warnings(self, before: set) -> None:
+        """Print any product-drift warnings for hosts added by this call.
+
+        :meth:`TestReport._verify_target_products` records drift versus
+        ``refhosts.yml`` in ``metadata.product_warnings`` and logs it, but
+        MCP clients only see command stdout -- so echo the warnings via
+        ``println`` for the hosts that were just connected.
+        """
+        added = sorted(set(self.metadata.targets) - before)
+        for host in added:
+            for line in self.metadata.product_warnings.get(host, []):
+                self.println(f"WARNING: {host}: {line}")
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -144,6 +144,23 @@ class Refhosts:
                 return False
         return True
 
+    def host_by_name(self, name: str) -> Host | None:
+        """Return the refhosts entry whose ``name`` matches, or ``None``.
+
+        Searches the configured location first, then ``default``, then any
+        remaining locations, so a connected host maps back to the metadata
+        row mtui would use for it. Returns ``None`` if no row matches.
+        """
+        ordered: list[str] = []
+        for loc in (self.location, self._default_location, *self.data):
+            if loc not in ordered:
+                ordered.append(loc)
+        for loc in ordered:
+            for candidate in self.data.get(loc, []):
+                if candidate.name == name:
+                    return candidate
+        return None
+
     def check_location_sanity(self, location: str) -> None:
         """Raise :class:`InvalidLocationError` if ``location`` is unknown."""
         if location not in self.data:

--- a/mtui/hosts/refhost/verify.py
+++ b/mtui/hosts/refhost/verify.py
@@ -1,0 +1,198 @@
+"""Compare a connected host's installed products against ``refhosts.yml``.
+
+When mtui connects a reference host it can know two things about that host's
+products: what is *actually installed* (parsed from ``/etc/products.d`` into a
+:class:`~mtui.types.systems.System`) and what the ``refhosts.yml`` metadata
+*says* should be there (a :class:`~mtui.hosts.refhost.models.Host` row).
+
+:func:`compare` checks the two for drift -- a wrong or wrong-version base
+product, a wrong architecture, missing or extra addons, or a dangling
+``baseproduct`` symlink -- so that validating an update on a host that is not
+the system we think it is gets surfaced. The check is advisory: callers warn
+and keep the host.
+
+Normalization (grounded on real refhosts across SLE 15/16 and SL-Micro):
+
+* Detected product *names* use the same identifiers as ``refhosts.yml``
+  (``SLES``, ``SLE_RT``, ``SLES-LTSS``, ``SL-Micro``, ``sle-module-*`` ...);
+  compared case-insensitively for safety.
+* Detected *version strings* come from
+  :func:`mtui.hosts.target.parsers.product.parse_product`:
+  ``"15-SP4"`` (service packs), ``"16.0"`` / ``"6.1"`` (dotted). Both are
+  normalized to a refhosts :class:`~mtui.hosts.refhost.models.Version`.
+* ``qa`` is dropped from the comparison on the refhosts side because
+  :func:`mtui.hosts.target.parsers.system.parse_system` intentionally skips
+  ``qa.prod`` on the detected side -- keeping it would report a phantom
+  "missing qa" on every host whose metadata lists it.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from .models import Host, Version
+
+#: Addon names parse_system never reports as installed (it skips
+#: ``qa.prod``); excluded from the refhosts side too so they are not
+#: reported as missing. Compared case-folded.
+_IGNORED_ADDONS = frozenset({"qa"})
+
+
+def _int_or_str(value: str) -> int | str:
+    """Return ``int(value)`` when numeric, else the original string."""
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def normalize_version(version: str) -> Version | None:
+    """Convert a detected version string to a refhosts :class:`Version`.
+
+    Handles the formats emitted by ``parse_product``:
+
+    * ``"15-SP4"`` -> ``Version(15, "SP4")`` (SLE 12/15 service packs)
+    * ``"16.0"`` / ``"6.1"`` -> ``Version(16, 0)`` / ``Version(6, 1)``
+    * ``"15"`` -> ``Version(15, None)``
+    * ``""`` -> ``None``
+    """
+    version = version.strip()
+    if not version:
+        return None
+    if m := re.fullmatch(r"(\d+)-SP(\d+)", version):
+        return Version(major=int(m.group(1)), minor=f"SP{m.group(2)}")
+    if "." in version:
+        major, _, minor = version.partition(".")
+        return Version(major=_int_or_str(major), minor=_int_or_str(minor))
+    return Version(major=_int_or_str(version), minor=None)
+
+
+def _fmt_version(version: Version | None) -> str:
+    """Render a :class:`Version` for warning messages (``""`` when None)."""
+    if version is None:
+        return ""
+    if version.minor is None or version.minor == "":
+        return str(version.major)
+    sep = "." if isinstance(version.minor, int) else "-"
+    return f"{version.major}{sep}{version.minor}"
+
+
+@dataclass
+class ProductDiff:
+    """Outcome of comparing detected products against refhosts metadata."""
+
+    #: ``/etc/products.d/baseproduct`` is a dangling symlink.
+    dangling_base: bool = False
+    #: Human-readable base product mismatch, or ``None`` when the base matches.
+    base_mismatch: str | None = None
+    #: Addons in ``refhosts.yml`` but not installed (``"name x.y"``).
+    missing_addons: list[str] = field(default_factory=list)
+    #: Addons installed but not in ``refhosts.yml`` (``"name x.y"``).
+    extra_addons: list[str] = field(default_factory=list)
+    #: Addons present on both sides with a differing version.
+    mismatched_addons: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when no drift was detected."""
+        return not (
+            self.dangling_base
+            or self.base_mismatch
+            or self.missing_addons
+            or self.extra_addons
+            or self.mismatched_addons
+        )
+
+    def warnings(self) -> list[str]:
+        """Return one warning line per drift class (empty when :attr:`ok`)."""
+        out: list[str] = []
+        if self.dangling_base:
+            out.append("dangling /etc/products.d/baseproduct symlink")
+        if self.base_mismatch:
+            out.append(f"base product mismatch: {self.base_mismatch}")
+        if self.missing_addons:
+            out.append(
+                "addons in metadata but not installed: "
+                + ", ".join(sorted(self.missing_addons))
+            )
+        if self.extra_addons:
+            out.append(
+                "addons installed but not in metadata: "
+                + ", ".join(sorted(self.extra_addons))
+            )
+        if self.mismatched_addons:
+            out.append(
+                "addons with version mismatch: "
+                + ", ".join(sorted(self.mismatched_addons))
+            )
+        return out
+
+
+def _named(name: str, version: Version | None) -> str:
+    """Render ``"name x.y"`` (or just ``"name"`` when version is None)."""
+    rendered = _fmt_version(version)
+    return f"{name} {rendered}" if rendered else name
+
+
+def compare(system, host: Host) -> ProductDiff:
+    """Compare a detected :class:`System` against a refhosts :class:`Host`.
+
+    Args:
+        system: The :class:`~mtui.types.systems.System` parsed from the host.
+        host: The :class:`Host` row from ``refhosts.yml`` for the same host.
+
+    Returns:
+        A :class:`ProductDiff` describing any base/addon/symlink drift.
+
+    """
+    diff = ProductDiff(dangling_base=bool(getattr(system, "dangling_base", False)))
+
+    base = system.get_base()
+    expected = host.product
+
+    # Base product: skip the name/version check when the base is a dangling
+    # placeholder (the dangling warning already covers it), but still check
+    # the architecture if we have one.
+    problems: list[str] = []
+    if not diff.dangling_base:
+        if base.name.casefold() != expected.name.casefold():
+            problems.append(f"name {base.name!r} != {expected.name!r} (metadata)")
+        detected_version = normalize_version(base.version)
+        if expected.version is not None and detected_version != expected.version:
+            problems.append(
+                f"version {base.version!r} != "
+                f"{_fmt_version(expected.version)!r} (metadata)"
+            )
+    if base.arch and host.arch and base.arch != host.arch:
+        problems.append(f"arch {base.arch!r} != {host.arch!r} (metadata)")
+    if problems:
+        diff.base_mismatch = "; ".join(problems)
+
+    # Addons: case-folded name -> (display name, normalized version), with the
+    # always-ignored addons (qa) dropped from both sides.
+    detected = {
+        p.name.casefold(): (p.name, normalize_version(p.version))
+        for p in system.get_addons()
+        if p.name.casefold() not in _IGNORED_ADDONS
+    }
+    metadata = {
+        a.name.casefold(): (a.name, a.version)
+        for a in host.addons
+        if a.name.casefold() not in _IGNORED_ADDONS
+    }
+
+    for key in metadata.keys() - detected.keys():
+        name, version = metadata[key]
+        diff.missing_addons.append(_named(name, version))
+    for key in detected.keys() - metadata.keys():
+        name, version = detected[key]
+        diff.extra_addons.append(_named(name, version))
+    for key in detected.keys() & metadata.keys():
+        det_name, det_version = detected[key]
+        meta_name, meta_version = metadata[key]
+        if meta_version is not None and det_version != meta_version:
+            diff.mismatched_addons.append(
+                f"{det_name} (installed {_fmt_version(det_version)} != "
+                f"metadata {_fmt_version(meta_version)})"
+            )
+
+    return diff

--- a/mtui/hosts/target/parsers/system.py
+++ b/mtui/hosts/target/parsers/system.py
@@ -48,13 +48,37 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
                 return (System(Product("rhel", "6", "x86_64")), False)
             return (System(Product(name, version, arch)), False)
 
-        if basefile := sftp.readlink("/etc/products.d/baseproduct"):
+        basefile = sftp.readlink("/etc/products.d/baseproduct")
+        if basefile and basefile in files:
             files.remove(basefile)
 
-        with sftp.open(f"/etc/products.d/{basefile}") as f:
-            logger.debug("Parsing basefile")
-            name, version, arch = product.parse_product(f)
-            base = Product(name, version, arch)
+        dangling_base = False
+        if not basefile:
+            # /etc/products.d/baseproduct is missing or not a symlink.
+            logger.warning(
+                "%s: /etc/products.d/baseproduct is missing or not a symlink",
+                connection.hostname,
+            )
+            dangling_base = True
+            base = Product("unknown", "", "")
+        else:
+            try:
+                with sftp.open(f"/etc/products.d/{basefile}") as f:
+                    logger.debug("Parsing basefile")
+                    name, version, arch = product.parse_product(f)
+                    base = Product(name, version, arch)
+            except OSError:
+                # Dangling symlink: the target product file is gone. Don't
+                # crash the connect; warn and fall back to a best-effort
+                # base derived from the symlink target name.
+                logger.warning(
+                    "%s: /etc/products.d/baseproduct -> %s is a dangling "
+                    "symlink (target product file missing)",
+                    connection.hostname,
+                    basefile,
+                )
+                dangling_base = True
+                base = Product(basefile.removesuffix(".prod"), "", "")
 
         addons: set[Product] = set()
         for x in files:
@@ -89,4 +113,4 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
             logger.info("Host: %s is transactional system", connection.hostname)
             break
 
-    return (System(base, addons), transactional)
+    return (System(base, addons, dangling_base=dangling_base), transactional)

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import stat
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from contextlib import suppress
@@ -18,6 +19,7 @@ from traceback import format_exc
 from typing import TYPE_CHECKING, Any, Literal
 
 from ..hosts.refhost import Attributes, RefhostsFactory, RefhostsResolveFailedError
+from ..hosts.refhost import verify as product_verify
 from ..hosts.target import Target, TargetLockedError
 from ..hosts.target.hostgroup import HostsGroup
 from ..support.config import Config
@@ -145,6 +147,16 @@ class TestReport(ABC):
         """
 
         self.openqa: OpenQAResults = OpenQAResults()
+
+        # hostname -> product-drift warning lines from the last connect
+        # (see _verify_target_products); commands print these so they
+        # reach MCP clients, which only see command stdout (not logs).
+        self.product_warnings: dict[str, list[str]] = {}
+        # Lazily-built, cached refhosts store for the product check, with
+        # a lock because connect_targets runs connect_target concurrently.
+        self._refhosts_store: Any = None
+        self._refhosts_store_built = False
+        self._refhosts_store_lock = threading.Lock()
 
     @property
     @abstractmethod
@@ -477,6 +489,75 @@ class TestReport(ABC):
         with suppress(TargetLockedError):
             target.lock(self.lock_comment)
 
+    def _get_refhosts_store(self):
+        """Build (once, thread-safe) the refhosts store, or None on failure.
+
+        connect_targets fans connect_target out across threads, so the
+        first lookup may race; guard the one-time build with a lock and
+        cache the (possibly ``None``) result.
+        """
+        if self._refhosts_store_built:
+            return self._refhosts_store
+        with self._refhosts_store_lock:
+            if not self._refhosts_store_built:
+                try:
+                    self._refhosts_store = self.refhostsFactory(self.config)
+                except Exception:
+                    logger.debug(
+                        "refhosts store unavailable for product check:\n%s",
+                        format_exc(),
+                    )
+                    self._refhosts_store = None
+                self._refhosts_store_built = True
+        return self._refhosts_store
+
+    def _verify_target_products(self, target) -> None:
+        """Warn if a connected host's products drift from ``refhosts.yml``.
+
+        Compares the host's detected :class:`~mtui.types.systems.System`
+        against its ``refhosts.yml`` :class:`Host` row (wrong/wrong-version
+        base, wrong arch, missing/extra/mismatched addons, dangling
+        baseproduct symlink). Drift is recorded in
+        :attr:`product_warnings` and logged at WARNING; the host is kept.
+
+        Best-effort: any failure is swallowed (logged at DEBUG) so the
+        check never breaks a connect. Hosts absent from ``refhosts.yml``
+        are skipped silently (DEBUG).
+        """
+        try:
+            system = getattr(target, "system", None)
+            if system is None:
+                return
+            store = self._get_refhosts_store()
+            if store is None:
+                return
+            meta = store.host_by_name(target.hostname)
+            if meta is None:
+                logger.debug(
+                    "refhosts.yml has no entry for %s; skipping product check",
+                    target.hostname,
+                )
+                self.product_warnings.pop(target.hostname, None)
+                return
+            diff = product_verify.compare(system, meta)
+            if diff.ok:
+                self.product_warnings.pop(target.hostname, None)
+                return
+            lines = diff.warnings()
+            self.product_warnings[target.hostname] = lines
+            for line in lines:
+                logger.warning(
+                    "%s: products differ from refhosts.yml metadata: %s",
+                    target.hostname,
+                    line,
+                )
+        except Exception:
+            logger.debug(
+                "product verification failed for %s:\n%s",
+                getattr(target, "hostname", "?"),
+                format_exc(),
+            )
+
     def connect_target(
         self, host
     ) -> tuple[Target, str] | tuple[Literal[False], Literal[False]]:
@@ -501,6 +582,7 @@ class TestReport(ABC):
             )
             target.connect()
             new_system = str(target.system)
+            self._verify_target_products(target)
             self._autolock_new_target(target)
         except KeyboardInterrupt:
             logger.warning("Connection to %s canceled by user", host)
@@ -585,6 +667,7 @@ class TestReport(ABC):
             if self:
                 self.systems[hostname] = str(self.targets[hostname].system)
 
+            self._verify_target_products(self.targets[hostname])
             self._autolock_new_target(self.targets[hostname])
 
         except Exception:

--- a/mtui/types/systems.py
+++ b/mtui/types/systems.py
@@ -16,12 +16,21 @@ class System:
     used for pretty-printing and for correct update handling.
     """
 
-    def __init__(self, base: Product, addons: set[Product] | None = None) -> None:
+    def __init__(
+        self,
+        base: Product,
+        addons: set[Product] | None = None,
+        dangling_base: bool = False,
+    ) -> None:
         """Initializes the `System` object.
 
         Args:
             base: The base product of the system.
             addons: A set of addons for the system.
+            dangling_base: True when ``/etc/products.d/baseproduct`` is a
+                dangling symlink (its target product file is missing), so
+                ``base`` is a best-effort guess derived from the symlink
+                target name rather than a parsed product file.
 
         """
         # TODO: check for correctness of base and addons types
@@ -29,6 +38,7 @@ class System:
             addons = set()
         self.__base = base
         self.__addons = addons
+        self.dangling_base = dangling_base
 
     def get_release(self) -> str:
         """Gets the release of the system.

--- a/tests/test_cmd_addhost.py
+++ b/tests/test_cmd_addhost.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from argparse import Namespace
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.addhost import AddHost
@@ -99,6 +100,53 @@ def test_add_host_keep_mode_stays_automatic(mock_config):
     prompt.set_prompt.assert_not_called()
     # The hosts are still added.
     prompt.metadata.connect_targets.assert_called_once_with()
+
+
+def test_add_host_prints_product_warnings_for_new_hosts(mock_config):
+    """Product-drift warnings recorded during connect are echoed to stdout so
+    MCP clients (which only see command stdout) can see them."""
+    prompt = _prompt()
+    prompt.metadata.targets = {}  # nothing connected yet
+    prompt.metadata.product_warnings = {"h1": ["arch 'x86_64' != 'aarch64' (metadata)"]}
+    args = Namespace(target=["h1"], keep_mode=False)
+
+    fake_sys = MagicMock()
+    fake_sys.stdout = StringIO()
+
+    def _connect(*_a, **_k):
+        # Simulate add_target connecting h1 between the before/after snapshot.
+        prompt.metadata.targets["h1"] = MagicMock()
+
+    with (
+        patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor"),
+        patch("mtui.commands.addhost.concurrent.futures.wait", side_effect=_connect),
+    ):
+        AddHost(args, mock_config, fake_sys, prompt)()
+
+    output = fake_sys.stdout.getvalue()
+    assert "WARNING: h1: arch 'x86_64' != 'aarch64' (metadata)" in output
+
+
+def test_add_host_no_warnings_prints_nothing(mock_config):
+    """A clean connect with no drift prints nothing extra."""
+    prompt = _prompt()
+    prompt.metadata.targets = {}
+    prompt.metadata.product_warnings = {}
+    args = Namespace(target=["h1"], keep_mode=False)
+
+    fake_sys = MagicMock()
+    fake_sys.stdout = StringIO()
+
+    def _connect(*_a, **_k):
+        prompt.metadata.targets["h1"] = MagicMock()
+
+    with (
+        patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor"),
+        patch("mtui.commands.addhost.concurrent.futures.wait", side_effect=_connect),
+    ):
+        AddHost(args, mock_config, fake_sys, prompt)()
+
+    assert fake_sys.stdout.getvalue() == ""
 
 
 def test_add_host_in_manual_mode_does_not_switch(mock_config):

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -301,6 +301,24 @@ class TestRefhosts:
         )
         assert rh.search(attrs) == []
 
+    def test_host_by_name_finds_in_default(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        host = rh.host_by_name("host-default-x86")
+        assert host is not None
+        assert host.name == "host-default-x86"
+        assert host.product.name == "sles"
+
+    def test_host_by_name_finds_in_other_location(self):
+        """A host living only under ``nuremberg`` is still found from default."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)  # default location
+        host = rh.host_by_name("host-nbg-only-here")
+        assert host is not None
+        assert host.arch == "ppc64le"
+
+    def test_host_by_name_unknown_returns_none(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        assert rh.host_by_name("no-such-host") is None
+
 
 class TestIsCandidateMatch:
     """Direct tests of the matcher to cover its branches."""

--- a/tests/test_refhost_verify.py
+++ b/tests/test_refhost_verify.py
@@ -1,0 +1,225 @@
+"""Tests for ``mtui.hosts.refhost.verify`` (product drift detection).
+
+The normalization rules are grounded on real refhosts across SLE 15/16 and
+SL-Micro (see the module docstring): detected version strings ``"16.0"`` /
+``"6.1"`` (dotted) and ``"15-SP4"`` (service pack), ``qa`` excluded on both
+sides, names compared case-insensitively.
+"""
+
+from mtui.hosts.refhost import verify
+from mtui.hosts.refhost.models import Addon, Host, Product, Version
+from mtui.types import Product as DetectedProduct
+from mtui.types.systems import System
+
+
+def _system(base, addons=(), dangling=False) -> System:
+    """Build a detected ``System`` from ``(name, version, arch)`` tuples."""
+    return System(
+        DetectedProduct(*base),
+        {DetectedProduct(*a) for a in addons},
+        dangling_base=dangling,
+    )
+
+
+def _host(name="h", arch="x86_64", product=("SLES", 16, 0), addons=()) -> Host:
+    """Build a refhosts ``Host`` from ``(name, major, minor)`` tuples."""
+    pname, major, minor = product
+    return Host(
+        name=name,
+        arch=arch,
+        product=Product(name=pname, version=Version(major=major, minor=minor)),
+        addons=tuple(
+            Addon(name=n, version=Version(major=amaj, minor=amin))
+            for n, amaj, amin in addons
+        ),
+    )
+
+
+class TestNormalizeVersion:
+    def test_dotted_int_minor(self):
+        # SLE 16 / SL-Micro: "16.0" -> Version(16, 0), "6.1" -> Version(6, 1)
+        assert verify.normalize_version("16.0") == Version(major=16, minor=0)
+        assert verify.normalize_version("6.1") == Version(major=6, minor=1)
+
+    def test_service_pack(self):
+        # SLE 12/15: "15-SP4" -> Version(15, "SP4")
+        assert verify.normalize_version("15-SP4") == Version(major=15, minor="SP4")
+
+    def test_major_only(self):
+        assert verify.normalize_version("15") == Version(major=15, minor=None)
+
+    def test_empty_is_none(self):
+        assert verify.normalize_version("") is None
+        assert verify.normalize_version("   ") is None
+
+
+class TestCompareBase:
+    def test_sle16_exact_match_no_warnings(self):
+        """A correctly-matching SLES 16.0 host (carme) yields no drift."""
+        system = _system(("SLES", "16.0", "x86_64"))
+        host = _host(product=("SLES", 16, 0), arch="x86_64")
+        diff = verify.compare(system, host)
+        assert diff.ok
+        assert diff.warnings() == []
+
+    def test_slmicro_exact_match_no_warnings(self):
+        """SL-Micro 6.1 with its extras addon matches metadata exactly."""
+        system = _system(
+            ("SL-Micro", "6.1", "x86_64"),
+            addons=[("SL-Micro-Extras", "6.1", "x86_64")],
+        )
+        host = _host(
+            product=("SL-Micro", 6, 1),
+            arch="x86_64",
+            addons=[("SL-Micro-Extras", 6, 1)],
+        )
+        assert verify.compare(system, host).ok
+
+    def test_base_name_mismatch(self):
+        system = _system(("SLED", "15-SP4", "x86_64"))
+        host = _host(product=("SLES", 15, "SP4"), arch="x86_64")
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert diff.base_mismatch is not None
+        assert "name" in diff.base_mismatch
+
+    def test_base_name_casefold_matches(self):
+        """Names differing only in case are treated as equal."""
+        system = _system(("sles", "16.0", "x86_64"))
+        host = _host(product=("SLES", 16, 0), arch="x86_64")
+        assert verify.compare(system, host).ok
+
+    def test_base_version_mismatch(self):
+        system = _system(("SLES", "15-SP4", "x86_64"))
+        host = _host(product=("SLES", 15, "SP3"), arch="x86_64")
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert "version" in (diff.base_mismatch or "")
+
+    def test_arch_mismatch(self):
+        system = _system(("SLES", "16.0", "x86_64"))
+        host = _host(product=("SLES", 16, 0), arch="aarch64")
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert "arch" in (diff.base_mismatch or "")
+
+
+class TestCompareAddons:
+    def test_extra_addon_detected(self):
+        """bojack-style drift: host has modules absent from metadata."""
+        system = _system(
+            ("SLE_RT", "15-SP4", "x86_64"),
+            addons=[
+                ("SLES-LTSS", "15-SP4", "x86_64"),
+                ("sle-module-basesystem", "15-SP4", "x86_64"),
+                ("sle-module-development-tools", "15-SP4", "x86_64"),
+            ],
+        )
+        host = _host(
+            product=("SLE_RT", 15, "SP4"),
+            arch="x86_64",
+            addons=[
+                ("SLES-LTSS", 15, "SP4"),
+                ("sle-module-basesystem", 15, "SP4"),
+            ],
+        )
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert diff.extra_addons == ["sle-module-development-tools 15-SP4"]
+        assert diff.missing_addons == []
+
+    def test_missing_addon_detected(self):
+        system = _system(
+            ("SLES", "15-SP4", "x86_64"),
+            addons=[("sle-module-basesystem", "15-SP4", "x86_64")],
+        )
+        host = _host(
+            product=("SLES", 15, "SP4"),
+            arch="x86_64",
+            addons=[
+                ("sle-module-basesystem", 15, "SP4"),
+                ("SLES-LTSS", 15, "SP4"),
+            ],
+        )
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert diff.missing_addons == ["SLES-LTSS 15-SP4"]
+        assert diff.extra_addons == []
+
+    def test_addon_version_mismatch(self):
+        system = _system(
+            ("SLES", "15-SP4", "x86_64"),
+            addons=[("sle-module-basesystem", "15-SP3", "x86_64")],
+        )
+        host = _host(
+            product=("SLES", 15, "SP4"),
+            arch="x86_64",
+            addons=[("sle-module-basesystem", 15, "SP4")],
+        )
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert diff.missing_addons == []
+        assert diff.extra_addons == []
+        assert len(diff.mismatched_addons) == 1
+        assert "sle-module-basesystem" in diff.mismatched_addons[0]
+
+    def test_qa_excluded_from_both_sides(self):
+        """``qa`` is dropped on the detected side, so metadata's ``qa`` must
+        not be reported as missing, and a detected ``qa`` not as extra."""
+        # parse_system never reports qa, so the detected addon set omits it.
+        system = _system(
+            ("SLES", "15-SP4", "x86_64"),
+            addons=[("sle-module-basesystem", "15-SP4", "x86_64")],
+        )
+        # metadata lists qa (as the real refhosts.yml does for many hosts).
+        host = _host(
+            product=("SLES", 15, "SP4"),
+            arch="x86_64",
+            addons=[
+                ("sle-module-basesystem", 15, "SP4"),
+                ("qa", 15, "SP4"),
+            ],
+        )
+        assert verify.compare(system, host).ok
+
+    def test_full_sle15_match_no_warnings(self):
+        """antares-style host whose module set matches metadata exactly."""
+        modules = [
+            "sle-module-basesystem",
+            "sle-module-server-applications",
+            "sle-module-desktop-applications",
+            "sle-module-development-tools",
+            "sle-module-web-scripting",
+        ]
+        system = _system(
+            ("SLES", "15-SP4", "aarch64"),
+            addons=[(m, "15-SP4", "aarch64") for m in modules]
+            + [("SLES-LTSS", "15-SP4", "aarch64")],
+        )
+        host = _host(
+            product=("SLES", 15, "SP4"),
+            arch="aarch64",
+            addons=[(m, 15, "SP4") for m in modules] + [("SLES-LTSS", 15, "SP4")],
+        )
+        assert verify.compare(system, host).ok
+
+
+class TestCompareDangling:
+    def test_dangling_base_warns_and_skips_base_check(self):
+        """A dangling baseproduct symlink is reported; the (placeholder)
+        base name/version are not additionally flagged as a mismatch."""
+        system = _system(("SLES", "", "x86_64"), dangling=True)
+        host = _host(product=("SLES", 16, 0), arch="x86_64")
+        diff = verify.compare(system, host)
+        assert not diff.ok
+        assert diff.dangling_base
+        assert diff.base_mismatch is None
+        assert any("dangling" in w for w in diff.warnings())
+
+    def test_dangling_still_checks_arch(self):
+        """Arch is still compared even with a dangling base."""
+        system = _system(("SLES", "", "x86_64"), dangling=True)
+        host = _host(product=("SLES", 16, 0), arch="aarch64")
+        diff = verify.compare(system, host)
+        assert diff.dangling_base
+        assert "arch" in (diff.base_mismatch or "")

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -304,6 +304,57 @@ class TestParseSystem:
         assert ("sle-ha", "12-SP5") in addons
 
     @patch("mtui.hosts.target.parsers.system.product")
+    def test_parse_dangling_baseproduct_symlink(self, mock_product_module):
+        """A dangling baseproduct symlink warns and degrades, not crash.
+
+        ``readlink`` resolves to ``SLES.prod`` but opening it raises
+        ``OSError`` (the target file is gone). parse_system must not crash:
+        it flags ``dangling_base`` and derives a best-effort base name from
+        the symlink target.
+        """
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = ["SLES.prod"]
+        sftp.readlink.return_value = "SLES.prod"
+
+        def _open(path, *args, **kwargs):
+            p = str(path)
+            if p == "/etc/products.d/SLES.prod":
+                raise OSError("dangling symlink target missing")
+            if "transactional-update.conf" in p:
+                raise FileNotFoundError(p)
+            return MagicMock()
+
+        sftp.open.side_effect = _open
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        system, transactional = parse_system(conn)
+
+        assert system.dangling_base is True
+        # Best-effort base name from the symlink target ("SLES.prod").
+        assert system.get_base().name == "SLES"
+        assert system.get_base().version == ""
+        assert transactional is False
+        # The missing base file was never handed to parse_product.
+        mock_product_module.parse_product.assert_not_called()
+
+    @patch("mtui.hosts.target.parsers.system.product")
+    def test_parse_missing_baseproduct_symlink(self, mock_product_module):
+        """An absent/empty baseproduct symlink degrades instead of crashing."""
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = []
+        sftp.readlink.return_value = ""
+        sftp.open.side_effect = _dispatch_open(transactional=False)
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        system, transactional = parse_system(conn)
+
+        assert system.dangling_base is True
+        assert system.get_base().name == "unknown"
+        assert transactional is False
+
+    @patch("mtui.hosts.target.parsers.system.product")
     def test_parse_sles_sap_16_adds_ha_addon(self, mock_product_module):
         """SLES_SAP 16 implicitly carries the sle-ha repo (workaround)."""
         conn, sftp = _mock_connection_with_sftp()

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -83,6 +83,88 @@ def test_get_package_list_empty(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _verify_target_products: drift check against refhosts.yml
+# ---------------------------------------------------------------------------
+
+
+def _target_with_system(hostname, base, addons=(), dangling=False) -> MagicMock:
+    from mtui.types import Product as DetectedProduct
+    from mtui.types.systems import System
+
+    target = MagicMock()
+    target.hostname = hostname
+    target.system = System(
+        DetectedProduct(*base),
+        {DetectedProduct(*a) for a in addons},
+        dangling_base=dangling,
+    )
+    return target
+
+
+def _refhost(name, arch, product, addons=()):
+    from mtui.hosts.refhost.models import Addon, Host, Product, Version
+
+    pname, major, minor = product
+    return Host(
+        name=name,
+        arch=arch,
+        product=Product(name=pname, version=Version(major=major, minor=minor)),
+        addons=tuple(
+            Addon(name=n, version=Version(major=amaj, minor=amin))
+            for n, amaj, amin in addons
+        ),
+    )
+
+
+def _stub_store(r: OBSTestReport, host) -> MagicMock:
+    """Wire a pre-built refhosts store whose host_by_name returns ``host``."""
+    store = MagicMock()
+    store.host_by_name.return_value = host
+    r._refhosts_store = store
+    r._refhosts_store_built = True
+    return store
+
+
+def test_verify_target_products_warns_on_drift(tmp_path: Path, caplog) -> None:
+    r = _make(tmp_path)
+    target = _target_with_system("h1", ("SLES", "16.0", "x86_64"))
+    # Metadata says aarch64 -> arch drift.
+    _stub_store(r, _refhost("h1", "aarch64", ("SLES", 16, 0)))
+    with caplog.at_level(logging.WARNING, logger="mtui.template.testreport"):
+        r._verify_target_products(target)
+    assert "h1" in r.product_warnings
+    assert any("refhosts.yml" in rec.message for rec in caplog.records)
+
+
+def test_verify_target_products_clears_stale_warning_on_match(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    target = _target_with_system("h1", ("SLES", "16.0", "x86_64"))
+    _stub_store(r, _refhost("h1", "x86_64", ("SLES", 16, 0)))
+    r.product_warnings["h1"] = ["stale"]
+    r._verify_target_products(target)
+    assert "h1" not in r.product_warnings
+
+
+def test_verify_target_products_skips_host_not_in_metadata(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    target = _target_with_system("h1", ("SLES", "16.0", "x86_64"))
+    _stub_store(r, None)
+    r._verify_target_products(target)
+    assert r.product_warnings == {}
+
+
+def test_verify_target_products_is_best_effort(tmp_path: Path) -> None:
+    """A failure in the check never propagates out of the connect path."""
+    r = _make(tmp_path)
+    target = _target_with_system("h1", ("SLES", "16.0", "x86_64"))
+    store = _stub_store(r, None)
+    store.host_by_name.side_effect = RuntimeError("boom")
+    # Must not raise.
+    r._verify_target_products(target)
+    assert r.product_warnings == {}
+
+
+# ---------------------------------------------------------------------------
 # _warn_missing_fields
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

When a reference host connects, mtui now compares the products **actually installed** on it (parsed from `/etc/products.d` into a `System`) against what **`refhosts.yml`** records for that host, and warns on drift:

- wrong or wrong-version **base product**, or wrong **architecture**
- addons that are **missing**, **unexpected**, or at a **different version**
- a **dangling `/etc/products.d/baseproduct` symlink** (which previously crashed `parse_system` mid-connect)

The check is **advisory**: it logs a `WARNING` per drift class and **keeps the host** — it never aborts a connect. Hosts absent from `refhosts.yml` are skipped silently. This catches the failure mode of validating an update on a host that is not the system its metadata claims.

## Why it prints (not just logs)

`add_host` also **prints** the warnings to stdout, because MCP clients (`mtui-mcp`) only see command output, not log records — logging alone would be invisible there.

## Normalization

Grounded on real refhosts across SLE 15/16 and SL-Micro:

- detected version strings `"16.0"`/`"6.1"` (dotted) and `"15-SP4"` (service pack) map to a refhosts `Version`
- product names compare case-insensitively (they share the same identifiers in practice)
- `qa` is dropped on **both** sides to mirror `parse_system` already skipping `qa.prod`

## Changes

- new `mtui/hosts/refhost/verify.py` — `compare()` → `ProductDiff`
- harden `parse_system` against a dangling/empty baseproduct symlink; expose `System.dangling_base`
- `Refhosts.host_by_name()` to map a connected host to its metadata row
- hook in `TestReport.connect_target` / `add_target` (best-effort, cached refhosts store, thread-safe)
- `add_host` prints per-host drift warnings
- tests for the comparator, parser hardening, `host_by_name`, the connect hook, and `add_host` output; CHANGELOG + `iui.rst`

## Testing

`uv run ruff format --check . && uv run ruff check . && uv run ty check && uv run pytest` — all green (1373 passed; pre-existing `rpm`/norpm `ty` diagnostics only).