### PR TITLE
fix(export): scope install-log dedup to after the HAS_UNTRACKED marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   args, got N") when given the wrong number of positional arguments, instead of
   a confusing `TypeError` from `len(*args)` (which unpacked the args into
   `len()`).
+- `export` now deduplicates install-log links against the correct part of the
+  template. The loop meant to find the `HAS_UNTRACKED` marker had its `o += 1`
+  outside the loop body, so the index was always `1` and the marker search was
+  dead; a URL appearing anywhere earlier in the template could wrongly suppress
+  adding the real link. The dedup is now scoped to the lines after the marker.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/update_workflow/export/base.py
+++ b/mtui/update_workflow/export/base.py
@@ -87,11 +87,16 @@ class BaseExport(ABC):
             filenames: A list of filenames to add.
 
         """
+        # Index just past the HAS_UNTRACKED marker; the install-log links are
+        # deduplicated against the template from there on. The ``o += 1`` used
+        # to sit outside the loop, so ``o`` was always 1 and the marker search
+        # was dead. If the marker is absent, scan the whole template so dups are
+        # still caught.
         o = 0
-        for line in self.template:
+        for i, line in enumerate(self.template):
             if "HAS_UNTRACKED" in line:
+                o = i + 1
                 break
-        o += 1
 
         index = len(self.template)
         if "## export MTUI:" in self.template[-1]:

--- a/tests/test_export_openqa.py
+++ b/tests/test_export_openqa.py
@@ -27,6 +27,41 @@ class ExportProbe(BaseExport):
         return self.template
 
 
+def test_installlogs_lines_dedups_only_after_untracked_marker(mock_config):
+    """Dedup of install-log links is scoped to after the HAS_UNTRACKED marker.
+
+    Regression: ``o += 1`` sat outside the marker-search loop, so ``o`` was
+    always 1 and the dedup scanned from index 1. A URL that merely happens to
+    appear before the marker would then wrongly suppress adding the real link in
+    the links section.
+    """
+    url = (
+        f"{mock_config.reports_url}/SUSE:Maintenance:1:1/"
+        f"{mock_config.install_logs}/x.log\n"
+    )
+    template = FileList(
+        [
+            "intro\n",
+            url,  # coincidental occurrence BEFORE the marker
+            "HAS_UNTRACKED_CHANGES: NO\n",
+            "## export MTUI:1 by tester\n",
+        ]
+    )
+    exporter = ExportProbe(
+        mock_config,
+        OpenQAResults(),
+        template,
+        False,
+        "SUSE:Maintenance:1:1",
+        False,
+    )
+    exporter.installlogs_lines(["x.log"])
+    links_at = exporter.template.index("Links for update logs:\n")
+    # The link must be present in the links section, not suppressed by the
+    # pre-marker occurrence.
+    assert url in exporter.template[links_at:]
+
+
 def test_inject_openqa_replaces_dashboard_results(mock_config):
     openqa = MagicMock()
     openqa.__bool__.return_value = True


### PR DESCRIPTION
`BaseExport.installlogs_lines` is supposed to find the `HAS_UNTRACKED` marker
line and deduplicate the install-log links it adds against the template *after*
that marker:

```python
o = 0
for line in self.template:
    if "HAS_UNTRACKED" in line:
        break
o += 1          # <-- dedented out of the loop
```

The `o += 1` sits outside the `for`, so the loop body is dead and `o` is always
`1`. The dedup check `if install_log not in self.template[o:]` therefore scans
from index 1 (nearly the whole template) instead of from just past the marker —
so a URL that merely appears earlier in the template can wrongly suppress adding
the real link in the links section.

Fix: compute `o` from the marker's index with `enumerate`; if the marker is
absent, fall back to scanning the whole template (so duplicates are still
caught).

## Test

`test_installlogs_lines_dedups_only_after_untracked_marker` places an identical
URL *before* the marker and asserts the link is still added to the links
section. Verified it fails on the old code and passes on the fix.

Gates: ruff format/check clean, ty clean, pytest green (18 export tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)