### PR TITLE
feat!: remove prerun and noninteractive modes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: Minimal command sequence (or `-p` prerun script) that triggers the bug.
+      description: Minimal command sequence that triggers the bug.
       placeholder: |
         1. mtui -a SUSE:Maintenance:1:1
         2. add_host …

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `add_host`'s connect pool — reach MCP clients directly; `add_host` no longer
   re-echoes them to stdout.
 
+### Removed
+
+- The `-p`/`--prerun` option and the `-n`/`--noninteractive` option are gone,
+  along with the prerun command-queue machinery they drove. A prerun script was
+  the only thing `--noninteractive` supported (mtui refused `-n` without `-p`),
+  so both flags are retired together. Drive mtui through its interactive prompt
+  (or the `mtui-mcp` server) instead; existing invocations that passed `-p` or
+  `-n` must drop those flags.
+
 ### Fixed
 
 - A failed `update` now reports the outcome of **every** host instead of only the

--- a/Documentation/cli.rst
+++ b/Documentation/cli.rst
@@ -87,22 +87,6 @@ and exit.
 Overrides the ``mtui.location`` configuration.
 
 
-``-n, --noninteractive``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-When set, MTUI is run in a non interactive mode without a command shell.
-MTUI automatically applies the update and exports the results to the
-maintenance template before it quits. User input is not required.
-
-
-``-p FILE, --prerun FILE``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Runs a script with a set of MTUI commands prior to starting the interactive shell
-or the update process. User input is not required if in non interactive mode
-(``-n`` parameter).
-
-
 ``-s SPEC, --sut SPEC``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/faq.rst
+++ b/Documentation/faq.rst
@@ -10,49 +10,6 @@
 Running MTUI
 ############
 
-Can I run MTUI in non-interactive mode?
-=======================================
-
-To simply run an update on the testhosts and export the log, it is
-sufficient to pass the ``-n`` or ``--non-interactive`` option to MTUI.
-However, there is an extension to this when also setting a prerun script
-with the ``-p`` (``--prerun``) option. MTUI then runs a user-defined,
-non-interactive session.
-
-Example::
-
-  # cat prerun.example
-  # this is a prerun example file
-  run uname -a
-  list_hosts
-
-  # mtui -n -p prerun.example -a SUSE:Maintenance:3601:126030
-  info: connecting to edna.qam.suse.cz
-  info: connecting to s390vsl048.suse.de
-  info: connecting to moe.qam.suse.cz
-
-  mtui> run uname -a
-  edna.qam.suse.cz:-> uname -a [0]
-  Linux edna 3.12.61-52.66-default #1 SMP Tue Jan 24 12:54:04 UTC 2017 (20041c8/kGraft-98c9d05) x86_64 x86_64 x86_64 GNU/Linux
-
-  s390vsl048.suse.de:-> uname -a [0]
-  Linux s390vsl048 3.12.61-52.69-default #1 SMP Thu Mar 23 15:48:05 UTC 2017 (08269c9) s390x s390x s390x GNU/Linux
-
-  moe.qam.suse.cz:-> uname -a [0]
-  Linux moe 3.12.61-52.66-default #1 SMP Tue Jan 24 12:54:04 UTC 2017 (20041c8/kGraft-98c9d05) x86_64 x86_64 x86_64 GNU/Linux
-
-  info: done
-
-  mtui> list_hosts
-  edna.qam.suse.cz     (sles12_module-x86_64): Enabled (parallel)
-  moe.qam.suse.cz      (sles12_module-x86_64): Enabled (parallel)
-  s390vsl048.suse.de   (sles12_module-s390x): Enabled (parallel)
-
-  mtui> quit
-  info: closing connection to edna.qam.suse.cz
-  info: closing connection to s390vsl048.suse.de
-  info: closing connection to moe.qam.suse.cz
-
 How do I change the default refhosts location?
 ==============================================
 

