### PR TITLE
fix(fileops): remove temp file when atomic_write_file fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   iterated `data.get("jira")` / `get("bugs")` / `get("packages").items()` with no
   default, so a partial/malformed metadata blob crashed the parse; these now fall
   back to empty, matching the existing handling of `repositories`.
+- `atomic_write_file` no longer leaves its temporary file behind in the
+  destination directory when the write or the final `move` fails. The `mkstemp`
+  temp file is now unlinked on any error before the exception propagates.
 - `mtui-mcp` now advertises `readOnlyHint=True` for the `openqa_jobs` tool (it
   only queries openQA) and drops a stale `"products"` entry from the read-only
   allow-list (no such command exists — it is `list_products`, already covered by

--- a/mtui/support/fileops.py
+++ b/mtui/support/fileops.py
@@ -10,6 +10,7 @@ import os
 import time
 from collections.abc import Callable
 from contextlib import chdir as chdir  # noqa: PLC0414  # re-exported for callers
+from contextlib import suppress
 from pathlib import Path
 from shutil import move
 from tempfile import mkstemp
@@ -75,7 +76,13 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, fname = mkstemp(dir=path.parent)
 
-    with os.fdopen(fd, "w") as f:
-        f.write(data)
-
-    move(fname, path)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+        move(fname, path)
+    except BaseException:
+        # Don't leave the temp file littering the destination directory if the
+        # write or the move failed (on a successful move it is already gone).
+        with suppress(OSError):
+            os.unlink(fname)
+        raise

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import ClassVar
+from unittest.mock import patch
 
 import pytest
 
@@ -93,6 +94,22 @@ def test_atomic_write_creates_missing_parent(create_temp):
     atomic_write_file(b"data: 1\n", target)
     assert target.exists()
     assert target.read_text() == "data: 1\n"
+
+
+def test_atomic_write_cleans_temp_on_move_failure(create_temp):
+    """A failed move must not leave the mkstemp temp file behind."""
+    target = Path(create_temp) / "out"
+    before = set(os.listdir(create_temp))
+
+    with (
+        patch("mtui.support.fileops.move", side_effect=OSError("boom")),
+        pytest.raises(OSError, match="boom"),
+    ):
+        atomic_write_file("data", target)
+
+    # No temp file leaked into the destination directory, and no partial target.
+    assert set(os.listdir(create_temp)) == before
+    assert not target.exists()
 
 
 def test_timestamp():


### PR DESCRIPTION
`atomic_write_file` creates a `mkstemp` temp file, writes to it, then `move`s it
into place:

```python
fd, fname = mkstemp(dir=path.parent)
with os.fdopen(fd, "w") as f:
    f.write(data)
move(fname, path)
```

If the write or the `move` raises (e.g. a permission or I/O error on the
destination), the temp file is left behind in the destination directory. Not
incorrect output, but litter accumulates on the error path.

## Fix

Wrap the write + move in `try/except`; on any failure unlink the temp file
before re-raising (on a successful move it is already gone).

## Test

`test_atomic_write_cleans_temp_on_move_failure` patches `move` to raise and
asserts the directory listing is unchanged (no temp leaked) and no partial
target exists. Verified it fails on the old code and passes on the fix.

Gates: ruff format/check clean, ty clean, pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)