### PR TITLE
fix(metadata): tolerate absent/null jira, bugs, packages in JSONParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   re-raises the `OSError` so the `ConnectingTargetFailedMessage` handler runs; the
   reconnect path (host rebooting) still swallows it and relies on its own
   `is_active()` give-up check.
+- Parsing a testreport's JSON metadata no longer raises `TypeError` when the
+  `jira`, `bugs`, or `packages` keys are absent or null. `JSONParser.parse`
+  iterated `data.get("jira")` / `get("bugs")` / `get("packages").items()` with no
+  default, so a partial/malformed metadata blob crashed the parse; these now fall
+  back to empty, matching the existing handling of `repositories`.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/test_reports/metadata_parsers.py
+++ b/mtui/test_reports/metadata_parsers.py
@@ -76,10 +76,10 @@ class JSONParser:
             data: The JSON object to parse.
 
         """
-        for i in data.get("jira"):
+        for i in data.get("jira") or []:
             results.jira[i] = "Description not available"
 
-        for i in data.get("bugs"):
+        for i in data.get("bugs") or []:
             results.bugs[i] = "Description not available"
 
         results.rrid = RequestReviewID(data.get("rrid"))
@@ -95,7 +95,7 @@ class JSONParser:
         results.giteacohash = data.get("gitea_commit_hash")
 
         packages = {}
-        for prod, pkgvers in data.get("packages").items():
+        for prod, pkgvers in (data.get("packages") or {}).items():
             pkgs = {pkg: ver for pkg, _, ver in (p.split() for p in pkgvers)}
             packages[prod] = pkgs
         results.repositories = frozenset(data.get("repositories", []))

--- a/tests/test_metadata_parsers.py
+++ b/tests/test_metadata_parsers.py
@@ -138,6 +138,25 @@ def test_json_parser_parse():
     assert results.repositories == frozenset(["test_repo"])
 
 
+def test_json_parser_parse_tolerates_missing_optional_keys():
+    """Absent/null jira, bugs and packages keys must not raise (use defaults)."""
+    results = MagicMock()
+    results.jira = {}
+    results.bugs = {}
+
+    # Minimal metadata: the list/dict-shaped keys are absent entirely, and one
+    # is explicitly null. Previously `.get()` returned None and iterating /
+    # `.items()` raised TypeError.
+    data = {"rrid": "SUSE:Maintenance:1:1", "packages": None}
+
+    JSONParser.parse(results, data)
+
+    assert results.jira == {}
+    assert results.bugs == {}
+    assert results.packages == {}
+    assert results.repositories == frozenset()
+
+
 # ---------------------------------------------------------------------------
 # *repoparse unit tests (was tests/test_repoparse.py).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`JSONParser.parse` iterated three metadata keys with no default:

```python
for i in data.get("jira"): ...
for i in data.get("bugs"): ...
for prod, pkgvers in data.get("packages").items(): ...
```

If any key is absent (or explicitly `null`), `.get()` returns `None` and the
loop / `.items()` raises `TypeError`, aborting the whole parse. The current
metadata.json contract always carries these keys, so it doesn't fire today — but
a partial or malformed blob shouldn't crash the parser, and the sibling line
already does the right thing (`data.get("repositories", [])`).

## Fix

`data.get("jira") or []`, `data.get("bugs") or []`, and
`(data.get("packages") or {}).items()` (handles both missing and null).

## Test

`test_json_parser_parse_tolerates_missing_optional_keys` parses a minimal blob
(keys absent, `packages` null) and asserts empty results. Verified it fails on
the old code (`TypeError`) and passes on the fix.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)