### PR TITLE
feat(refhosts): list_refhosts command + mcp tool to query/search the inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- New `list_refhosts` command (and `mcp__mtui__list_refhosts` tool) to query and
+  search the reference-host inventory **without connecting** — no SSH, no lock,
+  no loaded template. Reads the same source `add_host` resolves through
+  (`RefhostsFactory`) and filters by hostname glob (`--name`), arch (`--arch`),
+  base product (`--product`), version (`--version`, `15-SP6`/`15.6`/`15`), addon
+  (`--addon`), or a full `--testplatform` query; `--pool` groups by test-target
+  slot, `--json` emits structured output, and `--free` additionally probes each
+  matched host's live mtui-lock state (the only part that goes on the wire).
+  **Location is not used to scope the search** (it is being retired): every
+  location is searched and results are de-duplicated by host name, with
+  `--location` to restrict to one. Lets fleet maintenance and manual users find
+  refhosts through mtui instead of parsing `refhosts.yml` by hand.
 - The `testreport_read` MCP tool accepts optional `offset` (1-based first line)
   and `limit` (max lines) to return a line window instead of the whole file.
   Without them the behaviour is unchanged (full file). This lets a caller page a

--- a/mtui/commands/list_refhosts.py
+++ b/mtui/commands/list_refhosts.py
@@ -111,26 +111,28 @@ class ListRefhosts(Command):
         """Resolve refhosts and return the matched records (offline)."""
         refhosts = RefhostsFactory(self.config)
         a = self.args
-        records: list[dict] = []
         if a.testplatform:
-            attrs = Attributes.from_testplatform(a.testplatform)
-            if a.pool:
-                for host, slot in refhosts.search_pool(attrs, all_locations=True):
-                    records.append(self._record(host, None, slot))
-            else:
-                for host, loc in refhosts.query(attributes=attrs, location=a.location):
-                    records.append(self._record(host, loc, None))
+            hits = refhosts.query(
+                attributes=Attributes.from_testplatform(a.testplatform),
+                location=a.location,
+            )
         else:
-            for host, loc in refhosts.query(
+            hits = refhosts.query(
                 name=a.name,
                 arch=a.arch,
                 product=a.product,
                 version=a.version,
                 addon=a.addon,
                 location=a.location,
-            ):
-                slot = f"{host.product.name}-{self._ver_str(host.product.version)} {host.arch}"
-                records.append(self._record(host, loc, slot if a.pool else None))
+            )
+        records: list[dict] = []
+        for host, loc in hits:
+            slot = (
+                f"{host.product.name}-{self._ver_str(host.product.version)} {host.arch}"
+                if a.pool
+                else None
+            )
+            records.append(self._record(host, loc, slot))
         return records
 
     def _probe_locks(self, records: list[dict]) -> None:
@@ -142,8 +144,7 @@ class ListRefhosts(Command):
             target = Target(self.config, name, interactive=False)
             try:
                 target.connect()
-                holder = target.locked_by()
-                return name, f"locked: {holder}" if holder else "free"
+                return name, "locked" if target.is_locked() else "free"
             except Exception:  # noqa: BLE001 - best-effort probe
                 return name, "unreachable"
             finally:

