### PR TITLE
fix(mcp): suppress repeated InsecureRequestWarning in server log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `add_host`'s connect pool — reach MCP clients directly; `add_host` no longer
   re-echoes them to stdout.
 
+### Fixed
+
+- `mtui-mcp` no longer floods its log with a repeated
+  `Warning: InsecureRequestWarning: Unverified HTTPS request ...` line — one per
+  openQA (or other internal-host) request — when TLS verification is disabled
+  via `ssl_verify = false`. The MCP SDK records and re-emits warnings raised
+  while handling each request, which defeated the per-request suppression; the
+  warning is now silenced once at server start-up (only when verification is
+  off), so a genuine certificate problem is still reported when verification is
+  on.
+
 ## 18.1.0 - 2026-06-19
 
 ### Added

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -533,3 +533,14 @@ The capture is deliberately scoped:
   ``mtui-mcp`` logger, which is outside the captured ``mtui`` subtree and
   therefore never echoed back into the reply.
 
+.. note::
+
+   When TLS verification is disabled (``ssl_verify = false``), the
+   server silences urllib3's ``InsecureRequestWarning`` **once at
+   start-up**. The MCP SDK records and re-emits every Python warning
+   raised while it handles a request, so without this the warning would
+   otherwise reappear on the server log for *every* request to an
+   internal host reached without verification (openQA, the QAM
+   Dashboard, …). Suppression happens only when verification is off, so
+   a real certificate problem is still surfaced when it is on.
+

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -32,6 +32,7 @@ from ..cli.argparse import ArgsParseFailureError
 from ..cli.colors import create_logger
 from ..cli.colors import set_mode as set_color_mode
 from ..support.config import Config
+from ..support.http import disable_insecure_warnings, resolve_verify
 from ..support.systemcheck import detect_system
 from .args import get_parser
 from .registry import SessionRegistry
@@ -144,6 +145,22 @@ def main() -> int:
     cfg = Config(args.config)
     cfg.merge_args(args)
     cfg.distro, cfg.distro_ver, cfg.distro_kernel = detect_system()
+
+    # Suppress urllib3's InsecureRequestWarning here, at boot, when the user
+    # has disabled TLS verification — *before* FastMCP starts serving. The
+    # MCP SDK wraps every request handler in
+    # ``warnings.catch_warnings(record=True)``, which snapshots and restores
+    # ``warnings.filters`` per request and re-emits any recorded warning as
+    # ``logger.info("Warning: ...")``. A filter installed lazily on the first
+    # request (as ``disable_insecure_warnings`` does in the REPL path) is
+    # discarded when that request's ``catch_warnings`` block exits, and the
+    # helper's module-level idempotency guard then blocks re-installation, so
+    # the warning re-fires on every subsequent openQA request. Installing it
+    # before the first request means every per-request snapshot includes it,
+    # so it survives. Only when verification is actually off, mirroring the
+    # per-call-site contract.
+    if not resolve_verify(True, cfg.ssl_verify):
+        disable_insecure_warnings()
 
     # Provider selection is the whole of the per-client isolation
     # contract: under http each client gets its own isolated

--- a/tests/test_mcp_main.py
+++ b/tests/test_mcp_main.py
@@ -260,3 +260,95 @@ def test_main_happy_path_http_transport(
     )
     assert rc == 0
     fastmcp_instance.run.assert_called_once_with(transport="streamable-http")
