### PR TITLE
fix(messages): make UserMessage hashable (was infinite recursion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the last dash (`rsplit("-", 1)`) — the release field never contains a dash, but
   the version field can (e.g. a Debian-style `upstream-debrev` arriving through
   the dpkg querier).
+- Hashing a `UserMessage`/`UserError` (e.g. putting one in a `set` or using it
+  as a dict key) no longer raises `RecursionError`. `__hash__` returned
+  `hash(self)`, which called itself forever; it now hashes `str(self)`, matching
+  the existing `__eq__`.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/support/messages.py
+++ b/mtui/support/messages.py
@@ -21,7 +21,9 @@ class UserMessage(BaseException, ABC):
         return str(self) == str(x)
 
     def __hash__(self) -> int:
-        return hash(self)
+        # Must mirror __eq__ (which compares on str(self)); hashing self
+        # here would recurse forever.
+        return hash(str(self))
 
 
 class ErrorMessage(UserMessage, RuntimeError):  # noqa: N818

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -90,3 +90,15 @@ def test_messages():
     )
     assert str(messages.TestReportNotLoadedError()) == "TestReport not loaded"
     assert str(messages.MetadataNotLoadedError()) == "Metadata not found"
+
+
+def test_usermessage_is_hashable_and_consistent_with_eq():
+    """Hashing a UserMessage must not recurse and must agree with __eq__."""
+    a = messages.HostIsNotConnectedError("h")
+    b = messages.HostIsNotConnectedError("h")
+    # Previously __hash__ returned hash(self) -> RecursionError.
+    assert hash(a) == hash(str(a))
+    # __eq__ compares on str(self); equal objects must hash equal so they
+    # behave in sets/dicts.
+    assert a == b
+    assert len({a, b}) == 1


### PR DESCRIPTION
`UserMessage.__hash__` returned `hash(self)`:

```python
def __hash__(self) -> int:
    return hash(self)   # calls __hash__ again -> RecursionError
```

So hashing any `UserMessage`/`UserError` (putting one in a `set`, using it as a
dict key) raises `RecursionError`. Latent today (nothing hashes them), but an
unambiguous defect.

Fix: hash `str(self)`, matching `__eq__` (which compares on `str(self)`), so
equal messages also hash equal and behave correctly in sets/dicts.

Test: `hash(msg) == hash(str(msg))`; two equal messages collapse to one set
element.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)