--- a/mtui/commands/list_refhosts.py
+++ b/mtui/commands/list_refhosts.py
@@ -1,0 +1,224 @@
+"""The ``list_refhosts`` command: query/search the refhost inventory.
+
+Reads the refhost inventory (the same source ``add_host`` resolves through
+:data:`~mtui.hosts.refhost.RefhostsFactory`) and prints matching hosts
+**without connecting** — no SSH, no lock, no loaded template required. This
+lets fleet maintenance and manual users find refhosts through mtui instead of
+parsing ``refhosts.yml`` by hand.
+
+Location is **not** used to scope the search by default (it is being retired):
+every location is searched and results are de-duplicated by host name. The
+optional ``--free`` flag additionally connects to the matched hosts to report
+their live mtui-lock state (the only part that goes on the wire).
+"""
+
+import concurrent.futures
+import contextlib
+import json
+from logging import getLogger
+
+from ..cli.completion import complete_choices
+from ..hosts.refhost import Attributes, RefhostsFactory
+from ..hosts.target import Target
+from ..support.concurrency import ContextExecutor
+from . import Command
+
+logger = getLogger("mtui.commands.list_refhosts")
+
+
+class ListRefhosts(Command):
+    """Lists reference hosts from refhosts.yml (offline search, no connect).
+
+    With no filters every known refhost is listed. Filter by hostname glob,
+    arch, base product, version, or addon — or pass a full ``--testplatform``
+    query (same syntax ``add_host`` matches on). ``--pool`` groups the result
+    by test-target slot (one candidate per arch/codestream). Location is
+    ignored by default.
+    """
+
+    command = "list_refhosts"
+
+    @classmethod
+    def _add_arguments(cls, parser) -> None:
+        """Adds arguments to the command's argument parser."""
+        parser.add_argument(
+            "-T",
+            "--testplatform",
+            help="match a SMELT testplatform query "
+            "(e.g. 'base=sles(major=15,minor=6);arch=[x86_64]')",
+        )
+        parser.add_argument(
+            "-n", "--name", help="hostname glob, e.g. 'whale-*' or '*.qam.suse.cz'"
+        )
+        parser.add_argument(
+            "-a",
+            "--arch",
+            action="append",
+            help="arch filter (repeatable): x86_64 / aarch64 / ppc64le / s390x",
+        )
+        parser.add_argument(
+            "-p", "--product", help="base-product substring, e.g. sles / sled / SLE_HPC"
+        )
+        parser.add_argument(
+            "--version", help="product version: 15-SP6 / 15.6 / 15 (SP optional)"
+        )
+        parser.add_argument(
+            "--addon", action="append", help="addon-name substring (repeatable)"
+        )
+        parser.add_argument(
+            "-l",
+            "--location",
+            help="restrict to a single location (default: search all locations)",
+        )
+        parser.add_argument(
+            "--pool",
+            action="store_true",
+            help="group by test-target slot (product+version+arch+addons)",
+        )
+        parser.add_argument(
+            "--json", action="store_true", dest="as_json", help="emit JSON"
+        )
+        parser.add_argument(
+            "--free",
+            action="store_true",
+            help="also probe live mtui-lock state (connects to each matched host)",
+        )
+        parser.add_argument(
+            "-v", "--verbose", action="store_true", help="include addons in the output"
+        )
+
+    @staticmethod
+    def _ver_str(version) -> str:
+        if version is None:
+            return ""
+        if version.minor is None or version.minor == "":
+            return str(version.major)
+        return f"{version.major}-{version.minor}"
+
+    @classmethod
+    def _record(cls, host, location: str | None, slot: str | None) -> dict:
+        return {
+            "name": host.name,
+            "arch": host.arch,
+            "product": host.product.name,
+            "version": cls._ver_str(host.product.version),
+            "addons": [a.name for a in host.addons],
+            "location": location,
+            "slot": slot,
+        }
+
+    def _gather(self) -> list[dict]:
+        """Resolve refhosts and return the matched records (offline)."""
+        refhosts = RefhostsFactory(self.config)
+        a = self.args
+        records: list[dict] = []
+        if a.testplatform:
+            attrs = Attributes.from_testplatform(a.testplatform)
+            if a.pool:
+                for host, slot in refhosts.search_pool(attrs, all_locations=True):
+                    records.append(self._record(host, None, slot))
+            else:
+                for host, loc in refhosts.query(attributes=attrs, location=a.location):
+                    records.append(self._record(host, loc, None))
+        else:
+            for host, loc in refhosts.query(
+                name=a.name,
+                arch=a.arch,
+                product=a.product,
+                version=a.version,
+                addon=a.addon,
+                location=a.location,
+            ):
+                slot = f"{host.product.name}-{self._ver_str(host.product.version)} {host.arch}"
+                records.append(self._record(host, loc, slot if a.pool else None))
+        return records
+
+    def _probe_locks(self, records: list[dict]) -> None:
+        """Connect to each matched host (best-effort, parallel) and record its
+        live mtui-lock state under the ``lock`` key.
+        """
+
+        def probe(name: str) -> tuple[str, str]:
+            target = Target(self.config, name, interactive=False)
+            try:
+                target.connect()
+                holder = target.locked_by()
+                return name, f"locked: {holder}" if holder else "free"
+            except Exception:  # noqa: BLE001 - best-effort probe
+                return name, "unreachable"
+            finally:
+                with contextlib.suppress(Exception):
+                    target.close()
+
+        with ContextExecutor() as executor:
+            futures = [executor.submit(probe, r["name"]) for r in records]
+            states = dict(f.result() for f in concurrent.futures.as_completed(futures))
+        for r in records:
+            r["lock"] = states.get(r["name"], "unknown")
+
+    def __call__(self) -> None:
+        """Executes the ``list_refhosts`` command."""
+        records = self._gather()
+        if self.args.free and records:
+            self._probe_locks(records)
+
+        if self.args.as_json:
+            self.println(json.dumps(records, indent=2))
+            return
+
+        if not records:
+            self.println("no refhosts match")
+            return
+
+        self._render_table(records)
+
+    def _render_table(self, records: list[dict]) -> None:
+        """Print an aligned human table (grouped by slot when --pool)."""
+        verbose = self.args.verbose
+        free = self.args.free
+
+        def fmt(r: dict) -> str:
+            prod = f"{r['product']} {r['version']}".strip()
+            cols = [f"{r['name']:<34}", f"{prod:<22}", f"{r['arch']:<8}"]
+            if not self.args.pool:
+                cols.append(f"{r['location'] or '':<10}")
+            if free:
+                cols.append(f"{r.get('lock', ''):<22}")
+            if verbose:
+                cols.append(",".join(r["addons"]))
+            return " ".join(cols).rstrip()
+
+        if self.args.pool:
+            by_slot: dict[str, list[dict]] = {}
+            for r in records:
+                by_slot.setdefault(r["slot"] or "?", []).append(r)
+            for slot in sorted(by_slot):
+                self.println(f"== {slot} ==")
+                for r in by_slot[slot]:
+                    self.println("  " + fmt(r))
+        else:
+            for r in records:
+                self.println(fmt(r))
+
+        self.println(f"\n{len(records)} refhost(s)")
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(
+            [
+                ("-T", "--testplatform"),
+                ("-n", "--name"),
+                ("-a", "--arch"),
+                ("-p", "--product"),
+                ("--version",),
+                ("--addon",),
+                ("-l", "--location"),
+                ("--pool",),
+                ("--json",),
+                ("--free",),
+                ("-v", "--verbose"),
+            ],
+            line,
+            text,
+        )

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -8,6 +8,7 @@ the YAML source; the bound :data:`RefhostsFactory` singleton lives in
 the concrete resolvers without a circular import.
 """
 
+import fnmatch
 from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
@@ -160,6 +161,86 @@ class Refhosts:
                 if candidate.name == name:
                     return candidate
         return None
+
+    def query(
+        self,
+        *,
+        attributes: "list[Attributes] | None" = None,
+        name: str | None = None,
+        arch: "list[str] | None" = None,
+        product: str | None = None,
+        version: str | None = None,
+        addon: "list[str] | None" = None,
+        location: str | None = None,
+    ) -> list[tuple[Host, str]]:
+        """Return ``(host, location)`` for refhosts matching the filters.
+
+        Location is **not** used to scope the search by default (it is being
+        retired): every location is scanned and results are de-duplicated by
+        host name (first location wins, preserving first-seen order). Pass
+        ``location`` to restrict to a single one.
+
+        ``attributes`` (parsed from a ``testplatform``) and the field filters
+        (``name`` glob, ``arch``, ``product`` substring, ``version``,
+        ``addon`` substring) are alternatives — when ``attributes`` is given
+        the field filters are ignored. With neither, every host is returned.
+        """
+        locs = [location] if location is not None else list(self.data)
+        seen: set[str] = set()
+        out: list[tuple[Host, str]] = []
+        for loc in locs:
+            for host in self.data.get(loc, []):
+                if host.name in seen:
+                    continue
+                if attributes is not None:
+                    if not any(self.is_candidate_match(host, a) for a in attributes):
+                        continue
+                elif not self._field_match(host, name, arch, product, version, addon):
+                    continue
+                seen.add(host.name)
+                out.append((host, loc))
+        return out
+
+    @staticmethod
+    def _field_match(
+        host: Host,
+        name: str | None,
+        arch: "list[str] | None",
+        product: str | None,
+        version: str | None,
+        addon: "list[str] | None",
+    ) -> bool:
+        """True iff ``host`` satisfies every supplied ad-hoc field filter."""
+        if name and not fnmatch.fnmatch(host.name, name):
+            return False
+        if arch and host.arch not in arch:
+            return False
+        if product and product.lower() not in host.product.name.lower():
+            return False
+        if version and not Refhosts._version_str_match(host.product.version, version):
+            return False
+        if addon:
+            have = [a.name.lower() for a in host.addons]
+            if not all(any(want.lower() in n for n in have) for want in addon):
+                return False
+        return True
+
+    @staticmethod
+    def _version_str_match(hostver: "Version | None", want: str) -> bool:
+        """Loosely match a host version against ``15-SP6`` / ``15.6`` / ``15``.
+
+        ``SP`` is optional and case-insensitive; a bare major matches any
+        minor. A host with no version never matches a versioned query.
+        """
+        if hostver is None:
+            return False
+        parts = want.replace(".", "-").lower().split("-", 1)
+        if str(hostver.major).lower() != parts[0]:
+            return False
+        if len(parts) == 2 and parts[1]:
+            host_minor = "" if hostver.minor is None else str(hostver.minor).lower()
+            return host_minor.replace("sp", "") == parts[1].replace("sp", "")
+        return True
 
     def check_location_sanity(self, location: str) -> None:
         """Raise :class:`InvalidLocationError` if ``location`` is unknown."""

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -40,6 +40,7 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("list_metadata", "mtui.commands.simplelists", "ListMetadata"),
         ("list_packages", "mtui.commands.listpackages", "ListPackages"),
         ("list_products", "mtui.commands.products", "ListProducts"),
+        ("list_refhosts", "mtui.commands.list_refhosts", "ListRefhosts"),
         ("list_sessions", "mtui.commands.simplelists", "ListSessions"),
         ("list_timeout", "mtui.commands.simplelists", "ListTimeout"),
         ("list_update_commands", "mtui.commands.simplelists", "ListUpdateCommands"),

--- a/tests/test_list_refhosts.py
+++ b/tests/test_list_refhosts.py
@@ -200,8 +200,8 @@ def test_call_free_probes_lock_state(monkeypatch: pytest.MonkeyPatch) -> None:
         def connect(self) -> None:
             pass
 
-        def locked_by(self) -> str:
-            return "bob" if "nbg" in self.name else ""
+        def is_locked(self) -> bool:
+            return "nbg" in self.name
 
         def close(self) -> None:
             pass
@@ -210,5 +210,5 @@ def test_call_free_probes_lock_state(monkeypatch: pytest.MonkeyPatch) -> None:
     cmd = _cmd(arch=["x86_64"], as_json=True, free=True)
     cmd()
     data = {r["name"]: r["lock"] for r in _json.loads(_out(cmd))}
-    assert data["host-nbg-x86"] == "locked: bob"
+    assert data["host-nbg-x86"] == "locked"
     assert data["host-default-x86"] == "free"

--- a/tests/test_list_refhosts.py
+++ b/tests/test_list_refhosts.py
@@ -1,0 +1,214 @@
+"""Tests for the offline refhost query engine (:meth:`Refhosts.query` +
+helpers) and the ``list_refhosts`` command's record gathering.
+
+The engine is exercised directly against ``tests/fixtures/refhosts.yml``; the
+command's ``_gather`` is driven through a hand-built instance wired to a config
+that resolves the same fixture via the ``path`` resolver — no SSH, no Command
+harness, no template.
+"""
+
+from __future__ import annotations
+
+import io
+import json as _json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mtui.commands import list_refhosts as lr
+from mtui.commands.list_refhosts import ListRefhosts
+from mtui.hosts.refhost.store import Refhosts
+
+FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
+
+
+def _rh() -> Refhosts:
+    return Refhosts(FIXTURE, location="nuremberg")
+
+
+# --------------------------------------------------------------------------- #
+# Refhosts.query                                                              #
+# --------------------------------------------------------------------------- #
+def test_query_no_filter_lists_all_locations_deduped() -> None:
+    names = sorted(h.name for h, _loc in _rh().query())
+    # default + nuremberg, de-duplicated by name (location ignored)
+    assert names == [
+        "host-default-aarch64",
+        "host-default-noaddon",
+        "host-default-x86",
+        "host-nbg-only-here",
+        "host-nbg-x86",
+    ]
+
+
+def test_query_arch_filter() -> None:
+    names = {h.name for h, _ in _rh().query(arch=["x86_64"])}
+    assert names == {"host-default-noaddon", "host-default-x86", "host-nbg-x86"}
+
+
+def test_query_product_substring_and_version() -> None:
+    # product substring is case-insensitive; SP optional in version
+    hits = _rh().query(product="sles", version="15-SP5")
+    assert {h.name for h, _ in hits} == {
+        "host-default-aarch64",
+        "host-default-x86",
+        "host-nbg-only-here",
+        "host-nbg-x86",
+    }
+    assert _rh().query(product="sles", version="15.5") == hits  # 15.5 == 15-SP5
+
+
+def test_query_name_glob() -> None:
+    assert {h.name for h, _ in _rh().query(name="host-nbg-*")} == {
+        "host-nbg-only-here",
+        "host-nbg-x86",
+    }
+
+
+def test_query_location_scope_restricts() -> None:
+    # explicit location narrows to that location's rows only
+    only_nbg = {h.name for h, _ in _rh().query(location="nuremberg")}
+    assert "host-nbg-only-here" in only_nbg
+    assert "host-default-noaddon" not in only_nbg
+
+
+def test_query_empty_on_no_match() -> None:
+    assert _rh().query(arch=["s390x"], product="sles") == []
+
+
+def test_query_by_testplatform_attributes() -> None:
+    from mtui.hosts.refhost.models import Attributes
+
+    attrs = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")
+    names = {h.name for h, _ in _rh().query(attributes=attrs)}
+    assert names == {"host-default-x86", "host-nbg-x86"}
+
+
+# --------------------------------------------------------------------------- #
+# _version_str_match                                                          #
+# --------------------------------------------------------------------------- #
+def test_version_str_match_variants() -> None:
+    from mtui.hosts.refhost.models import Version
+
+    v = Version(15, "SP5")
+    assert Refhosts._version_str_match(v, "15-SP5") is True
+    assert Refhosts._version_str_match(v, "15.5") is True
+    assert Refhosts._version_str_match(v, "15") is True  # bare major matches any minor
+    assert Refhosts._version_str_match(v, "15-SP6") is False
+    assert Refhosts._version_str_match(v, "12") is False
+    assert Refhosts._version_str_match(None, "15") is False  # no version never matches
+
+
+# --------------------------------------------------------------------------- #
+# command _gather (record shape, pool slots, testplatform path)               #
+# --------------------------------------------------------------------------- #
+def _cfg() -> SimpleNamespace:
+    # makes RefhostsFactory(config) resolve the fixture via the 'path' resolver
+    return SimpleNamespace(
+        refhosts_resolvers="path", refhosts_path=FIXTURE, location="nuremberg"
+    )
+
+
+def _cmd(**args) -> ListRefhosts:
+    defaults = {
+        "testplatform": None,
+        "name": None,
+        "arch": None,
+        "product": None,
+        "version": None,
+        "addon": None,
+        "location": None,
+        "pool": False,
+        "as_json": False,
+        "free": False,
+        "verbose": False,
+    }
+    defaults.update(args)
+    cmd = ListRefhosts.__new__(ListRefhosts)
+    cmd.config = _cfg()
+    cmd.args = SimpleNamespace(**defaults)
+    cmd.sys = SimpleNamespace(stdout=io.StringIO())
+    return cmd
+
+
+def _out(cmd: ListRefhosts) -> str:
+    return cmd.sys.stdout.getvalue()
+
+
+def test_gather_field_filter_record_shape() -> None:
+    recs = _cmd(arch=["x86_64"], product="sles", version="15-SP5")._gather()
+    by_name = {r["name"]: r for r in recs}
+    assert set(by_name) == {"host-default-x86", "host-nbg-x86"}
+    r = by_name["host-nbg-x86"]
+    assert r["arch"] == "x86_64"
+    assert r["product"] == "sles"  # fixture uses lowercase; real yml uses SLES
+    assert r["version"] == "15-5"  # fixture minor is int 5; real yml is SP5
+    assert isinstance(r["addons"], list)
+
+
+def test_gather_pool_assigns_slots() -> None:
+    recs = _cmd(arch=["x86_64"], pool=True)._gather()
+    assert recs  # non-empty
+    assert all(r["slot"] for r in recs)
+
+
+def test_gather_testplatform_path() -> None:
+    recs = _cmd(testplatform="base=sles(major=15,minor=5);arch=[x86_64]")._gather()
+    assert {r["name"] for r in recs} == {"host-default-x86", "host-nbg-x86"}
+
+
+# --------------------------------------------------------------------------- #
+# command __call__ output (json / table / pool / empty / --free)              #
+# --------------------------------------------------------------------------- #
+def test_call_json_emits_record_list() -> None:
+    cmd = _cmd(arch=["x86_64"], as_json=True)
+    cmd()
+    data = _json.loads(_out(cmd))
+    assert {r["name"] for r in data} == {
+        "host-default-noaddon",
+        "host-default-x86",
+        "host-nbg-x86",
+    }
+
+
+def test_call_table_lists_hosts_and_count() -> None:
+    cmd = _cmd(arch=["aarch64"])
+    cmd()
+    out = _out(cmd)
+    assert "host-default-aarch64" in out
+    assert "refhost(s)" in out
+
+
+def test_call_pool_groups_by_slot() -> None:
+    cmd = _cmd(arch=["x86_64"], pool=True)
+    cmd()
+    assert "== " in _out(cmd)  # at least one slot header
+
+
+def test_call_no_match_message() -> None:
+    cmd = _cmd(arch=["s390x"], product="sles")
+    cmd()
+    assert "no refhosts match" in _out(cmd)
+
+
+def test_call_free_probes_lock_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeTarget:
+        def __init__(self, _config, name, interactive: bool = True) -> None:
+            self.name = name
+
+        def connect(self) -> None:
+            pass
+
+        def locked_by(self) -> str:
+            return "bob" if "nbg" in self.name else ""
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(lr, "Target", _FakeTarget)
+    cmd = _cmd(arch=["x86_64"], as_json=True, free=True)
+    cmd()
+    data = {r["name"]: r["lock"] for r in _json.loads(_out(cmd))}
+    assert data["host-nbg-x86"] == "locked: bob"
+    assert data["host-default-x86"] == "free"


### PR DESCRIPTION
Adds a `list_refhosts` command (and auto-registered `mcp__mtui__list_refhosts` tool) to **query/search the refhost inventory without connecting** — no SSH, no lock, no loaded template.

Motivation: fleet cleanups and manual searches currently parse `refhosts.yml` by hand because there is no list/search surface (only connect-time `add_host`/`search`). This exposes the same offline data through mtui.

## What
- `Refhosts.query()` — searches **all locations by default** (location is being retired; deduped by name, `--location` to narrow), via a `--testplatform` query (same matching as `add_host`) or ad-hoc filters: `--name` (glob), `--arch`, `--product` (substring), `--version` (`15-SP6`/`15.6`/`15`, SP optional), `--addon`.
- `list_refhosts` command: `--pool` (group by test-target slot), `--json`, `--free` (probe each matched host's live mtui-lock state — the only part that connects), `-v` (addons). Human table or JSON.

## Tests
Query engine (filters, all-locations dedup, location scope, testplatform, version matching), command record-gathering + all output modes (json/table/pool/empty), and the `--free` lock probe (mocked Target). Full suite green; ruff + ty clean; CHANGELOG updated.