### PR TITLE
fix(mcp): correct readOnlyHint allow-list (openqa_jobs in, dead 'products' out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
+  only queries openQA) and drops a stale `"products"` entry from the read-only
+  allow-list (no such command exists — it is `list_products`, already covered by
+  the `list_` prefix). Corrects the advisory hint shown to MCP clients; no
+  behavioural change to the commands themselves.
 - `mtui-mcp` no longer floods its log with a repeated
   `Warning: InsecureRequestWarning: Unverified HTTPS request ...` line — one per
   openQA (or other internal-host) request — when TLS verification is disabled

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -61,7 +61,11 @@ SUBPARSER_COMMANDS: frozenset[str] = frozenset({"config"})
 _READ_ONLY_PREFIXES: tuple[str, ...] = ("list_", "show_")
 
 #: Exact names that escape the prefix rule but are still side-effect-free.
-_READ_ONLY_EXACT: frozenset[str] = frozenset({"whoami", "products", "openqa_overview"})
+#: (``openqa_overview`` and ``openqa_jobs`` only query openQA; ``reload_products``
+#: is intentionally absent — it re-reads products from the hosts, a side effect.)
+_READ_ONLY_EXACT: frozenset[str] = frozenset(
+    {"whoami", "openqa_overview", "openqa_jobs"}
+)
 
 
 def _is_read_only(name: str) -> bool:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -297,12 +297,15 @@ def test_read_only_heuristic_matches_allow_list() -> None:
     """The internal helper honours the prefix + exact allow-list."""
     assert _is_read_only("whoami")
     assert _is_read_only("list_hosts")
+    assert _is_read_only("list_products")  # covered by the list_ prefix
     assert _is_read_only("show_log")
     assert _is_read_only("openqa_overview")
-    assert _is_read_only("products")
+    assert _is_read_only("openqa_jobs")  # exact: only queries openQA
     assert not _is_read_only("update")
     assert not _is_read_only("approve")
     assert not _is_read_only("config_set")
+    # reload_products re-reads products from the hosts -> NOT read-only.
+    assert not _is_read_only("reload_products")
 
 
 def test_read_only_annotation_set_for_known_safe_tools(


### PR DESCRIPTION
`_READ_ONLY_EXACT` (which drives the `readOnlyHint` annotation surfaced to MCP
clients) had two issues:

- It listed `"products"`, which is **not** a command name — the command is
  `list_products`, already covered by the `list_` prefix rule. Dead entry.
- It omitted `openqa_jobs`, which is side-effect-free (it only queries openQA),
  so that tool advertised `readOnlyHint=False`.

Swap `"products"` → `"openqa_jobs"`. `reload_products` is deliberately left out —
it re-reads products *from the hosts*, which is a side effect.

Advisory-hint only; no change to how any command runs.

## Test

Updated `test_read_only_heuristic_matches_allow_list` to assert real command
names: `list_products` (prefix) and `openqa_jobs` (exact) are read-only, and
`reload_products` is **not**.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)