### PR TITLE
fix: a failed update keeps the test repos instead of stripping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   allow-list (no such command exists — it is `list_products`, already covered by
   the `list_` prefix). Corrects the advisory hint shown to MCP clients; no
   behavioural change to the commands themselves.
+- A failed `update` no longer strips the test update repositories from the
+  affected hosts. The repo cleanup used to run unconditionally (in a `finally`),
+  so a host whose update failed was left with no issue repo — retrying or
+  diagnosing it (`zypper patches`) then saw nothing and the repo had to be
+  re-added by hand. The repos are now removed only on a successful update; on
+  failure they are kept (with a WARNING) for retry/diagnosis and removed by the
+  next successful update or an explicit `set_repo --remove`. The hosts are still
+  unlocked on failure as before.
 - `mtui-mcp` no longer floods its log with a repeated
   `Warning: InsecureRequestWarning: Unverified HTTPS request ...` line — one per
   openQA (or other internal-host) request — when TLS verification is disabled

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -602,23 +602,35 @@ class HostsGroup(UserDict[str, Target]):
             if "noscript" not in params and not testreport.config.auto:
                 testreport.run_scripts(PostScript, self)
                 testreport.run_scripts(CompareScript, self)
-        finally:
-            # Always remove the test update repositories that were added above,
-            # even if the update / scripts raised. Repo metadata changes are
-            # not transactional, so no reboot is required for transactional
-            # systems here.
+        except BaseException:
+            # The update (or its scripts) failed: KEEP the test update
+            # repositories in place. Stripping them here — as the old
+            # unconditional cleanup did — left a failed host with no issue repo,
+            # so retrying or diagnosing it (e.g. `zypper patches`) saw nothing
+            # and the repo had to be re-added by hand. The caller rolls the
+            # packages back (downgrade); the repos are removed by the next
+            # successful update or an explicit `set_repo --remove`.
+            logger.warning(
+                "update did not complete; leaving the test update repositories in "
+                "place for retry/diagnosis (remove later with `set_repo --remove`)"
+            )
+            raise
+
+        # Success: remove the test update repositories we added above. Repo
+        # metadata changes are not transactional, so no reboot is required for
+        # transactional systems here.
+        try:
+            self.update_lock()
+        except UpdateError:
+            logger.warning(
+                "Could not lock hosts to remove update repositories; "
+                "skipping repo cleanup."
+            )
+        else:
             try:
-                self.update_lock()
-            except UpdateError:
-                logger.warning(
-                    "Could not lock hosts to remove update repositories; "
-                    "skipping repo cleanup."
-                )
-            else:
-                try:
-                    self._fanout_set_repo("remove", testreport)
-                finally:
-                    self.unlock()
+                self._fanout_set_repo("remove", testreport)
+            finally:
+                self.unlock()
 
     def report_self(self, sink):
         """Reports the status of all hosts in the group.

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -788,8 +788,9 @@ def test_perform_update_removes_repos_at_end(mock_run, mock_fanout):
 
 @patch.object(HostsGroup, "_fanout_set_repo")
 @patch("mtui.hosts.target.hostgroup.RunCommand")
-def test_perform_update_removes_repos_even_when_run_fails(mock_run, mock_fanout):
-    """Repo cleanup runs even when the updater command itself raises."""
+def test_perform_update_keeps_repos_when_run_fails(mock_run, mock_fanout):
+    """On a failed update the test repos are KEPT (not stripped) so the host
+    can be retried/diagnosed without re-adding them."""
     t1 = _stub_target("h1")
     t1.packages = {}
     t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
@@ -805,7 +806,11 @@ def test_perform_update_removes_repos_even_when_run_fails(mock_run, mock_fanout)
         hg.perform_update(testreport, ["noprepare", "noscript"])
 
     operations = [c.args[0] for c in mock_fanout.call_args_list]
-    assert "remove" in operations
+    # Repo was added, but NOT removed on failure.
+    assert operations == ["add"]
+    assert "remove" not in operations
+    # The host is still unlocked despite keeping the repo.
+    t1.unlock.assert_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`HostsGroup.perform_update()` removed the test update repositories in a `finally`
block — so they were stripped **unconditionally, even when the update failed**.
A host whose update errored was then left with **no issue repo**: retrying or
diagnosing it (`zypper patches`, re-running the patch) saw nothing, and the repo
had to be re-added by hand. (Observed during a Product Increment run: one host's
update failed mid-flight and lost its repo while its peers kept theirs.)

## Fix

Remove the repos **only on a successful update**. On failure, keep them in place
(with a `WARNING`) so the host can be retried/diagnosed without re-adding; they
are removed by the next successful update or an explicit `set_repo --remove`. The
inner `finally: self.unlock()` is unchanged, so hosts are still unlocked on
failure, and the original exception still propagates (the caller's downgrade
rollback path is unaffected).

## Tests

- `test_perform_update_keeps_repos_when_run_fails` (was
  `…_removes_repos_even_when_run_fails`) — on failure `_fanout_set_repo` is called
  with `add` only, never `remove`, and the host is still unlocked.
- `test_perform_update_removes_repos_at_end` (success path) unchanged: add then remove.

Gates: `ruff format`/`ruff check` clean, `pytest` green (1386 passed), no new `ty` diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)