### PR TITLE
fix(locks): tolerate a malformed foreign-lock timestamp in time()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The kernel openQA result matrix now annotates a failed `ltp_` test's
   `result: failed` line as intended. The annotation used `text.replace(...)`
   without assigning the result back (strings are immutable), so it was a no-op.
+- Acquiring an update lock no longer crashes with `ValueError` when another
+  session's lockfile has a malformed or empty timestamp. `update_lock` reports a
+  foreign lock via `TargetLock.time()`, which did `float(timestamp)` unguarded; a
+  bad value aborted the whole lock-acquisition walk (blocking `update`/`prepare`/
+  `downgrade`). `time()` now returns `"unknown"` on a bad timestamp, mirroring the
+  already-hardened `age_seconds`.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -288,12 +288,24 @@ class TargetLock:
         """Returns the time the lock was created.
 
         Returns:
-            The time the lock was created.
+            The time the lock was created, or ``"unknown"`` when the stored
+            timestamp is missing or malformed. This mirrors ``age_seconds``:
+            a bad timestamp must not raise (this is called from
+            ``update_lock`` while reporting a foreign lock, where an exception
+            would abort the whole lock-acquisition walk).
 
         """
         self.load()
-        time = datetime.fromtimestamp(float(self._lock.timestamp))
-        return time.strftime(r"%A, %d.%m.%Y %H:%M UTC")
+        try:
+            ts = datetime.fromtimestamp(float(self._lock.timestamp))
+        except (ValueError, OverflowError, OSError):
+            logger.debug(
+                "%s: malformed lock timestamp %r",
+                self.connection.hostname,
+                self._lock.timestamp,
+            )
+            return "unknown"
+        return ts.strftime(r"%A, %d.%m.%Y %H:%M UTC")
 
     def unlock(self, force: bool = False) -> None:
         """Unlocks the target system.

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -255,6 +255,26 @@ class TestTargetLock:
         result = lock.time()
         assert "UTC" in result
 
+    def test_time_malformed_timestamp_returns_unknown(self, lock):
+        """A non-numeric timestamp must not raise (mirrors age_seconds).
+
+        time() is called from update_lock while reporting a foreign lock; a
+        bad timestamp there must not abort the whole lock-acquisition walk.
+        """
+        mock_file = MagicMock()
+        mock_file.readline.return_value = "notanumber:otheruser:99999"
+        lock.connection.sftp_open.return_value = mock_file
+
+        assert lock.time() == "unknown"
+
+    def test_time_empty_timestamp_returns_unknown(self, lock):
+        """An empty timestamp field is handled gracefully too."""
+        mock_file = MagicMock()
+        mock_file.readline.return_value = ":otheruser:99999"
+        lock.connection.sftp_open.return_value = mock_file
+
+        assert lock.time() == "unknown"
+
 
 # --- Stale lock reaping ---
 


### PR DESCRIPTION
`TargetLock.time()` formatted the lock timestamp unguarded:

```python
time = datetime.fromtimestamp(float(self._lock.timestamp))
```

`update_lock()` calls `time()` while logging a lock held by **another** session
("host X is locked since {time()} by {user}"). If that peer's lockfile has an
empty or non-numeric timestamp, `float(...)` raises `ValueError`, which isn't
caught here — so the whole lock-acquisition walk aborts and `update` / `prepare`
/ `downgrade` fail until the bad lockfile is removed manually.

`age_seconds()` was already hardened against this exact case (`try/except
ValueError → return None`); `time()` was missed.

## Fix

Catch `(ValueError, OverflowError, OSError)`, log a debug breadcrumb (same as
`age_seconds`), and return `"unknown"` so reporting a foreign lock can never
crash the operation.

## Tests

- `test_time_malformed_timestamp_returns_unknown` (non-numeric)
- `test_time_empty_timestamp_returns_unknown` (empty field)

Both verified to fail on the old code (`ValueError`) and pass on the fix; the
existing well-formed `time()` test still passes.

Gates: ruff format/check clean, ty clean, pytest green (41 in test_locks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)