### PR TITLE
fix(mcp): encode append+REMAINDER flags once (commit -m, lock -c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `export` and otherwise overflowed the reply — using the same 1-indexed line
   numbers `testreport_patch` consumes; the reply still reports the file's total
   `line_count` (plus `offset`/`returned_lines` when a window is requested).
-
 - Connecting a reference host now verifies that its installed products match
   what `refhosts.yml` records for that host. On any drift — wrong or
   wrong-version base product, wrong architecture, addons that are missing,
@@ -67,6 +66,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `%s` placeholders, the other passed one too many. The exception arguments and
   the log-call arities are now correct (matching the `update` check), so a lock is
   attributed to the right host and the diagnostic prints real values.
+- `mtui-mcp` no longer corrupts the message for `commit` and the comment for
+  `lock` when given more than one word. Both options are `append` + `REMAINDER`,
+  and the kwargs→argv encoder emitted the flag once per token (`-m a -m b`); with
+  `REMAINDER` the second flag is swallowed as a value, so the committed message
+  became e.g. `"a -m b"`. The encoder now emits an `append`+remainder/multi-`nargs`
+  flag once followed by all its tokens, so the message/comment round-trips intact.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/mcp/_argv.py
+++ b/mtui/mcp/_argv.py
@@ -8,7 +8,11 @@ inverse of :func:`mtui.mcp._schema.action_to_parameter`:
 
 * ``store_true`` / ``store_false`` / ``store_const`` → emit the long
   flag iff the value is the "on" side.
-* ``append`` → emit ``[flag, item]`` per element of the list value.
+* ``append`` → emit ``[flag, item]`` per element of the list value, EXCEPT
+  when the action's ``nargs`` consumes a remainder/multi
+  (``REMAINDER``/``*``/``+``/integer ``N`` — e.g. ``commit -m``, ``lock -c``):
+  there the flag is emitted once followed by every token, so argparse rebuilds
+  ``[[v1, v2, ...]]`` instead of swallowing a repeated flag as a value.
 * Positional ``nargs=REMAINDER``/``*``/``+`` → append elements verbatim
   at the end (after every flag-shaped argument), preserving order.
 * Optional scalar → emit ``[long_flag, str(value)]``.
@@ -171,8 +175,20 @@ def kwargs_to_argv(
             if not value:
                 continue
             flag = _long_flag(action)
-            for item in value:
-                flag_tokens.extend([flag, str(item)])
+            if action.nargs in (argparse.REMAINDER, "*", "+") or isinstance(
+                action.nargs, int
+            ):
+                # append + a remainder/multi nargs (commit -m, lock -c) stores
+                # ONE sub-list per flag occurrence and the command reads
+                # value[0]. Emit the flag once followed by every token so
+                # argparse rebuilds ``[[v1, v2, ...]]``; ``--flag v1 --flag v2``
+                # would let REMAINDER swallow the second ``--flag`` as a value,
+                # producing ``[[v1, '--flag', v2]]`` and a corrupted message.
+                flag_tokens.append(flag)
+                flag_tokens.extend(str(item) for item in value)
+            else:
+                for item in value:
+                    flag_tokens.extend([flag, str(item)])
             continue
 
         # ---- positional ----------------------------------------------

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -350,6 +350,32 @@ def test_remainder_positional_appended_after_flags() -> None:
     assert parsed.hosts == ["h1"]
 
 
+def test_append_remainder_flag_round_trip_commit() -> None:
+    """``commit -m`` (append + REMAINDER) re-emits the flag once, not per token.
+
+    Regression: the append encoder used to emit ``-m a -m b``; with REMAINDER
+    the second ``-m`` is swallowed as a value, so the command's
+    ``" ".join(self.args.msg[0])`` produced ``"a -m b"`` instead of ``"a b"``.
+    """
+    parser = Command.registry["commit"].argparser(__import__("sys"))
+    argv = kwargs_to_argv(parser, {"msg": ["a", "b"]})
+    assert argv == ["--msg", "a", "b"]
+    parsed = parser.parse_args(argv)
+    assert parsed.msg == [["a", "b"]]
+    assert " ".join(parsed.msg[0]) == "a b"
+
+
+def test_append_remainder_flag_round_trip_lock_with_target() -> None:
+    """``lock -t h1 -c ...`` keeps the REMAINDER comment last and intact."""
+    parser = Command.registry["lock"].argparser(__import__("sys"))
+    argv = kwargs_to_argv(parser, {"hosts": ["h1"], "comment": ["busy", "testing"]})
+    # target must precede the REMAINDER comment so it isn't swallowed.
+    assert argv == ["--target", "h1", "--comment", "busy", "testing"]
+    parsed = parser.parse_args(argv)
+    assert parsed.hosts == ["h1"]
+    assert " ".join(parsed.comment[0]) == "busy testing"
+
+
 def test_store_const_flag_round_trip() -> None:
     """``update --noscript`` round-trips both ways."""
     parser = Command.registry["update"].argparser(__import__("sys"))


### PR DESCRIPTION
## Problem

`commit` (`-m/--msg`) and `lock` (`-c/--comment`) are declared
`action="append", nargs=REMAINDER` and read `self.args.msg[0]` /
`self.args.comment[0]`. Over MCP, the kwargs→argv encoder's `append` branch
emits the flag once per list element:

```
commit(msg=["a", "b"]) -> ["-m", "a", "-m", "b"]
```

But with `REMAINDER`, the first `-m` swallows everything after it, so argparse
parses `msg = [["a", "-m", "b"]]` and the command builds
`" ".join(msg[0]) == "a -m b"` — a corrupted SVN commit message (and, for
`lock`, a corrupted cross-session host-lock comment) for any multi-word input.
Single-element lists happened to be fine, which is why it went unnoticed.

## Fix

Encode `append` actions whose `nargs` consumes a remainder/multi
(`REMAINDER`, `"*"`, `"+"`, integer `N`) the same way the optional-scalar
branch already handles `reject -m`: emit the flag once followed by all tokens.
Plain `append` actions (`nargs` `None`/`"?"`, e.g. `-t/--target`, `assign -g`)
keep the existing flag-per-item form.

`lock`'s `-t` is declared before `-c`, so the encoder still emits the target
before the REMAINDER comment (which must come last).

## Tests

- `commit msg=["a","b"]` → `["--msg","a","b"]` → `msg[0]` joins to `"a b"`.
- `lock` with target + multi-word comment keeps the comment last and intact.

Gates: ruff format/check clean, ty clean, pytest green (35 in test_mcp_tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)