### PR TITLE
fix(rpmver): split version/release on the last dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `REMAINDER` the second flag is swallowed as a value, so the committed message
   became e.g. `"a -m b"`. The encoder now emits an `append`+remainder/multi-`nargs`
   flag once followed by all its tokens, so the message/comment round-trips intact.
+- `RPMVersion` no longer raises `ValueError: too many values to unpack` when a
+  version string contains more than one dash. The version/release split now uses
+  the last dash (`rsplit("-", 1)`) — the release field never contains a dash, but
+  the version field can (e.g. a Debian-style `upstream-debrev` arriving through
+  the dpkg querier).
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/types/rpmver.py
+++ b/mtui/types/rpmver.py
@@ -49,8 +49,12 @@ class RPMVersion:
             ver = ver.replace("." + x, "")
 
         if "-" in ver:
-            # split rpm version string into version and release string
-            (self.ver, self.rel) = ver.rsplit("-")
+            # Split the rpm version string into version and release on the
+            # LAST dash: the release field never contains a dash, but the
+            # version field can (e.g. Debian-style "upstream-debrev" coming
+            # through the dpkg querier). Without maxsplit, such a string
+            # raised "too many values to unpack".
+            (self.ver, self.rel) = ver.rsplit("-", 1)
         else:
             self.ver = ver
             self.rel = "0"

--- a/tests/test_rpm_version.py
+++ b/tests/test_rpm_version.py
@@ -55,6 +55,18 @@ def test_version_none():
         RPMVersion(None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
+def test_version_with_multiple_dashes_splits_on_last():
+    """A version field that itself contains a dash splits on the LAST dash.
+
+    Regression: ``rsplit("-")`` without maxsplit raised "too many values to
+    unpack" for such strings (reachable via the dpkg/ubuntu querier).
+    """
+    v = RPMVersion("1.2-3-4")
+    assert v.ver == "1.2-3"
+    assert v.rel == "4"
+    assert str(v) == "1.2-3-4"
+
+
 @pytest.mark.parametrize(
     ("version", "s"), [("1.2.3-7.3", "1.2.3-7.3"), ("2.3", "2.3"), ("0.8+1-0", "0.8+1")]
 )


### PR DESCRIPTION
`RPMVersion.__init__` parsed the version string with:

```python
(self.ver, self.rel) = ver.rsplit("-")
```

`rsplit("-")` (no maxsplit) returns *all* dash-separated parts, but the target
unpacks exactly two names — so any version string with two or more dashes raises
`ValueError: too many values to unpack`. The release field never contains a dash,
but the version field can (e.g. a Debian-style `upstream-debrev` coming through
the dpkg/ubuntu querier), making this reachable.

Fix: `ver.rsplit("-", 1)` — the last dash is the version/release boundary.

Test: `RPMVersion("1.2-3-4")` → `ver="1.2-3"`, `rel="4"`, `str()` round-trips.

Gates: ruff format/check clean, pytest green (18 in test_rpm_version). (`ty`
still reports the 8 pre-existing `rpm.labelCompare` diagnostics in this file —
unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)