--- a/mtui/cli/args.py
+++ b/mtui/cli/args.py
@@ -79,23 +79,10 @@ def get_parser(sys) -> ArgumentParser:
         "(format: hostname,hostname2)",
     )
     parser.add_argument(
-        "-p",
-        "--prerun",
-        type=Path,
-        help="script with a set of MTUI commands to run at start",
-    )
-    parser.add_argument(
         "-w",
         "--connection_timeout",
         type=int,
         help="override config mtui.connection_timeout",
-    )
-    parser.add_argument(
-        "-n",
-        "--noninteractive",
-        action="store_true",
-        default=False,
-        help="noninteractive update shell",
     )
     parser.add_argument(
         "-d",

--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -3,7 +3,7 @@
 Replaces the historical :mod:`cmd`-based prompt. The previous
 implementation inherited from :class:`cmd.Cmd` and relied on GNU
 ``readline`` for line editing, history, and tab completion. This module
-exposes ``CommandPrompt``, ``CmdQueue``, ``QuitLoopError``, and
+exposes ``CommandPrompt``, ``QuitLoopError``, and
 ``CommandAlreadyBoundError``; the input loop is driven by
 :class:`prompt_toolkit.PromptSession` and history goes through the shared
 :mod:`mtui.cli._history` backend.
@@ -59,60 +59,12 @@ class QuitLoopError(RuntimeError):
     """Exception raised to exit the command loop."""
 
 
-class _LoopExitError(Exception):
-    """Internal sentinel: input phase requests :meth:`cmdloop` to return."""
-
-
 class _LoopContinueError(Exception):
     """Internal sentinel: input phase requests :meth:`cmdloop` to reprompt.
 
     Used by the ``KeyboardInterrupt`` handler so the loop skips dispatch
     and goes straight to the next read cycle.
     """
-
-
-class CmdQueue(list):
-    """A list-like object that supports prerun commands.
-
-    This class echoes the prompt with the command that's being popped
-    and is about to be executed.
-    """
-
-    def __init__(self, iterable, prompt, term) -> None:
-        """Initializes the command queue.
-
-        Args:
-            iterable: An iterable of commands.
-            prompt: The command prompt string.
-            term: The terminal object.
-
-        """
-        self.prompt = prompt
-        self.term = term
-        list.__init__(self, iterable)
-
-    def pop(self, i=-1, /) -> Any:  # type: ignore[override]
-        """Pops a command from the queue and echoes it to the terminal.
-
-        Args:
-            i: The index of the command to pop.
-
-        Returns:
-            The popped command.
-
-        """
-        val = list.pop(self, i)
-        self.echo_prompt(val)
-        return val
-
-    def echo_prompt(self, val) -> None:
-        """Echoes the prompt and a command to the terminal.
-
-        Args:
-            val: The command to echo.
-
-        """
-        self.term.stdout.write(f"{self.prompt}{val}\n")
 
 
 class CommandPrompt:
@@ -178,10 +130,6 @@ class CommandPrompt:
         # mtui.cli.term.prompt_user and mtui.commands.quit so the file
         # is not raced.
         self._history = get_history(default_history_path())
-
-        # cmdqueue stays a plain list until set_cmdqueue wraps it in a
-        # CmdQueue (preserving the prerun echo behaviour).
-        self.cmdqueue: list[str] = []
 
         self.commands: dict[str, type[Command]] = {}
 
@@ -346,19 +294,6 @@ class CommandPrompt:
         setattr(self, f"help_{name}", help)
         setattr(self, f"complete_{name}", complete)
 
-    def set_cmdqueue(self, queue: list[str]) -> None:
-        """Sets the command queue for prerun commands.
-
-        Args:
-            queue: A list of commands to run.
-
-        """
-        q = queue[:]
-        if not self.interactive:
-            q.append("quit")
-
-        self.cmdqueue = CmdQueue(q, self.prompt, self.sys)
-
     def _dispatch(self, line: str) -> None:
         """Parse ``line`` and invoke the matching ``do_<name>`` closure.
 
@@ -369,7 +304,7 @@ class CommandPrompt:
         previous ``cmd.Cmd.default`` behaviour.
 
         ``postcmd`` is invoked here (rather than in the loop) so every
-        dispatch path — interactive prompt, prerun queue drain, and the
+        dispatch path — interactive prompt and the
         ``EOFError → "EOF"`` shortcut — gets the same post-command hook
         treatment.
         """
@@ -388,12 +323,8 @@ class CommandPrompt:
     def cmdloop(self, intro: str | None = None) -> None:
         """Run the main command loop.
 
-        Drains :attr:`cmdqueue` first (so prerun commands run without
-        needing a TTY-attached :class:`PromptSession`); only when the
-        queue is empty *and* the session is interactive do we ask
-        :class:`PromptSession` for a new line. Non-interactive sessions
-        with an empty queue exit immediately, matching the previous
-        behaviour of appending ``quit`` to the prerun queue.
+        Asks :class:`PromptSession` for a new line each iteration and
+        dispatches it.
 
         Args:
             intro: Optional banner string printed before the first
@@ -407,8 +338,6 @@ class CommandPrompt:
         while True:
             try:
                 line = self._read_next_line()
-            except _LoopExitError:
-                return
             except _LoopContinueError:
                 continue
 
@@ -439,35 +368,22 @@ class CommandPrompt:
     def _read_next_line(self) -> str:
         """Acquire the next line for dispatch.
 
-        Centralises queue-drain → PromptSession → control-key handling
-        so :meth:`cmdloop` only deals with dispatch-phase exceptions.
+        Centralises PromptSession → control-key handling so
+        :meth:`cmdloop` only deals with dispatch-phase exceptions.
 
         Returns:
             The raw input line (still un-stripped; :meth:`_dispatch`
             normalises it).
 
         Raises:
-            _LoopExitError: when the loop must return (non-interactive
-                session with an empty queue, or any unexpected input
-                error logged through the normal dispatch error path).
             _LoopContinueError: when the loop must skip dispatch and
                 reprompt (Ctrl-C / ``KeyboardInterrupt``).
 
         """
         try:
-            if self.cmdqueue:
-                return self.cmdqueue.pop(0)
-            if not self.interactive:
-                # Non-interactive with an empty queue: we are done.
-                # Touching PromptSession on a non-TTY stdin would raise.
-                raise _LoopExitError
             return self._session.prompt(self.prompt)
         except KeyboardInterrupt:
-            # Drop to interactive mode. Effective only if we were in
-            # prerun; for an already-interactive session it just clears
-            # the partial input and reprompts.
-            self.interactive = True
-            self.cmdqueue = []
+            # Ctrl-C on a partial input line clears it and reprompts.
             self.println()
             raise _LoopContinueError from None
         except EOFError:

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -40,11 +40,6 @@ def main() -> int:
 
     set_color_mode(args.color)
 
-    if args.noninteractive and not args.prerun:
-        logger.error("--noninteractive makes no sense without --prerun")
-        p.print_help()
-        sys.exit(1)
-
     cfg = Config(args.config)
 
     sys.exit(run_mtui(cfg, logger, args))
@@ -76,7 +71,6 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
     # the user one at a time (no stdin races, no interleaved prompt text).
     prompter = Prompter()
     prompt = CommandPrompt(config, logger, sys, CommandPromptDisplay, prompter=prompter)
-    prompt.interactive = not args.noninteractive
     if args.update:
         if args.update.kind == "kernel":
             config.kernel = True
@@ -111,18 +105,6 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
                 prompt.do_add_host(x.print_args())
             except ArgsParseFailureError as e:
                 logger.error("failed to add host %s: %s", x, e)
-
-    if args.prerun:
-        if args.prerun.is_file():
-            prompt.set_cmdqueue(
-                [
-                    x.rstrip()
-                    for x in args.prerun.read_text().splitlines()
-                    if not x.startswith("#")
-                ]
-            )
-        else:
-            logger.error("Prerun command file %s isn't file", str(args.prerun))
 
     prompt.cmdloop(intro="Maintenance Test Update Installer")
     return 0

--- a/mtui/mcp/args.py
+++ b/mtui/mcp/args.py
@@ -12,9 +12,9 @@ def get_parser(sys) -> ArgumentParser:
     The parser intentionally mirrors :func:`mtui.cli.args.get_parser` for
     the flags that ``Config.merge_args`` and the testreport-loading code
     care about (``-l``, ``-t``, ``-c``, ``-g``, ``--color``, ``--debug``,
-    ``-V``) so the same ``Namespace`` shape can be reused. REPL-only flags
-    (``-p/--prerun``, ``-n/--noninteractive``) are dropped, and three
-    MCP-server flags (``--transport``, ``--host``, ``--port``) are added.
+    ``-V``) so the same ``Namespace`` shape can be reused. The REPL-only
+    update/SUT flags are omitted, and three MCP-server flags
+    (``--transport``, ``--host``, ``--port``) are added.
 
     Templates and hosts are loaded per session at runtime via the
     ``load_template`` and ``add_host`` tools, so the server takes no

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -35,7 +35,6 @@ def test_get_parser_args():
             "host1,host2",
             "-w",
             "600",
-            "-n",
             "-d",
             "-c",
             "/test/config",
@@ -50,7 +49,6 @@ def test_get_parser_args():
     assert parsed_args.template_dir == Path("/test/template_dir")
     assert parsed_args.sut[0].print_args() == "-t host1 -t host2"
     assert parsed_args.connection_timeout == 600
-    assert parsed_args.noninteractive is True
     assert parsed_args.debug is True
     assert parsed_args.config == Path("/test/config")
     assert parsed_args.gitea_token == "test_gitea_token"
@@ -67,7 +65,6 @@ def test_get_parser_args():
             "host3,host4",
             "--connection_timeout",
             "1200",
-            "--noninteractive",
             "--debug",
             "--config",
             "/test/config_long",
@@ -82,7 +79,6 @@ def test_get_parser_args():
     assert parsed_args.template_dir == Path("/test/template_dir_long")
     assert parsed_args.sut[0].print_args() == "-t host3 -t host4"
     assert parsed_args.connection_timeout == 1200
-    assert parsed_args.noninteractive is True
     assert parsed_args.debug is True
     assert parsed_args.config == Path("/test/config_long")
     assert parsed_args.gitea_token == "test_gitea_token_long"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,39 +25,6 @@ def test_main_args_parse_failure(monkeypatch):
         assert result == 2
 
 
-def test_main_noninteractive_without_prerun(monkeypatch, caplog):
-    """Test main function with --noninteractive but without --prerun."""
-    monkeypatch.setattr("sys.argv", ["mtui", "--noninteractive"])
-
-    # Test the logic without sys.exit by directly calling the problematic code path
-    with (
-        patch("mtui.main.get_parser") as mock_get_parser,
-        patch("mtui.main.Config") as mock_config_class,
-    ):
-        # Setup mocks
-        mock_parser = MagicMock()
-        mock_get_parser.return_value = mock_parser
-
-        # Mock parse_args to return a valid Namespace with noninteractive=True but prerun=False
-        mock_args = Namespace(
-            config="test_config.json",
-            noninteractive=True,
-            prerun=None,
-            debug=False,
-            update=None,
-            sut=None,
-        )
-        mock_parser.parse_args.return_value = mock_args
-
-        # Mock Config to return a mock config instance
-        mock_config_instance = MagicMock()
-        mock_config_class.return_value = mock_config_instance
-
-        # Verify the condition is met (this would normally call sys.exit(1))
-        assert mock_args.noninteractive is True
-        assert mock_args.prerun is None
-
-
 def test_run_mtui_with_debug():
     """Test run_mtui with debug flag."""
     mock_config = MagicMock()
@@ -73,9 +40,7 @@ def test_run_mtui_with_debug():
             mock_command_prompt_class.return_value = mock_prompt_instance
 
             # Test with debug flag
-            mock_args = Namespace(
-                debug=True, update=None, sut=None, prerun=None, noninteractive=False
-            )
+            mock_args = Namespace(debug=True, update=None, sut=None)
 
             # Call run_mtui and check result
             result = run_mtui(mock_config, mock_logger, mock_args)
@@ -102,9 +67,7 @@ def test_run_mtui_quits_when_explicit_update_not_loaded():
         prompt.metadata = NullTestReport(mock_config)
         update = MagicMock()
         update.kind = "auto"
-        args = Namespace(
-            debug=False, update=update, sut=None, prerun=None, noninteractive=False
-        )
+        args = Namespace(debug=False, update=update, sut=None)
 
         result = run_mtui(mock_config, mock_logger, args)
 
@@ -126,9 +89,7 @@ def test_run_mtui_starts_session_when_update_loads():
         prompt.metadata = MagicMock()  # a real (non-Null) test report
         update = MagicMock()
         update.kind = "auto"
-        args = Namespace(
-            debug=False, update=update, sut=None, prerun=None, noninteractive=False
-        )
+        args = Namespace(debug=False, update=update, sut=None)
 
         result = run_mtui(mock_config, mock_logger, args)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -84,19 +84,8 @@ def test_command_prompt_init():
 
 
 # --------------------------------------------------------------------------- #
-# CmdQueue                                                                    #
+# Command registration                                                        #
 # --------------------------------------------------------------------------- #
-
-
-def test_cmd_queue_pop_echoes():
-    """``CmdQueue.pop`` echoes the prompt + popped line to the terminal."""
-    term = MagicMock()
-    queue = repl.CmdQueue(["test_cmd"], "mtui> ", term)
-
-    val = queue.pop(0)
-
-    assert val == "test_cmd"
-    term.stdout.write.assert_called_with("mtui> test_cmd\n")
 
 
 # --------------------------------------------------------------------------- #
@@ -202,65 +191,6 @@ def test_get_names_includes_registered_commands():
 
 
 # --------------------------------------------------------------------------- #
-# Queue + non-interactive behaviour                                           #
-# --------------------------------------------------------------------------- #
-
-
-def test_set_cmdqueue_interactive_keeps_queue_as_is():
-    """Interactive sessions must not get an auto-appended ``quit``."""
-    p = _make_prompt()
-    p.interactive = True
-    p.set_cmdqueue(["a", "b"])
-    assert list(p.cmdqueue) == ["a", "b"]
-    assert isinstance(p.cmdqueue, repl.CmdQueue)
-
-
-def test_set_cmdqueue_non_interactive_appends_quit():
-    """Non-interactive sessions terminate by appending ``quit``."""
-    p = _make_prompt()
-    p.interactive = False
-    p.set_cmdqueue(["a", "b"])
-    assert list(p.cmdqueue) == ["a", "b", "quit"]
-
-
-def test_cmdloop_non_interactive_drains_queue_without_session(monkeypatch):
-    """Non-interactive cmdloop drains the queue without touching PromptSession.
-
-    Locks in PLAN.md Risk #3: ``PromptSession.prompt`` raises on non-TTY
-    stdin, so the loop must read from ``cmdqueue`` exclusively when
-    ``interactive=False``. We assert ``_session.prompt`` is never
-    invoked.
-    """
-    p = _make_prompt()
-    p.interactive = False
-
-    do_foo = MagicMock()
-    do_quit = MagicMock()
-    _bind_do(p, "foo", do_foo)
-    _bind_do(p, "quit", do_quit)
-
-    session_prompt = MagicMock()
-    monkeypatch.setattr(p._session, "prompt", session_prompt)
-
-    p.set_cmdqueue(["foo"])  # auto-appends "quit"
-    p.cmdloop()
-
-    do_foo.assert_called_once_with("")
-    do_quit.assert_called_once_with("")
-    session_prompt.assert_not_called()
-
-
-def test_cmdloop_non_interactive_empty_queue_returns(monkeypatch):
-    """An empty queue + non-interactive session exits without prompting."""
-    p = _make_prompt()
-    p.interactive = False
-    session_prompt = MagicMock()
-    monkeypatch.setattr(p._session, "prompt", session_prompt)
-    p.cmdloop()
-    session_prompt.assert_not_called()
-
-
-# --------------------------------------------------------------------------- #
 # cmdloop control flow                                                        #
 # --------------------------------------------------------------------------- #
 
@@ -291,28 +221,24 @@ def _mock_prompt(monkeypatch, p: repl.CommandPrompt, lines: list[Any]) -> MagicM
     return mock
 
 
-def test_cmdloop_keyboard_interrupt_resets_state(monkeypatch):
-    """``KeyboardInterrupt`` clears the queue and forces interactive mode.
+def test_cmdloop_keyboard_interrupt_reprompts(monkeypatch):
+    """``KeyboardInterrupt`` at the prompt clears the line and reprompts.
 
-    Mimics the prerun → ctrl-C → interactive-mode drop documented in
-    PLAN.md step 6: ``KeyboardInterrupt`` flips ``interactive`` back to
-    ``True``, drops any remaining prerun lines, and reprompts.
+    Ctrl-C on a partial input line must not tear down the REPL: the
+    input phase raises ``_LoopContinueError`` so the loop skips dispatch
+    and reads the next line. We feed Ctrl-C then ``"quit"`` and assert
+    the prompt was asked twice (i.e. the loop survived the interrupt).
     """
     p = _make_prompt()
     _seed_quit(p)
     # First prompt call raises Ctrl-C; second returns "quit" to exit.
-    # The Ctrl-C handler must clear the queue and force interactive=True.
-    _mock_prompt(monkeypatch, p, [KeyboardInterrupt, "quit"])
+    mock = _mock_prompt(monkeypatch, p, [KeyboardInterrupt, "quit"])
 
-    # Pretend we entered cmdloop with a queue and non-interactive mode
-    # AFTER the first prompt call has already happened (e.g. the user
-    # cleared the queue manually); we cannot truly seed the queue here
-    # because the first iteration would pop from it instead of calling
-    # session.prompt. So just observe the post-Ctrl-C state.
     p.cmdloop()
 
+    # Two prompt reads: the interrupted one and the one that returns quit.
+    assert mock.call_count == 2
     assert p.interactive is True
-    assert p.cmdqueue == []
 
 
 def test_cmdloop_keyboard_interrupt_during_command_returns_to_prompt(


### PR DESCRIPTION
## Summary

Removes the `-p`/`--prerun` and `-n`/`--noninteractive` command-line options and the command-queue machinery that backed them.

A prerun script was the **only** thing `--noninteractive` ever supported — mtui refused `-n` unless `-p` was also given — so the two flags are retired together. Users drive mtui through its interactive prompt or the `mtui-mcp` server instead.

## Changes

- **`mtui/cli/args.py`** — drop the `-p/--prerun` and `-n/--noninteractive` arguments.
- **`mtui/main.py`** — remove the `--noninteractive`-without-`--prerun` guard, the `prompt.interactive` assignment (now defaults to `True`), and the prerun-file → command-queue block.
- **`mtui/cli/repl.py`** — delete the `CmdQueue` class, `set_cmdqueue`, the `cmdqueue` attribute, and the now-dead `_LoopExitError` sentinel; `cmdloop`/`_read_next_line` read solely from the prompt_toolkit session. The Ctrl-C reprompt and the "Ctrl-C aborts the command, not the REPL" safety nets are preserved.
- **`mtui/mcp/args.py`** — refresh the docstring that referenced the removed REPL flags.
- **Docs** — remove the `-n`/`-p` sections in `cli.rst`, the prerun FAQ in `faq.rst`, the `-p` mention in the bug-report template, and add a `### Removed` entry to the changelog.
- **Tests** — drop the prerun/queue tests and rework the Ctrl-C test to assert reprompt-and-continue.

The broader `interactive` flag (MCP/headless path via `prompter is None`) is intentionally **untouched**.

## Breaking change

The `-p`/`--prerun` and `-n`/`--noninteractive` options are removed. Existing invocations passing `-p` or `-n` must drop those flags.

## Verification

All CI-matching gates pass locally:

- `uv run ruff format --check .` — 293 files already formatted
- `uv run ruff check .` — passed
- `uv run ty check` — passed
- `uv run pytest` — **1434 passed**
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html` — built with no warnings
- `uv run python -m mtui --help` — runs clean, no `-p`/`-n`