### PR TITLE
fix: prepare --installed actually installs (missing zypper/yum verb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   success/failure summary, and raises an error naming **all** failed hosts (a
   single-host failure still re-raises that host's original error unchanged). No
   reboot is attempted when any host failed.
+- `prepare --installed` (`-i`) now actually installs/updates the already-installed
+  packages. The `installed_only` zypper and yum command templates were missing
+  the install verb (`zypper -n -y -l $pkg` / `yum -y $pkg`), so the gated command
+  ran an invalid no-op and prepared nothing. They now run `zypper -n in …` /
+  `yum -y install …`, matching the non-`--installed` path (just limited to
+  packages already present). The slmicro template was already correct.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/update_workflow/actions/prepare.py
+++ b/mtui/update_workflow/actions/prepare.py
@@ -22,7 +22,7 @@ def zypper_prepare(force: bool = False, testing: bool = False) -> dict[str, Temp
     return {
         "command": Template(f"zypper -n in -y -l {parameter} $package"),
         "installed_only": Template(
-            f"if $(rpm -q $package &>/dev/null); then zypper -n -y -l {parameter} $package ; fi"
+            f"if $(rpm -q $package &>/dev/null); then zypper -n in -y -l {parameter} $package ; fi"
         ),
     }
 
@@ -44,7 +44,7 @@ def yum_prepare(force: bool = False, testing: bool = False) -> dict[str, Templat
     return {
         "command": Template(f"yum -y {parameter} install $package"),
         "installed_only": Template(
-            f"rpm -q $package &>/dev/null && yum {parameter} -y $package"
+            f"rpm -q $package &>/dev/null && yum {parameter} -y install $package"
         ),
     }
 

--- a/tests/test_actions_prepare.py
+++ b/tests/test_actions_prepare.py
@@ -52,6 +52,25 @@ def test_zypper_prepare_force_adds_force_resolution() -> None:
     )
 
 
+def test_zypper_installed_only_actually_installs() -> None:
+    """The ``installed_only`` zypper command must carry the ``in`` subcommand;
+    otherwise ``prepare --installed`` runs an invalid zypper call that updates
+    nothing. It should behave like ``command``, just gated on the package being
+    already installed."""
+    cmds = zypper_prepare()
+    sub = cmds["installed_only"].safe_substitute(package="bash")
+    assert "zypper -n in " in sub
+    assert "rpm -q bash" in sub  # still gated on already-installed
+
+
+def test_yum_installed_only_actually_installs() -> None:
+    """The ``installed_only`` yum command must carry the ``install`` verb."""
+    cmds = yum_prepare()
+    sub = cmds["installed_only"].safe_substitute(package="bash")
+    assert "install bash" in sub
+    assert "rpm -q bash" in sub
+
+
 def test_preparer_dispatch_known_key() -> None:
     """The ``preparer`` registry returns ``zypper_prepare`` for known keys."""
     fn = preparer[("15", False)]


### PR DESCRIPTION
## Context

Reviewing `prepare` vs the prepare step inside `update`: both go through the same
`HostsGroup.perform_prepare` with the same default flags, so they already behave
identically (good). But that review surfaced a real bug in the one sub-path that
differs — `prepare --installed` / `-i`.

## Problem

The `installed_only` command templates omit the install verb:

```python
"command":        Template("zypper -n in -y -l $package"),   # ok
"installed_only": Template("... then zypper -n -y -l $package ; fi"),  # no `in`!
```

So `prepare --installed` runs `zypper -n -y -l <pkg>` (and yum runs
`yum -y <pkg>`) — invalid commands with no subcommand, which prepare/update
nothing. The flag is meant to behave like the default path but only for packages
that are already installed; instead it silently does nothing. (slmicro's template
already had `pkg in` and is unaffected.)

## Fix

Add the verb so `installed_only` matches `command`, just gated on the package
being present:

- zypper: `zypper -n in -y -l … $package`
- yum: `yum … -y install $package`

## Tests

- `test_zypper_installed_only_actually_installs`, `test_yum_installed_only_actually_installs`
  assert the install verb is present and the `rpm -q` gate is kept.

Gates: `ruff format`/`ruff check` clean, `pytest` green (1388 passed), no new `ty` diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)