### PR TITLE
fix(openqa/kernel): annotate failed ltp result (replace result was discarded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   outside the loop body, so the index was always `1` and the marker search was
   dead; a URL appearing anywhere earlier in the template could wrongly suppress
   adding the real link. The dedup is now scoped to the lines after the marker.
+- The kernel openQA result matrix now annotates a failed `ltp_` test's
+  `result: failed` line as intended. The annotation used `text.replace(...)`
+  without assigning the result back (strings are immutable), so it was a no-op.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/data_sources/openqa/kernel.py
+++ b/mtui/data_sources/openqa/kernel.py
@@ -122,7 +122,7 @@ class KernelOpenQA(OpenQA):
                     test.name, "-", test.arch, test.result
                 )
                 if test.result == "failed":
-                    text.replace("failed", "failed:")
+                    text = text.replace("failed", "failed:")
                     for module in test.modules:
                         if test.modules[module] == "failed":
                             text += f"\n      {module}: ...\n"

--- a/tests/test_openqa_kernel.py
+++ b/tests/test_openqa_kernel.py
@@ -1,0 +1,52 @@
+"""Tests for ``mtui.data_sources.openqa.kernel``."""
+
+from __future__ import annotations
+
+from mtui.data_sources.openqa.kernel import KernelOpenQA
+from mtui.types.test import Test as _Test  # aliased: avoids pytest "Test*" collection
+
+
+def test_result_matrix_failed_annotates_result_and_lists_failed_modules() -> None:
+    """A failed ltp_ test gets its ``result: failed`` annotated to ``failed:``.
+
+    Regression: ``text.replace(...)`` discarded its result (strings are
+    immutable), so the annotation never happened.
+    """
+    test = _Test(
+        name="ltp_syscalls",
+        result="failed",
+        test_id=1,
+        arch="x86_64",
+        modules={"open01": "failed", "read01": "passed"},
+    )
+    [line] = KernelOpenQA._result_matrix([test])
+    assert "result: failed:" in line
+    # Only the failed module is listed.
+    assert "open01:" in line
+    assert "read01:" not in line
+
+
+def test_result_matrix_passed_is_left_unannotated() -> None:
+    """A passing ltp_ test keeps a plain ``result: passed`` line."""
+    test = _Test(
+        name="ltp_syscalls",
+        result="passed",
+        test_id=1,
+        arch="x86_64",
+        modules={},
+    )
+    [line] = KernelOpenQA._result_matrix([test])
+    assert "result: passed" in line
+    assert "failed:" not in line
+
+
+def test_result_matrix_skips_non_ltp_tests() -> None:
+    """Tests whose name does not start with ``ltp_`` produce no matrix rows."""
+    test = _Test(
+        name="boot",
+        result="failed",
+        test_id=1,
+        arch="x86_64",
+        modules={},
+    )
+    assert KernelOpenQA._result_matrix([test]) == []


### PR DESCRIPTION
`KernelOpenQA._result_matrix` annotates a failed `ltp_` test's result line
before listing its failed modules:

```python
if test.result == "failed":
    text.replace("failed", "failed:")   # result discarded
    for module in test.modules:
        ...
```

`str.replace` returns a new string; Python strings are immutable, so the call
is a no-op and `result: failed` is never turned into `result: failed:`.

Fix: `text = text.replace("failed", "failed:")`.

## Tests

New `tests/test_openqa_kernel.py` covers `_result_matrix`: a failed `ltp_` test
is annotated and lists only its failed modules; a passing test stays plain; a
non-`ltp_` test produces no row.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)