### PR TITLE
feat: testreport_read accepts offset/limit to page large reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- The `testreport_read` MCP tool accepts optional `offset` (1-based first line)
+  and `limit` (max lines) to return a line window instead of the whole file.
+  Without them the behaviour is unchanged (full file). This lets a caller page a
+  large report — a Product Increment `log` runs to thousands of lines after
+  `export` and otherwise overflowed the reply — using the same 1-indexed line
+  numbers `testreport_patch` consumes; the reply still reports the file's total
+  `line_count` (plus `offset`/`returned_lines` when a window is requested).
+
 - Connecting a reference host now verifies that its installed products match
   what `refhosts.yml` records for that host. On any drift — wrong or
   wrong-version base product, wrong architecture, addons that are missing,

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -8,6 +8,8 @@ directly on the file path tracked by ``session.metadata.path``:
 
 * :func:`testreport_read` — return the file's bytes plus a line count
   computed with the same convention :func:`testreport_patch` consumes.
+  Optional ``offset``/``limit`` read a 1-indexed line window so a large
+  report (a Product Increment log) can be paged instead of overflowing.
 * :func:`testreport_patch` — splice an inclusive 1-indexed line range,
   written atomically via ``NamedTemporaryFile`` + :func:`os.replace`.
 * :func:`testreport_write` — full-file overwrite, also atomic.
