### PR TITLE
fix(downgrade): skip version-less hosts and don't strand locks on missing downgrader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   ran an invalid no-op and prepared nothing. They now run `zypper -n in …` /
   `yum -y install …`, matching the non-`--installed` path (just limited to
   packages already present). The slmicro template was already correct.
+- `downgrade` (the rollback after a failed `update`, and the standalone command)
+  no longer crashes with `KeyError(<hostname>)` when one host in a multi-host
+  group reports no downgradable versions (package not installed, or the list
+  command produced no output): that host is now simply skipped for the package
+  instead of aborting the whole downgrade.
+- `downgrade` no longer leaves every host locked when a host has no downgrader
+  for its product. The `MissingDowngraderError` early-return happened after the
+  group was locked but outside the `try/finally` that unlocks it; the doer lookup
+  now runs before locking (matching `prepare`), so the early return cannot strand
+  the locks.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -411,8 +411,10 @@ class HostsGroup(UserDict[str, Target]):
         """
         ver_re = re.compile(r"(.*) = (.*)")
         versions: dict[str, dict[str, str]] = {}
-        self.update_lock()
 
+        # Resolve the per-host doer commands *before* taking the lock: if a host
+        # has no downgrader the early return below must not leave the group
+        # locked (the finally that unlocks only guards the second try block).
         try:
             reboot = {
                 t.hostname: t.doer("downgrader")["reboot"].substitute()
@@ -427,6 +429,8 @@ class HostsGroup(UserDict[str, Target]):
         except MissingDowngraderError as e:
             logger.error("%s", e)
             return
+
+        self.update_lock()
 
         try:
             self._fanout_set_repo("remove", testreport)
@@ -467,7 +471,7 @@ class HostsGroup(UserDict[str, Target]):
                         package=package, version=versions[h][package]
                     )
                     for h, t in self.data.items()
-                    if package in versions[h]
+                    if h in versions and package in versions[h]
                 }
                 if cmd:
                     self.run(cmd)

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -676,6 +676,38 @@ def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
 
 
 @patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_host_without_versions_does_not_keyerror(mock_run):
+    """A host whose list_command yields no versions is skipped, not a KeyError."""
+    t1 = _stub_target("h1")
+    t1.lastout.return_value = ""  # nothing parses -> no entry in `versions`
+    t1.doer.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="x")),
+    }
+    t1.check.return_value = MagicMock()
+    hg = HostsGroup([t1])
+    # Must not raise KeyError('h1'); the package is simply skipped.
+    hg.perform_downgrade(["pkg-a"], MagicMock())
+    t1.doer.return_value["command"].safe_substitute.assert_not_called()
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_missing_downgrader_does_not_lock(mock_run):
+    """A missing downgrader returns early without leaving hosts locked."""
+    from mtui.support.messages import MissingDowngraderError
+
+    t1 = _stub_target("h1", transactional=True)
+    t1.doer.side_effect = MissingDowngraderError("16")
+    hg = HostsGroup([t1])
+    hg.perform_downgrade(["pkg-a"], MagicMock())
+    # The early return happens before update_lock(), so the host is never
+    # locked (and therefore never stuck locked).
+    t1.lock.assert_not_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
 def test_perform_downgrade_unlocks_on_error(mock_run):
     t1 = _stub_target("h1")
     t1.lastout.return_value = ""


### PR DESCRIPTION
Two distinct defects in `HostsGroup.perform_downgrade` (which runs both as the
standalone `downgrade` command and as the automatic rollback after a failed
`update`).

## 1. `KeyError(<hostname>)` aborts a multi-host downgrade

The per-package command dict iterates **every** host and tests
`if package in versions[h]`:

```python
for h, t in self.data.items()
if package in versions[h]      # KeyError if h has no entry
```

But `versions` only gets a key for a host whose `list_command` produced
parseable `name = version` lines. A host that listed nothing (package not
installed, command errored) has no key, so `versions[h]` raises `KeyError`
before the `in` test can act as a guard — taking down the whole downgrade.

Fix: `if h in versions and package in versions[h]`.

## 2. Missing downgrader leaves every host locked

`update_lock()` ran *before* the `try`, but the `MissingDowngraderError`
early-return is outside the `try/finally` that unlocks (that `finally` guards
only the *second* `try`). A transactional host with no downgrader for its
product → early return → the whole group stays locked.

Fix: resolve the per-host reboot/init_snapshot doer commands **before**
`update_lock()` — exactly what `perform_prepare` already does — so the early
return happens before any lock is taken.

## Tests

- `test_perform_downgrade_host_without_versions_does_not_keyerror`
- `test_perform_downgrade_missing_downgrader_does_not_lock`

Gates: ruff format/check clean, ty clean, pytest green (60 in test_hostgroup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)