### PR TITLE
feat(mcp): surface command log output (INFO+) in tool replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- Connecting a reference host now verifies that its installed products matchV
+- Connecting a reference host now verifies that its installed products match
   what `refhosts.yml` records for that host. On any drift — wrong or
   wrong-version base product, wrong architecture, addons that are missing,
   unexpected, or at a different version, or a dangling
-  `/etc/products.d/baseproduct` symlink — `add_host` prints a `WARNING` per
-  drift class and keeps the host (the check never aborts a connect). `qa` is
-  ignored on both sides to match the products mtui already skips. This catches
-  validating an update on a host that is not the system its metadata claims;
-  hosts absent from `refhosts.yml` are skipped silently.
+  `/etc/products.d/baseproduct` symlink — mtui logs a `WARNING` per drift class
+  and keeps the host (the check never aborts a connect). `qa` is ignored on both
+  sides to match the products mtui already skips. This catches validating an
+  update on a host that is not the system its metadata claims; hosts absent from
+  `refhosts.yml` are skipped silently.
+- Under `mtui-mcp`, a command's own `mtui` log records (`INFO` and above) emitted
+  while it runs are now included in the tool reply, not just what it prints to
+  stdout. The capture follows the command into the worker threads it fans out to
+  (MTUI's thread pools now propagate context), so warnings logged off the main
+  thread — such as the per-host product-drift report above, emitted on
+  `add_host`'s connect pool — reach MCP clients directly; `add_host` no longer
+  re-echoes them to stdout.
 
 ## 18.1.0 - 2026-06-19
 

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -68,7 +68,7 @@ When a host connects, mtui checks that the products actually installed on
 it (from ``/etc/products.d``) match what ``refhosts.yml`` records for that
 host. Any drift — a wrong or wrong-version base product, a wrong
 architecture, addons that are missing, unexpected, or at a different
-version, or a dangling ``/etc/products.d/baseproduct`` symlink — is printed
+version, or a dangling ``/etc/products.d/baseproduct`` symlink — is logged
 as a ``WARNING`` and the host is kept (the check never aborts a connect).
 The ``qa`` product is ignored, and hosts not listed in ``refhosts.yml`` are
 skipped silently.

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -499,3 +499,37 @@ For those, raise the timeout in the client's own configuration:
 
 The heartbeat itself never *caps* execution time; if your client
 honours progress it will simply wait as long as the server takes.
+
+
+Command output and logging
+===========================
+
+A tool call returns the text the command wrote to **stdout**. In
+addition, any log record a command emits through the ``mtui`` logger
+tree (``mtui.commands.*``, ``mtui.template.*``, ``mtui.checks.*``, …) at
+``INFO`` level or above *while it runs* is captured and appended to that
+same reply, prefixed with its level (``WARNING: …``, ``ERROR: …``). This
+means conditions a command reports by logging rather than printing — for
+example the product-drift warnings emitted when ``add_host`` connects a
+reference host whose installed products disagree with ``refhosts.yml`` —
+reach the client even though they never touched stdout.
+
+The capture is deliberately scoped:
+
+* **``INFO`` and above only.** ``DEBUG`` records stay out of the reply
+  (use ``--debug`` to see them on the server's stderr).
+* **Per call, by capture token.** A unique token is set for the duration
+  of one command and the capturing handler admits only records tagged
+  with it. The token rides along into any worker threads the command
+  fans out to — MTUI's thread pools are
+  :class:`~mtui.support.concurrency.ContextExecutor` instances that copy
+  the caller's :mod:`contextvars` context into each task — so a
+  command's own background work is captured too (for example the
+  product-drift warnings logged on ``add_host``'s connect pool). Records
+  produced under a *different* token, including a concurrent
+  ``--transport http`` client's call, never bleed into this reply.
+* **The server's own bookkeeping is excluded.** Lines the session logs
+  about a call (e.g. "command … wrote to stderr") go through the
+  ``mtui-mcp`` logger, which is outside the captured ``mtui`` subtree and
+  therefore never echoed back into the reply.
+

--- a/mtui/commands/addhost.py
+++ b/mtui/commands/addhost.py
@@ -4,6 +4,7 @@ import concurrent.futures
 from logging import getLogger
 
 from ..cli.completion import complete_choices
+from ..support.concurrency import ContextExecutor
 from . import Command
 
 logger = getLogger("mtui.commands.addhost")
@@ -45,34 +46,17 @@ class AddHost(Command):
             self.config.kernel = False
             self.prompt.set_prompt(self.prompt.session)
 
-        before = set(self.metadata.targets)
-
         if not self.args.target:
             for tp in self.metadata.testplatforms:
                 self.metadata.refhosts_from_tp(tp)
             self.metadata.connect_targets()
         else:
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with ContextExecutor() as executor:
                 connections = [
                     executor.submit(self.metadata.add_target, hostname)
                     for hostname in self.args.target
                 ]
                 concurrent.futures.wait(connections)
-
-        self._report_product_warnings(before)
-
-    def _report_product_warnings(self, before: set) -> None:
-        """Print any product-drift warnings for hosts added by this call.
-
-        :meth:`TestReport._verify_target_products` records drift versus
-        ``refhosts.yml`` in ``metadata.product_warnings`` and logs it, but
-        MCP clients only see command stdout -- so echo the warnings via
-        ``println`` for the hosts that were just connected.
-        """
-        added = sorted(set(self.metadata.targets) - before)
-        for host in added:
-            for line in self.metadata.product_warnings.get(host, []):
-                self.println(f"WARNING: {host}: {line}")
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/commands/quit.py
+++ b/mtui/commands/quit.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
+from ..support.concurrency import ContextExecutor
 from . import Command
 
 
@@ -41,7 +42,7 @@ class Quit(Command):
         """Executes the `quit` command."""
         args_ = [self.args.bootarg] if self.args.bootarg else []
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextExecutor() as executor:
             targets = [
                 executor.submit(self._close_target, target, args_)
                 for target in set(self.targets)

--- a/mtui/commands/removehost.py
+++ b/mtui/commands/removehost.py
@@ -4,6 +4,7 @@ import concurrent.futures
 
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
+from ..support.concurrency import ContextExecutor
 from . import Command
 
 
@@ -39,7 +40,7 @@ class RemoveHost(Command):
         """Executes the `remove_host` command."""
         targets = list(self.parse_hosts(enabled=False).keys())
         # for target in targets:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextExecutor() as executor:
             conn = [executor.submit(self._remove_target, target) for target in targets]
             concurrent.futures.wait(conn, timeout=30)
 

--- a/mtui/data_sources/qem_dashboard/dashboard_openqa.py
+++ b/mtui/data_sources/qem_dashboard/dashboard_openqa.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from os.path import join
 from typing import Any, Self
 
+from ...support.concurrency import ContextExecutor
 from ...types import RequestReviewID, URLs
 from .client import _FUTURE_TIMEOUT, FAILED_RESULTS
 from .incident import QEMIncident
@@ -33,7 +34,7 @@ class DashboardAutoOpenQA:
         # Fetch the two top-level settings lists concurrently; they are
         # independent of each other.
         incident_number = self.incident.incident_number
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextExecutor() as executor:
             incident_settings_future = executor.submit(
                 self.client.incident_settings, incident_number
             )
@@ -74,7 +75,7 @@ class DashboardAutoOpenQA:
                 return self.client.incident_jobs(setting_id)
             return self.client.update_jobs(setting_id)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextExecutor() as executor:
             futures = [
                 executor.submit(_fetch, source, setting_id)
                 for source, _, setting_id in tasks

--- a/mtui/hosts/target/actions.py
+++ b/mtui/hosts/target/actions.py
@@ -6,13 +6,14 @@ import sys
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, ValuesView
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from contextlib import suppress
 from pathlib import Path
 from threading import Lock
 from typing import Any
 
 from ...cli.term import prompt_user
+from ...support.concurrency import ContextExecutor
 from ...types import ExecutionMode
 from . import Target
 
@@ -94,7 +95,7 @@ def run_parallel(
     spinner = _TtySpinner(desc) if desc else None
     if spinner is not None:
         spinner.start()
-    ex = ThreadPoolExecutor(max_workers=len(work))
+    ex = ContextExecutor(max_workers=len(work))
     try:
         futures = [ex.submit(fn, *args) for fn, args in work]
         for f in as_completed(futures):

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -35,22 +35,38 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextvars
 import io
+import logging
 import shlex
 import time
-from logging import Logger, getLogger
+from logging import Handler, Logger, LogRecord, getLogger
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from ..cli.argparse import ArgsParseFailureError
 from ..cli.display import CommandPromptDisplay
 from ..commands import Command
+from ..support.concurrency import ContextExecutor
 from ..test_reports.null_report import NullTestReport
 
 if TYPE_CHECKING:
     from ..support.config import Config
 
 logger = getLogger("mtui.mcp.session")
+
+#: Per-call capture token. ``_run_sync`` sets this to a unique object for
+#: the duration of one command (and, via
+#: :class:`mtui.support.concurrency.ContextExecutor`, the value propagates
+#: into any worker threads the command fans out to). Each
+#: :class:`_LogCaptureHandler` admits only records whose ambient token
+#: matches its own, so concurrent sessions never capture each other's log
+#: lines. Default ``None`` means "no command in flight" -> nothing
+#: captured.
+_capture_token: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "mtui_mcp_capture_token", default=None
+)
+
 
 #: Default heartbeat interval, in seconds, between
 #: ``notifications/progress`` frames emitted while a long-running tool
@@ -62,6 +78,69 @@ logger = getLogger("mtui.mcp.session")
 #: nothing on the wire and stops well-behaved clients from timing out
 #: on ``run`` / ``update`` / ``set_repo`` / ``commit`` etc.).
 DEFAULT_PROGRESS_INTERVAL_SECONDS: float = 10.0
+
+
+class _LogCaptureHandler(Handler):
+    """Tee ``mtui`` log records emitted *during a command* into its stdout.
+
+    The MCP layer hands the client only what a command wrote to its
+    per-call :class:`io.StringIO` (see :meth:`McpSession._run_sync`).
+    Records logged through the standard library — e.g. the product-drift
+    ``logger.warning`` lines from
+    :meth:`mtui.test_reports.testreport.TestReport._verify_target_products`
+    — never touch that buffer, so without this handler MCP clients would
+    miss them.
+
+    Two scoping rules keep the capture tight:
+
+    * **Level.** Only ``INFO`` and above is teed in; ``DEBUG`` stays out.
+    * **Capture token.** :meth:`filter` admits only records whose ambient
+      :data:`_capture_token` matches this handler's token. The token is
+      set per call by :meth:`McpSession._run_sync` and propagates into
+      worker threads via :class:`mtui.support.concurrency.ContextExecutor`,
+      so a command's own fan-out (e.g. the connect thread pool that emits
+      product-drift warnings) is captured while concurrent sessions —
+      each with a different token — never bleed into one another's reply.
+
+    Installed on the ``mtui`` logger (not ``mtui-mcp``) for the duration
+    of a single ``_run_sync`` call and removed in its ``finally`` — so a
+    session's own bookkeeping (``mtui-mcp``: the per-call "wrote to
+    stderr" notice, ``notify:`` lines) is *not* captured.
+    """
+
+    def __init__(self, stream: io.StringIO, token: object) -> None:
+        """Bind the handler to one call's stdout buffer and capture token.
+
+        Args:
+            stream: The per-call :class:`io.StringIO` to tee records into.
+            token: The unique per-call object stored in
+                :data:`_capture_token`; only records emitted while that
+                same token is the ambient value are captured.
+
+        """
+        super().__init__(level=logging.INFO)
+        self._stream = stream
+        self._token = token
+
+    def filter(self, record: LogRecord) -> bool:
+        """Admit only records whose ambient capture token is this call's."""
+        return _capture_token.get() is self._token
+
+    def emit(self, record: LogRecord) -> None:
+        """Write the record as ``LEVEL: message`` into the bound stream.
+
+        The level label is derived from ``record.levelno`` rather than
+        ``record.levelname`` because mtui's :class:`ColorFormatter`
+        mutates ``levelname`` in place (lowercasing/colourising it) when
+        another handler on the same logger formats the shared record
+        first; reading ``levelno`` keeps this output stable and
+        uncoloured regardless of handler ordering.
+        """
+        try:
+            level = logging.getLevelName(record.levelno)
+            self._stream.write(f"{level}: {record.getMessage()}\n")
+        except Exception:  # noqa: BLE001 - logging must never raise into callers
+            self.handleError(record)
 
 
 class McpCommandError(RuntimeError):
@@ -239,7 +318,8 @@ class McpSession:
         ``load_update``) call ``self.prompt.println`` directly. While a
         command is running the per-call StringIO is active and the
         write lands in the captured output; outside a call we have
-        nowhere to put the text, so it goes to the log at INFO.
+        nowhere to put the text, so it goes to the log at WARNING (it is
+        addressed at a human, not routine status).
 
         Args:
             msg: The string to print.
@@ -249,7 +329,7 @@ class McpSession:
         if self._current_stdout is not None:
             self._current_stdout.write(msg + eol)
         else:
-            self.log.info(msg)
+            self.log.warning(msg)
 
     def load_update(self, update, autoconnect: bool) -> None:
         """Loads an update and swaps in the resulting TestReport.
@@ -340,7 +420,7 @@ class McpSession:
             except Exception as exc:  # noqa: BLE001 - best-effort teardown
                 self.log.warning("error disconnecting host %s: %s", name, exc)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ContextExecutor() as executor:
             futures = [executor.submit(_close_one, name) for name in hostnames]
             concurrent.futures.wait(futures, timeout=45)
 
@@ -454,6 +534,34 @@ class McpSession:
         prev_stdout = self._current_stdout
         self.display = display
         self._current_stdout = fake_sys.stdout
+
+        # Tee the command's own ``mtui.*`` log records (INFO+) into the
+        # captured stdout so MCP clients see warnings/errors the command
+        # logs rather than prints — e.g. product-drift warnings emitted
+        # by ``TestReport._verify_target_products``. Scoped by a per-call
+        # capture token (set in this context and propagated into worker
+        # threads via ``ContextExecutor``) so a command's own fan-out is
+        # captured while concurrent http sessions never cross-pollute, and
+        # bound to the ``mtui`` logger (not ``self.log``/``mtui-mcp``) so
+        # the session's own bookkeeping below is not echoed back.
+        #
+        # The ``mtui`` logger defaults to an effective level of WARNING
+        # (inherited from root), which would drop INFO records before any
+        # handler sees them, so temporarily lower it to INFO for the call
+        # when it is currently stricter. The raw level is saved and
+        # restored in ``finally`` so a user's ``set_log_level`` choice is
+        # left untouched (under MCP that command targets the separate
+        # ``mtui-mcp`` logger, but restoring the exact prior value keeps
+        # this safe regardless).
+        cap_logger = getLogger("mtui")
+        cap_token = object()
+        cap_handler = _LogCaptureHandler(fake_sys.stdout, cap_token)
+        token_reset = _capture_token.set(cap_token)
+        prev_cap_level = cap_logger.level
+        lowered_cap_level = cap_logger.getEffectiveLevel() > logging.INFO
+        if lowered_cap_level:
+            cap_logger.setLevel(logging.INFO)
+        cap_logger.addHandler(cap_handler)
         try:
             try:
                 args_ns = cmd_cls.parse_args(shlex.join(argv), fake_sys)
@@ -499,5 +607,9 @@ class McpSession:
 
             return fake_sys.stdout.getvalue()
         finally:
+            cap_logger.removeHandler(cap_handler)
+            _capture_token.reset(token_reset)
+            if lowered_cap_level:
+                cap_logger.setLevel(prev_cap_level)
             self.display = prev_display
             self._current_stdout = prev_stdout

--- a/mtui/support/concurrency.py
+++ b/mtui/support/concurrency.py
@@ -1,0 +1,56 @@
+"""Concurrency helpers shared across MTUI.
+
+Currently a single export: :class:`ContextExecutor`, a drop-in
+:class:`concurrent.futures.ThreadPoolExecutor` that propagates the
+caller's :mod:`contextvars` context into every worker thread.
+
+A plain ``ThreadPoolExecutor`` does **not** copy context into its
+workers (unlike :func:`asyncio.to_thread`), so any
+:class:`contextvars.ContextVar` set on the submitting thread reads back
+its default inside a pool task. MTUI relies on context propagation so a
+per-call marker (set once at the top of a command) stays visible in the
+worker threads that command fans out to -- most importantly the
+``mtui-mcp`` log-capture token (see
+:class:`mtui.mcp.session._LogCaptureHandler`), which lets the MCP layer
+attribute a worker thread's log records to the originating tool call.
+
+Routing MTUI's thread pools through this class instead of the bare
+``ThreadPoolExecutor`` keeps that behaviour uniform across every command
+and every transport (stdio / http / REPL); code that does not set any
+context var is unaffected (copying an unmodified context is cheap and
+side-effect free).
+"""
+
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextvars import copy_context
+from typing import Any, TypeVar, override
+
+_T = TypeVar("_T")
+
+
+class ContextExecutor(ThreadPoolExecutor):
+    """A ``ThreadPoolExecutor`` that runs tasks in a copy of the caller's context.
+
+    Each :meth:`submit` snapshots the current :mod:`contextvars` context
+    at call time and runs the task inside that copy on the worker thread,
+    so :class:`~contextvars.ContextVar` values set by the submitter are
+    visible to the task (and to anything it logs). The copy is taken per
+    submit, matching the semantics of :func:`asyncio.to_thread`.
+    """
+
+    @override
+    def submit(self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> Future[_T]:
+        """Submit ``fn`` to run inside a copy of the caller's context.
+
+        Args:
+            fn: The callable to execute on a worker thread.
+            *args: Positional arguments forwarded to ``fn``.
+            **kwargs: Keyword arguments forwarded to ``fn``.
+
+        Returns:
+            A :class:`concurrent.futures.Future` for the call.
+
+        """
+        ctx = copy_context()
+        return super().submit(lambda: ctx.run(fn, *args, **kwargs))

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -22,6 +22,7 @@ from ..hosts.refhost import Attributes, RefhostsFactory, RefhostsResolveFailedEr
 from ..hosts.refhost import verify as product_verify
 from ..hosts.target import Target, TargetLockedError
 from ..hosts.target.hostgroup import HostsGroup
+from ..support.concurrency import ContextExecutor
 from ..support.config import Config
 from ..support.exceptions import InvalidGiteaHashError, UpdateError
 from ..support.fileops import ensure_dir_exists
@@ -599,7 +600,7 @@ class TestReport(ABC):
         """Connects to all targets."""
         targets: dict[str, Target] = {}
         new_systems: dict[str, str] = {}
-        executor = concurrent.futures.ThreadPoolExecutor()
+        executor = ContextExecutor()
         hosts: set[str] = {host for host in self.hostnames if host not in self.targets}
 
         if hosts:

--- a/mtui/update_workflow/export/downloader.py
+++ b/mtui/update_workflow/export/downloader.py
@@ -1,6 +1,5 @@
 """Functions for downloading logs from openQA."""
 
-import concurrent.futures
 import os.path
 from collections.abc import Callable
 from logging import getLogger
@@ -8,6 +7,7 @@ from pathlib import Path
 
 import requests
 
+from ...support.concurrency import ContextExecutor
 from ...support.fileops import atomic_write_file
 from ...support.http import VerifyPolicy, get_bytes
 from ...support.messages import ResultsMissingError
@@ -128,7 +128,7 @@ def download_logs(
                 (host.host, x.name, x.test_id, x.arch) for x in host.results
             ]
 
-    with concurrent.futures.ThreadPoolExecutor() as e:
+    with ContextExecutor() as e:
         for host, name, test_id, arch in results_matrix:
             test = {"name": name, "test_id": test_id, "arch": arch}
             dl = downloader.get(name.split("_")[0], _emptylog)

--- a/tests/test_cmd_addhost.py
+++ b/tests/test_cmd_addhost.py
@@ -42,7 +42,7 @@ def test_add_host_with_explicit_targets_submits_per_host(mock_config):
     args = Namespace(target=["h1", "h2"], keep_mode=False)
 
     with (
-        patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor") as tpe,
+        patch("mtui.commands.addhost.ContextExecutor") as tpe,
         patch("mtui.commands.addhost.concurrent.futures.wait") as wait,
     ):
         executor = MagicMock()
@@ -102,11 +102,17 @@ def test_add_host_keep_mode_stays_automatic(mock_config):
     prompt.metadata.connect_targets.assert_called_once_with()
 
 
-def test_add_host_prints_product_warnings_for_new_hosts(mock_config):
-    """Product-drift warnings recorded during connect are echoed to stdout so
-    MCP clients (which only see command stdout) can see them."""
+def test_add_host_does_not_echo_product_warnings_to_stdout(mock_config):
+    """add_host no longer re-echoes product-drift warnings to stdout.
+
+    Drift is reported once, via ``logger.warning`` in
+    ``TestReport._verify_target_products`` (covered in test_testreport.py);
+    under MCP the session tees those records into the reply
+    (test_mcp_session.py). The old ``println(f"WARNING: ...")`` echo --
+    which duplicated the logger output in the REPL -- is gone.
+    """
     prompt = _prompt()
-    prompt.metadata.targets = {}  # nothing connected yet
+    prompt.metadata.targets = {}
     prompt.metadata.product_warnings = {"h1": ["arch 'x86_64' != 'aarch64' (metadata)"]}
     args = Namespace(target=["h1"], keep_mode=False)
 
@@ -114,39 +120,17 @@ def test_add_host_prints_product_warnings_for_new_hosts(mock_config):
     fake_sys.stdout = StringIO()
 
     def _connect(*_a, **_k):
-        # Simulate add_target connecting h1 between the before/after snapshot.
         prompt.metadata.targets["h1"] = MagicMock()
 
     with (
-        patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor"),
+        patch("mtui.commands.addhost.ContextExecutor"),
         patch("mtui.commands.addhost.concurrent.futures.wait", side_effect=_connect),
     ):
         AddHost(args, mock_config, fake_sys, prompt)()
 
     output = fake_sys.stdout.getvalue()
-    assert "WARNING: h1: arch 'x86_64' != 'aarch64' (metadata)" in output
-
-
-def test_add_host_no_warnings_prints_nothing(mock_config):
-    """A clean connect with no drift prints nothing extra."""
-    prompt = _prompt()
-    prompt.metadata.targets = {}
-    prompt.metadata.product_warnings = {}
-    args = Namespace(target=["h1"], keep_mode=False)
-
-    fake_sys = MagicMock()
-    fake_sys.stdout = StringIO()
-
-    def _connect(*_a, **_k):
-        prompt.metadata.targets["h1"] = MagicMock()
-
-    with (
-        patch("mtui.commands.addhost.concurrent.futures.ThreadPoolExecutor"),
-        patch("mtui.commands.addhost.concurrent.futures.wait", side_effect=_connect),
-    ):
-        AddHost(args, mock_config, fake_sys, prompt)()
-
-    assert fake_sys.stdout.getvalue() == ""
+    assert "WARNING:" not in output
+    assert output == ""
 
 
 def test_add_host_in_manual_mode_does_not_switch(mock_config):

--- a/tests/test_cmd_removehost.py
+++ b/tests/test_cmd_removehost.py
@@ -41,7 +41,7 @@ def test_remove_host_happy_closes_and_pops(mock_config):
         return MagicMock()
 
     with (
-        patch("mtui.commands.removehost.concurrent.futures.ThreadPoolExecutor") as tpe,
+        patch("mtui.commands.removehost.ContextExecutor") as tpe,
         patch("mtui.commands.removehost.concurrent.futures.wait"),
     ):
         executor = MagicMock()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,98 @@
+"""Tests for :class:`mtui.support.concurrency.ContextExecutor`.
+
+The contract these tests pin:
+
+* a :class:`~contextvars.ContextVar` set on the submitting thread is
+  visible inside the worker task (a plain ``ThreadPoolExecutor`` would
+  read the default);
+* each ``submit`` snapshots the context at call time, not at construction;
+* worker exceptions still propagate via ``Future.result`` (inherited
+  ``ThreadPoolExecutor`` behaviour is preserved through the override).
+"""
+
+from __future__ import annotations
+
+import contextvars
+import threading
+
+import pytest
+
+from mtui.support.concurrency import ContextExecutor
+
+_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "test_var", default="DEFAULT"
+)
+
+
+def test_context_var_propagates_into_worker() -> None:
+    """A ContextVar set before submit is readable inside the worker."""
+    _var.set("SET-BY-CALLER")
+
+    def read_var() -> str:
+        return _var.get()
+
+    with ContextExecutor(max_workers=2) as ex:
+        result = ex.submit(read_var).result()
+
+    assert result == "SET-BY-CALLER"
+
+
+def test_worker_runs_on_a_different_thread() -> None:
+    """Sanity: the task really runs on a pool thread, not inline."""
+    caller = threading.get_ident()
+
+    def worker() -> int:
+        return threading.get_ident()
+
+    with ContextExecutor(max_workers=1) as ex:
+        worker_tid = ex.submit(worker).result()
+
+    assert worker_tid != caller
+
+
+def test_each_submit_snapshots_context_at_call_time() -> None:
+    """Two submits see the value current at their own submit call."""
+
+    def read_var() -> str:
+        return _var.get()
+
+    with ContextExecutor(max_workers=1) as ex:
+        _var.set("first")
+        f1 = ex.submit(read_var)
+        _var.set("second")
+        f2 = ex.submit(read_var)
+        r1, r2 = f1.result(), f2.result()
+
+    assert r1 == "first"
+    assert r2 == "second"
+
+
+def test_default_when_no_context_var_set() -> None:
+    """With nothing set in the context, the worker reads the default.
+
+    Runs inside a brand-new :class:`contextvars.Context` (which starts
+    empty) so the assertion is independent of any value other tests left
+    on the main thread's context.
+    """
+
+    def run_in_fresh_context() -> str:
+        def read_var() -> str:
+            return _var.get()
+
+        with ContextExecutor(max_workers=1) as ex:
+            return ex.submit(read_var).result()
+
+    fresh = contextvars.Context()
+    assert fresh.run(run_in_fresh_context) == "DEFAULT"
+
+
+def test_worker_exception_propagates_via_result() -> None:
+    """A worker exception is re-raised by ``Future.result`` (inherited)."""
+
+    def boom() -> None:
+        raise ValueError("worker failed")
+
+    with ContextExecutor(max_workers=1) as ex:
+        future = ex.submit(boom)
+        with pytest.raises(ValueError, match="worker failed"):
+            future.result()

--- a/tests/test_export_downloader.py
+++ b/tests/test_export_downloader.py
@@ -151,7 +151,7 @@ def test_download_logs_dispatches_via_thread_pool() -> None:
     fake_executor.__enter__.return_value = fake_executor
     fake_executor.__exit__.return_value = False
     with patch(
-        "mtui.update_workflow.export.downloader.concurrent.futures.ThreadPoolExecutor",
+        "mtui.update_workflow.export.downloader.ContextExecutor",
         return_value=fake_executor,
     ):
         download_logs([host], "/r", "/i", "tolerant")

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -15,7 +15,9 @@ group does not pull it in); each test is a tiny synchronous wrapper.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
+import threading
 import time
 from pathlib import Path
 from typing import ClassVar
@@ -26,6 +28,7 @@ import pytest
 from mtui.commands import Command
 from mtui.commands.whoami import Whoami
 from mtui.mcp.session import McpCommandError, McpSession
+from mtui.support.concurrency import ContextExecutor
 
 
 def _config(tmp_path: Path) -> MagicMock:
@@ -148,3 +151,126 @@ def test_set_prompt_records_session_label(tmp_path: Path) -> None:
     assert sess.session == "SUSE:Maintenance:1:1"
     sess.set_prompt(None)
     assert sess.session is None
+
+
+# --------------------------------------------------------------------------- #
+# Log capture into the reply                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class _LoggingCommand(Command):
+    """Test-only command that logs at several levels via the ``mtui`` tree."""
+
+    command = "_mcp_test_logging_command"
+
+    def __call__(self) -> None:  # pragma: no cover - exercised by test
+        log = logging.getLogger("mtui.commands._mcp_test_logging_command")
+        log.warning("drift on h1")
+        log.info("connected h1")
+        log.debug("low-level noise")
+        self.println("stdout line")
+
+
+class _QuietCommand(Command):
+    """Test-only command that logs nothing and prints one line."""
+
+    command = "_mcp_test_quiet_command"
+
+    def __call__(self) -> None:  # pragma: no cover - exercised by test
+        self.println("quiet line")
+
+
+def test_run_command_captures_mtui_log_records_into_reply(tmp_path: Path) -> None:
+    """INFO+ records a command logs via the ``mtui`` tree land in the reply."""
+    sess = _make_session(tmp_path)
+    out = asyncio.run(sess.run_command(_LoggingCommand, []))
+
+    assert "WARNING: drift on h1" in out
+    assert "INFO: connected h1" in out
+    # The command's own stdout is preserved alongside the captured logs.
+    assert "stdout line" in out
+    # DEBUG stays below the INFO capture threshold.
+    assert "low-level noise" not in out
+
+
+def test_run_command_log_capture_does_not_leak_across_calls(tmp_path: Path) -> None:
+    """The capture handler is detached in ``finally``; a later reply is clean."""
+    sess = _make_session(tmp_path)
+
+    first = asyncio.run(sess.run_command(_LoggingCommand, []))
+    assert "WARNING: drift on h1" in first
+
+    # A subsequent command that logs nothing must not inherit the first
+    # call's handler nor any of its records.
+    second = asyncio.run(sess.run_command(_QuietCommand, []))
+    assert second == "quiet line\n"
+    assert "drift on h1" not in second
+
+    # And no handler was left attached to the shared 'mtui' logger.
+    mtui_logger = logging.getLogger("mtui")
+    assert not any(
+        type(h).__name__ == "_LogCaptureHandler" for h in mtui_logger.handlers
+    )
+
+
+def test_run_command_captures_context_executor_worker_records(tmp_path: Path) -> None:
+    """Records logged on a ``ContextExecutor`` worker thread are captured.
+
+    This is the real-world path: ``add_host`` fans out host connects to a
+    thread pool, and the product-drift warnings are logged on those pool
+    workers. ``ContextExecutor`` propagates the per-call capture token
+    into the worker, so those records reach the reply.
+    """
+    sess = _make_session(tmp_path)
+
+    def _emit_drift(host: str) -> None:
+        logging.getLogger("mtui.commands._mcp_test_pool_worker").warning(
+            "drift on %s", host
+        )
+
+    class _PoolCommand(Command):
+        command = "_mcp_test_pool_command"
+
+        def __call__(self) -> None:  # pragma: no cover - exercised by test
+            with ContextExecutor() as ex:
+                list(
+                    concurrent.futures.as_completed(
+                        [ex.submit(_emit_drift, h) for h in ("h1", "h2")]
+                    )
+                )
+            self.println("main line")
+
+    out = asyncio.run(sess.run_command(_PoolCommand, []))
+    assert "main line" in out
+    # Worker-thread warnings are captured because ContextExecutor carried
+    # the call's capture token into the pool threads.
+    assert "WARNING: drift on h1" in out
+    assert "WARNING: drift on h2" in out
+
+
+def test_run_command_excludes_records_without_capture_token(tmp_path: Path) -> None:
+    """A record on a raw thread (no token propagation) is not captured.
+
+    A bare :class:`threading.Thread` does not inherit the call's
+    contextvars, so its records carry no capture token and must stay out
+    of the reply — this is what keeps concurrent sessions isolated.
+    """
+    sess = _make_session(tmp_path)
+
+    def _emit_from_raw_thread() -> None:
+        logging.getLogger("mtui.commands._mcp_test_raw_thread").warning(
+            "from a raw thread"
+        )
+
+    class _RawThreadCommand(Command):
+        command = "_mcp_test_raw_thread_command"
+
+        def __call__(self) -> None:  # pragma: no cover - exercised by test
+            t = threading.Thread(target=_emit_from_raw_thread)
+            t.start()
+            t.join()
+            self.println("main line")
+
+    out = asyncio.run(sess.run_command(_RawThreadCommand, []))
+    assert "main line" in out
+    assert "from a raw thread" not in out


### PR DESCRIPTION
## Problem

MCP tool replies returned only what a command printed to **stdout**, so any
condition a command reports through the logger never reached the client.
Most visibly, the per-host product-drift warnings emitted by `add_host`'s
connect path (`TestReport._verify_target_products`, logged at `WARNING`)
were invisible over MCP — the operator saw nothing about hosts whose
installed products disagree with `refhosts.yml`.

A first attempt scoped the capture by the calling thread id, but the drift
warnings are logged on `ThreadPoolExecutor` **worker threads** spawned by
the connect path, so they were filtered out.

## Fix

Capture each command's own `mtui.*` log records (`INFO` and above) for the
duration of the call and append them to the reply, prefixed with their
level (`WARNING: …`, `INFO: …`).

- **Scoped by a per-call `contextvars` token**, not a thread id, so the
  capture follows the command into the worker threads it fans out to while
  keeping concurrent `--transport http` sessions isolated.
- To make that work **uniformly across every command**, MTUI's thread
  pools now go through a new `ContextExecutor` (a `ThreadPoolExecutor` that
  copies the caller's context into each task — a plain pool does not).
  Converted: `testreport.connect_targets`, `add_host`, `remove_host`,
  `quit`, `export/downloader`, `target/actions`,
  `qem_dashboard/dashboard_openqa`, and the MCP session disconnect path.
- `add_host` no longer re-echoes the drift warnings to stdout — the logger
  output now reaches clients directly (removes the prior duplicate
  `WARNING:` block).
- The `mtui` logger is temporarily lowered to `INFO` during a call
  (restored afterwards) so `INFO` records are not dropped before the
  handler. `set_log_level` targets the separate `mtui-mcp` logger and is
  unaffected. `mtui-mcp` bookkeeping (e.g. "wrote to stderr", `notify:`)
  stays out of replies because it is outside the captured `mtui` subtree.

### Before / after (MCP `add_host` reply)

Before: only main-thread lines; per-host drift warnings missing.
After:
```
INFO: add_host: switching to manual workflow
WARNING: ganymede.qam.suse.cz: products differ from refhosts.yml metadata: addons installed but not in metadata: sle-ha 15-SP7
WARNING: titan.qam.suse.cz: products differ from refhosts.yml metadata: addons installed but not in metadata: sle-ha 15-SP7
```

## Tests

- New `tests/test_concurrency.py` — `ContextExecutor` context propagation,
  per-submit snapshot, default isolation, exception propagation.
- `tests/test_mcp_session.py` — capture into the reply (incl. worker-thread
  records via `ContextExecutor`), no cross-call leak, and exclusion of
  records emitted on a raw (token-less) thread.
- Repointed patch targets in `test_cmd_addhost`, `test_cmd_removehost`,
  `test_export_downloader`.

## Gates

`ruff format --check` · `ruff check` · `ty check` · `pytest` (1381 passed) ·
`sphinx-build -W` — all green.

Docs (`Documentation/mcp.rst`, `iui.rst`) and `CHANGELOG.md` updated.