### PR TITLE
fix: update reports every host's outcome, not just the first failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A failed `update` now reports the outcome of **every** host instead of only the
+  first failure. The post-update check aborted on the first host that failed, so a
+  parallel update that broke on several hosts surfaced just one `UpdateError` and
+  the rest went unreported. mtui now checks all hosts, logs a per-host
+  success/failure summary, and raises an error naming **all** failed hosts (a
+  single-host failure still re-raises that host's original error unchanged). No
+  reboot is attempted when any host failed.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -584,10 +584,40 @@ class HostsGroup(UserDict[str, Target]):
         try:
             try:
                 self.run(commands)
+                # Check every host, collecting failures rather than aborting on
+                # the first one — otherwise a parallel update that failed on
+                # several hosts surfaced only the first host's UpdateError and
+                # the rest went unreported. The per-host outcome is logged below.
+                failures: list[UpdateError] = []
                 for t in self.data.values():
-                    t.check("updater")(
-                        t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit()
-                    )
+                    try:
+                        t.check("updater")(
+                            t.hostname,
+                            t.lastout(),
+                            t.lastin(),
+                            t.lasterr(),
+                            t.lastexit(),
+                        )
+                    except UpdateError as e:
+                        if e.host is None:
+                            e.host = t.hostname
+                        failures.append(e)
+
+                failed_hosts = {e.host for e in failures}
+                ok_hosts = sorted(hn for hn in self.data if hn not in failed_hosts)
+                if ok_hosts:
+                    logger.info("update succeeded on: %s", ", ".join(ok_hosts))
+                for e in failures:
+                    logger.error("update failed on %s", e)
+
+                if len(failures) == 1:
+                    # Preserve the exact single-host error the caller used to get.
+                    raise failures[0]
+                if failures:
+                    hosts = ", ".join(sorted(str(e.host) for e in failures))
+                    detail = "; ".join(str(e) for e in failures)
+                    raise UpdateError(f"update failed on {hosts} ({detail})")
+
                 self._reboot(reboot)
             finally:
                 self.unlock()

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -764,6 +764,79 @@ def test_perform_update_unlocks_when_run_fails(mock_run):
     t1.unlock.assert_called()
 
 
+@patch.object(HostsGroup, "_reboot")
+@patch.object(HostsGroup, "_fanout_set_repo")
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_update_reports_all_host_failures(
+    mock_run, mock_fanout, mock_reboot, caplog
+):
+    """Every host is checked and reported; the raised error names all failed
+    hosts, not just the first, and no reboot happens on failure."""
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t2 = _stub_target("h2")
+    t2.packages = {}
+    for t, host in ((t1, "h1"), (t2, "h2")):
+        t.doer.return_value = _doer_dict(command="zypper up", reboot="")
+        t.check.return_value = MagicMock(
+            side_effect=UpdateError("Dependency Error", host)
+        )
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1, t2])
+
+    with (
+        caplog.at_level(logging.ERROR, logger="mtui.target.hostgroup"),
+        pytest.raises(UpdateError) as ei,
+    ):
+        hg.perform_update(testreport, ["noprepare", "noscript"])
+
+    msg = str(ei.value)
+    assert "h1" in msg  # aggregated, not just the first
+    assert "h2" in msg
+    logged = " ".join(r.message for r in caplog.records)
+    assert "h1" in logged  # both logged per-host
+    assert "h2" in logged
+    mock_reboot.assert_not_called()  # no reboot on failure
+    t1.unlock.assert_called()
+    t2.unlock.assert_called()
+
+
+@patch.object(HostsGroup, "_reboot")
+@patch.object(HostsGroup, "_fanout_set_repo")
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_update_single_failure_reraises_original(
+    mock_run, mock_fanout, mock_reboot
+):
+    """A single failing host re-raises that host's original UpdateError unchanged
+    (backward compatible); the passing host is not reported as failed."""
+    t1 = _stub_target("h1")
+    t1.packages = {}
+    t2 = _stub_target("h2")
+    t2.packages = {}
+    t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
+    t2.doer.return_value = _doer_dict(command="zypper up", reboot="")
+    orig = UpdateError("Dependency Error", "h1")
+    t1.check.return_value = MagicMock(side_effect=orig)
+    t2.check.return_value = MagicMock()  # h2 passes
+    testreport = MagicMock()
+    testreport.config.auto = False
+    testreport.get_package_list.return_value = ["pkg"]
+    testreport.rrid.maintenance_id = "1"
+    testreport.rrid.review_id = "2"
+    hg = HostsGroup([t1, t2])
+
+    with pytest.raises(UpdateError) as ei:
+        hg.perform_update(testreport, ["noprepare", "noscript"])
+
+    assert ei.value is orig  # exact original error, unchanged
+    assert str(ei.value) == "h1: Dependency Error"
+    mock_reboot.assert_not_called()
+
+
 @patch.object(HostsGroup, "_fanout_set_repo")
 @patch("mtui.hosts.target.hostgroup.RunCommand")
 def test_perform_update_removes_repos_at_end(mock_run, mock_fanout):


### PR DESCRIPTION
## Problem

`HostsGroup.perform_update()` ran the post-update check in a plain loop:

```python
for t in self.data.values():
    t.check("updater")(t.hostname, t.lastout(), t.lastin(), t.lasterr(), t.lastexit())
```

The first host whose check raised `UpdateError` aborted the loop, so a **parallel
update that failed on several hosts surfaced only the first host's error** and the
rest went unreported. (Observed during a Product Increment run: `update` returned
a single `UpdateError(<one host>)` while 4 hosts had actually failed — the other
three silently stayed un-updated.)

## Fix

Check **every** host, collecting failures instead of aborting on the first:

- Log a per-host **success/failure summary** (`update succeeded on: …` /
  `update failed on <host>: <reason>`).
- A **single** failing host re-raises that host's **original** `UpdateError`
  unchanged (backward compatible — same error the caller used to get).
- **Multiple** failures raise an aggregated `UpdateError` naming all failed hosts
  with each reason.
- **No reboot** is attempted when any host failed (unchanged: the raise happens
  before `_reboot`). Hosts are still unlocked in the `finally`.

The caller's `UpdateError` handling (rollback + re-raise) is unaffected.

## Tests

- `test_perform_update_reports_all_host_failures` — two failing hosts → both
  logged, error names both, `_reboot` not called, both unlocked.
- `test_perform_update_single_failure_reraises_original` — one failing host →
  the exact original `UpdateError` is re-raised; passing host not reported failed.
- Existing happy-path / unlock-on-failure tests unchanged.

Gates: `ruff format`/`ruff check` clean, `pytest` green (1388 passed), no new `ty` diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)