### PR TITLE
fix: run aborts non-interactive command timeouts instead of waiting forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (an interactive prompt, `read`, `cat` with no redirect) previously blocked
   forever waiting for input that never came; it now receives EOF and
   proceeds/aborts instead of hanging the session.
+- A command run over a non-interactive session (`mtui-mcp`) that produces no
+  output for the whole `connection_timeout` window (default 300s) now aborts
+  with a command-timeout instead of looping forever. There is no human to ask
+  "keep waiting?" in that context, so a silent/stuck command previously wedged
+  the call until the session was killed. Interactive sessions are unchanged
+  (they still prompt, or silently wait when no prompter is wired); raise
+  `connection_timeout` for legitimately long, fully silent commands.
 
 ## 18.1.0 - 2026-06-19
 

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -441,6 +441,23 @@ class Connection:
                         f"Session lost during command execution on {self.hostname}"
                     )
 
+                # Non-interactive (e.g. mtui-mcp): there is no human to ask
+                # whether to keep waiting, so a command that produced no output
+                # for the whole timeout window is treated as stuck and aborted,
+                # rather than looping forever (which previously wedged the run
+                # until the session was killed). The window is
+                # ``connection_timeout`` (default 300s); raise it in config for
+                # legitimately long, fully silent commands.
+                if not self._interactive:
+                    logger.warning(
+                        'command "%s" timed out on %s after %ss with no output; '
+                        "aborting (non-interactive session)",
+                        command,
+                        self.hostname,
+                        self.timeout,
+                    )
+                    raise CommandTimeoutError
+
                 # No prompt callback wired: silently wait. Matches the
                 # long-standing Enter / Y default but emits a WARNING
                 # so the silence is observable in logs.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -322,6 +322,24 @@ def test_run_command_timeout_no_callback_waits_silently(
     ), [rec.message for rec in caplog.records]
 
 
+def test_run_command_timeout_noninteractive_aborts(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """Non-interactive session (mtui-mcp): an inactivity timeout aborts with
+    CommandTimeoutError instead of looping forever. Distinct from the
+    interactive default, which waits silently."""
+    conn = Connection("test_host", 22, 300, interactive=False)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+
+    with (
+        patch("select.select", return_value=([], [], [])),
+        pytest.raises(CommandTimeoutError),
+    ):
+        conn.run("sleep infinity")
+
+
 def test_run_command_timeout_callback_runs_on_calling_thread(
     mock_ssh_client, mock_ssh_config, mock_path
 ):


### PR DESCRIPTION
## Problem

Under a **non-interactive** session (`mtui-mcp`) there is no human to answer the
SSH command-timeout "keep waiting? (Y/n)" prompt. In that case the timeout branch
of `Connection.run()` logged a WARNING and **looped forever** when a command
produced no output for the whole `connection_timeout` window (default 300s). A
stuck/silent command therefore wedged the `run` until the session was killed.

## Fix

When the session is non-interactive (`interactive=False`, i.e. `mtui-mcp`), treat
the inactivity timeout as a real timeout and raise `CommandTimeoutError` instead
of looping. Interactive sessions are **unchanged**: they still prompt via the
wired callback, or fall back to the documented "silently wait" default when no
prompter is wired (that default is keyed on `interactive=True`, which the existing
`test_run_command_timeout_no_callback_waits_silently` pins). Raise
`connection_timeout` in config for legitimately long, fully silent commands.

## Tests

- `test_run_command_timeout_noninteractive_aborts` — `interactive=False` + inactivity timeout → `CommandTimeoutError`.
- Existing interactive/silent-wait and prompt-callback tests remain green (behaviour preserved).

Gates: `ruff format`/`ruff check` clean, `pytest` green.

Note: touches the same `run()` timeout region as #192 (closing stdin); the two are
independent fixes — whichever merges first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)