### PR TITLE
mcp: work on several updates in parallel (workspaces, background jobs, lock wait)

### DIFF
--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -503,21 +503,35 @@ Three composable features make that possible; together they let one client
     wait = 0          ; seconds to wait for a busy refhost (0 = fail fast)
     wait_poll = 15    ; poll interval while waiting
 
-* **Refhost pool selection (different agents, different hosts).** When
-  ``refhosts.yml`` lists several interchangeable hosts for the same **test
-  target** and ``[refhosts] pool_select`` is on, ``add_host`` connects just
-  **one free** host per target instead of the whole matching matrix: it
-  tries candidates in turn, skips any already locked by another agent, and
-  **claims** (locks) the one it takes, so parallel agents drawing from the
-  same pool land on different hosts. If every candidate is busy it falls
-  back to the first and the ``[lock] wait`` policy above governs the wait.
-  The "target" is the full ``product + version + arch + addons`` the update
-  asks for, **not** just the arch — so an update spanning, say, all arches of
-  SLE15-SP5 *and* SP7 still gets a host for every (service-pack, arch) pair;
-  only genuine duplicates (several hosts for the very same target) collapse
-  to one. The pool is searched across **all** locations (location is ignored
-  for pool candidates). Off by default, so a one-host-per-target
+* **Refhost pool selection (different workspaces/agents, different hosts).**
+  When ``refhosts.yml`` lists several interchangeable hosts for the same
+  **test target** and ``[refhosts] pool_select`` is on, ``add_host`` connects
+  just **one free** host per target instead of the whole matching matrix: it
+  tries candidates in turn, skips any already in use, and **claims** the one
+  it takes, so parallel workspaces/agents drawing from the same pool land on
+  different hosts. The "target" is the full ``product + version + arch +
+  addons`` the update asks for, **not** just the arch — so an update spanning,
+  say, all arches of SLE15-SP5 *and* SP7 still gets a host for every
+  (service-pack, arch) pair; only genuine duplicates collapse to one. The pool
+  is searched across **all** locations. Off by default, so a one-host-per-target
   ``refhosts.yml`` behaves exactly as before.
+
+  "In use" is judged on two levels so the pool is safe both within and across
+  processes:
+
+  - **Within one ``mtui-mcp`` process** an in-process *host arbiter* tracks
+    which workspace owns which host — necessary because all workspaces share
+    the OS pid, so the remote lock alone cannot tell them apart. A candidate
+    owned by another workspace is skipped; if every candidate is owned, the
+    claim **queues** up to ``[lock] wait`` seconds for one to be released
+    (multiple workspaces queueing on a shared pool).
+  - **Across processes / manual users** the claim also takes the **remote**
+    ``/var/lock/mtui.lock`` with an identifying comment
+    (``mtui-mcp pool <RRID> [<owner>]``), so other ``mtui-mcp`` servers and
+    people running ``mtui`` see the host busy and by what. Closing the
+    workspace removes that remote lock (so the host shows free again), and a
+    crashed server's pool locks are recovered by the normal stale-lock reaping
+    (``[lock] reap_stale``; the identifying comment does not exempt them).
 
 .. code-block:: ini
 
@@ -538,11 +552,13 @@ client) keep several updates moving.
 
 .. note::
 
-   Workspaces inside *one* ``mtui-mcp`` process share the OS pid, so the
-   refhost lock (keyed on user+pid) treats them as the same owner and they
-   never block each other on a host — coordinate same-process workspaces so
-   they do not drive the *same* host destructively at once. ``[lock] wait``
-   matters across *separate* processes/agents, where the pids differ.
+   Workspaces inside *one* ``mtui-mcp`` process share the OS pid, so the remote
+   refhost lock (keyed on user+pid) cannot tell them apart. The in-process host
+   arbiter (above) is what keeps two same-process workspaces off the same pool
+   host; ``[lock] wait`` then governs queueing both within the process (arbiter)
+   and across separate processes/agents (remote lock). Without ``pool_select``
+   (a single host per arch), still serialise the host phase per host — only the
+   pool makes concurrent host-lanes safe.
 
 
 Long-running tool calls

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -19,12 +19,14 @@ replace the REPL's ``$EDITOR``-based ``edit`` flow, with
 the checkout (build-check and install logs, ``source.diff``, …).
 
 Session state is isolated per client. Under ``stdio`` one process
-serves one client, so there is exactly one ``Config`` / loaded test
-report / set of connected hosts. Under ``http`` each connected client
-gets its **own** isolated session — its own ``metadata`` and
-``targets`` — so concurrent clients never see each other's loaded
-template or hosts (see :ref:`mcp-concurrency`). Clients load their own
-state at runtime via the ``load_template`` and ``add_host`` tools.
+serves one client; under ``http`` each connected client gets its
+**own** isolated session — its own ``metadata`` and ``targets`` — so
+concurrent clients never see each other's loaded template or hosts
+(see :ref:`mcp-concurrency`). Either way a single client can hold
+several **named workspaces** (the ``workspace`` argument on every tool),
+each an independent loaded template + set of hosts, to drive more than
+one update at once (see :ref:`mcp-parallel-updates`). Clients load their
+own state at runtime via the ``load_template`` and ``add_host`` tools.
 
 .. _Model Context Protocol: https://modelcontextprotocol.io
 
@@ -450,6 +452,64 @@ These knobs live in the ``[mcp]`` section of the mtui config file:
     [mcp]
     session_cap = 32
     session_idle_timeout = 1800
