### PR TITLE
fix(hostlog): raise ValueError (not TypeError) on wrong positional arg count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   as a dict key) no longer raises `RecursionError`. `__hash__` returned
   `hash(self)`, which called itself forever; it now hashes `str(self)`, matching
   the existing `__eq__`.
+- `HostLog.append`/`insert` now raise the intended `ValueError` ("it need 5
+  args, got N") when given the wrong number of positional arguments, instead of
+  a confusing `TypeError` from `len(*args)` (which unpacked the args into
+  `len()`).
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/types/hostlog.py
+++ b/mtui/types/hostlog.py
@@ -49,7 +49,7 @@ class HostLog(list[CommandLog]):
             runtime = int(items[4])
         else:
             if len(args) != 5:
-                raise ValueError(f"it need 5 args, got {len(*args)}")
+                raise ValueError(f"it need 5 args, got {len(args)}")
             command = to_string(args[0])
             stdout = to_string(args[1])
             stderr = to_string(args[2])
@@ -86,7 +86,7 @@ class HostLog(list[CommandLog]):
             runtime = int(args[0][4])
         else:
             if len(args) != 5:
-                raise ValueError(f"it need 5 args, got {len(*args)}")
+                raise ValueError(f"it need 5 args, got {len(args)}")
             command = to_string(args[0])
             stdout = to_string(args[1])
             stderr = to_string(args[2])

--- a/tests/test_types_expanded.py
+++ b/tests/test_types_expanded.py
@@ -205,6 +205,16 @@ class TestHostLog:
         with pytest.raises(ValueError, match="it need 5 args"):
             hl.append(["too", "few"])
 
+    def test_append_positional_wrong_count_raises_valueerror(self):
+        """Wrong positional-arg count raises ValueError, not a TypeError.
+
+        Regression: the error path did ``len(*args)`` which unpacks args into
+        ``len()`` and raised ``TypeError`` instead of the intended ValueError.
+        """
+        hl = HostLog()
+        with pytest.raises(ValueError, match="it need 5 args, got 3"):
+            hl.append("a", "b", "c")
+
     def test_append_bytes_conversion(self):
         """Test appending converts bytes to strings."""
         hl = HostLog()

--- a/tests/test_types_expanded.py
+++ b/tests/test_types_expanded.py
@@ -215,6 +215,12 @@ class TestHostLog:
         with pytest.raises(ValueError, match="it need 5 args, got 3"):
             hl.append("a", "b", "c")
 
+    def test_insert_positional_wrong_count_raises_valueerror(self):
+        """insert() has the same wrong-arg-count guard as append() (len(args))."""
+        hl = HostLog()
+        with pytest.raises(ValueError, match="it need 5 args, got 3"):
+            hl.insert(0, "a", "b", "c")
+
     def test_append_bytes_conversion(self):
         """Test appending converts bytes to strings."""
         hl = HostLog()


### PR DESCRIPTION
`HostLog.append` and `HostLog.insert` validate their argument count and, on the
positional path, build the error with `len(*args)`:

```python
if len(args) != 5:
    raise ValueError(f"it need 5 args, got {len(*args)}")
```

`len(*args)` *unpacks* `args` into `len()`, which takes exactly one argument — so
for any count other than 1 the f-string raises `TypeError: len() takes exactly
one argument` instead of the intended `ValueError`, losing the helpful "got N"
diagnostic. (The single-sequence path uses `len(args[0])` and is fine.)

Fix: `len(args)` on both lines.

Test: `append("a","b","c")` now raises `ValueError("it need 5 args, got 3")`.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)