+
+
+# --------------------------------------------------------------------------- #
+# Boot-time InsecureRequestWarning suppression                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_main_suppresses_insecure_warning_when_verify_off(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_environment: dict[str, MagicMock],
+) -> None:
+    """``ssl_verify = false`` -> the urllib3 warning is silenced at boot.
+
+    The MCP SDK wraps every request handler in
+    ``warnings.catch_warnings(record=True)``, which snapshots and
+    restores ``warnings.filters`` per request. Installing the ignore
+    filter lazily on the first request loses it on that request's exit
+    (and the helper's idempotency guard then blocks re-installation),
+    so it must be installed before the server loop starts.
+    """
+    disable = MagicMock(name="disable_insecure_warnings")
+    monkeypatch.setattr(mcp_main, "disable_insecure_warnings", disable)
+    stub_environment["config"].ssl_verify = False
+
+    rc, _ = _run_with_fake_fastmcp(monkeypatch, lambda: None)
+
+    assert rc == 0
+    disable.assert_called_once_with()
+
+
+@pytest.mark.parametrize("ssl_verify", [True, None, "/etc/ssl/ca-bundle.pem"])
+def test_main_keeps_insecure_warning_when_verifying(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_environment: dict[str, MagicMock],
+    ssl_verify: object,
+) -> None:
+    """When verification is on (or a CA bundle), the warning stays active.
+
+    A truthy ``ssl_verify`` (``True`` or a CA-bundle path) and the
+    unset default (``None`` -> resolves to ``True``) all keep the
+    insecure-request warning, so a genuine misconfiguration is never
+    masked.
+    """
+    disable = MagicMock(name="disable_insecure_warnings")
+    monkeypatch.setattr(mcp_main, "disable_insecure_warnings", disable)
+    stub_environment["config"].ssl_verify = ssl_verify
+
+    rc, _ = _run_with_fake_fastmcp(monkeypatch, lambda: None)
+
+    assert rc == 0
+    disable.assert_not_called()
+
+
+def test_boot_suppression_survives_sdk_catch_warnings_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_environment: dict[str, MagicMock],
+) -> None:
+    """End-to-end: the real suppression survives per-request snapshots.
+
+    This drives the *actual* ``disable_insecure_warnings`` (not a mock)
+    through ``main()`` with verification off, then simulates the SDK's
+    ``warnings.catch_warnings(record=True)`` request wrapper twice. The
+    bug was that a filter installed inside the first request is
+    discarded on its exit, so the second request re-records the warning;
+    installing it at boot means both requests record nothing.
+    """
+    import warnings
+
+    from urllib3.exceptions import InsecureRequestWarning
+
+    from mtui.support import http as _http
+
+    # Reset the helper's module-level idempotency guard so this test's
+    # boot install is the one that takes effect, not a leftover from an
+    # earlier test in the session.
+    monkeypatch.setattr(_http, "_warnings_disabled", False)
+    stub_environment["config"].ssl_verify = False
+
+    rc, _ = _run_with_fake_fastmcp(monkeypatch, lambda: None)
+    assert rc == 0
+
+    def simulated_request() -> int:
+        # Mirror mcp/server/lowlevel/server.py: each handler runs inside
+        # ``catch_warnings(record=True)`` and re-emits what it recorded.
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.warn(
+                "Unverified HTTPS request", InsecureRequestWarning, stacklevel=2
+            )
+            return len(recorded)
+
+    assert simulated_request() == 0
+    assert simulated_request() == 0


### PR DESCRIPTION
## Problem

When TLS verification is disabled (`ssl_verify = false`), `mtui-mcp` floods its
log with a repeated line on **every** openQA (or other internal-host) request:

```
INFO  Warning: InsecureRequestWarning: Unverified HTTPS request is being made to host 'openqa.suse.de'. ...  server.py:723
```

## Root cause

The MCP SDK wraps every request handler in `warnings.catch_warnings(record=True)`
(`mcp/server/lowlevel/server.py:705`), which **snapshots and restores
`warnings.filters` per request** and then re-emits any recorded warning via
`logger.info("Warning: ...")` (line 723).

mtui's `disable_insecure_warnings()` installs the urllib3 ignore-filter only
once, gated by the module-level `_warnings_disabled` flag. That first install
happened *inside* a request, so the SDK discarded it when that request's
`catch_warnings` block exited — and the idempotency flag then blocked
re-installation. Result: the filter is gone for request 2+, so the warning
re-fires every time.

Verified: a filter installed *before* the first request is captured by every
per-request snapshot and survives the save/restore cycle.

## Fix

Install the filter once at server start-up in `mtui/mcp/main.py`, before
`FastMCP` begins serving and **only when verification is actually off**. Every
per-request snapshot then includes it, so it survives. A genuine certificate
problem is still reported when verification is on (the warning is only ever
raised when verify is off).

The shared `mtui/support/http.py` helper and the REPL path are untouched.

## Tests

- New `tests/test_mcp_main.py` cases:
  - `ssl_verify = false` → `disable_insecure_warnings()` is called at boot.
  - `ssl_verify` truthy / CA-bundle path / unset → it is **not** called.
  - End-to-end: drives the real helper through `main()` and simulates the SDK's
    `catch_warnings(record=True)` request wrapper twice, asserting zero warnings
    are recorded on both requests. (This test fails — `1 == 0` — when the fix is
    reverted, reproducing the original bug.)

## Gates

`ruff format --check`, `ruff check`, `ty check` all clean; full `pytest` suite
1386 passed.

## Changelog

Added under `[Unreleased] → ### Fixed` in `CHANGELOG.md`; documented in
`Documentation/mcp.rst`.