### PR TITLE
fix(get): download only from enabled hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `job.get("test", "")`, matching the defensive pattern already used elsewhere
   in the connector, so one odd job no longer aborts the whole install-result
   summary during `export`.
+- `get` now downloads only from **enabled** hosts, matching `put` and its own
+  docstring. It previously contacted every connected host, including ones the
+  tester had deliberately disabled (e.g. a refhost parked during a batch).
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/commands/sftpcmd.py
+++ b/mtui/commands/sftpcmd.py
@@ -84,5 +84,8 @@ class SFTPGet(Command):
 
     def __call__(self) -> None:
         """Executes the `get` command."""
-        self.metadata.perform_get(self.targets, self.args.filename[0])
+        # Work only on enabled hosts, matching `put` and the docstring (a
+        # disabled host has been deliberately parked and must not be contacted).
+        targets = self.targets.select(enabled=True)
+        self.metadata.perform_get(targets, self.args.filename[0])
         logger.info("downloaded %s", self.args.filename[0])

--- a/tests/test_cmd_sftpcmd.py
+++ b/tests/test_cmd_sftpcmd.py
@@ -1,4 +1,4 @@
-"""Tests for the `put` (SFTPPut) command."""
+"""Tests for the `put` (SFTPPut) and `get` (SFTPGet) commands."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from mtui.commands.sftpcmd import SFTPPut
+from mtui.commands.sftpcmd import SFTPGet, SFTPPut
 from mtui.hosts.target.hostgroup import HostsGroup
 
 
@@ -64,3 +64,18 @@ def test_sftp_put_missing_file_logs_error(mock_config, caplog):
     SFTPPut(args, mock_config, MagicMock(), prompt)()
 
     assert any("not found" in r.message for r in caplog.records)
+
+
+def test_sftp_get_only_targets_enabled_hosts(mock_config):
+    """`get` must skip disabled hosts (parity with `put` and the docstring)."""
+    enabled = _target("h1")
+    disabled = _target("h2")
+    disabled.state = "disabled"
+    prompt = _prompt(HostsGroup([enabled, disabled]))
+    args = Namespace(filename=[Path("/remote/file")])
+
+    SFTPGet(args, mock_config, MagicMock(), prompt)()
+
+    # perform_get receives a group containing only the enabled host.
+    targets = prompt.metadata.perform_get.call_args.args[0]
+    assert targets.names() == ["h1"]


### PR DESCRIPTION
`SFTPGet.__call__` passed `self.targets` (every connected host) to
`perform_get`, whereas `SFTPPut` correctly narrows to
`self.targets.select(enabled=True)` — and `SFTPGet`'s own docstring already
claims "Downloads a file from all **enabled** hosts".

So `get` would contact a host the tester had deliberately **disabled** (e.g. a
refhost parked during a batch run). Low blast radius (read-only SFTP), but a
surprising inconsistency with `put` and with the documented behaviour.

## Fix

`targets = self.targets.select(enabled=True)` before `perform_get`.

## Test

`test_sftp_get_only_targets_enabled_hosts`: a group with one enabled + one
disabled host hands `perform_get` only the enabled one. Verified it fails on the
old code and passes on the fix.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)