### PR TITLE
fix(connection): re-raise OSError on initial connect so failures are reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `get` now downloads only from **enabled** hosts, matching `put` and its own
   docstring. It previously contacted every connected host, including ones the
   tester had deliberately disabled (e.g. a refhost parked during a batch).
+- Connecting to an unreachable host now reports the clean "connecting to <host>
+  failed: <reason>" message instead of a confusing downstream crash. A network
+  `OSError` on the initial connect was logged but swallowed, so `Connection`
+  returned a dead transport and `Target.connect` then blew up in
+  `is_locked()`/`parse_system()` with an opaque error. The initial connect now
+  re-raises the `OSError` so the `ConnectingTargetFailedMessage` handler runs; the
+  reconnect path (host rebooting) still swallows it and relies on its own
+  `is_active()` give-up check.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -238,11 +238,19 @@ class Connection:
 
         except OSError:
             if quiet:
+                # Reconnect path (e.g. host rebooting): an unreachable host is
+                # expected; swallow and let reconnect()'s is_active() check
+                # decide when to give up.
                 logger.debug(
                     "No valid connection to %s:%s (yet)", self.hostname, self.port
                 )
             else:
+                # Initial/explicit connect: re-raise so the caller
+                # (Target.connect) reports ConnectingTargetFailedMessage instead
+                # of proceeding with a dead transport and failing later in
+                # is_locked()/parse_system() with an opaque error.
                 logger.error("No valid connection to %s:%s", self.hostname, self.port)
+                raise
         except Exception as e:
             # general Exception
             logger.debug("%s: %s", self.hostname, e)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -524,12 +524,21 @@ def test_connect_sshexception_propagates(
         Connection("test_host", 22, 300)
 
 
-def test_connect_oserror_is_logged_not_raised(
+def test_connect_oserror_is_logged_and_raised(
     mock_ssh_client, mock_ssh_config, mock_path, caplog
 ):
-    """Network-level OSError on connect is logged but not re-raised."""
+    """A network-level OSError on the *initial* connect is logged AND re-raised.
+
+    Re-raising lets the caller (Target.connect) report the clean
+    ConnectingTargetFailedMessage instead of proceeding with a dead transport
+    and crashing later in is_locked()/parse_system(). The reconnect path
+    (quiet=True) still swallows it -- see the next test.
+    """
     mock_ssh_client.connect.side_effect = OSError("network")
-    with caplog.at_level("ERROR", logger="mtui.connection"):
+    with (
+        caplog.at_level("ERROR", logger="mtui.connection"),
+        pytest.raises(OSError, match="network"),
+    ):
         Connection("test_host", 22, 300)
     assert any("No valid connection" in r.message for r in caplog.records)
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -513,6 +513,30 @@ def test_connect_success_wires_up_lock_and_system(mock_config, monkeypatch):
     assert target.transactional is False
 
 
+def test_connect_failure_surfaces_connecting_failed_message(mock_config, caplog):
+    """A connection error is reported as ConnectingTargetFailedMessage + re-raised.
+
+    Relies on Connection() propagating the failure (e.g. a network OSError) so
+    Target.connect's handler can run, rather than returning a dead transport.
+    """
+    conn_class = MagicMock()
+    conn_class.side_effect = OSError("network")
+    target = Target(  # type: ignore[arg-type]
+        mock_config,
+        "host.example.com",
+        connection=conn_class,  # ty: ignore[invalid-argument-type]
+        lock=MagicMock(),  # ty: ignore[invalid-argument-type]
+    )
+    with (
+        caplog.at_level("CRITICAL", logger="mtui.target"),
+        pytest.raises(OSError, match="network"),
+    ):
+        target.connect()
+    assert any(
+        "connecting to host.example.com failed" in r.message for r in caplog.records
+    )
+
+
 def test_connect_warns_when_already_locked(mock_config, monkeypatch, caplog):
     """A fresh pre-existing lock is logged at warning but does not abort connect."""
     conn_class = MagicMock()


### PR DESCRIPTION
## Problem

`Connection.connect()`'s `OSError` branch logged the failure but did **not**
re-raise when `quiet=False`:

```python
except OSError:
    if quiet:
        logger.debug("No valid connection to %s:%s (yet)", ...)
    else:
        logger.error("No valid connection to %s:%s", ...)   # falls through
```

`__init__` always calls `connect(quiet=False)`, so an unreachable host
(connection refused / timed out / no route) yielded a `Connection` with a dead
transport that `__init__` returned **successfully**. `Target.connect` wraps only
the constructor in its `except Exception -> ConnectingTargetFailedMessage`
handler, so control then fell through to `is_locked()` and
`parse_system(self.connection)` running against the dead transport — crashing
with an opaque low-level error instead of the intended
"connecting to <host> failed: <reason>".

(Auth failures and generic `SSHException` already re-raise; only the plain
network `OSError` was swallowed.)

## Fix

Re-raise in the non-quiet `OSError` branch. The `quiet=True` reconnect path
(host rebooting) still swallows it and lets `reconnect()`'s `is_active()` loop
decide when to give up — unchanged.

## Tests

- The previously-pinning `test_connect_oserror_is_logged_not_raised` is updated
  (now `..._is_logged_and_raised`) to assert the initial connect raises while
  still logging "No valid connection".
- New `test_connect_failure_surfaces_connecting_failed_message` (target) asserts
  `Target.connect` logs `ConnectingTargetFailedMessage` and re-raises when the
  connection fails.
- The `quiet=True` swallow test is unaffected and still passes.

Gates: ruff format/check clean, ty clean, pytest green (126 connection+target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)