### PR TITLE
fix: set_repo surfaces a no-op add/remove and a failed zypper ar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the call until the session was killed. Interactive sessions are unchanged
   (they still prompt, or silently wait when no prompter is wired); raise
   `connection_timeout` for legitimately long, fully silent commands.
+- `set_repo` no longer returns silent success when it does nothing. If none of
+  the update's products match a host's installed products (e.g. the host's parsed
+  products drifted from what the update targets), no repo was ever registered;
+  this now logs a `WARNING` naming the host and the mismatched product sets
+  instead of appearing to succeed. A failed `zypper ar` (non-zero exit) is also
+  surfaced as a `WARNING` rather than ignored.
 
 ## 18.1.0 - 2026-06-19
 

--- a/mtui/hosts/target/repo_manager.py
+++ b/mtui/hosts/target/repo_manager.py
@@ -62,15 +62,43 @@ class RepoManager:
         def name(product, rrid) -> str:
             return f"issue-{product.name}:{product.version}:p={rrid.maintenance_id}:{rrid.review_id}"
 
+        matched = 0
         for x, y in ur:
+            matched += 1
             if "ar" in cmd:
                 logger.info("Adding repo %s on %s", y, t.hostname)
                 t.run(f"zypper {cmd} {name(x, rrid)} {y} {name(x, rrid)}")
+                # Surface a failed add instead of returning silent success: a
+                # non-zero zypper exit here means the repo was NOT registered.
+                if t.lastexit() not in (0, "0"):
+                    err = t.lasterr().strip() or t.lastout().strip()
+                    logger.warning(
+                        "adding repo %s on %s failed: zypper exited %s%s",
+                        name(x, rrid),
+                        t.hostname,
+                        t.lastexit(),
+                        f" ({err.splitlines()[-1]})" if err else "",
+                    )
             elif "rr" in cmd:
                 logger.info("Removing repo %s on %s", y, t.hostname)
                 t.run(f"zypper {cmd} {y}")
             else:
                 t.unlock(force=True)
                 raise ValueError
+
+        # No product/repo matched the host's installed products, so nothing was
+        # (un)registered. Previously this returned silent "success" — warn so the
+        # no-op is visible (e.g. a host whose parsed products drifted from what
+        # the update targets, the cause of an add that mysteriously did nothing).
+        if matched == 0:
+            op = "add" if "ar" in cmd else "remove" if "rr" in cmd else cmd
+            logger.warning(
+                "set_repo %s on %s did nothing: none of the update's products %s "
+                "match the host's installed products %s",
+                op,
+                t.hostname,
+                sorted(str(p) for p in repos),
+                sorted(str(p) for p in t.system.flatten()),
+            )
 
         t.run("zypper -n ref")

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -108,3 +108,53 @@ def test_run_zypper_skips_products_not_in_flattened_system(mock_target, mock_rri
     assert any("https://wanted/repo" in c for c in commands)
     assert not any("https://other/repo" in c for c in commands)
     assert commands[-1] == "zypper -n ref"
+
+
+def test_run_zypper_warns_when_no_product_matches(mock_target, mock_rrid, caplog):
+    """No repo product matches the host's system: warn instead of silent no-op.
+
+    Reproduces the observed bug where ``set_repo --add`` returned success but
+    added nothing because none of the update's products matched the host's
+    (drifted) installed products. Only ``zypper -n ref`` runs; a WARNING fires.
+    """
+    import logging
+
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "16.0", "x86_64")}
+    repos = {Product("opensuse", "15.4", "x86_64"): "https://other/repo"}
+
+    with caplog.at_level(logging.WARNING, logger="mtui.target.repo_manager"):
+        mock_target.repo_manager.run_zypper("ar", repos, mock_rrid)
+
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert not any("zypper ar" in c for c in commands)
+    assert commands == ["zypper -n ref"]
+    assert any(
+        "did nothing" in r.message and "host1.example.com" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_run_zypper_ar_warns_on_zypper_failure(mock_target, mock_rrid, caplog):
+    """A non-zero ``zypper ar`` exit is surfaced as a WARNING, not swallowed."""
+    import logging
+
+    mock_target.state = "enabled"
+    mock_target.connection.run.return_value = 4  # zypper add failed
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = "Repository already exists."
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SLES", "15-SP5", "x86_64")}
+    repos = {Product("SLES", "15-SP5", "x86_64"): "https://example/repo"}
+
+    with caplog.at_level(logging.WARNING, logger="mtui.target.repo_manager"):
+        mock_target.repo_manager.run_zypper("ar", repos, mock_rrid)
+
+    assert any(
+        "failed: zypper exited 4" in r.message and "issue-SLES" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]


### PR DESCRIPTION
## Problem

`set_repo --add` could return **silent success while adding nothing**.
`RepoManager.run_zypper()` only emits a `zypper ar` for products that are in the
target's flattened system:

```python
ur = ((x, y) for x, y in repos.items() if x in t.system.flatten())
for x, y in ur:
    ...
```

If none of the update's products match the host's installed products (e.g. the
host's parsed products have drifted from what the update targets), the generator
is empty, the loop body never runs, and the method falls through to
`zypper -n ref` — reporting success having registered no repo. Observed in the
field: `set_repo --add` did nothing on one host while succeeding on its peers,
with no indication why. The `zypper ar` exit code was also ignored, so a genuine
add failure was swallowed too.

## Fix

- Count matched products; if **zero**, log a `WARNING` naming the host and both
  product sets (update's vs the host's), so the no-op is visible and diagnosable.
- After a `zypper ar`, check the exit code and log a `WARNING` if the add failed,
  instead of silently continuing.

Behaviour is otherwise unchanged: matching repos are still added/removed and the
method still finishes with `zypper -n ref`.

## Tests

- `test_run_zypper_warns_when_no_product_matches` — no matching product → only
  `zypper -n ref` runs and a "did nothing" WARNING fires.
- `test_run_zypper_ar_warns_on_zypper_failure` — non-zero `zypper ar` exit → WARNING.

Gates: `ruff format`/`ruff check` clean, `pytest` green (1388 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)