### PR TITLE
test(update): lock in -t/--target host-subset narrowing

### DIFF
--- a/tests/test_cmd_update.py
+++ b/tests/test_cmd_update.py
@@ -9,7 +9,7 @@ import pytest
 
 from mtui.commands.update import Update
 from mtui.hosts.target.hostgroup import HostsGroup
-from mtui.support.messages import NoRefhostsDefinedError
+from mtui.support.messages import HostIsNotConnectedError, NoRefhostsDefinedError
 
 
 def _target(hostname):
@@ -43,3 +43,35 @@ def test_update_empty_targets_raises(mock_config):
     args = Namespace(newpackage=None, noprepare=None, noscript=None, hosts=None)
     with pytest.raises(NoRefhostsDefinedError):
         Update(args, mock_config, MagicMock(), prompt)()
+
+
+def test_update_without_target_uses_all_enabled_hosts(mock_config):
+    """With no ``-t``, perform_update receives every enabled host."""
+    prompt = _prompt(HostsGroup([_target("h1"), _target("h2")]))
+    args = Namespace(newpackage=None, noprepare=None, noscript=None, hosts=None)
+
+    Update(args, mock_config, MagicMock(), prompt)()
+
+    targets = prompt.metadata.perform_update.call_args.args[0]
+    assert sorted(targets.names()) == ["h1", "h2"]
+
+
+def test_update_target_narrows_to_named_subset(mock_config):
+    """``update -t h1`` runs only on h1, leaving the rest of the group out."""
+    prompt = _prompt(HostsGroup([_target("h1"), _target("h2")]))
+    args = Namespace(newpackage=None, noprepare=None, noscript=None, hosts=["h1"])
+
+    Update(args, mock_config, MagicMock(), prompt)()
+
+    targets = prompt.metadata.perform_update.call_args.args[0]
+    assert targets.names() == ["h1"]
+
+
+def test_update_target_unknown_host_raises(mock_config):
+    """A ``-t`` host that is not connected is rejected, not silently ignored."""
+    prompt = _prompt(HostsGroup([_target("h1")]))
+    args = Namespace(newpackage=None, noprepare=None, noscript=None, hosts=["nope"])
+
+    with pytest.raises(HostIsNotConnectedError):
+        Update(args, mock_config, MagicMock(), prompt)()
+    prompt.metadata.perform_update.assert_not_called()


### PR DESCRIPTION
## Context

Investigating whether `update` can act on a subset of hosts (to retry just the
hosts a parallel update left failed). It turns out it **already can** — there was
no gap, only missing test coverage:

- `update` registers `-t/--target` via `_add_hosts_arg`.
- `parse_hosts()` → `self.targets.select(self.args.hosts)` returns a *new*
  `HostsGroup` holding only the named hosts.
- `HostsGroup.perform_update` operates exclusively on `self.data`, so the prepare,
  `set_repo` fanout, update, reboot, and repo-cleanup all stay within the subset.

This is exposed identically over MCP (`mcp__mtui__update` `hosts=[...]`).

## Change

Test-only. Adds command-level coverage that locks in the narrowing so a future
refactor can't silently widen `update` back to the whole group (the
retry-a-failed-host workflow, paired with the per-host result reporting in #197,
depends on it):

- no `-t` → `perform_update` receives every enabled host
- `-t h1` → `perform_update` receives only `h1`
- `-t <unknown>` → `HostIsNotConnectedError`, `perform_update` not called

No production code change; no CHANGELOG entry (no user-visible behaviour change).

Gates: `ruff format`/`check` clean, `ty` clean, `pytest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)