### PR TITLE
fix(qem-dashboard): tolerate jobs with no test/name field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   bad value aborted the whole lock-acquisition walk (blocking `update`/`prepare`/
   `downgrade`). `time()` now returns `"unknown"` on a bad timestamp, mirroring the
   already-hardened `age_seconds`.
+- The QEM-dashboard openQA accounting no longer crashes with `TypeError` when a
+  dashboard job has no `test`/`name`. `_has_passed_install_jobs` and
+  `_get_logs_url` tested `"qam-incidentinstall" in job.get("test")`, which raised
+  on a `None` value (a normalized job whose `name` was absent); they now use
+  `job.get("test", "")`, matching the defensive pattern already used elsewhere
+  in the connector, so one odd job no longer aborts the whole install-result
+  summary during `export`.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/data_sources/qem_dashboard/dashboard_openqa.py
+++ b/mtui/data_sources/qem_dashboard/dashboard_openqa.py
@@ -129,7 +129,7 @@ class DashboardAutoOpenQA:
     def _normalize_job(
         job: dict[str, Any], source: str, setting: dict[str, Any]
     ) -> dict[str, Any]:
-        settings = setting.get("settings") or {}
+        settings = setting.get("settings", {}) or {}
         normalized = {
             "id": job.get("job_id"),
             "test": job.get("name"),
@@ -165,7 +165,7 @@ class DashboardAutoOpenQA:
         return all(
             cls._normalize_result(job.get("result"))
             for job in jobs
-            if "qam-incidentinstall" in job.get("test")
+            if "qam-incidentinstall" in (job.get("test", "") or "")
         )
 
     def _get_logs_url(self, jobs) -> list[URLs] | None:
@@ -184,12 +184,12 @@ class DashboardAutoOpenQA:
                     "file",
                     self.config.openqa_install_logs,
                 ),
-                str(job.get("result") or ""),
+                str(job.get("result", "") or ""),
             )
             for job in jobs
             if (
-                "qam-incidentinstall" in job.get("test")
-                and "SLFO" not in job.get("test")
+                "qam-incidentinstall" in (job.get("test", "") or "")
+                and "SLFO" not in (job.get("test", "") or "")
                 and self._normalize_result(job.get("result"))
             )
         ]
@@ -328,7 +328,7 @@ class DashboardAutoOpenQA:
         hoisted_build: str | None = None
         if source == "aggregate":
             builds = {
-                self._val((job.get("settings") or {}).get("BUILD"))
+                self._val((job.get("settings", {}) or {}).get("BUILD"))
                 for job in section_jobs
             }
             if len(builds) == 1:

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -689,3 +689,33 @@ def test_load_jobs_top_level_settings_timeout_returns_empty(
     assert any(
         "update_settings fetch timed out" in rec.message for rec in caplog.records
     )
+
+
+def test_has_passed_install_jobs_tolerates_missing_test_field(mock_config):
+    """A job whose ``test`` is None must be skipped, not crash the filter.
+
+    Regression: ``"qam-incidentinstall" in job.get("test")`` raised TypeError
+    when ``test`` was None (a normalized job with no ``name``).
+    """
+    jobs = [
+        {"test": None, "result": "passed"},  # would TypeError on `in None`
+        {"test": "qam-incidentinstall", "result": "passed"},
+    ]
+    assert DashboardAutoOpenQA._has_passed_install_jobs(jobs) is True
+
+
+def test_get_logs_url_tolerates_missing_test_field(mock_config):
+    """``_get_logs_url`` skips a None-``test`` job instead of crashing."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        {"test": None, "result": "passed", "id": 1, "settings": {}},
+        {
+            "test": "qam-incidentinstall",
+            "result": "passed",
+            "id": 2,
+            "settings": {"DISTRI": "sle", "ARCH": "x86_64", "VERSION": "15-SP5"},
+        },
+    ]
+    urls = dashboard._get_logs_url(jobs)
+    assert urls is not None
+    assert len(urls) == 1  # only the matching job, no crash on the None one


### PR DESCRIPTION
`_has_passed_install_jobs` and `_get_logs_url` filter dashboard jobs with:

```python
if "qam-incidentinstall" in job.get("test")
```

`_normalize_job` sets `"test": job.get("name")`, which is `None` when a dashboard
job carries no `name`. `"…" in None` raises `TypeError`, which propagates out of
`DashboardAutoOpenQA.run()` — so a single malformed job aborts the **whole**
install-result summary during `export`, not just that job. The rest of the same
connector already guards this with `job.get("test") or ""` (e.g. `_pretty_print`);
these two spots didn't.

## Fix

Use `job.get("test") or ""` in both filters (three sites).

## Tests

- `test_has_passed_install_jobs_tolerates_missing_test_field`
- `test_get_logs_url_tolerates_missing_test_field`

Both verified to fail on the old code (`TypeError`) and pass on the fix; a
None-`test` job is now skipped while the valid job is still processed.

Gates: ruff format/check clean, ty clean, pytest green (20 in
test_qem_dashboard_connector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)