@@ -207,21 +209,52 @@ async def _heartbeat(ctx: Context | None, message: str) -> None:
 
 async def testreport_read(
     session: McpSession,
+    offset: int = 1,  # noqa: PT028 - tool entrypoint, not a pytest test
+    limit: int | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Return the loaded testreport file's content and line count.
 
+    By default the whole file is returned. ``offset``/``limit`` request a
+    1-indexed inclusive line window — the same numbering ``testreport_patch``
+    consumes — so a large report (a Product Increment ``log`` runs to thousands
+    of lines after ``export``) can be paged instead of overflowing the caller.
+    ``offset`` is the first line to return (1-based, default 1); ``limit`` caps
+    how many lines to return (default: to end of file). ``line_count`` is always
+    the file's *total* line count so the caller can page; when a window was
+    requested the reply also carries ``offset`` and ``returned_lines``.
+
     Acquires ``session._lock`` so the snapshot is coherent with any
     in-flight command dispatch (e.g. a concurrent ``commit``).
     """
+    if offset < 1:
+        raise McpCommandError("", f"offset must be >= 1 (got {offset})", 1)
+    if limit is not None and limit < 0:
+        raise McpCommandError("", f"limit must be >= 0 (got {limit})", 1)
+
     await _heartbeat(ctx, "testreport_read: waiting for session lock")
     async with session._lock:
         path = _resolve_testreport_path(session)
         content = path.read_text(encoding="utf-8", errors="replace")
+
+    windowed = offset != 1 or limit is not None
+    if not windowed:
+        return {
+            "path": str(path),
+            "line_count": _count_lines(content),
+            "content": content,
+        }
+
+    # 1-indexed line slicing matching testreport_patch's numbering.
+    lines = content.splitlines(keepends=True)
+    start = offset - 1
+    sliced = lines[start:] if limit is None else lines[start : start + limit]
     return {
         "path": str(path),
-        "line_count": _count_lines(content),
-        "content": content,
+        "line_count": len(lines),
+        "offset": offset,
+        "returned_lines": len(sliced),
+        "content": "".join(sliced),
     }
 
 
@@ -404,9 +437,13 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
 
     globals().setdefault("Context", _Context)
 
-    async def _read(ctx: Context | None = None) -> dict[str, Any]:
+    async def _read(
+        offset: int = 1,
+        limit: int | None = None,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
-        return await testreport_read(session, ctx=ctx)
+        return await testreport_read(session, offset=offset, limit=limit, ctx=ctx)
 
     async def _logs(ctx: Context | None = None) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
@@ -432,8 +469,11 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         return await testreport_write(session, content, ctx=ctx)
 
     read_desc = (
-        "Read the currently loaded testreport file. Returns the path, "
-        "line count, and full content (utf-8, errors replaced). "
+        "Read the currently loaded testreport file. Returns the path, total "
+        "line count, and content (utf-8, errors replaced). By default returns "
+        "the whole file; pass `offset` (1-based first line) and/or `limit` (max "
+        "lines) to read a line window instead — use this to page a large report "
+        "(a Product Increment log can be thousands of lines) without overflowing. "
         f"{_READ_FIRST_WARNING}"
     )
     patch_desc = (

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -119,6 +119,67 @@ def test_read_returns_file_contents(tmp_path: Path) -> None:
     assert result["path"] == str(file)
     assert result["line_count"] == 5
     assert result["content"] == body
+    # Default (no window) reply keeps its original shape.
+    assert "offset" not in result
+    assert "returned_lines" not in result
+
+
+def test_read_window_offset_and_limit(tmp_path: Path) -> None:
+    """``offset``/``limit`` return a 1-indexed line window (matches patch numbering)."""
+    file = tmp_path / "report.txt"
+    file.write_text("a\nb\nc\nd\ne\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    result: dict[str, Any] = asyncio.run(
+        tt.testreport_read(sess, offset=2, limit=2)  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result["content"] == "b\nc\n"
+    assert result["line_count"] == 5  # total, not the window size
+    assert result["offset"] == 2
+    assert result["returned_lines"] == 2
+
+
+def test_read_window_offset_to_end(tmp_path: Path) -> None:
+    """``offset`` with no ``limit`` reads to end of file."""
+    file = tmp_path / "report.txt"
+    file.write_text("a\nb\nc\nd\ne\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    result: dict[str, Any] = asyncio.run(
+        tt.testreport_read(sess, offset=4)  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result["content"] == "d\ne\n"
+    assert result["returned_lines"] == 2
+    assert result["line_count"] == 5
+
+
+def test_read_window_offset_past_end_is_empty(tmp_path: Path) -> None:
+    """An offset beyond the file yields empty content, not an error."""
+    file = tmp_path / "report.txt"
+    file.write_text("a\nb\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    result: dict[str, Any] = asyncio.run(
+        tt.testreport_read(sess, offset=99)  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result["content"] == ""
+    assert result["returned_lines"] == 0
+    assert result["line_count"] == 2
+
+
+def test_read_window_rejects_bad_offset_and_limit(tmp_path: Path) -> None:
+    """``offset < 1`` and ``limit < 0`` are rejected with McpCommandError."""
+    file = tmp_path / "report.txt"
+    file.write_text("a\nb\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    with pytest.raises(tt.McpCommandError):
+        asyncio.run(tt.testreport_read(sess, offset=0))  # ty: ignore[invalid-argument-type]
+    with pytest.raises(tt.McpCommandError):
+        asyncio.run(tt.testreport_read(sess, limit=-1))  # ty: ignore[invalid-argument-type]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

`testreport_read` returns the whole `log`. For a **Product Increment** the report
runs to thousands of lines after `export` (per-arch package tables for every host
— ~5k lines / ~200 KB), which overflows the tool reply's token budget: the report
becomes **unreadable through the MCP surface**, so there's no way to find the
line numbers `testreport_patch` needs.

## Change

Add optional `offset` (1-based first line) and `limit` (max lines) to
`testreport_read`, returning a **line window** using the same 1-indexed numbering
`testreport_patch` consumes. Default behaviour is unchanged (whole file, same
reply shape). The reply always reports the file's **total** `line_count` so a
caller can page; when a window is requested it also carries `offset` and
`returned_lines`. `offset < 1` / `limit < 0` are rejected; an `offset` past EOF
returns empty content (not an error).

## Tests

- `test_read_window_offset_and_limit`, `test_read_window_offset_to_end`,
  `test_read_window_offset_past_end_is_empty`, `test_read_window_rejects_bad_offset_and_limit`
- existing `test_read_returns_file_contents` extended to pin the unchanged default reply shape.

Gates: `ruff format`/`ruff check` clean, `pytest` green (1390 passed), no new `ty` diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)