### PR TITLE
test(fileops): restore dir perms so tmpdir teardown can clean up

### DIFF
--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -46,8 +46,16 @@ class TestEnsureDirExists:
             pytest.fail("ensure_dir_exists raised unexpectedly")
 
         os.chmod(subdir, 0)
-        with pytest.raises(PermissionError):
-            ensure_dir_exists(Path(subdir) / "bar")
+        try:
+            with pytest.raises(PermissionError):
+                ensure_dir_exists(Path(subdir) / "bar")
+        finally:
+            # Restore write/exec so pytest's tmpdir teardown can remove subdir.
+            # Without this the mode-0 directory is undeletable; pytest renames it
+            # to garbage-<uuid> and the leftovers pile up under
+            # /tmp/pytest-of-<user>/ across runs, emitting an rm_rf warning each
+            # time it retries.
+            os.chmod(subdir, 0o755)
 
     def test_on_create(self, create_temp):
         d = self.mkpath(create_temp, "c")


### PR DESCRIPTION
## Problem

Running the suite on a developed tree emits a pile of warnings (38+ here):

```
PytestWarning: (rm_rf) error removing /tmp/pytest-of-<user>/garbage-<uuid>/fileops2
  <class 'OSError'>: [Errno 39] Directory not empty: '.../fileops2'
```

`test_create_permission_denied` `chmod`s a temp subdir to mode `0` to provoke a
`PermissionError` from `ensure_dir_exists`, but never restores the mode. pytest's
`tmpdir_factory` teardown then can't delete the mode-0 directory, renames it to
`garbage-<uuid>`, and the undeletable leftovers **accumulate under
`/tmp/pytest-of-<user>/` across runs** — every subsequent run retries the cleanup
and emits one `rm_rf` warning per stale dir, so the count grows over time.

## Fix

Restore `0o755` on the subdir in a `finally`, so the directory is deletable and
teardown succeeds. No production code change.

## Verification

- Before: `1386 passed, 38 warnings`.
- After: `1386 passed` (no warnings); two back-to-back full runs leave **zero**
  `garbage-*` dirs behind.
- `ruff format`/`check` clean, `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)