### PR TITLE
fix(checks): correct lock-error reporting in prepare/downgrade checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   group was locked but outside the `try/finally` that unlocks it; the doer lookup
   now runs before locking (matching `prepare`), so the early return cannot strand
   the locks.
+- The post-`prepare` and post-`downgrade` zypper checks now report a detected
+  package-manager lock correctly. The `UpdateError` raised on "ZYpp transaction
+  already in progress" had its `(reason, host)` arguments swapped (so `.host`
+  became the literal reason and the message read backwards), and the matching
+  `downgrade` log calls were malformed — one passed **no** arguments for its four
+  `%s` placeholders, the other passed one too many. The exception arguments and
+  the log-call arities are now correct (matching the `update` check), so a lock is
+  attributed to the right host and the diagnostic prints real values.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/update_workflow/checks/downgrade.py
+++ b/mtui/update_workflow/checks/downgrade.py
@@ -25,16 +25,19 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
             '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
-        )
-        raise UpdateError(hostname, "update stack locked")
-    if "System management is locked" in stderr:
-        logger.critical(
-            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
             stderr,
-            exitcode,
+        )
+        raise UpdateError("update stack locked", hostname)
+    if "System management is locked" in stderr:
+        logger.critical(
+            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            hostname,
+            stdin,
+            stdout,
+            stderr,
         )
         raise UpdateError("update stack locked", hostname)
     if "(c): c" in stdout:

--- a/mtui/update_workflow/checks/prepare.py
+++ b/mtui/update_workflow/checks/prepare.py
@@ -30,7 +30,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
             stdout,
             stderr,
         )
-        raise UpdateError(hostname, "update stack locked")
+        raise UpdateError("update stack locked", hostname)
     if "System management is locked" in stderr:
         logger.critical(
             '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',

--- a/tests/test_checks_downgrade.py
+++ b/tests/test_checks_downgrade.py
@@ -29,9 +29,25 @@ def test_zypper_clean_run_returns_none() -> None:
 
 
 def test_zypper_zypp_lock_raises() -> None:
-    """A ZYpp transaction lock in stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
+    """A ZYpp transaction lock in stderr raises ``UpdateError(reason, host)``."""
+    with pytest.raises(UpdateError) as ei:
         zypper("h", "", "in pkg", "A ZYpp transaction is already in progress.", 0)
+    # Args must be (reason, host) -- previously swapped.
+    assert ei.value.reason == "update stack locked"
+    assert ei.value.host == "h"
+
+
+def test_zypper_lock_branches_logging_is_well_formed(monkeypatch) -> None:
+    """Both lock branches log with matching %-args (no zero-arg / extra-arg bug).
+
+    With ``logging.raiseExceptions`` re-enabled a wrong arg count would raise a
+    ``TypeError`` in ``handleError`` instead of the intended ``UpdateError``.
+    """
+    monkeypatch.setattr(logging, "raiseExceptions", True)
+    with pytest.raises(UpdateError):
+        zypper("h", "out", "in pkg", "A ZYpp transaction is already in progress.", 0)
+    with pytest.raises(UpdateError):
+        zypper("h", "out", "in pkg", "System management is locked", 0)
 
 
 def test_zypper_system_management_locked_raises() -> None:

--- a/tests/test_checks_prepare.py
+++ b/tests/test_checks_prepare.py
@@ -22,9 +22,23 @@ def test_zypper_clean_run_returns_none() -> None:
 
 
 def test_zypper_zypp_lock_raises() -> None:
-    """A ZYpp transaction lock stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
+    """A ZYpp transaction lock stderr raises ``UpdateError(reason, host)``."""
+    with pytest.raises(UpdateError) as ei:
         zypper("h", "", "in pkg", "A ZYpp transaction is already in progress.", 0)
+    # Args must be (reason, host) -- not swapped.
+    assert ei.value.reason == "update stack locked"
+    assert ei.value.host == "h"
+
+
+def test_zypper_zypp_lock_logging_is_well_formed(monkeypatch) -> None:
+    """The critical log in the ZYpp branch has matching %-args (no logging error).
+
+    Re-enables ``logging.raiseExceptions`` so a wrong arg count would surface as
+    a ``TypeError`` from ``handleError`` instead of the intended ``UpdateError``.
+    """
+    monkeypatch.setattr(logging, "raiseExceptions", True)
+    with pytest.raises(UpdateError):
+        zypper("h", "out", "in pkg", "A ZYpp transaction is already in progress.", 0)
 
 
 def test_zypper_system_management_locked_raises() -> None:


### PR DESCRIPTION
The post-`prepare` and post-`downgrade` zypper checks misreport a detected
package-manager lock, in two ways.

## 1. Swapped `UpdateError` arguments

`checks/prepare.py:33` and `checks/downgrade.py` raised
`UpdateError(hostname, "update stack locked")`, but the constructor is
`UpdateError(reason, host=None)` — and every other call site (16 of them, incl.
the `update` and `install` checks) passes `(reason, host)`. So `.host` became the
literal `"update stack locked"`, `.reason` became the hostname, and `__str__`
read backwards (`"update stack locked: <host>"`). This also mis-keys per-host
failure attribution in the update flow.

## 2. Malformed `logger.critical` calls (downgrade only)

- The "A ZYpp transaction is already in progress." branch had **four** `%s`
  placeholders and **zero** arguments → it logged literal `%s` (hostname/stderr
  lost).
- The "System management is locked" branch passed **five** arguments for **four**
  placeholders → a `TypeError` in `logging.handleError` (under the default
  `raiseExceptions=True`), losing the message entirely.

## Fix

Align both files with the already-correct `update` check:
`UpdateError("update stack locked", hostname)` and four matching args
`(hostname, stdin, stdout, stderr)`.

## Tests

Updated `test_checks_prepare.py` / `test_checks_downgrade.py` to assert the
corrected `(reason, host)` attributes, and added tests that exercise the lock
branches with `logging.raiseExceptions=True` so any future arg-count regression
surfaces as a failure rather than silent log loss.

Gates: ruff format/check clean, ty clean, pytest green (25 check tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)