### PR TITLE
fix: run closes stdin so commands cannot block on input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   warning is now silenced once at server start-up (only when verification is
   off), so a genuine certificate problem is still reported when verification is
   on.
+- `run` now closes the write half of the SSH channel after dispatching the
+  command, sending EOF to the remote command's stdin. A command that reads input
+  (an interactive prompt, `read`, `cat` with no redirect) previously blocked
+  forever waiting for input that never came; it now receives EOF and
+  proceeds/aborts instead of hanging the session.
 
 ## 18.1.0 - 2026-06-19
 

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -379,6 +379,19 @@ class Connection:
         try:
             if session := self.new_session():
                 session.exec_command(command)
+                # run() never feeds stdin to the remote command, so close the
+                # write half of the channel right away. This sends EOF to the
+                # command's stdin: one that reads input (an interactive prompt,
+                # `read`, `cat`, ...) gets EOF and proceeds/aborts instead of
+                # blocking forever waiting for input that will never arrive.
+                try:
+                    session.shutdown_write()
+                except Exception:
+                    logger.debug(
+                        "shutdown_write failed on %s; continuing",
+                        self.hostname,
+                        exc_info=True,
+                    )
             else:
                 return None
         except (paramiko.ChannelException, paramiko.SSHException):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -172,6 +172,46 @@ def test_run_command_success(mock_ssh_client, mock_ssh_config, mock_path):
     mock_session.exec_command.assert_called_once_with("ls -l")
 
 
+def test_run_closes_stdin_after_exec(mock_ssh_client, mock_ssh_config, mock_path):
+    """run() must close the channel's write half so the remote command's
+    stdin gets EOF and can't block forever waiting for input."""
+    conn = Connection("test_host", 22, 300)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"", b""]
+    mock_session.recv_ready.side_effect = [False, False]
+    mock_session.recv_stderr_ready.side_effect = [False, False]
+
+    with patch("select.select", return_value=([mock_session], [], [])):
+        conn.run("read x")
+
+    mock_session.exec_command.assert_called_once_with("read x")
+    mock_session.shutdown_write.assert_called_once_with()
+
+
+def test_run_survives_shutdown_write_failure(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """A channel that can't shutdown_write must not break run()."""
+    conn = Connection("test_host", 22, 300)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.shutdown_write.side_effect = OSError("no write half")
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"ok", b""]
+    mock_session.recv_ready.side_effect = [True, False]
+    mock_session.recv_stderr_ready.side_effect = [False, False]
+
+    with patch("select.select", return_value=([mock_session], [], [])):
+        exit_code = conn.run("true")
+
+    assert exit_code == 0
+    assert conn.stdout == "ok"
+
+
 def test_run_command_timeout(mock_ssh_client, mock_ssh_config, mock_path):
     """Timeout + callback returning 'n' must raise ``CommandTimeoutError``.
 


### PR DESCRIPTION
## Problem

`run()` never feeds the remote command any input, but `exec_command()` left the
channel's **write half open**. A command that reads stdin — an interactive
prompt, shell `read`, `cat` with no redirect — then blocked forever waiting for
input that never arrived.

Observed in the field under `mtui-mcp`: a package's migration script ignored
`--help` and dropped into a "migrate this system? [y/n]" prompt; the `run` wedged
and the remote process kept running on the refhost for ~an hour.

## Fix

Close the write half of the channel right after dispatch (`shutdown_write()`), so
the remote command's stdin gets **EOF** and proceeds/aborts instead of hanging.
Failures to `shutdown_write` are tolerated (debug-logged) so an odd channel can't
break `run()`.

## Tests

- `test_run_closes_stdin_after_exec` — asserts `shutdown_write()` is called after `exec_command`.
- `test_run_survives_shutdown_write_failure` — a channel that can't shutdown_write still runs.

Gates: `ruff format`/`ruff check` clean, `pytest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)