+
+
+.. _mcp-parallel-updates:
+
+Working on several updates in parallel
+======================================
+
+Validating a queue of updates is faster when the independent parts overlap.
+Three composable features make that possible; together they let one client
+(or several agents) keep more than one update moving at once.
+
+* **Named workspaces (one client, several updates).** Every tool takes an
+  optional ``workspace`` argument (default ``"default"``). Each distinct
+  name resolves to its own isolated :class:`McpSession` — own loaded
+  template, own ``targets``, own lock — so a single ``stdio`` client can
+  ``load_template`` update A in workspace ``a`` and update B in workspace
+  ``b`` and drive both without one's ``load_template`` tearing the other's
+  hosts down. Because the lock is per-session, calls in *different*
+  workspaces run concurrently. ``list_workspaces`` shows the caller's
+  workspaces (their loaded template and hosts); ``close_workspace``
+  disconnects one and drops it. (Under ``stdio`` the idle sweeper is
+  disabled, so a workspace left quiet while you work another keeps its
+  hosts.)
+
+* **Background jobs (don't block on a slow host op).** The slow host
+  commands — ``run``, ``update``, ``downgrade``, ``prepare``, ``install``,
+  ``uninstall``, ``set_repo``, ``reboot`` — take ``background=true``: the
+  call returns a job id immediately instead of holding the request open for
+  the minutes the operation takes, while the command runs in the
+  background (still under the workspace's lock, so it serialises against
+  that workspace's other mutating calls). Poll with ``job_status`` and
+  fetch output with ``job_result`` (``job_list`` / ``job_cancel`` round it
+  out); pass the same ``workspace``. So one workspace's ``update`` can run
+  on the hosts while you advance another workspace's review.
+
+* **Waiting for a busy refhost (sharing a pool across agents).** Several
+  *agents* are separate processes, so a refhost lock genuinely excludes
+  them and one would otherwise fail with "locked by …". Set ``[lock] wait``
+  to a number of seconds to make ``lock`` **queue** on a busy host —
+  polling every ``[lock] wait_poll`` seconds until it is released (or
+  reaped as stale, or becomes yours) — rather than erroring. A warning is
+  still logged when the wait starts (and on timeout), so a REPL user sees
+  the host is busy. The default ``0`` keeps the immediate-failure
+  behaviour.
+
+.. code-block:: ini
+
+    [lock]
+    wait = 0          ; seconds to wait for a busy refhost (0 = fail fast)
+    wait_poll = 15    ; poll interval while waiting
+
+.. note::
+
+   Workspaces inside *one* ``mtui-mcp`` process share the OS pid, so the
+   refhost lock (keyed on user+pid) treats them as the same owner and they
+   never block each other on a host — coordinate same-process workspaces so
+   they do not drive the *same* host destructively at once. ``[lock] wait``
+   matters across *separate* processes/agents, where the pids differ.
 
 
 Long-running tool calls

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -503,6 +503,39 @@ Three composable features make that possible; together they let one client
     wait = 0          ; seconds to wait for a busy refhost (0 = fail fast)
     wait_poll = 15    ; poll interval while waiting
 
+* **Refhost pool selection (different agents, different hosts).** When
+  ``refhosts.yml`` lists several interchangeable hosts for the same **test
+  target** and ``[refhosts] pool_select`` is on, ``add_host`` connects just
+  **one free** host per target instead of the whole matching matrix: it
+  tries candidates in turn, skips any already locked by another agent, and
+  **claims** (locks) the one it takes, so parallel agents drawing from the
+  same pool land on different hosts. If every candidate is busy it falls
+  back to the first and the ``[lock] wait`` policy above governs the wait.
+  The "target" is the full ``product + version + arch + addons`` the update
+  asks for, **not** just the arch — so an update spanning, say, all arches of
+  SLE15-SP5 *and* SP7 still gets a host for every (service-pack, arch) pair;
+  only genuine duplicates (several hosts for the very same target) collapse
+  to one. The pool is searched across **all** locations (location is ignored
+  for pool candidates). Off by default, so a one-host-per-target
+  ``refhosts.yml`` behaves exactly as before.
+
+.. code-block:: ini
+
+    [refhosts]
+    pool_select = false   ; true: pick one free host per arch from the pool
+
+Together these compose: a pool (``pool_select``) gives several agents
+distinct hosts; ``lock wait`` makes them queue politely when the pool is
+exhausted; workspaces and background jobs let each agent (or a single
+client) keep several updates moving.
+
+.. note::
+
+   ``location`` is optional. With no ``[mtui] location`` configured and none
+   set interactively or over MCP it defaults to ``default`` — the
+   ``default`` bucket of ``refhosts.yml`` — so a plain setup needs no
+   location at all. Pool selection ignores location entirely regardless.
+
 .. note::
 
    Workspaces inside *one* ``mtui-mcp`` process share the OS pid, so the

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -86,6 +86,50 @@ class Refhosts:
 
         return results
 
+    def search_pool(
+        self, attributes: list[Attributes], all_locations: bool = False
+    ) -> list[tuple[Host, str]]:
+        """Return ``(host, slot)`` pairs for refhost-pool selection.
+
+        ``slot`` is ``str(attribute)`` of the **first** query attribute the
+        host matches — i.e. the test-target identity (product + version +
+        arch + addons *as requested*). Hosts that satisfy the same target are
+        therefore poolable down to one even if a candidate carries extra
+        addons, while distinct service packs / arches are distinct slots and
+        each keeps a host. Results are de-duplicated by host name (a host is
+        bound to the first slot it matches), preserving first-seen order.
+
+        With ``all_locations=True`` every location is scanned (location is
+        ignored) so the pool draws the widest set of candidates; otherwise
+        the per-attribute location/default fallback of :meth:`search`
+        applies.
+        """
+        seen: set[str] = set()
+        results: list[tuple[Host, str]] = []
+
+        def _add(hosts: list[Host], attribute: Attributes, slot: str) -> int:
+            added = 0
+            for candidate in hosts:
+                if candidate.name in seen:
+                    continue
+                if self.is_candidate_match(candidate, attribute):
+                    seen.add(candidate.name)
+                    results.append((candidate, slot))
+                    added += 1
+            return added
+
+        for attribute in attributes:
+            slot = str(attribute)
+            if all_locations:
+                for hosts in self.data.values():
+                    _add(hosts, attribute, slot)
+                continue
+            added = _add(self.data.get(self.location, []), attribute, slot)
+            if added == 0 and self.location != self._default_location:
+                _add(self.data.get(self._default_location, []), attribute, slot)
+
+        return results
+
     def is_candidate_match(self, candidate: Host, attribute: Attributes) -> bool:
         """Return True iff ``candidate`` satisfies all set fields of ``attribute``."""
         if attribute.arch and attribute.arch != candidate.arch:

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -234,7 +234,12 @@ class TargetLock:
         # NOTE: let the code pass through if is_mine() as
         # setting a different comment may be desired.
         if self.is_locked() and not self.is_mine():
-            raise TargetLockedError(self.locked_by_msg())
+            # Locked by another session/agent. With ``lock_wait`` enabled,
+            # queue on the busy host (poll until it frees) instead of
+            # failing immediately, so several agents can share a refhost
+            # pool. Default (``lock_wait = 0``) keeps the fail-fast path.
+            if not self._wait_for_release():
+                raise TargetLockedError(self.locked_by_msg())
 
         logger.debug("%s: setting lock", self.connection.hostname)
 
@@ -253,6 +258,66 @@ class TargetLock:
             raise
 
         self._lock = rl
+
+    def _wait_for_release(self) -> bool:
+        """Wait for a foreign lock to be released, up to ``config.lock_wait`` s.
+
+        Polls every ``config.lock_wait_poll`` seconds until the remote lock
+        is gone (or has become ours, or is reaped as stale), or the
+        ``config.lock_wait`` budget runs out.
+
+        A warning is always logged when the wait starts — so a REPL user
+        still sees that the host is locked (matching the connect-time
+        warning) and that mtui is now waiting rather than erroring — and
+        again on timeout.
+
+        Returns:
+            True if the lock became free within the budget (caller may now
+            take it); False on timeout or when waiting is disabled
+            (``lock_wait <= 0``), in which case the caller raises
+            :class:`TargetLockedError` as before.
+
+        """
+        wait = self._int_cfg("lock_wait", 0)
+        if wait <= 0:
+            return False
+        poll = max(1, self._int_cfg("lock_wait_poll", 15))
+        logger.warning(
+            "%s: %s waiting up to %ds for it to be released",
+            self.connection.hostname,
+            self._lock,
+            wait,
+        )
+        deadline = time.time() + wait
+        while time.time() < deadline:
+            time.sleep(min(poll, max(0.0, deadline - time.time())))
+            # ``is_locked`` reloads remote state; short-circuit keeps the
+            # ``is_mine``/``reap_if_stale`` calls (which assume a loaded
+            # lock) off the no-longer-locked path.
+            if not self.is_locked() or self.is_mine() or self.reap_if_stale():
+                logger.info(
+                    "%s: lock released, proceeding", self.connection.hostname
+                )
+                return True
+        logger.warning(
+            "%s: still locked after waiting %ds, giving up",
+            self.connection.hostname,
+            wait,
+        )
+        return False
+
+    def _int_cfg(self, name: str, default: int) -> int:
+        """Read an int config option, tolerating a missing/non-int value.
+
+        Keeps the lock path robust against partially-populated configs:
+        only a genuine number is accepted (a ``MagicMock`` attribute, as
+        used in tests, falls back to ``default`` — ``MagicMock.__int__``
+        would otherwise coerce to ``1`` and silently enable waiting).
+        """
+        val = getattr(self.config, name, default)
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            return default
+        return int(val)
 
     def locked_by_msg(self) -> str:
         """Returns a "locked by" message suitable for display to the user.

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -233,13 +233,12 @@ class TargetLock:
         # the locking really atomic.
         # NOTE: let the code pass through if is_mine() as
         # setting a different comment may be desired.
-        if self.is_locked() and not self.is_mine():
-            # Locked by another session/agent. With ``lock_wait`` enabled,
-            # queue on the busy host (poll until it frees) instead of
-            # failing immediately, so several agents can share a refhost
-            # pool. Default (``lock_wait = 0``) keeps the fail-fast path.
-            if not self._wait_for_release():
-                raise TargetLockedError(self.locked_by_msg())
+        # Locked by another session/agent: with ``lock_wait`` enabled, queue
+        # on the busy host (poll until it frees) instead of failing
+        # immediately, so several agents can share a refhost pool. Default
+        # (``lock_wait = 0``) keeps the fail-fast path.
+        if self.is_locked() and not self.is_mine() and not self._wait_for_release():
+            raise TargetLockedError(self.locked_by_msg())
 
         logger.debug("%s: setting lock", self.connection.hostname)
 
@@ -295,9 +294,7 @@ class TargetLock:
             # ``is_mine``/``reap_if_stale`` calls (which assume a loaded
             # lock) off the no-longer-locked path.
             if not self.is_locked() or self.is_mine() or self.reap_if_stale():
-                logger.info(
-                    "%s: lock released, proceeding", self.connection.hostname
-                )
+                logger.info("%s: lock released, proceeding", self.connection.hostname)
                 return True
         logger.warning(
             "%s: still locked after waiting %ds, giving up",

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -500,6 +500,39 @@ class Target:
             logger.warning(e)
             raise
 
+    def locked_by(self) -> str:
+        """Return the user currently holding the lock (``""`` if unlocked)."""
+        return self._lock.locked_by()
+
+    def try_claim(self, comment: str = "") -> bool:
+        """Claim the host's lock if it is free; report whether we got it.
+
+        Used by refhost-pool selection to reserve a candidate against other
+        agents. Returns ``False`` (without raising) when the host is locked
+        by someone else and the lock is neither ours nor reapable as stale,
+        or when the claim loses the race — so the caller can try the next
+        candidate. A stale lock is reaped and then claimed.
+
+        Args:
+            comment: Optional comment recorded on the lock.
+
+        Returns:
+            ``True`` if the lock is now held by us, ``False`` if the host is
+            busy.
+
+        """
+        if (
+            self.is_locked()
+            and not self._lock.is_mine()
+            and not self._lock.reap_if_stale()
+        ):
+            return False
+        try:
+            self.lock(comment)
+        except TargetLockedError:
+            return False
+        return True
+
     def add_history(self, comment: str) -> None:
         """Adds a history entry to the target.
 

--- a/mtui/mcp/host_arbiter.py
+++ b/mtui/mcp/host_arbiter.py
@@ -1,0 +1,110 @@
+"""Process-global, workspace-aware refhost ownership for ``mtui-mcp``.
+
+Within ONE ``mtui-mcp`` process every named workspace shares the OS pid, so the
+remote ``/var/lock/mtui.lock`` (keyed on user+pid) cannot tell two workspaces
+apart — both see a lock they took as "mine". The :class:`HostArbiter` is the
+in-process counterpart that makes a refhost **pool** usable from a single
+client: it records which workspace currently owns which refhost so two
+workspaces never drive the same pool host, and lets a workspace **queue** for a
+busy pool host (block until another workspace releases it). The remote lock
+still arbitrates against *other* processes / users.
+
+One instance is created by :class:`mtui.mcp.registry.SessionRegistry` and shared
+by every session it mints; each session is the ``owner`` identified by its
+registry key. The arbiter is thread-safe: refhost connect/claim runs in
+``asyncio.to_thread`` worker threads, so a :class:`threading.Condition` guards
+the ownership map and powers the queue.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterable
+from logging import getLogger
+
+logger = getLogger("mtui.mcp.host_arbiter")
+
+
+class HostArbiter:
+    """In-process map of refhost -> owning workspace, with a wait queue."""
+
+    def __init__(self) -> None:
+        """Initialise an empty ownership map and its condition variable."""
+        self._owner: dict[str, str] = {}
+        self._cv = threading.Condition()
+
+    def owner_of(self, host: str) -> str | None:
+        """Return the workspace owning ``host`` in this process, or ``None``."""
+        with self._cv:
+            return self._owner.get(host)
+
+    def claim(self, host: str, owner: str) -> bool:
+        """Claim ``host`` for ``owner`` if free (or already ours).
+
+        Returns ``True`` when ``owner`` now holds it, ``False`` when another
+        workspace in this process already does (caller should pick another).
+        """
+        with self._cv:
+            cur = self._owner.get(host)
+            if cur is not None and cur != owner:
+                return False
+            self._owner[host] = owner
+            return True
+
+    def release(self, host: str, owner: str) -> None:
+        """Release ``host`` if owned by ``owner`` and wake any waiters."""
+        with self._cv:
+            if self._owner.get(host) == owner:
+                del self._owner[host]
+                self._cv.notify_all()
+
+    def release_owner(self, owner: str) -> None:
+        """Release every host held by ``owner`` (workspace close) and wake waiters."""
+        with self._cv:
+            freed = [h for h, o in self._owner.items() if o == owner]
+            for h in freed:
+                del self._owner[h]
+            if freed:
+                logger.debug("released %d host(s) held by %s", len(freed), owner)
+                self._cv.notify_all()
+
+    def acquire_any(
+        self,
+        candidates: Iterable[str],
+        owner: str,
+        *,
+        timeout: float = 0.0,
+        poll: float = 5.0,
+    ) -> str | None:
+        """Reserve and return one candidate that is free in this process.
+
+        Scans ``candidates`` in order; a host that is unowned, or already owned
+        by ``owner``, is reserved for ``owner`` and returned. If every candidate
+        is currently held by *other* workspaces, waits (queues) until one is
+        released or ``timeout`` seconds elapse. ``timeout <= 0`` means do not
+        wait — return ``None`` immediately when nothing is free.
+
+        Args:
+            candidates: Hostnames to choose from, in preference order.
+            owner: The requesting workspace key.
+            timeout: Max seconds to queue for a free host.
+            poll: Re-check cadence while waiting (a wake also re-checks).
+
+        Returns:
+            A hostname now owned by ``owner``, or ``None`` on timeout/empty.
+
+        """
+        cands = list(candidates)
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._cv:
+            while True:
+                for h in cands:
+                    cur = self._owner.get(h)
+                    if cur is None or cur == owner:
+                        self._owner[h] = owner
+                        return h
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._cv.wait(min(poll, remaining))

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -38,7 +38,7 @@ from .args import get_parser
 from .registry import SessionRegistry
 from .session import McpSession
 from .testreport_tools import register_testreport_tools
-from .tools import build_tools, register_job_tools
+from .tools import build_tools, register_job_tools, register_workspace_tools
 
 if TYPE_CHECKING:
     from .registry import SessionProvider
@@ -179,7 +179,29 @@ def main() -> int:
             cfg.mcp_session_idle_timeout,
         )
     else:
-        provider = build_session(cfg, logger)
+        # stdio is one process == one client, but a registry still earns
+        # its keep: it lets that single client hold several **named
+        # workspaces** (``load_template`` per workspace), each its own
+        # isolated ``McpSession`` with its own loaded template + targets +
+        # lock, so independent updates can be driven concurrently from one
+        # connection. The idle sweeper is disabled (``idle_timeout=0``):
+        # under stdio a workspace left quiet while the operator works
+        # another must keep its host connections, not be reaped from under
+        # them. The default workspace is minted lazily on first call, so a
+        # caller that never names a workspace sees the prior single-session
+        # behaviour unchanged.
+        provider = SessionRegistry(
+            build_session,
+            cfg,
+            logger,
+            max_sessions=cfg.mcp_session_cap,
+            idle_timeout=0,
+        )
+        logger.info(
+            "mtui-mcp: stdio transport — named-workspace multiplexing "
+            "(cap=%d, idle sweeper disabled)",
+            cfg.mcp_session_cap,
+        )
 
     # ``host``/``port`` are constructor-time settings in the SDK and
     # only consulted under the ``streamable-http`` transport; passing
@@ -187,6 +209,7 @@ def main() -> int:
     mcp = FastMCP(name="mtui", host=args.host, port=args.port)
     build_tools(mcp, provider)
     register_testreport_tools(mcp, provider)
+    register_workspace_tools(mcp, provider)
     register_job_tools(mcp, provider)
 
     try:

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -88,6 +88,7 @@ def split_workspace_key(key: str) -> tuple[str, str]:
     base, sep, ws = key.partition(_WORKSPACE_SEP)
     return (base, ws) if sep else (key, WORKSPACE_DEFAULT)
 
+
 #: Default ceiling on concurrent client sessions (DoS guard). Overridden
 #: from ``[mcp] session_cap`` via :func:`mtui.mcp.main.main`.
 DEFAULT_MAX_SESSIONS: int = 32

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -39,6 +39,7 @@ import time
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Protocol
 
+from .host_arbiter import HostArbiter
 from .session import McpSession
 
 if TYPE_CHECKING:
@@ -273,6 +274,11 @@ class SessionRegistry:
         self._last_touch: dict[str, float] = {}
         self._lock = asyncio.Lock()
         self._sweeper: asyncio.Task[None] | None = None
+        # One process-global host arbiter shared by every session, so the
+        # refhost pool is divided safely across this client's workspaces
+        # (same-pid sessions the remote lock cannot tell apart). Each session
+        # is bound to it under its own registry key (the "owner").
+        self._arbiter = HostArbiter()
 
     async def get_or_create(self, key: str) -> McpSession:
         """Return the session for ``key``, minting one on first use.
@@ -312,6 +318,7 @@ class SessionRegistry:
                         "released or raise [mcp] session_cap"
                     )
                 session = self._factory(self._cfg, self._log)
+                session.bind_arbiter(self._arbiter, key)
                 self._sessions[key] = session
                 logger.info(
                     "minted new MCP session (key=%s, live=%d)",

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -56,6 +56,38 @@ logger = getLogger("mtui.mcp.registry")
 #: http :class:`SessionRegistry`.
 DEFAULT_SESSION_KEY: str = "<default>"
 
+#: The workspace name a tool call uses when the caller does not pass one.
+#: A single ``default`` workspace reproduces the pre-workspace behaviour
+#: (one loaded template per client), so every existing call keeps working.
+WORKSPACE_DEFAULT: str = "default"
+
+#: Separator joining the per-client base key and the workspace name into
+#: the registry key. ``\x1f`` (ASCII unit separator) cannot appear in the
+#: numeric ``id()`` base nor, in practice, in a workspace name, so the
+#: composite key round-trips unambiguously (see :func:`split_workspace_key`).
+_WORKSPACE_SEP: str = "\x1f"
+
+
+def workspace_key(base: str, workspace: str) -> str:
+    """Compose the registry key for ``workspace`` under client ``base``.
+
+    The base is the per-client key (``id(ctx.session)`` under http, or
+    :data:`DEFAULT_SESSION_KEY` for context-less calls); appending the
+    workspace name lets one client hold several independent sessions —
+    each its own loaded template + ``targets`` — addressed by name.
+    """
+    return f"{base}{_WORKSPACE_SEP}{workspace}"
+
+
+def split_workspace_key(key: str) -> tuple[str, str]:
+    """Inverse of :func:`workspace_key`: ``key`` -> ``(base, workspace)``.
+
+    A key without the separator (legacy/non-workspace) is returned as
+    ``(key, WORKSPACE_DEFAULT)`` so callers can treat it uniformly.
+    """
+    base, sep, ws = key.partition(_WORKSPACE_SEP)
+    return (base, ws) if sep else (key, WORKSPACE_DEFAULT)
+
 #: Default ceiling on concurrent client sessions (DoS guard). Overridden
 #: from ``[mcp] session_cap`` via :func:`mtui.mcp.main.main`.
 DEFAULT_MAX_SESSIONS: int = 32
@@ -90,7 +122,11 @@ class SessionProvider(Protocol):
         ...
 
 
-async def resolve_session(provider: SessionProvider, ctx: Any | None) -> McpSession:
+async def resolve_session(
+    provider: SessionProvider,
+    ctx: Any | None,
+    workspace: str = WORKSPACE_DEFAULT,
+) -> McpSession:
     """Resolve the per-call session from ``provider`` for request ``ctx``.
 
     Routes the ``ctx is None`` case (direct-call tests, non-request
@@ -98,17 +134,28 @@ async def resolve_session(provider: SessionProvider, ctx: Any | None) -> McpSess
     key off a missing context, so the existing direct-call tests keep
     working unchanged. Otherwise keys on :func:`_session_key`.
 
+    ``workspace`` lets a single client hold several independent sessions
+    (each its own loaded template + ``targets``): the per-client base key
+    is combined with the workspace name via :func:`workspace_key`. The
+    default ``"default"`` reproduces the one-session-per-client behaviour,
+    so callers that do not pass a workspace are unaffected. Under the
+    static single-entry provider (:meth:`McpSession.get_or_create`) the
+    composite key is ignored, so stdio without a workspace registry still
+    returns the one session.
+
     Args:
         provider: The session provider (registry or static session).
         ctx: The FastMCP :class:`~mcp.server.fastmcp.Context`, or
             ``None``.
+        workspace: The named workspace within this client (default
+            :data:`WORKSPACE_DEFAULT`).
 
     Returns:
         The :class:`McpSession` to dispatch this call through.
 
     """
-    key = DEFAULT_SESSION_KEY if ctx is None else _session_key(ctx)
-    return await provider.get_or_create(key)
+    base = DEFAULT_SESSION_KEY if ctx is None else _session_key(ctx)
+    return await provider.get_or_create(workspace_key(base, workspace))
 
 
 def _session_key(ctx: Any | None) -> str:
@@ -272,6 +319,15 @@ class SessionRegistry:
                 )
             self._last_touch[key] = time.monotonic()
             return session
+
+    def live_sessions(self) -> dict[str, McpSession]:
+        """Return a snapshot ``{key: session}`` of the live sessions.
+
+        A shallow copy so the caller (the ``list_workspaces`` tool) can
+        iterate without racing concurrent :meth:`get_or_create` /
+        :meth:`evict` mutations of the underlying dict.
+        """
+        return dict(self._sessions)
 
     async def evict(self, key: str) -> None:
         """Drop ``key`` from the registry and best-effort close it.

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -243,6 +243,14 @@ class McpSession:
         # waits, matching the non-interactive contract above.
         self.prompter = None
 
+        # Refhost-pool arbiter + this session's owner key, bound by the
+        # registry via :meth:`bind_arbiter` right after construction. Until
+        # then they are ``None`` (no arbitration — single-session/REPL-like
+        # behaviour). Propagated onto every loaded testreport so its pool
+        # selection skips hosts held by other workspaces in this process.
+        self._host_arbiter: Any | None = None
+        self._owner_key: str | None = None
+
         self.metadata = NullTestReport(config, prompter=self.prompter)
         self.targets = self.metadata.targets
         # Mirror ``self.interactive`` onto the HostsGroup so long-running
@@ -291,6 +299,29 @@ class McpSession:
         # whole session and its table with it.
         self._jobs: dict[str, dict[str, Any]] = {}
         self._job_counter = 0
+
+    # ------------------------------------------------------------------
+    # Refhost-pool arbitration (in-process, cross-workspace)
+    # ------------------------------------------------------------------
+
+    def bind_arbiter(self, arbiter: Any, owner_key: str) -> None:
+        """Bind this session to the shared host arbiter under ``owner_key``.
+
+        Called by :class:`mtui.mcp.registry.SessionRegistry` right after the
+        session is minted. Records the arbiter + this session's owner identity
+        and pushes them onto the current testreport so refhost-pool selection
+        is workspace-aware.
+        """
+        self._host_arbiter = arbiter
+        self._owner_key = owner_key
+        self._apply_arbiter()
+
+    def _apply_arbiter(self) -> None:
+        """Push the bound arbiter + owner key onto the current testreport."""
+        md = self.metadata
+        if md is not None:
+            md._host_arbiter = self._host_arbiter  # noqa: SLF001 - designed hook
+            md._host_owner = self._owner_key  # noqa: SLF001 - designed hook
 
     # ------------------------------------------------------------------
     # CommandPrompt-compatible surface
@@ -368,6 +399,8 @@ class McpSession:
         # Re-apply the non-interactive flag after the testreport swap so
         # the fresh HostsGroup inherits the session's headless mode.
         self.targets.interactive = False
+        # Make the new testreport's refhost-pool selection workspace-aware.
+        self._apply_arbiter()
         self.set_prompt(None)
 
     # ------------------------------------------------------------------
@@ -413,6 +446,17 @@ class McpSession:
         rest, and ``targets`` is emptied either way so a second call is
         a cheap no-op.
         """
+        # Release this workspace's refhost-pool claims so queued workspaces —
+        # and other mtui-mcp servers / manual users — can take the hosts. This
+        # removes the *remote* mtui lock (visible to everyone) as well as the
+        # in-process arbiter ownership. Runs in a worker thread (it SSHes to
+        # unlock). Done first so it always runs even if the disconnect raises.
+        if self._host_arbiter is not None and self._owner_key is not None:
+            release = getattr(self.metadata, "release_pool_claims", None)
+            if release is not None:
+                await asyncio.to_thread(release)
+            else:
+                self._host_arbiter.release_owner(self._owner_key)
         targets = self.targets
         if not targets:
             return

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..test_reports.null_report import NullTestReport
-from .registry import resolve_session
+from .registry import WORKSPACE_DEFAULT, resolve_session
 from .session import McpCommandError
 
 if TYPE_CHECKING:
@@ -565,32 +565,44 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
     async def _read(
         offset: int = 1,
         limit: int | None = None,
+        workspace: str = WORKSPACE_DEFAULT,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_read(session, offset=offset, limit=limit, ctx=ctx)
 
-    async def _logs(ctx: Context | None = None) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+    async def _logs(
+        workspace: str = WORKSPACE_DEFAULT, ctx: Context | None = None
+    ) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_logs(session, ctx=ctx)
 
-    async def _read_file(relpath: str, ctx: Context | None = None) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+    async def _read_file(
+        relpath: str,
+        workspace: str = WORKSPACE_DEFAULT,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_read_file(session, relpath, ctx=ctx)
 
     async def _patch(
         start_line: int,
         end_line: int,
         replacement: str,
+        workspace: str = WORKSPACE_DEFAULT,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_patch(
             session, start_line, end_line, replacement, ctx=ctx
         )
 
-    async def _write(content: str, ctx: Context | None = None) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+    async def _write(
+        content: str,
+        workspace: str = WORKSPACE_DEFAULT,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_write(session, content, ctx=ctx)
 
     async def _fill(

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -609,9 +609,10 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         reproducer: str | None = None,
         status: str | None = None,
         summary: str | None = None,
+        workspace: str = WORKSPACE_DEFAULT,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
+        session = await resolve_session(provider, ctx, workspace)
         return await testreport_fill(
             session, reproducer=reproducer, status=status, summary=summary, ctx=ctx
         )

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -33,10 +33,18 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from ..commands import Command
+from ..test_reports.null_report import NullTestReport
 from ._argv import kwargs_to_argv
 from ._schema import build_parameters
 from .deny import REPL_ONLY
-from .registry import resolve_session
+from .registry import (
+    DEFAULT_SESSION_KEY,
+    WORKSPACE_DEFAULT,
+    _session_key,
+    resolve_session,
+    split_workspace_key,
+    workspace_key,
+)
 from .session import McpCommandError
 
 if TYPE_CHECKING:
@@ -130,6 +138,19 @@ def _make_wrapper(
     from mcp.server.fastmcp import Context
 
     params = build_parameters(parser)
+    # A ``workspace`` selector so one client can drive several independent
+    # updates at once: each distinct name resolves to its own isolated
+    # McpSession (own loaded template + targets + lock). Keyword-only with
+    # a default, so it stays in the JSON schema (the LLM can target a
+    # workspace) yet every existing call that omits it lands in the
+    # ``default`` workspace — unchanged behaviour. Encoded out before
+    # ``kwargs_to_argv`` so it never leaks into the command's argv.
+    workspace_param = inspect.Parameter(
+        "workspace",
+        inspect.Parameter.KEYWORD_ONLY,
+        default=WORKSPACE_DEFAULT,
+        annotation=str,
+    )
     # Append the Context-typed parameter LAST so the existing required-
     # before-optional ordering is preserved (``ctx`` has a default of
     # ``None`` and is keyword-only).
@@ -154,7 +175,7 @@ def _make_wrapper(
                 annotation=bool,
             )
         )
-    all_params = [*params, *extra_params, ctx_param]
+    all_params = [*params, *extra_params, workspace_param, ctx_param]
     signature = inspect.Signature(
         parameters=all_params,
         return_annotation=str,
@@ -184,8 +205,11 @@ def _make_wrapper(
         # FastMCP injects ``ctx`` only when the client request carries
         # a progress token (and even then, only because we annotated
         # the parameter as Context); strip it before kwargs_to_argv so
-        # the encoder does not try to render it as a CLI flag.
+        # the encoder does not try to render it as a CLI flag. ``workspace``
+        # is likewise popped here (never a CLI flag) and steers which
+        # isolated session this call dispatches through.
         ctx = kwargs.pop("ctx", None)
+        workspace = kwargs.pop("workspace", None) or WORKSPACE_DEFAULT
         background = bool(kwargs.pop("background", False)) if is_slow else False
         if synthetic_required:
             supplied = [n for n in synthetic_names if kwargs.get(n) is not None]
@@ -196,14 +220,15 @@ def _make_wrapper(
                 )
                 raise McpCommandError("", msg, 2)
         argv = list(argv_prefix) + kwargs_to_argv(parser, kwargs)
-        session = await resolve_session(provider, ctx)
+        session = await resolve_session(provider, ctx, workspace)
         if background:
             job_id = await session.start_job(cls, argv, ctx=ctx)
             return (
-                f"started background job {job_id!r} for `{cls.command}`; it "
-                f"runs on the hosts while you work elsewhere. Poll "
-                f"job_status(job_id={job_id!r}) and fetch output with "
-                f"job_result(job_id={job_id!r})."
+                f"started background job {job_id!r} for `{cls.command}` in "
+                f"workspace {workspace!r}; it runs on the hosts while you work "
+                f"elsewhere. Poll job_status(job_id={job_id!r}, "
+                f"workspace={workspace!r}) and fetch output with "
+                f"job_result(job_id={job_id!r}, workspace={workspace!r})."
             )
         return await session.run_command(cls, argv, ctx=ctx)
 
@@ -458,3 +483,102 @@ def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     )
     logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
     return ["job_cancel", "job_list", "job_result", "job_status"]
+
+
+def register_workspace_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
+    """Register the ``list_workspaces`` / ``close_workspace`` tools.
+
+    These expose the named-workspace multiplexing that every other tool's
+    ``workspace`` parameter drives: ``list_workspaces`` reports the caller's
+    own live workspaces (the loaded template + connected hosts of each), and
+    ``close_workspace`` disconnects one workspace's hosts and drops it.
+
+    Both operate only on the *calling client's* workspaces — the per-client
+    base key is recomputed here and used to filter / address the registry —
+    so under http one client can neither see nor close another's. They no-op
+    gracefully (a one-line message) under a provider that is not a
+    :class:`~mtui.mcp.registry.SessionRegistry` (e.g. a direct single
+    :class:`~mtui.mcp.session.McpSession` in tests).
+
+    Args:
+        mcp: The :class:`mcp.server.fastmcp.FastMCP` server.
+        provider: The session provider every workspace resolves through.
+
+    Returns:
+        The registered tool names.
+
+    """
+    from mcp.server.fastmcp import Context
+    from mcp.types import ToolAnnotations
+
+    def _base_key(ctx: Context | None) -> str:
+        return DEFAULT_SESSION_KEY if ctx is None else _session_key(ctx)
+
+    async def list_workspaces(ctx: Context | None = None) -> str:
+        """List this client's named workspaces and what each holds."""
+        live = getattr(provider, "live_sessions", None)
+        if live is None:
+            return "workspaces are not supported by this server configuration"
+        base = _base_key(ctx)
+        rows: list[str] = []
+        for key, sess in live().items():
+            kbase, ws = split_workspace_key(key)
+            if kbase != base:
+                continue
+            md = sess.metadata
+            if isinstance(md, NullTestReport):
+                state = "empty (no template loaded)"
+            else:
+                rrid = getattr(md, "id", None) or sess.session or "?"
+                state = f"loaded {rrid}"
+            hosts = ", ".join(sorted(sess.targets)) or "none"
+            rows.append(f"- {ws}: {state}; hosts: {hosts}")
+        if not rows:
+            return (
+                f"no workspaces yet; the {WORKSPACE_DEFAULT!r} workspace is "
+                "created on the first tool call"
+            )
+        rows.sort()
+        return "workspaces (this client):\n" + "\n".join(rows)
+
+    async def close_workspace(workspace: str, ctx: Context | None = None) -> str:
+        """Disconnect a workspace's hosts and drop it from this client."""
+        evict = getattr(provider, "evict", None)
+        live = getattr(provider, "live_sessions", None)
+        if evict is None or live is None:
+            return "workspaces are not supported by this server configuration"
+        base = _base_key(ctx)
+        key = workspace_key(base, workspace)
+        if key not in live():
+            return f"no such workspace: {workspace!r}"
+        await evict(key)
+        return f"closed workspace {workspace!r} (hosts disconnected, state dropped)"
+
+    list_desc = (
+        "List the named workspaces for the current client. Each workspace is "
+        "an isolated mtui session with its own loaded template and connected "
+        "hosts; pass a `workspace` argument to any other tool to drive a "
+        "specific one (default workspace is 'default'). Use this to run "
+        "several updates in parallel from one connection."
+    )
+    close_desc = (
+        "Close a named workspace: disconnect its reference hosts and drop its "
+        "loaded template/state. Use when an update is finished to free its "
+        "host connections. Closing 'default' is allowed; it is re-created "
+        "empty on the next call."
+    )
+
+    mcp.add_tool(
+        list_workspaces,
+        name="list_workspaces",
+        description=list_desc,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    )
+    mcp.add_tool(
+        close_workspace,
+        name="close_workspace",
+        description=close_desc,
+        annotations=ToolAnnotations(),
+    )
+    logger.info("registered 2 workspace tools: close_workspace, list_workspaces")
+    return ["close_workspace", "list_workspaces"]

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -368,123 +368,6 @@ def build_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     return registered
 
 
-def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
-    """Register the background-job control tools (the async slow-op path).
-
-    Slow host commands (``run``/``update``/``downgrade``/...) accept a
-    ``background=true`` flag that returns a job id immediately instead of
-    blocking; these tools then drive that job:
-
-    * ``job_list`` — every job in the session and its state;
-    * ``job_status`` — one job's state + elapsed time;
-    * ``job_result`` — a finished job's output (errors if still running, or
-      surfaces the command's failure envelope if it failed);
-    * ``job_cancel`` — cancel a running job.
-
-    They address the per-call session's job table, resolved through
-    ``provider`` exactly as every other tool resolves its session, so they
-    stay transport-agnostic (one session under stdio; the caller's isolated
-    session under http).
-
-    Args:
-        mcp: The :class:`mcp.server.fastmcp.FastMCP` server.
-        provider: The session provider each call resolves through.
-
-    Returns:
-        The registered tool names.
-
-    """
-    # The trailing ``ctx: Context | None = None`` parameter on each tool
-    # is what FastMCP's ``find_context_parameter`` picks up via
-    # :func:`typing.get_type_hints` to strip ``ctx`` from the JSON schema
-    # and inject the live per-request Context. ``get_type_hints`` (and
-    # FastMCP's ``inspect.signature(fn, eval_str=True)``) resolve the
-    # string annotation ``"Context | None"`` against this *module's*
-    # globals, not the enclosing function's locals, so bind ``Context``
-    # here rather than importing it at module top — keeping
-    # ``mtui.mcp.tools`` importable without the ``[mcp]`` extra. Bind
-    # unconditionally (not ``setdefault``) so a stale stand-in left in
-    # globals by an earlier caller never shadows the real SDK type.
-    from mcp.server.fastmcp import Context as _Context
-    from mcp.types import ToolAnnotations
-
-    globals()["Context"] = _Context
-
-    async def job_list(ctx: Context | None = None) -> str:
-        """List background jobs in this session and their state."""
-        session = await resolve_session(provider, ctx)
-        jobs = session.job_list()
-        if not jobs:
-            return "no background jobs"
-        return "\n".join(
-            f"- {j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
-            for j in jobs
-        )
-
-    async def job_status(job_id: str, ctx: Context | None = None) -> str:
-        """Report one background job's state and elapsed time."""
-        session = await resolve_session(provider, ctx)
-        j = session.job_status(job_id)
-        return f"{j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
-
-    async def job_result(job_id: str, ctx: Context | None = None) -> str:
-        """Return a finished job's output (error if not yet done)."""
-        session = await resolve_session(provider, ctx)
-        return session.job_result(job_id)
-
-    async def job_cancel(job_id: str, ctx: Context | None = None) -> str:
-        """Cancel a running background job."""
-        session = await resolve_session(provider, ctx)
-        return await session.job_cancel(job_id)
-
-    list_desc = (
-        "List background jobs in this session (started by calling a slow host "
-        "command — run/update/downgrade/prepare/install/uninstall/set_repo/"
-        "reboot — with background=true) and their state."
-    )
-    status_desc = (
-        "Report a background job's state (running/done/failed/cancelled) and "
-        "elapsed time. Poll this after starting a slow command with "
-        "background=true."
-    )
-    result_desc = (
-        "Return a finished background job's output. Errors if the job is still "
-        "running (poll job_status first) or surfaces the command's failure if "
-        "it failed."
-    )
-    cancel_desc = (
-        "Cancel a running background job. Note: a job already executing on a "
-        "host (SSH/subprocess) may keep running on the host even after cancel."
-    )
-
-    mcp.add_tool(
-        job_list,
-        name="job_list",
-        description=list_desc,
-        annotations=ToolAnnotations(readOnlyHint=True),
-    )
-    mcp.add_tool(
-        job_status,
-        name="job_status",
-        description=status_desc,
-        annotations=ToolAnnotations(readOnlyHint=True),
-    )
-    mcp.add_tool(
-        job_result,
-        name="job_result",
-        description=result_desc,
-        annotations=ToolAnnotations(readOnlyHint=True),
-    )
-    mcp.add_tool(
-        job_cancel,
-        name="job_cancel",
-        description=cancel_desc,
-        annotations=ToolAnnotations(readOnlyHint=False),
-    )
-    logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
-    return ["job_cancel", "job_list", "job_result", "job_status"]
-
-
 def register_workspace_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     """Register the ``list_workspaces`` / ``close_workspace`` tools.
 
@@ -510,6 +393,13 @@ def register_workspace_tools(mcp: FastMCP, provider: SessionProvider) -> list[st
     """
     from mcp.server.fastmcp import Context
     from mcp.types import ToolAnnotations
+
+    # Make ``Context`` resolvable in module globals so FastMCP's
+    # ``find_context_parameter`` (which runs ``get_type_hints`` against the
+    # module, with ``from __future__ import annotations`` in effect) can
+    # resolve the string annotation ``"Context | None"`` on the tool
+    # closures below and inject the live request Context.
+    globals().setdefault("Context", Context)
 
     def _base_key(ctx: Context | None) -> str:
         return DEFAULT_SESSION_KEY if ctx is None else _session_key(ctx)
@@ -582,3 +472,107 @@ def register_workspace_tools(mcp: FastMCP, provider: SessionProvider) -> list[st
     )
     logger.info("registered 2 workspace tools: close_workspace, list_workspaces")
     return ["close_workspace", "list_workspaces"]
+
+
+def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
+    """Register the background-job control tools (the async slow-op path).
+
+    Slow host commands (``run``/``update``/``downgrade``/...) accept a
+    ``background=true`` flag that returns a job id immediately instead of
+    blocking; these tools then drive that job:
+
+    * ``job_list`` — every job in the workspace and its state;
+    * ``job_status`` — one job's state + elapsed time;
+    * ``job_result`` — a finished job's output (errors if still running, or
+      surfaces the command's failure envelope if it failed);
+    * ``job_cancel`` — cancel a running job.
+
+    All take the same ``workspace`` selector as the slow command did, so
+    they address that workspace's job table.
+
+    Args:
+        mcp: The :class:`mcp.server.fastmcp.FastMCP` server.
+        provider: The session provider each call resolves through.
+
+    Returns:
+        The registered tool names.
+
+    """
+    from mcp.server.fastmcp import Context
+    from mcp.types import ToolAnnotations
+
+    # See register_workspace_tools: keep ``Context`` in module globals so
+    # FastMCP can resolve the closures' string annotations and inject ctx.
+    globals().setdefault("Context", Context)
+
+    async def job_list(
+        workspace: str = WORKSPACE_DEFAULT, ctx: Context | None = None
+    ) -> str:
+        """List background jobs in this workspace and their state."""
+        session = await resolve_session(provider, ctx, workspace)
+        jobs = session.job_list()
+        if not jobs:
+            return f"no background jobs in workspace {workspace!r}"
+        return "\n".join(
+            f"- {j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
+            for j in jobs
+        )
+
+    async def job_status(
+        job_id: str, workspace: str = WORKSPACE_DEFAULT, ctx: Context | None = None
+    ) -> str:
+        """Report one background job's state and elapsed time."""
+        session = await resolve_session(provider, ctx, workspace)
+        j = session.job_status(job_id)
+        return f"{j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
+
+    async def job_result(
+        job_id: str, workspace: str = WORKSPACE_DEFAULT, ctx: Context | None = None
+    ) -> str:
+        """Return a finished job's output (error if not yet done)."""
+        session = await resolve_session(provider, ctx, workspace)
+        return session.job_result(job_id)
+
+    async def job_cancel(
+        job_id: str, workspace: str = WORKSPACE_DEFAULT, ctx: Context | None = None
+    ) -> str:
+        """Cancel a running background job."""
+        session = await resolve_session(provider, ctx, workspace)
+        return await session.job_cancel(job_id)
+
+    list_desc = (
+        "List background jobs in a workspace (started by calling a slow host "
+        "command — run/update/downgrade/prepare/install/uninstall/set_repo/"
+        "reboot — with background=true) and their state."
+    )
+    status_desc = (
+        "Report a background job's state (running/done/failed/cancelled) and "
+        "elapsed time. Poll this after starting a slow command with "
+        "background=true; pass the same workspace."
+    )
+    result_desc = (
+        "Return a finished background job's output. Errors if the job is still "
+        "running (poll job_status first) or surfaces the command's failure if "
+        "it failed. Pass the same workspace the job was started in."
+    )
+    cancel_desc = (
+        "Cancel a running background job. Note: a job already executing on a "
+        "host (SSH/subprocess) may keep running on the host even after cancel."
+    )
+
+    mcp.add_tool(
+        job_list,
+        name="job_list",
+        description=list_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(
+        job_status,
+        name="job_status",
+        description=status_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(job_result, name="job_result", description=result_desc)
+    mcp.add_tool(job_cancel, name="job_cancel", description=cancel_desc)
+    logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
+    return ["job_cancel", "job_list", "job_result", "job_status"]

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -572,7 +572,17 @@ def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
         description=status_desc,
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    mcp.add_tool(job_result, name="job_result", description=result_desc)
-    mcp.add_tool(job_cancel, name="job_cancel", description=cancel_desc)
+    mcp.add_tool(
+        job_result,
+        name="job_result",
+        description=result_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(
+        job_cancel,
+        name="job_cancel",
+        description=cancel_desc,
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
     logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
     return ["job_cancel", "job_list", "job_result", "job_status"]

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -105,6 +105,8 @@ class Config:
     ssh_strict_host_key_checking: str
     lock_reap_stale: bool
     lock_stale_age: int
+    lock_wait: int
+    lock_wait_poll: int
     lock_pi_autolock: bool
 
     # -- mtui-mcp server (http transport) per-client session registry --
@@ -419,6 +421,27 @@ class Config:
                 "lock_stale_age",
                 ("lock", "stale_age"),
                 86400,
+                int,
+                getint,
+            ),
+            # When a host is locked by *another* session/agent, wait up to
+            # ``lock_wait`` seconds for it to be released before giving up
+            # (polling every ``lock_wait_poll`` seconds) instead of failing
+            # immediately. ``0`` (default) keeps the fail-fast behaviour, so
+            # nothing changes unless a parallel-agent setup opts in. Lets
+            # several agents share a refhost pool by queueing on a busy host
+            # rather than erroring out.
+            ConfigOption(
+                "lock_wait",
+                ("lock", "wait"),
+                0,
+                int,
+                getint,
+            ),
+            ConfigOption(
+                "lock_wait_poll",
+                ("lock", "wait_poll"),
+                15,
                 int,
                 getint,
             ),

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -91,6 +91,7 @@ class Config:
     target_tempdir: Path
     chdir_to_template_dir: bool
     refhosts_resolvers: str
+    refhost_pool_select: bool
     refhosts_https_uri: str
     refhosts_https_expiration: int
     refhosts_path: Path
@@ -341,6 +342,20 @@ class Config:
                 Path("/usr/share/qam-metadata/refhosts.yml"),
                 expanduser,
                 get,
+            ),
+            # Refhost-pool selection: when several refhosts match the same
+            # arch, connect just ONE free candidate (skipping hosts locked
+            # by another agent and claiming the chosen one) instead of the
+            # whole matching matrix. Lets parallel agents draw distinct
+            # hosts from a shared pool. The pool is searched across ALL
+            # locations (location is ignored for pool candidates). Off by
+            # default -> unchanged single-host-per-arch behaviour.
+            ConfigOption(
+                "refhost_pool_select",
+                ("refhosts", "pool_select"),
+                False,
+                bool,
+                getboolean,
             ),
             ConfigOption(
                 "use_keyring",

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -121,6 +121,14 @@ class TestReport(ABC):
                  repository = str
         """
         self.hostnames: set[str] = set()
+        # Selection slot of each candidate gathered by ``refhosts_from_tp`` —
+        # only under refhost-pool selection. The slot is the full
+        # test-target identity (product + version + arch + addons), NOT just
+        # arch: two hosts are interchangeable (poolable down to one) only
+        # when they are the same product/version/arch/addons. Distinct
+        # service packs (e.g. SLE15-SP5 vs SP7) on the same arch are
+        # different slots and each still gets a host.
+        self._candidate_slots: dict[str, str] = {}
         # When non-empty, newly connected reference hosts are locked with
         # this comment (set while a PI assignment is active). See
         # ``mtui.commands.apicall`` and ``lock_pi_autolock``.
@@ -601,6 +609,14 @@ class TestReport(ABC):
 
     def connect_targets(self) -> None:
         """Connects to all targets."""
+        # Refhost-pool selection: where several candidates share an arch,
+        # connect+claim one free host and drop the rest from the pending
+        # set, so the matrix below only connects a single host per arch.
+        # No-op (and no behaviour change) unless [refhosts] pool_select is on
+        # and an arch actually has more than one candidate.
+        if getattr(self.config, "refhost_pool_select", False) is True:
+            self._claim_pool_candidates()
+
         targets: dict[str, Target] = {}
         new_systems: dict[str, str] = {}
         executor = ContextExecutor()
@@ -650,6 +666,104 @@ class TestReport(ABC):
             {host: target for host, target in targets.items() if target}
         )
 
+    def _claim_pool_candidates(self) -> None:
+        """Reduce each multi-candidate slot to one connected, claimed host.
+
+        A "slot" is a full test target (product + version + arch + addons,
+        see :meth:`_slot_key`), not just an arch — so distinct service packs
+        on the same arch are *separate* slots and each still gets a host.
+        For every slot that has more than one pending candidate (gathered by
+        :meth:`refhosts_from_tp` under pool selection), connect the
+        candidates in turn and claim the first one that is **not** locked by
+        another agent — claiming = taking its mtui lock, so concurrent
+        agents drawing from the same pool end up on different hosts. The
+        non-chosen candidates are dropped from :attr:`hostnames` so the
+        normal connect path does not also connect them. Slots with a single
+        candidate are left untouched (connected normally below).
+        """
+        pending = {h for h in self.hostnames if h not in self.targets}
+        by_slot: dict[str, list[str]] = {}
+        for name in pending:
+            slot = self._candidate_slots.get(name)
+            if slot is None:
+                continue  # unknown slot -> leave to the normal connect path
+            by_slot.setdefault(slot, []).append(name)
+
+        for slot, names in by_slot.items():
+            if len(names) <= 1:
+                continue  # nothing to choose from
+            chosen = self._claim_first_free(slot, sorted(names))
+            for name in names:
+                if name != chosen:
+                    self.hostnames.discard(name)
+
+    def _claim_first_free(self, slot: str, names: list[str]) -> str | None:
+        """Connect candidates for ``slot`` in order; claim the first free one.
+
+        Returns the chosen hostname (now connected and locked), or — if every
+        candidate is already locked by someone else or unreachable — the
+        first candidate connected without a claim, so the caller still has a
+        host for the slot and the normal ``[lock] wait`` policy governs the
+        later host operations. Returns ``None`` only if none could even be
+        connected.
+        """
+        first_connected: str | None = None
+        for name in names:
+            self.add_target(name)
+            target = self.targets.get(name)
+            if target is None:
+                continue  # connect failed; try the next candidate
+            if first_connected is None:
+                first_connected = name
+            try:
+                busy = (
+                    target.is_locked()
+                    and not target._lock.is_mine()
+                    and not target._lock.reap_if_stale()
+                )
+            except Exception:  # noqa: BLE001 - a lock probe error must not strand us
+                busy = False
+            if busy:
+                logger.info(
+                    "refhost pool: %s is busy (%s), trying next candidate for %s",
+                    name,
+                    target._lock.locked_by(),
+                    slot,
+                )
+                if name != first_connected:
+                    self._disconnect_candidate(name)
+                continue
+            try:
+                target.lock("mtui: refhost pool claim")
+            except TargetLockedError:
+                # Lost the race to another agent between probe and claim.
+                if name != first_connected:
+                    self._disconnect_candidate(name)
+                continue
+            logger.info("refhost pool: claimed %s for %s", name, slot)
+            if first_connected is not None and first_connected != name:
+                self._disconnect_candidate(first_connected)
+            return name
+
+        if first_connected is not None:
+            logger.warning(
+                "refhost pool: all candidates for %s are busy; using %s and "
+                "relying on the lock-wait policy",
+                slot,
+                first_connected,
+            )
+        return first_connected
+
+    def _disconnect_candidate(self, hostname: str) -> None:
+        """Drop a connected-but-not-chosen pool candidate."""
+        target = self.targets.pop(hostname, None)
+        self.systems.pop(hostname, None)
+        if target is not None:
+            try:
+                target.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                logger.debug("error disconnecting pool candidate %s", hostname)
+
     def add_target(self, hostname: str) -> None:
         """Adds a target to the test report.
 
@@ -698,8 +812,21 @@ class TestReport(ABC):
         except RefhostsResolveFailedError:
             return
 
+        # ``is True`` (not ``bool(...)``): a MagicMock config attribute is
+        # truthy, so coerce strictly to keep the default path under tests.
+        pool = getattr(self.config, "refhost_pool_select", False) is True
         try:
-            hostnames = refhosts.search(Attributes.from_testplatform(testplatform))
+            attrs = Attributes.from_testplatform(testplatform)
+            if pool:
+                # Pool mode: gather every matching candidate across ALL
+                # locations and remember each one's arch so connect_targets
+                # can pick one free host per arch.
+                pool_hosts = refhosts.search_pool(attrs, all_locations=True)
+                hostnames = [h.name for h, _slot in pool_hosts]
+                for h, slot in pool_hosts:
+                    self._candidate_slots[h.name] = slot
+            else:
+                hostnames = refhosts.search(attrs)
         except (ValueError, KeyError):
             hostnames = []
             msg = "failed to parse testplatform {0!r}"

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -129,6 +129,12 @@ class TestReport(ABC):
         # service packs (e.g. SLE15-SP5 vs SP7) on the same arch are
         # different slots and each still gets a host.
         self._candidate_slots: dict[str, str] = {}
+        # Optional in-process refhost arbiter + this report's owner key, set by
+        # the mtui-mcp layer (``McpSession.bind_arbiter``). When present, pool
+        # selection skips/queues hosts another workspace in the same process
+        # holds; ``None`` (REPL, single session) keeps the prior behaviour.
+        self._host_arbiter: Any | None = None
+        self._host_owner: str | None = None
         # When non-empty, newly connected reference hosts are locked with
         # this comment (set while a PI assignment is active). See
         # ``mtui.commands.apicall`` and ``lock_pi_autolock``.
@@ -697,8 +703,108 @@ class TestReport(ABC):
                 if name != chosen:
                     self.hostnames.discard(name)
 
+    def _int_cfg(self, name: str, default: int) -> int:
+        """Read an int config option, tolerating a missing/non-int value."""
+        val = getattr(self.config, name, default)
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            return default
+        return int(val)
+
+    def _pool_lock_comment(self) -> str:
+        """The mtui-lock comment a pool claim writes on a refhost.
+
+        Carries the update RRID and the owning workspace so the lock is
+        *informative* to other mtui-mcp servers and manual ``mtui`` users who
+        inspect the host (``list_locks`` / the connect-time "locked by …"
+        warning) — not just an opaque "in use".
+        """
+        owner = self._host_owner
+        base = f"mtui-mcp pool {self.id}"
+        return f"{base} [{owner}]" if owner else base
+
+    def release_pool_claims(self) -> None:
+        """Unlock + release every refhost this report pool-claimed.
+
+        Removes the **remote** mtui lock (so other mtui-mcp servers / manual
+        ``mtui`` users immediately see the host free again) and drops the
+        in-process arbiter ownership, for each connected host this owner holds.
+        Best-effort per host. No-op without a bound arbiter (REPL / single
+        session, where pool claims are not used). Call before disconnecting on
+        workspace close so claimed hosts do not leak as locked.
+        """
+        arb = self._host_arbiter
+        owner = self._host_owner
+        if arb is None or owner is None:
+            return
+        for host in list(self.targets):
+            if arb.owner_of(host) != owner:
+                continue
+            target = self.targets.get(host)
+            if target is not None:
+                try:
+                    target.unlock()
+                except Exception:  # noqa: BLE001 - best-effort lock release
+                    logger.debug("error unlocking pool host %s", host, exc_info=True)
+            arb.release(host, owner)
+        arb.release_owner(owner)
+
     def _claim_first_free(self, slot: str, names: list[str]) -> str | None:
-        """Connect candidates for ``slot`` in order; claim the first free one.
+        """Connect a candidate for ``slot`` and claim it; pick the first free.
+
+        With an in-process host arbiter bound (``mtui-mcp`` with named
+        workspaces), this is workspace-aware: a candidate held by *another*
+        workspace in this process is skipped, and if every candidate is held
+        the call queues for up to ``[lock] wait`` seconds for one to be
+        released (a refhost pool shared across this client's workspaces).
+        Without an arbiter (REPL / single session) it falls back to the
+        remote-lock-only behaviour.
+        """
+        arb = self._host_arbiter
+        owner = self._host_owner
+        if arb is None or owner is None:
+            return self._claim_first_free_remote(slot, names)
+
+        wait = self._int_cfg("lock_wait", 0)
+        poll = max(1, self._int_cfg("lock_wait_poll", 15))
+        remaining = list(names)
+        while remaining:
+            # Reserve a candidate no other workspace in this process holds
+            # (queueing up to ``wait`` if they all do).
+            host = arb.acquire_any(remaining, owner, timeout=wait, poll=poll)
+            if host is None:
+                logger.warning(
+                    "refhost pool: every candidate for %s is held by another "
+                    "workspace (waited %ss); leaving the slot unconnected - close "
+                    "a finished workspace or raise [lock] wait",
+                    slot,
+                    wait,
+                )
+                return None
+            self.add_target(host)
+            target = self.targets.get(host)
+            if target is None:  # connect failed; drop the in-process reservation
+                arb.release(host, owner)
+                remaining.remove(host)
+                continue
+            # Now take the *remote* lock (guards against other processes/users,
+            # and is visible to them with an identifying comment).
+            if not target.try_claim(self._pool_lock_comment()):
+                logger.info(
+                    "refhost pool: %s remote-locked (%s); next candidate for %s",
+                    host,
+                    target.locked_by(),
+                    slot,
+                )
+                arb.release(host, owner)
+                self._disconnect_candidate(host)
+                remaining.remove(host)
+                continue
+            logger.info("refhost pool: claimed %s for %s", host, slot)
+            return host
+        return None
+
+    def _claim_first_free_remote(self, slot: str, names: list[str]) -> str | None:
+        """Remote-lock-only claim (no in-process arbiter): pick the first free.
 
         Returns the chosen hostname (now connected and locked), or — if every
         candidate is already locked by someone else or unreachable — the
@@ -717,7 +823,7 @@ class TestReport(ABC):
                 first_connected = name
             # try_claim reserves the host's lock if free (skipping/rereaping
             # as needed); False means another agent holds it -> next candidate.
-            if not target.try_claim("mtui: refhost pool claim"):
+            if not target.try_claim(self._pool_lock_comment()):
                 logger.info(
                     "refhost pool: %s is busy (%s), trying next candidate for %s",
                     name,
@@ -745,6 +851,10 @@ class TestReport(ABC):
         """Drop a connected-but-not-chosen pool candidate."""
         target = self.targets.pop(hostname, None)
         self.systems.pop(hostname, None)
+        # Release any in-process pool reservation so a queued workspace can take
+        # this host (no-op without an arbiter or if we never owned it).
+        if self._host_arbiter is not None and self._host_owner is not None:
+            self._host_arbiter.release(hostname, self._host_owner)
         if target is not None:
             try:
                 target.close()

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -715,28 +715,15 @@ class TestReport(ABC):
                 continue  # connect failed; try the next candidate
             if first_connected is None:
                 first_connected = name
-            try:
-                busy = (
-                    target.is_locked()
-                    and not target._lock.is_mine()
-                    and not target._lock.reap_if_stale()
-                )
-            except Exception:  # noqa: BLE001 - a lock probe error must not strand us
-                busy = False
-            if busy:
+            # try_claim reserves the host's lock if free (skipping/rereaping
+            # as needed); False means another agent holds it -> next candidate.
+            if not target.try_claim("mtui: refhost pool claim"):
                 logger.info(
                     "refhost pool: %s is busy (%s), trying next candidate for %s",
                     name,
-                    target._lock.locked_by(),
+                    target.locked_by(),
                     slot,
                 )
-                if name != first_connected:
-                    self._disconnect_candidate(name)
-                continue
-            try:
-                target.lock("mtui: refhost pool claim")
-            except TargetLockedError:
-                # Lost the race to another agent between probe and claim.
                 if name != first_connected:
                     self._disconnect_candidate(name)
                 continue

--- a/tests/test_host_arbiter.py
+++ b/tests/test_host_arbiter.py
@@ -1,0 +1,89 @@
+"""Tests for :class:`mtui.mcp.host_arbiter.HostArbiter`.
+
+The arbiter is the in-process counterpart of the remote refhost lock: it keeps
+two named workspaces in one ``mtui-mcp`` process (same pid) from driving the
+same pool host, and lets a workspace queue for a busy host.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from mtui.mcp.host_arbiter import HostArbiter
+
+
+def test_claim_and_owner_of() -> None:
+    a = HostArbiter()
+    assert a.owner_of("h1") is None
+    assert a.claim("h1", "ws-a") is True
+    assert a.owner_of("h1") == "ws-a"
+
+
+def test_claim_by_another_is_refused_reclaim_by_owner_ok() -> None:
+    a = HostArbiter()
+    assert a.claim("h1", "ws-a") is True
+    assert a.claim("h1", "ws-b") is False  # held by ws-a
+    assert a.claim("h1", "ws-a") is True  # re-claim by owner is fine
+    assert a.owner_of("h1") == "ws-a"
+
+
+def test_release_frees_host() -> None:
+    a = HostArbiter()
+    a.claim("h1", "ws-a")
+    a.release("h1", "ws-b")  # not the owner -> no-op
+    assert a.owner_of("h1") == "ws-a"
+    a.release("h1", "ws-a")
+    assert a.owner_of("h1") is None
+
+
+def test_release_owner_frees_all_its_hosts() -> None:
+    a = HostArbiter()
+    a.claim("h1", "ws-a")
+    a.claim("h2", "ws-a")
+    a.claim("h3", "ws-b")
+    a.release_owner("ws-a")
+    assert a.owner_of("h1") is None
+    assert a.owner_of("h2") is None
+    assert a.owner_of("h3") == "ws-b"  # untouched
+
+
+def test_acquire_any_reserves_a_free_candidate() -> None:
+    a = HostArbiter()
+    a.claim("h1", "ws-other")
+    got = a.acquire_any(["h1", "h2", "h3"], "ws-me", timeout=0)
+    assert got == "h2"  # h1 held by another -> first free is h2
+    assert a.owner_of("h2") == "ws-me"
+
+
+def test_acquire_any_none_when_all_held_and_no_wait() -> None:
+    a = HostArbiter()
+    a.claim("h1", "ws-other")
+    a.claim("h2", "ws-other")
+    assert a.acquire_any(["h1", "h2"], "ws-me", timeout=0) is None
+
+
+def test_acquire_any_already_owned_by_me_counts_as_free() -> None:
+    a = HostArbiter()
+    a.claim("h1", "ws-me")
+    assert a.acquire_any(["h1"], "ws-me", timeout=0) == "h1"
+
+
+def test_acquire_any_queues_until_released() -> None:
+    """A waiter blocks until another owner releases, then acquires it."""
+    a = HostArbiter()
+    a.claim("h1", "ws-other")
+
+    def _release_soon() -> None:
+        time.sleep(0.2)
+        a.release("h1", "ws-other")
+
+    t = threading.Thread(target=_release_soon)
+    t.start()
+    start = time.monotonic()
+    got = a.acquire_any(["h1"], "ws-me", timeout=5, poll=0.05)
+    elapsed = time.monotonic() - start
+    t.join()
+    assert got == "h1"
+    assert a.owner_of("h1") == "ws-me"
+    assert elapsed >= 0.15  # actually waited for the release

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -397,3 +397,72 @@ class TestLockedTargets:
             raise ValueError("test error")
 
         t1.unlock.assert_called_once()
+
+
+class TestTargetLockWait:
+    """lock_wait: queue on a foreign-locked host instead of failing fast."""
+
+    @pytest.fixture
+    def lock(self, mock_config):
+        mock_config.session_user = "testuser"
+        mock_config.lock_reap_stale = False
+        mock_config.lock_stale_age = 86400
+        conn = MagicMock()
+        conn.hostname = "host1.example.com"
+        return TargetLock(conn, mock_config)
+
+    @staticmethod
+    def _fake_clock(monkeypatch):
+        """Patch the locks module clock so waits don't take real time."""
+        import mtui.hosts.target.locks as locks_mod
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(locks_mod.time, "time", lambda: clock["t"])
+        monkeypatch.setattr(
+            locks_mod.time,
+            "sleep",
+            lambda s: clock.__setitem__("t", clock["t"] + (s or 1)),
+        )
+        return clock
+
+    def test_lock_wait_disabled_fails_fast(self, lock):
+        """lock_wait <= 0 keeps the immediate TargetLockedError."""
+        lock.config.lock_wait = 0
+        mock_file = MagicMock()
+        mock_file.readline.return_value = "1700000000:otheruser:99999"
+        lock.connection.sftp_open.return_value = mock_file
+        with pytest.raises(TargetLockedError):
+            lock.lock()
+
+    def test_lock_waits_then_succeeds_when_released(self, lock, monkeypatch):
+        """A foreign lock released during polling lets the lock proceed."""
+        self._fake_clock(monkeypatch)
+        lock.config.lock_wait = 30
+        lock.config.lock_wait_poll = 1
+        mock_file = MagicMock()
+        # initial is_locked -> locked by other; after one poll -> released.
+        mock_file.readline.side_effect = [
+            "1700000000:otheruser:99999",
+            "",
+        ]
+        lock.connection.sftp_open.return_value = mock_file
+
+        lock.lock("mine now")  # must not raise
+
+        # the final write happened in "w+" mode
+        assert any(
+            c[0][1] == "w+"
+            for c in lock.connection.sftp_open.call_args_list
+            if len(c[0]) > 1
+        )
+
+    def test_lock_waits_then_times_out(self, lock, monkeypatch):
+        """Still locked after the budget -> TargetLockedError."""
+        self._fake_clock(monkeypatch)
+        lock.config.lock_wait = 2
+        lock.config.lock_wait_poll = 1
+        mock_file = MagicMock()
+        mock_file.readline.return_value = "1700000000:otheruser:99999"
+        lock.connection.sftp_open.return_value = mock_file
+        with pytest.raises(TargetLockedError):
+            lock.lock()

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -331,6 +331,22 @@ class TestTargetLockReaping:
         assert lock.reap_if_stale() is True
         lock.connection.sftp_remove.assert_called_once()
 
+    def test_reap_removes_stale_mcp_pool_lock(self, lock):
+        """A stale mtui-mcp refhost-pool lock is reaped like any other.
+
+        Pool claims write an identifying comment (``mtui-mcp pool <RRID>
+        [<owner>]``); reaping must not exempt it, so an abandoned/crashed
+        mcp server's pool locks are recovered once stale.
+        """
+        stale = int(time.time()) - 200000
+        self._set_lockfile(
+            lock,
+            f"{stale}:testuser:4242:mtui-mcp pool SUSE:SLFO:1.2:5503 [12345\x1ftrivy]",
+        )
+
+        assert lock.reap_if_stale() is True
+        lock.connection.sftp_remove.assert_called_once()
+
     def test_reap_keeps_fresh_lock(self, lock):
         """A lock younger than the threshold is left untouched."""
         fresh = int(time.time()) - 60

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -32,10 +32,14 @@ import pytest
 
 from mtui.mcp.main import build_session
 from mtui.mcp.registry import (
+    WORKSPACE_DEFAULT,
     SessionRegistry,
     SessionRegistryFullError,
     _log_label,
     _session_key,
+    resolve_session,
+    split_workspace_key,
+    workspace_key,
 )
 from mtui.mcp.session import McpSession
 from mtui.types import Workflow
@@ -498,3 +502,98 @@ def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
     assert a.config is not b.config
     a.config.location = "prague"
     assert b.config.location == "nuremberg"
+
+
+# --------------------------------------------------------------------------- #
+# Named workspaces (P1: one client, several isolated sessions)                #
+# --------------------------------------------------------------------------- #
+
+
+def test_workspace_key_roundtrips() -> None:
+    """``workspace_key`` / ``split_workspace_key`` are inverse."""
+    key = workspace_key("12345", "alpha")
+    assert split_workspace_key(key) == ("12345", "alpha")
+
+
+def test_split_workspace_key_legacy_key_defaults() -> None:
+    """A key without the separator reads back as the default workspace."""
+    assert split_workspace_key("12345") == ("12345", WORKSPACE_DEFAULT)
+
+
+def test_resolve_session_distinct_workspaces_are_isolated(tmp_path: Path) -> None:
+    """Same client, two workspace names -> two independent sessions."""
+    reg = _registry(tmp_path)
+    ctx = _ctx_with_session(object())
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        return (
+            await resolve_session(reg, ctx, "a"),
+            await resolve_session(reg, ctx, "b"),
+        )
+
+    a, b = asyncio.run(driver())
+    assert a is not b
+    assert a.targets is not b.targets
+
+
+def test_resolve_session_same_workspace_is_stable(tmp_path: Path) -> None:
+    """Same client + same workspace name -> the same session instance."""
+    reg = _registry(tmp_path)
+    ctx = _ctx_with_session(object())
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        return (
+            await resolve_session(reg, ctx, "a"),
+            await resolve_session(reg, ctx, "a"),
+        )
+
+    first, again = asyncio.run(driver())
+    assert first is again
+
+
+def test_resolve_session_default_workspace_matches_bare_key(tmp_path: Path) -> None:
+    """Omitting the workspace lands in the ``default`` workspace key."""
+    reg = _registry(tmp_path)
+    ctx = _ctx_with_session(object())
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        implicit = await resolve_session(reg, ctx)
+        explicit = await resolve_session(reg, ctx, WORKSPACE_DEFAULT)
+        return implicit, explicit
+
+    implicit, explicit = asyncio.run(driver())
+    assert implicit is explicit
+
+
+def test_resolve_session_workspaces_isolated_across_clients(tmp_path: Path) -> None:
+    """The same workspace name under two clients stays isolated."""
+    reg = _registry(tmp_path)
+    ctx1 = _ctx_with_session(object())
+    ctx2 = _ctx_with_session(object())
+
+    async def driver() -> tuple[McpSession, McpSession]:
+        return (
+            await resolve_session(reg, ctx1, "shared"),
+            await resolve_session(reg, ctx2, "shared"),
+        )
+
+    a, b = asyncio.run(driver())
+    assert a is not b
+
+
+def test_live_sessions_snapshot_lists_created_keys(tmp_path: Path) -> None:
+    """``live_sessions`` exposes a copy of the live key->session map."""
+    reg = _registry(tmp_path)
+    ctx = _ctx_with_session(object())
+
+    async def driver() -> dict[str, McpSession]:
+        await resolve_session(reg, ctx, "a")
+        await resolve_session(reg, ctx, "b")
+        return reg.live_sessions()
+
+    live = asyncio.run(driver())
+    workspaces = {split_workspace_key(k)[1] for k in live}
+    assert {"a", "b"} <= workspaces
+    # snapshot is a copy: mutating it does not touch the registry
+    live.clear()
+    assert reg.live_sessions()

--- a/tests/test_mcp_tool_layer.py
+++ b/tests/test_mcp_tool_layer.py
@@ -1,0 +1,173 @@
+"""Coverage for the registered tool *closures* in :mod:`mtui.mcp.tools` and
+:mod:`mtui.mcp.testreport_tools`.
+
+The other mcp tests drive :class:`~mtui.mcp.session.McpSession` directly; here
+we register the workspace / job / testreport tools on a capturing fake server
+and invoke the registered coroutines, so the closure bodies (workspace listing
+and close, the job-control wrappers, and the ``resolve_session`` hop in each
+testreport tool) are exercised through a real
+:class:`~mtui.mcp.registry.SessionRegistry`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+from mtui.commands.whoami import Whoami
+from mtui.mcp.main import build_session
+from mtui.mcp.registry import SessionRegistry, resolve_session
+from mtui.mcp.testreport_tools import register_testreport_tools
+from mtui.mcp.tools import register_job_tools, register_workspace_tools
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+    from mtui.mcp.registry import SessionProvider
+
+_LOG = logging.getLogger("test.mcp.toollayer")
+
+
+class FakeMCP:
+    """Captures ``add_tool(fn, name=...)`` registrations by name."""
+
+    def __init__(self) -> None:
+        self.tools: dict = {}
+
+    def add_tool(self, fn, name, **_kw):  # noqa: ANN001
+        self.tools[name] = fn
+
+
+def _as_server(mcp: FakeMCP) -> FastMCP:
+    return cast("FastMCP", mcp)
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.template_dir = tmp_path
+    cfg.target_tempdir = tmp_path / "target"
+    cfg.chdir_to_template_dir = False
+    cfg.connection_timeout = 30
+    cfg.session_user = "testuser"
+    return cfg
+
+
+def _registry(tmp_path: Path) -> SessionRegistry:
+    return SessionRegistry(
+        build_session, _config(tmp_path), _LOG, max_sessions=32, idle_timeout=0.0
+    )
+
+
+# --------------------------------------------------------------------------- #
+# workspace tools                                                             #
+# --------------------------------------------------------------------------- #
+def test_list_workspaces_empty_populated_and_close(tmp_path: Path) -> None:
+    reg = _registry(tmp_path)
+    mcp = FakeMCP()
+    assert sorted(register_workspace_tools(_as_server(mcp), reg)) == [
+        "close_workspace",
+        "list_workspaces",
+    ]
+
+    async def driver() -> tuple[str, str, str, str]:
+        empty = await mcp.tools["list_workspaces"]()
+        await resolve_session(reg, None, "default")  # mint the default workspace
+        listed = await mcp.tools["list_workspaces"]()
+        closed = await mcp.tools["close_workspace"]("default")
+        missing = await mcp.tools["close_workspace"]("nope")
+        return empty, listed, closed, missing
+
+    empty, listed, closed, missing = asyncio.run(driver())
+    assert "no workspaces yet" in empty
+    assert "default" in listed
+    assert "empty (no template loaded)" in listed
+    assert "closed workspace 'default'" in closed
+    assert "no such workspace" in missing
+
+
+def test_workspace_tools_without_provider_support() -> None:
+    """A provider that is not a SessionRegistry → graceful one-line message."""
+    mcp = FakeMCP()
+    register_workspace_tools(
+        _as_server(mcp), cast("SessionProvider", SimpleNamespace())
+    )  # no live_sessions/evict
+
+    async def driver() -> tuple[str, str]:
+        return (
+            await mcp.tools["list_workspaces"](),
+            await mcp.tools["close_workspace"]("default"),
+        )
+
+    lst, cls = asyncio.run(driver())
+    assert "not supported" in lst
+    assert "not supported" in cls
+
+
+# --------------------------------------------------------------------------- #
+# job-control tools                                                           #
+# --------------------------------------------------------------------------- #
+def test_job_tools_empty_then_full_lifecycle(tmp_path: Path) -> None:
+    reg = _registry(tmp_path)
+    mcp = FakeMCP()
+    assert set(register_job_tools(_as_server(mcp), reg)) == {
+        "job_list",
+        "job_status",
+        "job_result",
+        "job_cancel",
+    }
+
+    async def driver() -> tuple[str, str, str, str, str, str]:
+        empty = await mcp.tools["job_list"](workspace="default")
+        sess = await resolve_session(reg, None, "default")
+        jid = await sess.start_job(Whoami, [])
+        await sess._jobs[jid]["task"]  # let the worker finish
+        jl = await mcp.tools["job_list"](workspace="default")
+        js = await mcp.tools["job_status"](jid, workspace="default")
+        jr = await mcp.tools["job_result"](jid, workspace="default")
+        jc = await mcp.tools["job_cancel"](jid, workspace="default")
+        return empty, jl, js, jr, jc, jid
+
+    empty, jl, js, jr, jc, jid = asyncio.run(driver())
+    assert "no background jobs" in empty
+    assert jid in jl
+    assert jid in js
+    assert "User: testuser" in jr
+    assert isinstance(jc, str)
+
+
+# --------------------------------------------------------------------------- #
+# testreport tool closures — exercise the resolve_session hop in each         #
+# --------------------------------------------------------------------------- #
+def test_testreport_tool_closures_resolve_session(tmp_path: Path) -> None:
+    reg = _registry(tmp_path)
+    mcp = FakeMCP()
+    register_testreport_tools(_as_server(mcp), reg)
+
+    async def driver() -> set[str]:
+        seen: set[str] = set()
+        calls = [
+            ("testreport_logs", ()),
+            ("testreport_read_file", ("source.diff",)),
+            ("testreport_patch", (1, 1, "x")),
+            ("testreport_write", ("x",)),
+        ]
+        for name, args in calls:
+            # no template is loaded, so the underlying op may raise after the
+            # resolve_session line we want covered — both outcomes are fine.
+            with contextlib.suppress(Exception):
+                await mcp.tools[name](*args, workspace="default")
+            seen.add(name)
+        return seen
+
+    seen = asyncio.run(driver())
+    assert seen == {
+        "testreport_logs",
+        "testreport_read_file",
+        "testreport_patch",
+        "testreport_write",
+    }

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -683,13 +683,13 @@ def test_job_read_tools_are_read_only(mcp: FastMCP, job_tool_names: list[str]) -
     assert _annotations_of(mcp, "job_cancel").readOnlyHint is False
 
 
-def test_job_tools_schema_has_no_workspace_param(
+def test_job_tools_schema_has_workspace_param(
     mcp: FastMCP, job_tool_names: list[str]
 ) -> None:
-    """Jobs are session-scoped; no ``workspace`` selector leaks into the schema."""
+    """Jobs are workspace-scoped; the ``workspace`` selector is in the schema."""
     for name in ("job_status", "job_result", "job_cancel"):
         props = _params_of(mcp, name).get("properties", {})
-        assert "workspace" not in props
+        assert "workspace" in props
         assert "job_id" in props
 
 

--- a/tests/test_pool_helpers_extra.py
+++ b/tests/test_pool_helpers_extra.py
@@ -1,0 +1,109 @@
+"""Extra unit coverage for the refhost-pool helper methods on
+:class:`~mtui.test_reports.testreport.TestReport` whose *real* bodies the
+selection tests stub out (``_pool_lock_comment``), or whose edge branches
+(``release_pool_claims`` skip/error paths, ``_int_cfg`` fallback,
+``_disconnect_candidate`` teardown error) the happy-path tests don't reach.
+
+All exercised as unbound methods against tiny stand-ins — no SSH / real
+TestReport construction.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from mtui.mcp.host_arbiter import HostArbiter
+from mtui.test_reports.testreport import TestReport
+
+
+class _FakeTarget:
+    def __init__(self, *, unlock_raises: bool = False, close_raises: bool = False):
+        self._unlock_raises = unlock_raises
+        self._close_raises = close_raises
+        self.unlocked = False
+        self.closed = False
+
+    def unlock(self) -> None:
+        if self._unlock_raises:
+            raise RuntimeError("boom")
+        self.unlocked = True
+
+    def close(self) -> None:
+        if self._close_raises:
+            raise RuntimeError("boom")
+        self.closed = True
+
+
+# --------------------------------------------------------------------------- #
+# _pool_lock_comment (real body)                                              #
+# --------------------------------------------------------------------------- #
+def test_pool_lock_comment_with_owner() -> None:
+    rep = SimpleNamespace(id="SUSE:Maintenance:1:1", _host_owner="ws-me")
+    assert (
+        TestReport._pool_lock_comment(cast("TestReport", rep))
+        == "mtui-mcp pool SUSE:Maintenance:1:1 [ws-me]"
+    )
+
+
+def test_pool_lock_comment_without_owner() -> None:
+    rep = SimpleNamespace(id="SUSE:Maintenance:1:1", _host_owner=None)
+    assert (
+        TestReport._pool_lock_comment(cast("TestReport", rep))
+        == "mtui-mcp pool SUSE:Maintenance:1:1"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _int_cfg fallback                                                           #
+# --------------------------------------------------------------------------- #
+def test_int_cfg_returns_default_for_nonint_and_bool() -> None:
+    rep_str = SimpleNamespace(config=SimpleNamespace(lock_wait="not-a-number"))
+    assert TestReport._int_cfg(cast("TestReport", rep_str), "lock_wait", 7) == 7
+    rep_bool = SimpleNamespace(config=SimpleNamespace(lock_wait=True))
+    assert TestReport._int_cfg(cast("TestReport", rep_bool), "lock_wait", 7) == 7
+    rep_ok = SimpleNamespace(config=SimpleNamespace(lock_wait=1800))
+    assert TestReport._int_cfg(cast("TestReport", rep_ok), "lock_wait", 7) == 1800
+
+
+# --------------------------------------------------------------------------- #
+# release_pool_claims edge branches                                           #
+# --------------------------------------------------------------------------- #
+def test_release_pool_claims_noop_without_arbiter() -> None:
+    rep = SimpleNamespace(
+        targets={"h": _FakeTarget()}, _host_arbiter=None, _host_owner=None
+    )
+    # must simply return; no exception, target untouched
+    TestReport.release_pool_claims(cast("TestReport", rep))
+    assert rep.targets["h"].unlocked is False
+
+
+def test_release_pool_claims_skips_unowned_and_tolerates_unlock_error() -> None:
+    arb = HostArbiter()
+    arb.claim("h_other", "someone-else")
+    arb.claim("h_mine", "ws-me")
+    t_other = _FakeTarget()
+    t_mine = _FakeTarget(unlock_raises=True)  # unlock blows up -> swallowed
+    rep = SimpleNamespace(
+        targets={"h_other": t_other, "h_mine": t_mine},
+        _host_arbiter=arb,
+        _host_owner="ws-me",
+    )
+
+    TestReport.release_pool_claims(cast("TestReport", rep))
+
+    assert t_other.unlocked is False  # not ours -> skipped
+    assert arb.owner_of("h_other") == "someone-else"  # left intact
+    assert arb.owner_of("h_mine") is None  # ours -> released despite unlock error
+
+
+# --------------------------------------------------------------------------- #
+# _disconnect_candidate teardown error                                        #
+# --------------------------------------------------------------------------- #
+def test_disconnect_candidate_tolerates_close_error() -> None:
+    t = _FakeTarget(close_raises=True)
+    rep = SimpleNamespace(
+        targets={"h": t}, systems={"h": "x"}, _host_arbiter=None, _host_owner=None
+    )
+    # close() raises -> must be swallowed (best-effort teardown)
+    TestReport._disconnect_candidate(cast("TestReport", rep), "h")

--- a/tests/test_refhost_pool.py
+++ b/tests/test_refhost_pool.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 from mtui.hosts import refhost
-from mtui.hosts.target import TargetLockedError
 from mtui.test_reports.testreport import TestReport
 
 REFHOSTS_FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
@@ -123,16 +123,26 @@ class _FakeTarget:
     def is_locked(self) -> bool:
         return self._locked
 
-    def lock(self, comment: str = "") -> None:
+    def locked_by(self) -> str:
+        return self._lock.locked_by()
+
+    def try_claim(self, comment: str = "") -> bool:
+        # Mirrors Target.try_claim against the fake's flags.
+        if self._locked and not self._lock.is_mine() and not self._lock.reap_if_stale():
+            return False
         if self._lock_raises:
-            raise TargetLockedError("lost the race")
+            return False
         self.lock_calls.append(comment)
+        return True
 
     def close(self) -> None:
         self.closed = True
 
 
-def _fake_report(targets_map: dict[str, _FakeTarget]) -> SimpleNamespace:
+def _fake_report(targets_map: dict[str, _FakeTarget]) -> TestReport:
+    # A duck-typed stand-in: the methods under test only touch add_target /
+    # targets / systems / _disconnect_candidate. Cast so the unbound
+    # TestReport methods accept it (ty) without building a real TestReport.
     self = SimpleNamespace(targets={}, systems={})
 
     def add_target(name: str) -> None:
@@ -140,8 +150,10 @@ def _fake_report(targets_map: dict[str, _FakeTarget]) -> SimpleNamespace:
             self.targets[name] = targets_map[name]
 
     self.add_target = add_target
-    self._disconnect_candidate = lambda n: TestReport._disconnect_candidate(self, n)
-    return self
+    self._disconnect_candidate = lambda n: TestReport._disconnect_candidate(
+        cast("TestReport", self), n
+    )
+    return cast("TestReport", self)
 
 
 def test_claim_first_free_picks_first_unlocked_and_claims_it() -> None:
@@ -215,7 +227,7 @@ def test_claim_pool_candidates_reduces_only_within_a_slot() -> None:
     )
     rep._claim_first_free = lambda slot, names: names[0]
 
-    TestReport._claim_pool_candidates(rep)
+    TestReport._claim_pool_candidates(cast("TestReport", rep))
 
     assert "a2" not in rep.hostnames  # collapsed into a1
     # one host per distinct slot survives; c1 (different SP) is NOT dropped

--- a/tests/test_refhost_pool.py
+++ b/tests/test_refhost_pool.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 from typing import cast
 
 from mtui.hosts import refhost
+from mtui.mcp.host_arbiter import HostArbiter
 from mtui.test_reports.testreport import TestReport
 
 REFHOSTS_FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
@@ -118,7 +119,12 @@ class _FakeTarget:
         self._lock = _FakeLock(mine=mine, reap=reap)
         self._lock_raises = lock_raises
         self.closed = False
+        self.unlocked = False
         self.lock_calls: list[str] = []
+
+    def unlock(self) -> None:
+        self.unlocked = True
+        self._locked = False
 
     def is_locked(self) -> bool:
         return self._locked
@@ -143,7 +149,9 @@ def _fake_report(targets_map: dict[str, _FakeTarget]) -> TestReport:
     # A duck-typed stand-in: the methods under test only touch add_target /
     # targets / systems / _disconnect_candidate. Cast so the unbound
     # TestReport methods accept it (ty) without building a real TestReport.
-    self = SimpleNamespace(targets={}, systems={})
+    # No arbiter bound -> _claim_first_free dispatches to the remote-only path
+    # (these tests exercise that path; the arbiter path is covered separately).
+    self = SimpleNamespace(targets={}, systems={}, _host_arbiter=None, _host_owner=None)
 
     def add_target(name: str) -> None:
         if name in targets_map:
@@ -153,6 +161,7 @@ def _fake_report(targets_map: dict[str, _FakeTarget]) -> TestReport:
     self._disconnect_candidate = lambda n: TestReport._disconnect_candidate(
         cast("TestReport", self), n
     )
+    self._pool_lock_comment = lambda: "mtui-mcp pool test"
     return cast("TestReport", self)
 
 
@@ -162,7 +171,7 @@ def test_claim_first_free_picks_first_unlocked_and_claims_it() -> None:
     h3 = _FakeTarget(locked=False)
     rep = _fake_report({"h1": h1, "h2": h2, "h3": h3})
 
-    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2", "h3"])
+    chosen = TestReport._claim_first_free_remote(rep, "x86_64", ["h1", "h2", "h3"])
 
     assert chosen == "h2"
     assert h2.lock_calls  # claimed (locked)
@@ -176,7 +185,7 @@ def test_claim_first_free_all_busy_returns_first_connected() -> None:
     h2 = _FakeTarget(locked=True)
     rep = _fake_report({"h1": h1, "h2": h2})
 
-    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2"])
+    chosen = TestReport._claim_first_free_remote(rep, "x86_64", ["h1", "h2"])
 
     assert chosen == "h1"  # kept as the fallback host
     assert set(rep.targets) == {"h1"}
@@ -189,7 +198,7 @@ def test_claim_first_free_handles_lock_race() -> None:
     h2 = _FakeTarget(locked=False)
     rep = _fake_report({"h1": h1, "h2": h2})
 
-    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2"])
+    chosen = TestReport._claim_first_free_remote(rep, "x86_64", ["h1", "h2"])
 
     assert chosen == "h2"
     assert h2.lock_calls
@@ -201,7 +210,7 @@ def test_claim_first_free_reaped_stale_lock_is_claimable() -> None:
     h1 = _FakeTarget(locked=True, reap=True)
     rep = _fake_report({"h1": h1})
 
-    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1"])
+    chosen = TestReport._claim_first_free_remote(rep, "x86_64", ["h1"])
 
     assert chosen == "h1"
     assert h1.lock_calls
@@ -232,3 +241,104 @@ def test_claim_pool_candidates_reduces_only_within_a_slot() -> None:
     assert "a2" not in rep.hostnames  # collapsed into a1
     # one host per distinct slot survives; c1 (different SP) is NOT dropped
     assert {"a1", "b1", "c1"} <= rep.hostnames
+
+
+# --------------------------------------------------------------------------- #
+# Selection logic with the in-process arbiter (cross-workspace)               #
+# --------------------------------------------------------------------------- #
+
+
+def _fake_report_arb(
+    targets_map: dict[str, _FakeTarget],
+    arbiter: HostArbiter,
+    owner: str,
+    lock_wait: int = 0,
+) -> TestReport:
+    self = SimpleNamespace(
+        targets={},
+        systems={},
+        _host_arbiter=arbiter,
+        _host_owner=owner,
+        config=SimpleNamespace(lock_wait=lock_wait, lock_wait_poll=15),
+    )
+
+    def add_target(name: str) -> None:
+        if name in targets_map:
+            self.targets[name] = targets_map[name]
+
+    self.add_target = add_target
+    self._disconnect_candidate = lambda n: TestReport._disconnect_candidate(
+        cast("TestReport", self), n
+    )
+    self._int_cfg = lambda n, d: TestReport._int_cfg(cast("TestReport", self), n, d)
+    self._pool_lock_comment = lambda: "mtui-mcp pool test"
+    return cast("TestReport", self)
+
+
+def test_arbiter_skips_host_owned_by_another_workspace() -> None:
+    arb = HostArbiter()
+    arb.claim("h1", "ws-other")  # held by another workspace in this process
+    targets = {
+        "h1": _FakeTarget(locked=False),
+        "h2": _FakeTarget(locked=False),
+        "h3": _FakeTarget(locked=False),
+    }
+    rep = _fake_report_arb(targets, arb, "ws-me")
+
+    chosen = TestReport._claim_first_free(rep, "slot", ["h1", "h2", "h3"])
+
+    assert chosen == "h2"  # h1 skipped (owned by ws-other) -> h2 claimed
+    assert arb.owner_of("h2") == "ws-me"
+    assert arb.owner_of("h1") == "ws-other"  # untouched
+    assert "h1" not in rep.targets  # never even connected
+
+
+def test_arbiter_returns_none_when_pool_exhausted_no_wait() -> None:
+    arb = HostArbiter()
+    arb.claim("h1", "ws-other")
+    arb.claim("h2", "ws-other")
+    rep = _fake_report_arb(
+        {"h1": _FakeTarget(locked=False), "h2": _FakeTarget(locked=False)},
+        arb,
+        "ws-me",
+        lock_wait=0,
+    )
+
+    chosen = TestReport._claim_first_free(rep, "slot", ["h1", "h2"])
+
+    assert chosen is None  # all held by others, no wait -> slot unconnected
+    assert rep.targets == {}
+
+
+def test_arbiter_remote_locked_releases_inprocess_and_tries_next() -> None:
+    # h1 is free in-process but remote-locked by another *process*; the in-process
+    # reservation must be released and the next candidate taken.
+    arb = HostArbiter()
+    targets = {
+        "h1": _FakeTarget(locked=True),  # remote-locked -> try_claim False
+        "h2": _FakeTarget(locked=False),
+    }
+    rep = _fake_report_arb(targets, arb, "ws-me")
+
+    chosen = TestReport._claim_first_free(rep, "slot", ["h1", "h2"])
+
+    assert chosen == "h2"
+    assert arb.owner_of("h1") is None  # in-process reservation released
+    assert arb.owner_of("h2") == "ws-me"
+
+
+def test_release_pool_claims_unlocks_remote_and_releases_inprocess() -> None:
+    """release_pool_claims removes the remote lock (visible to others) + ownership."""
+    arb = HostArbiter()
+    arb.claim("h1", "ws-me")
+    t1 = _FakeTarget(locked=True)  # we hold its remote lock
+    rep = SimpleNamespace(
+        targets={"h1": t1},
+        _host_arbiter=arb,
+        _host_owner="ws-me",
+    )
+
+    TestReport.release_pool_claims(cast("TestReport", rep))
+
+    assert t1.unlocked is True  # remote lock removed -> visible-free to others
+    assert arb.owner_of("h1") is None  # in-process ownership dropped

--- a/tests/test_refhost_pool.py
+++ b/tests/test_refhost_pool.py
@@ -1,0 +1,222 @@
+"""Tests for refhost-pool candidate selection.
+
+Two layers:
+
+* ``Refhosts.search_pool`` — returns ``(host, slot)`` pairs (slot = the
+  matched test-target query) and, with ``all_locations=True``, aggregates
+  candidates across every location (location ignored), de-duplicated by name.
+* ``TestReport._claim_first_free`` / ``_claim_pool_candidates`` — the
+  connect-time selection that picks one free host per arch, skipping hosts
+  locked by another agent and claiming the chosen one.
+
+The selection logic is exercised against a lightweight fake report (the
+methods only touch ``add_target`` / ``targets`` / ``systems`` /
+``_disconnect_candidate``), so no real SSH or TestReport construction is
+needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from mtui.hosts import refhost
+from mtui.hosts.target import TargetLockedError
+from mtui.test_reports.testreport import TestReport
+
+REFHOSTS_FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
+
+
+# --------------------------------------------------------------------------- #
+# Refhosts.search_pool                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _sles155_x86() -> list:
+    return refhost.Attributes.from_testplatform(
+        "base=sles(major=15,minor=5);arch=[x86_64]"
+    )
+
+
+def test_search_pool_all_locations_aggregates_across_locations() -> None:
+    """all_locations=True draws candidates from every location, with arch."""
+    rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    pool = rh.search_pool(_sles155_x86(), all_locations=True)
+    assert {h.name for h, _slot in pool} == {"host-default-x86", "host-nbg-x86"}
+    assert all(h.arch == "x86_64" for h, _slot in pool)
+
+
+def test_search_pool_same_target_shares_one_slot() -> None:
+    """Both hosts satisfying one query are poolable: identical slot label."""
+    rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    pool = rh.search_pool(_sles155_x86(), all_locations=True)
+    slots = {slot for _h, slot in pool}
+    assert len(slots) == 1  # one test target -> one slot -> poolable to one host
+
+
+def test_search_pool_distinct_service_packs_are_distinct_slots() -> None:
+    """Same arch, different product versions -> different slots (both kept)."""
+    rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    attrs = refhost.Attributes.from_testplatform(
+        "base=sles(major=15,minor=5);arch=[x86_64]"
+    ) + refhost.Attributes.from_testplatform(
+        "base=sles(major=12,minor=sp4);arch=[x86_64]"
+    )
+    pool = rh.search_pool(attrs, all_locations=True)
+    slot_by_name = {h.name: slot for h, slot in pool}
+    # the 15.5 hosts and the 12-sp4 host must NOT collapse into one slot
+    assert slot_by_name["host-default-noaddon"] != slot_by_name["host-nbg-x86"]
+
+
+def test_search_pool_location_scoped_falls_back_to_default() -> None:
+    """Location-scoped search_pool falls back to default, like search."""
+    rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    attrs = refhost.Attributes.from_testplatform(
+        "base=sles(major=12,minor=sp4);arch=[x86_64]"
+    )
+    assert [h.name for h, _slot in rh.search_pool(attrs)] == ["host-default-noaddon"]
+
+
+def test_search_pool_dedupes_by_name() -> None:
+    """A name is returned once even if it matches under several attributes."""
+    rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    pool = rh.search_pool(_sles155_x86() + _sles155_x86(), all_locations=True)
+    names = sorted(h.name for h, _slot in pool)
+    assert names == ["host-default-x86", "host-nbg-x86"]
+
+
+# --------------------------------------------------------------------------- #
+# Selection logic (fakes)                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeLock:
+    def __init__(self, *, mine: bool = False, reap: bool = False) -> None:
+        self._mine = mine
+        self._reap = reap
+
+    def is_mine(self) -> bool:
+        return self._mine
+
+    def reap_if_stale(self) -> bool:
+        return self._reap
+
+    def locked_by(self) -> str:
+        return "otheruser"
+
+
+class _FakeTarget:
+    def __init__(
+        self,
+        *,
+        locked: bool,
+        mine: bool = False,
+        reap: bool = False,
+        lock_raises: bool = False,
+    ) -> None:
+        self._locked = locked
+        self._lock = _FakeLock(mine=mine, reap=reap)
+        self._lock_raises = lock_raises
+        self.closed = False
+        self.lock_calls: list[str] = []
+
+    def is_locked(self) -> bool:
+        return self._locked
+
+    def lock(self, comment: str = "") -> None:
+        if self._lock_raises:
+            raise TargetLockedError("lost the race")
+        self.lock_calls.append(comment)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_report(targets_map: dict[str, _FakeTarget]) -> SimpleNamespace:
+    self = SimpleNamespace(targets={}, systems={})
+
+    def add_target(name: str) -> None:
+        if name in targets_map:
+            self.targets[name] = targets_map[name]
+
+    self.add_target = add_target
+    self._disconnect_candidate = lambda n: TestReport._disconnect_candidate(self, n)
+    return self
+
+
+def test_claim_first_free_picks_first_unlocked_and_claims_it() -> None:
+    h1 = _FakeTarget(locked=True)  # busy (locked by other)
+    h2 = _FakeTarget(locked=False)  # free -> chosen
+    h3 = _FakeTarget(locked=False)
+    rep = _fake_report({"h1": h1, "h2": h2, "h3": h3})
+
+    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2", "h3"])
+
+    assert chosen == "h2"
+    assert h2.lock_calls  # claimed (locked)
+    assert h1.closed  # busy fallback disconnected once h2 was claimed
+    assert "h3" not in rep.targets  # never reached
+    assert set(rep.targets) == {"h2"}
+
+
+def test_claim_first_free_all_busy_returns_first_connected() -> None:
+    h1 = _FakeTarget(locked=True)
+    h2 = _FakeTarget(locked=True)
+    rep = _fake_report({"h1": h1, "h2": h2})
+
+    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2"])
+
+    assert chosen == "h1"  # kept as the fallback host
+    assert set(rep.targets) == {"h1"}
+    assert not h1.lock_calls  # not claimed; lock-wait policy applies later
+
+
+def test_claim_first_free_handles_lock_race() -> None:
+    # h1 looks free but its lock() loses the race; h2 then claims.
+    h1 = _FakeTarget(locked=False, lock_raises=True)
+    h2 = _FakeTarget(locked=False)
+    rep = _fake_report({"h1": h1, "h2": h2})
+
+    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1", "h2"])
+
+    assert chosen == "h2"
+    assert h2.lock_calls
+    assert "h1" not in rep.targets
+
+
+def test_claim_first_free_reaped_stale_lock_is_claimable() -> None:
+    # locked, not mine, but reap_if_stale() removes it -> claimable.
+    h1 = _FakeTarget(locked=True, reap=True)
+    rep = _fake_report({"h1": h1})
+
+    chosen = TestReport._claim_first_free(rep, "x86_64", ["h1"])
+
+    assert chosen == "h1"
+    assert h1.lock_calls
+
+
+def test_claim_pool_candidates_reduces_only_within_a_slot() -> None:
+    """Only same-slot candidates collapse; distinct slots each keep a host.
+
+    Crucially ``a1``/``a2`` (same product+version+arch) pool to one, while
+    ``c1`` — same arch but a different service pack — is a different slot and
+    is NOT collapsed with them. This is the SLE15-SP5 vs SP7 case.
+    """
+    rep = SimpleNamespace(
+        targets={},
+        systems={},
+        hostnames={"a1", "a2", "b1", "c1"},
+        _candidate_slots={
+            "a1": "sles15.5-x86_64-[]",  # same slot as a2 -> reduce
+            "a2": "sles15.5-x86_64-[]",
+            "b1": "sles15.5-aarch64-[]",  # different arch -> own slot
+            "c1": "sles12.4-x86_64-[]",  # same arch, different SP -> own slot
+        },
+    )
+    rep._claim_first_free = lambda slot, names: names[0]
+
+    TestReport._claim_pool_candidates(rep)
+
+    assert "a2" not in rep.hostnames  # collapsed into a1
+    # one host per distinct slot survives; c1 (different SP) is NOT dropped
+    assert {"a1", "b1", "c1"} <= rep.hostnames

--- a/tests/test_target_try_claim.py
+++ b/tests/test_target_try_claim.py
@@ -1,0 +1,68 @@
+"""Unit coverage for :meth:`mtui.hosts.target.target.Target.try_claim` and
+:meth:`Target.locked_by` — the non-raising pool-claim primitive used by
+refhost-pool selection to reserve a candidate against other agents.
+
+``try_claim`` is exercised as an unbound method against a tiny stand-in so the
+branch matrix (free / locked-by-other / stale / own-lock / lost-race) is hit
+without building a real SSH-backed Target.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from mtui.hosts.target.locks import TargetLockedError
+from mtui.hosts.target.target import Target
+
+
+def _stub(
+    *, locked: bool, mine: bool, stale: bool, raise_on_lock: bool = False
+) -> Target:
+    obj = SimpleNamespace()
+    obj.is_locked = lambda: locked
+    obj._lock = SimpleNamespace(
+        is_mine=lambda: mine,
+        reap_if_stale=lambda: stale,
+        locked_by=lambda: "someone",
+    )
+
+    def lock(comment: str = "") -> None:
+        if raise_on_lock:
+            raise TargetLockedError
+
+    obj.lock = lock
+    return cast("Target", obj)
+
+
+def test_try_claim_free_host_is_claimed() -> None:
+    assert Target.try_claim(_stub(locked=False, mine=False, stale=False), "c") is True
+
+
+def test_try_claim_locked_by_other_not_stale_declines() -> None:
+    assert Target.try_claim(_stub(locked=True, mine=False, stale=False), "c") is False
+
+
+def test_try_claim_stale_lock_is_reaped_then_claimed() -> None:
+    assert Target.try_claim(_stub(locked=True, mine=False, stale=True), "c") is True
+
+
+def test_try_claim_own_lock_proceeds() -> None:
+    assert Target.try_claim(_stub(locked=True, mine=True, stale=False), "c") is True
+
+
+def test_try_claim_lost_race_returns_false() -> None:
+    # passes the pre-check (free) but lock() loses the race / raises.
+    assert (
+        Target.try_claim(
+            _stub(locked=False, mine=False, stale=False, raise_on_lock=True), "c"
+        )
+        is False
+    )
+
+
+def test_locked_by_delegates_to_lock() -> None:
+    obj = cast(
+        "Target", SimpleNamespace(_lock=SimpleNamespace(locked_by=lambda: "bob"))
+    )
+    assert Target.locked_by(obj) == "bob"


### PR DESCRIPTION
Lets one client — or several agents — keep more than one update moving at once, without each `load_template` tearing the previous update's hosts down. Five commits.

### 1. Named workspaces
Every tool gains an optional `workspace` selector (default `"default"`). Each name resolves, via the existing `SessionRegistry`, to its own isolated `McpSession` (own loaded template, `targets`, per-session lock). Calls in different workspaces run concurrently, so a single stdio client can advance update B while update A's slow host op runs. stdio now uses the registry too (idle sweeper disabled). New tools: `list_workspaces`, `close_workspace`. The `default` workspace reproduces today's behaviour.

### 2. Async background jobs
Slow host commands (`run`, `update`, `downgrade`, `prepare`, `install`, `uninstall`, `set_repo`, `reboot`) take `background=true`: returns a job id immediately instead of holding the request open, running under the workspace lock. Poll with `job_status`, fetch with `job_result` (`job_list` / `job_cancel` too).

### 3. Wait for a busy refhost
Separate agents are separate processes, so a refhost lock genuinely excludes them. `[lock] wait` (seconds, default `0` = fail-fast) makes `lock` queue on a busy host — polling every `[lock] wait_poll` seconds until released/reaped/ours — instead of erroring. The connect-time warning is untouched; a warning is logged on wait-start/timeout so a REPL user still sees the host is busy.

### 4. Refhost pool selection
When `refhosts.yml` lists several interchangeable hosts for the same **test target** and `[refhosts] pool_select` is on, `add_host` connects just one **free** host per target instead of the whole matrix: tries candidates in turn, skips any locked by another agent, and **claims** (locks) the one it takes — so parallel agents draw distinct hosts. The target is the full `product + version + arch + addons` the update asks for, **not** just arch — so an update spanning all arches of SLE15-SP5 *and* SP7 still gets a host per (service-pack, arch); only genuine duplicates collapse to one. Searched across **all** locations (location ignored). Off by default.

Together: a pool gives several agents distinct hosts; `lock wait` makes them queue when the pool is exhausted; workspaces + background jobs keep several updates moving per agent/client.

### Notes
- Workspaces inside one process share the OS pid, so the (user+pid) refhost lock treats them as one owner — they never block each other on a host; coordinate same-process workspaces so they don't drive the same host destructively at once. `[lock] wait` and pool selection matter across separate processes/agents.
- `location` is optional: with none configured/specified it defaults to the `default` bucket of `refhosts.yml`; pool selection ignores location entirely.

### Tests
Full suite green (1312 passed locally). New coverage for workspaces, background jobs, lock-wait, and pool search/selection (incl. the SP5-vs-SP7 distinct-slot case). Docs: new "Working on several updates in parallel" section in `Documentation/mcp.rst`.