### PR TITLE
feat(mcp): async background jobs for slow host commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Under `mtui-mcp`, the slow host commands (`run`, `update`, `downgrade`,
+  `prepare`, `install`, `uninstall`, `set_repo`, `reboot`) accept a
+  `background=true` flag: instead of holding the request open for the minutes
+  the operation takes, the call returns a job id immediately and runs the
+  command in the background under the session lock. Four new tools drive the
+  job — `job_list` (every job in the session and its state), `job_status`
+  (one job's state and elapsed time), `job_result` (a finished job's output,
+  erroring while it still runs and surfacing the command's failure envelope if
+  it failed), and `job_cancel`. Jobs are scoped to the session (one process
+  under stdio; the caller's isolated session under http), so a client can fire
+  off a slow host op and keep issuing other calls while it runs. A cancelled
+  job already executing on a host may keep running there to completion — the
+  same caveat as interrupting a foreground `run`.
 - New `list_refhosts` command (and `mcp__mtui__list_refhosts` tool) to query and
   search the reference-host inventory **without connecting** — no SSH, no lock,
   no loaded template. Reads the same source `add_host` resolves through

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -500,6 +500,52 @@ For those, raise the timeout in the client's own configuration:
 The heartbeat itself never *caps* execution time; if your client
 honours progress it will simply wait as long as the server takes.
 
+Background jobs (don't block on a slow host op)
+-----------------------------------------------
+
+The heartbeat keeps a *synchronous* call alive, but the client is
+still parked on that one request until the command finishes. When you
+would rather fire off a slow host operation and keep working, the eight
+slow host commands —
+``run``, ``update``, ``downgrade``, ``prepare``, ``install``,
+``uninstall``, ``set_repo``, ``reboot`` — accept a ``background=true``
+flag. Instead of holding the request open for the minutes the op takes,
+the call returns **immediately** with a job id::
+
+    run(command=["zypper", "-n", "patch"], background=true)
+    -> "started background job 'run-1' for `run`; it runs on the hosts
+        while you work elsewhere. Poll job_status(job_id='run-1') and
+        fetch output with job_result(job_id='run-1')."
+
+The command still runs under the session lock for its whole duration —
+so it serialises against the session's other mutating calls exactly
+like a foreground call — but you are free to issue other (read-only)
+tool calls meanwhile and poll the job:
+
+* ``job_list`` — every job in the session and its state;
+* ``job_status(job_id=…)`` — one job's state
+  (``running`` / ``done`` / ``failed`` / ``cancelled``) and elapsed
+  time;
+* ``job_result(job_id=…)`` — a finished job's captured stdout. It
+  *errors* while the job is still running (poll ``job_status`` first)
+  and surfaces the command's failure envelope (stdout, error, exit
+  code) if it failed — exactly as a foreground failure would have;
+* ``job_cancel(job_id=…)`` — cancel a running job.
+
+Jobs are scoped to the session: under stdio that is the single process;
+under http it is the caller's isolated session, so one client never
+sees another's jobs. The job table lives in memory and persists for the
+session's lifetime — finished records are not evicted — but under http
+the registry's idle-TTL sweep drops the whole session (and its jobs)
+once it goes quiet.
+
+.. note::
+
+   Cancellation detaches the awaiter, but a job already executing on a
+   host (an SSH command or subprocess) may keep running to completion
+   on that host even after ``job_cancel`` returns — the same caveat as
+   interrupting a foreground ``run`` with Ctrl-C.
+
 
 Command output and logging
 ===========================

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -38,7 +38,7 @@ from .args import get_parser
 from .registry import SessionRegistry
 from .session import McpSession
 from .testreport_tools import register_testreport_tools
-from .tools import build_tools
+from .tools import build_tools, register_job_tools
 
 if TYPE_CHECKING:
     from .registry import SessionProvider
@@ -193,6 +193,7 @@ def main() -> int:
     mcp = FastMCP(name="mtui", host=args.host, port=args.port)
     build_tools(mcp, provider)
     register_testreport_tools(mcp, provider)
+    register_job_tools(mcp, provider)
 
     try:
         if args.transport == "http":

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import contextvars
 import io
 import logging
@@ -276,6 +277,20 @@ class McpSession:
         # ``Command.__init__`` picks up the right StringIO-bound
         # writer. ``None`` outside a call.
         self.display: CommandPromptDisplay | None = None
+
+        # Background-job table for the async ("don't block on a slow host
+        # op") path. A backgrounded command still acquires this session's
+        # ``_lock`` for its whole duration — so it serialises against the
+        # session's other mutating calls exactly like a foreground call —
+        # but ``start_job`` returns a handle immediately instead of
+        # holding the request open. Polled via ``job_status`` /
+        # ``job_result`` (which read this table and need no lock), so the
+        # client can meanwhile issue other (read-only) calls. Keyed by job
+        # id. Records persist for the session's lifetime (finished jobs are
+        # never evicted); under http the registry's idle sweep drops the
+        # whole session and its table with it.
+        self._jobs: dict[str, dict[str, Any]] = {}
+        self._job_counter = 0
 
     # ------------------------------------------------------------------
     # CommandPrompt-compatible surface
@@ -613,3 +628,151 @@ class McpSession:
                 cap_logger.setLevel(prev_cap_level)
             self.display = prev_display
             self._current_stdout = prev_stdout
+
+    # ------------------------------------------------------------------
+    # Background jobs (async path for slow host operations)
+    # ------------------------------------------------------------------
+
+    async def start_job(
+        self,
+        cmd_cls: type[Command],
+        argv: list[str],
+        *,
+        ctx: Any | None = None,
+    ) -> str:
+        """Start ``cmd_cls`` in the background and return its job id.
+
+        The command runs in an :func:`asyncio.create_task` worker that
+        acquires this session's ``_lock`` for its whole duration (so it
+        serialises against the session's other mutating calls exactly
+        like :meth:`run_command`) and executes the body in
+        :func:`asyncio.to_thread`. Unlike :meth:`run_command` this
+        returns **immediately** with a handle, so the client is not held
+        on one request for the minutes a ``run`` / ``update`` /
+        ``downgrade`` can take and can meanwhile issue other calls.
+
+        Outcome is recorded on the job record and read back via
+        :meth:`job_status` / :meth:`job_result`. ``ctx`` is accepted for
+        signature parity but no heartbeat is emitted (the call returns at
+        once; there is nothing to keep alive).
+
+        Args:
+            cmd_cls: The :class:`Command` subclass to run.
+            argv: Already-split command-line tokens.
+            ctx: Unused; accepted for caller parity.
+
+        Returns:
+            The new job id (``"<command>-<n>"``).
+
+        """
+        self._job_counter += 1
+        job_id = f"{cmd_cls.command}-{self._job_counter}"
+        job: dict[str, Any] = {
+            "id": job_id,
+            "command": cmd_cls.command,
+            "argv": list(argv),
+            "state": "running",
+            "started": time.monotonic(),
+            "finished": None,
+            "result": None,
+            "error": None,
+            "exit_code": None,
+            "task": None,
+        }
+        self._jobs[job_id] = job
+
+        async def _runner() -> None:
+            try:
+                async with self._lock:
+                    out = await asyncio.to_thread(self._run_sync, cmd_cls, argv)
+                job["result"] = out
+                job["state"] = "done"
+            except McpCommandError as exc:
+                job["state"] = "failed"
+                job["error"] = str(exc)
+                job["result"] = exc.stdout
+                job["exit_code"] = exc.exit_code
+            except asyncio.CancelledError:
+                job["state"] = "cancelled"
+                raise
+            except Exception as exc:  # noqa: BLE001 - record, never crash the loop
+                job["state"] = "failed"
+                job["error"] = repr(exc)
+            finally:
+                job["finished"] = time.monotonic()
+
+        job["task"] = asyncio.create_task(_runner())
+        return job_id
+
+    def _job_view(self, job: dict[str, Any]) -> dict[str, Any]:
+        """Public-facing snapshot of ``job`` (no asyncio Task object)."""
+        end = job["finished"] if job["finished"] is not None else time.monotonic()
+        return {
+            "id": job["id"],
+            "command": job["command"],
+            "state": job["state"],
+            "elapsed_s": round(end - job["started"], 1),
+        }
+
+    def job_list(self) -> list[dict[str, Any]]:
+        """Return a view of every job started in this session."""
+        return [self._job_view(j) for j in self._jobs.values()]
+
+    def job_status(self, job_id: str) -> dict[str, Any]:
+        """Return ``job_id``'s state view, or raise if unknown."""
+        job = self._jobs.get(job_id)
+        if job is None:
+            raise McpCommandError("", f"no such job: {job_id}", 1)
+        return self._job_view(job)
+
+    def job_result(self, job_id: str) -> str:
+        """Return a finished job's stdout, or raise the right envelope.
+
+        * unknown id -> :class:`McpCommandError` (exit 1)
+        * still running -> :class:`McpCommandError` telling the caller to
+          poll ``job_status`` (the job keeps running)
+        * failed -> :class:`McpCommandError` carrying the command's
+          captured stdout / error / exit code, exactly as a foreground
+          failure would have surfaced
+        * cancelled -> :class:`McpCommandError` (exit 1)
+        * done -> the captured stdout string
+        """
+        job = self._jobs.get(job_id)
+        if job is None:
+            raise McpCommandError("", f"no such job: {job_id}", 1)
+        state = job["state"]
+        if state == "running":
+            elapsed = round(time.monotonic() - job["started"], 1)
+            raise McpCommandError(
+                "",
+                f"job {job_id} still running ({elapsed}s); poll job_status",
+                1,
+            )
+        if state == "failed":
+            raise McpCommandError(
+                job["result"] or "",
+                job["error"] or "job failed",
+                job["exit_code"] or 1,
+            )
+        if state == "cancelled":
+            raise McpCommandError("", f"job {job_id} was cancelled", 1)
+        return job["result"] or ""
+
+    async def job_cancel(self, job_id: str) -> str:
+        """Cancel a running job; raise if the id is unknown.
+
+        Cancels the worker task. NOTE: if the job is mid
+        :func:`asyncio.to_thread` (an SSH/subprocess body), cancellation
+        detaches the awaiter but the underlying host operation may keep
+        running to completion — the same caveat as interrupting a
+        foreground ``run``. A finished job is a no-op.
+        """
+        job = self._jobs.get(job_id)
+        if job is None:
+            raise McpCommandError("", f"no such job: {job_id}", 1)
+        task = job.get("task")
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        return f"cancelled job {job_id}"

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -56,6 +56,24 @@ logger = getLogger("mtui.mcp.tools")
 #: list is stable and visible in code review.
 SUBPARSER_COMMANDS: frozenset[str] = frozenset({"config"})
 
+#: Commands that touch the reference hosts and can run for minutes. These
+#: gain a ``background`` parameter: when true the call returns a job id at
+#: once (see :meth:`McpSession.start_job`) instead of holding the request
+#: open, so a slow host op does not stop the client from issuing other
+#: calls. Polled via the ``job_status`` / ``job_result`` tools.
+SLOW_COMMANDS: frozenset[str] = frozenset(
+    {
+        "run",
+        "update",
+        "downgrade",
+        "prepare",
+        "install",
+        "uninstall",
+        "set_repo",
+        "reboot",
+    }
+)
+
 #: A command becomes ``readOnlyHint=True`` if its name starts with one
 #: of these prefixes. Strict allow-list per Q2 in PLAN step 7.
 _READ_ONLY_PREFIXES: tuple[str, ...] = ("list_", "show_")
@@ -121,7 +139,22 @@ def _make_wrapper(
         default=None,
         annotation=Context,
     )
-    all_params = [*params, ctx_param]
+    # Slow host commands gain a ``background`` flag: when true the call
+    # returns a job id immediately instead of blocking (see
+    # ``McpSession.start_job``). Only added for SLOW_COMMANDS so read-only
+    # / instant tools keep a clean schema.
+    is_slow = cls.command in SLOW_COMMANDS
+    extra_params: list[inspect.Parameter] = []
+    if is_slow:
+        extra_params.append(
+            inspect.Parameter(
+                "background",
+                inspect.Parameter.KEYWORD_ONLY,
+                default=False,
+                annotation=bool,
+            )
+        )
+    all_params = [*params, *extra_params, ctx_param]
     signature = inspect.Signature(
         parameters=all_params,
         return_annotation=str,
@@ -153,6 +186,7 @@ def _make_wrapper(
         # the parameter as Context); strip it before kwargs_to_argv so
         # the encoder does not try to render it as a CLI flag.
         ctx = kwargs.pop("ctx", None)
+        background = bool(kwargs.pop("background", False)) if is_slow else False
         if synthetic_required:
             supplied = [n for n in synthetic_names if kwargs.get(n) is not None]
             if len(supplied) != 1:
@@ -163,6 +197,14 @@ def _make_wrapper(
                 raise McpCommandError("", msg, 2)
         argv = list(argv_prefix) + kwargs_to_argv(parser, kwargs)
         session = await resolve_session(provider, ctx)
+        if background:
+            job_id = await session.start_job(cls, argv, ctx=ctx)
+            return (
+                f"started background job {job_id!r} for `{cls.command}`; it "
+                f"runs on the hosts while you work elsewhere. Poll "
+                f"job_status(job_id={job_id!r}) and fetch output with "
+                f"job_result(job_id={job_id!r})."
+            )
         return await session.run_command(cls, argv, ctx=ctx)
 
     # ``inspect.Signature`` lives on a dunder slot; ty does not model it
@@ -299,3 +341,120 @@ def build_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
     registered.sort()
     logger.info("registered %d MCP tools: %s", len(registered), ", ".join(registered))
     return registered
+
+
+def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
+    """Register the background-job control tools (the async slow-op path).
+
+    Slow host commands (``run``/``update``/``downgrade``/...) accept a
+    ``background=true`` flag that returns a job id immediately instead of
+    blocking; these tools then drive that job:
+
+    * ``job_list`` — every job in the session and its state;
+    * ``job_status`` — one job's state + elapsed time;
+    * ``job_result`` — a finished job's output (errors if still running, or
+      surfaces the command's failure envelope if it failed);
+    * ``job_cancel`` — cancel a running job.
+
+    They address the per-call session's job table, resolved through
+    ``provider`` exactly as every other tool resolves its session, so they
+    stay transport-agnostic (one session under stdio; the caller's isolated
+    session under http).
+
+    Args:
+        mcp: The :class:`mcp.server.fastmcp.FastMCP` server.
+        provider: The session provider each call resolves through.
+
+    Returns:
+        The registered tool names.
+
+    """
+    # The trailing ``ctx: Context | None = None`` parameter on each tool
+    # is what FastMCP's ``find_context_parameter`` picks up via
+    # :func:`typing.get_type_hints` to strip ``ctx`` from the JSON schema
+    # and inject the live per-request Context. ``get_type_hints`` (and
+    # FastMCP's ``inspect.signature(fn, eval_str=True)``) resolve the
+    # string annotation ``"Context | None"`` against this *module's*
+    # globals, not the enclosing function's locals, so bind ``Context``
+    # here rather than importing it at module top — keeping
+    # ``mtui.mcp.tools`` importable without the ``[mcp]`` extra. Bind
+    # unconditionally (not ``setdefault``) so a stale stand-in left in
+    # globals by an earlier caller never shadows the real SDK type.
+    from mcp.server.fastmcp import Context as _Context
+    from mcp.types import ToolAnnotations
+
+    globals()["Context"] = _Context
+
+    async def job_list(ctx: Context | None = None) -> str:
+        """List background jobs in this session and their state."""
+        session = await resolve_session(provider, ctx)
+        jobs = session.job_list()
+        if not jobs:
+            return "no background jobs"
+        return "\n".join(
+            f"- {j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
+            for j in jobs
+        )
+
+    async def job_status(job_id: str, ctx: Context | None = None) -> str:
+        """Report one background job's state and elapsed time."""
+        session = await resolve_session(provider, ctx)
+        j = session.job_status(job_id)
+        return f"{j['id']}: {j['state']} ({j['elapsed_s']}s) [{j['command']}]"
+
+    async def job_result(job_id: str, ctx: Context | None = None) -> str:
+        """Return a finished job's output (error if not yet done)."""
+        session = await resolve_session(provider, ctx)
+        return session.job_result(job_id)
+
+    async def job_cancel(job_id: str, ctx: Context | None = None) -> str:
+        """Cancel a running background job."""
+        session = await resolve_session(provider, ctx)
+        return await session.job_cancel(job_id)
+
+    list_desc = (
+        "List background jobs in this session (started by calling a slow host "
+        "command — run/update/downgrade/prepare/install/uninstall/set_repo/"
+        "reboot — with background=true) and their state."
+    )
+    status_desc = (
+        "Report a background job's state (running/done/failed/cancelled) and "
+        "elapsed time. Poll this after starting a slow command with "
+        "background=true."
+    )
+    result_desc = (
+        "Return a finished background job's output. Errors if the job is still "
+        "running (poll job_status first) or surfaces the command's failure if "
+        "it failed."
+    )
+    cancel_desc = (
+        "Cancel a running background job. Note: a job already executing on a "
+        "host (SSH/subprocess) may keep running on the host even after cancel."
+    )
+
+    mcp.add_tool(
+        job_list,
+        name="job_list",
+        description=list_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(
+        job_status,
+        name="job_status",
+        description=status_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(
+        job_result,
+        name="job_result",
+        description=result_desc,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    mcp.add_tool(
+        job_cancel,
+        name="job_cancel",
+        description=cancel_desc,
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
+    return ["job_cancel", "job_list", "job_result", "job_status"]

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -1,0 +1,130 @@
+"""Tests for the background-job (async slow-op) path in :mod:`mtui.mcp.session`.
+
+A backgrounded command runs in an asyncio task that holds the session lock
+for its duration and records its outcome on the job table; ``job_status`` /
+``job_result`` read that table. These tests drive the lifecycle with the
+real ``whoami`` command (fast, no hosts) and ``asyncio.run`` wrappers,
+matching the style of ``test_mcp_session.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.commands.whoami import Whoami
+from mtui.mcp.session import McpCommandError, McpSession
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.template_dir = tmp_path
+    cfg.target_tempdir = tmp_path / "target"
+    cfg.chdir_to_template_dir = False
+    cfg.connection_timeout = 30
+    cfg.session_user = "testuser"
+    return cfg
+
+
+def _make_session(tmp_path: Path) -> McpSession:
+    return McpSession(_config(tmp_path), logging.getLogger("test.mcp.jobs"))
+
+
+def test_start_job_runs_and_result_returns_stdout(tmp_path: Path) -> None:
+    """A backgrounded command finishes 'done' and yields its stdout."""
+    sess = _make_session(tmp_path)
+
+    async def driver() -> tuple[str, dict, str]:
+        job_id = await sess.start_job(Whoami, [])
+        await sess._jobs[job_id]["task"]  # let the worker finish
+        return job_id, sess.job_status(job_id), sess.job_result(job_id)
+
+    job_id, status, result = asyncio.run(driver())
+    assert job_id.startswith("whoami-")
+    assert status["state"] == "done"
+    assert status["command"] == "whoami"
+    assert result.startswith("User: testuser, app pid: ")
+
+
+def test_job_result_failed_surfaces_error_envelope(tmp_path: Path) -> None:
+    """A job whose command fails records 'failed'; job_result raises."""
+    sess = _make_session(tmp_path)
+
+    async def driver() -> str:
+        job_id = await sess.start_job(Whoami, ["--nonexistent-flag"])
+        await sess._jobs[job_id]["task"]
+        return job_id
+
+    job_id = asyncio.run(driver())
+    assert sess.job_status(job_id)["state"] == "failed"
+    with pytest.raises(McpCommandError):
+        sess.job_result(job_id)
+
+
+def test_job_result_running_tells_caller_to_poll(tmp_path: Path) -> None:
+    """job_result on a still-running job raises, pointing at job_status."""
+    sess = _make_session(tmp_path)
+    gate = asyncio.Event()
+
+    async def driver() -> None:
+        # A job whose body blocks until we release the gate.
+        async def _blocker() -> None:
+            try:
+                async with sess._lock:
+                    await gate.wait()
+            except asyncio.CancelledError:
+                raise
+
+        job_id = "blocker-1"
+        sess._jobs[job_id] = {
+            "id": job_id,
+            "command": "blocker",
+            "argv": [],
+            "state": "running",
+            "started": 0.0,
+            "finished": None,
+            "result": None,
+            "error": None,
+            "exit_code": None,
+            "task": asyncio.create_task(_blocker()),
+        }
+        with pytest.raises(McpCommandError, match="still running"):
+            sess.job_result(job_id)
+        gate.set()
+        sess._jobs[job_id]["task"].cancel()
+
+    asyncio.run(driver())
+
+
+def test_job_status_unknown_id_raises(tmp_path: Path) -> None:
+    """Querying an unknown job id raises a clean error."""
+    sess = _make_session(tmp_path)
+    with pytest.raises(McpCommandError, match="no such job"):
+        sess.job_status("nope-1")
+
+
+def test_job_list_reports_started_jobs(tmp_path: Path) -> None:
+    """job_list enumerates every started job with its state."""
+    sess = _make_session(tmp_path)
+
+    async def driver() -> list[dict]:
+        a = await sess.start_job(Whoami, [])
+        b = await sess.start_job(Whoami, [])
+        await sess._jobs[a]["task"]
+        await sess._jobs[b]["task"]
+        return sess.job_list()
+
+    jobs = asyncio.run(driver())
+    assert len(jobs) == 2
+    assert all(j["state"] == "done" for j in jobs)
+
+
+def test_job_cancel_unknown_id_raises(tmp_path: Path) -> None:
+    """Cancelling an unknown job id raises a clean error."""
+    sess = _make_session(tmp_path)
+    with pytest.raises(McpCommandError, match="no such job"):
+        asyncio.run(sess.job_cancel("nope-1"))

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -35,9 +35,11 @@ from mtui.mcp._schema import build_parameters  # noqa: E402
 from mtui.mcp.deny import REPL_ONLY  # noqa: E402
 from mtui.mcp.session import McpSession  # noqa: E402
 from mtui.mcp.tools import (  # noqa: E402
+    SLOW_COMMANDS,
     SUBPARSER_COMMANDS,
     _is_read_only,
     build_tools,
+    register_job_tools,
 )
 
 if TYPE_CHECKING:
@@ -648,3 +650,110 @@ def test_loadtemplate_rejects_both_review_ids(
         asyncio.run(_call())
     assert ei.value.exit_code == 2
     assert "exactly one" in ei.value.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Background-job tool layer                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def job_tool_names(mcp: FastMCP, session: McpSession) -> list[str]:
+    """Tool names registered by :func:`register_job_tools` against ``mcp``."""
+    return register_job_tools(mcp, session)
+
+
+def test_register_job_tools_registers_four_tools(
+    job_tool_names: list[str],
+) -> None:
+    """The four background-job control tools must be registered."""
+    assert sorted(job_tool_names) == [
+        "job_cancel",
+        "job_list",
+        "job_result",
+        "job_status",
+    ]
+
+
+def test_job_read_tools_are_read_only(mcp: FastMCP, job_tool_names: list[str]) -> None:
+    """``job_list`` / ``job_status`` / ``job_result`` are side-effect-free."""
+    for name in ("job_list", "job_status", "job_result"):
+        assert _annotations_of(mcp, name).readOnlyHint is True
+    # cancel mutates job state -> no read-only hint.
+    assert _annotations_of(mcp, "job_cancel").readOnlyHint is False
+
+
+def test_job_tools_schema_has_no_workspace_param(
+    mcp: FastMCP, job_tool_names: list[str]
+) -> None:
+    """Jobs are session-scoped; no ``workspace`` selector leaks into the schema."""
+    for name in ("job_status", "job_result", "job_cancel"):
+        props = _params_of(mcp, name).get("properties", {})
+        assert "workspace" not in props
+        assert "job_id" in props
+
+
+def test_slow_command_schema_exposes_background_boolean(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """Every SLOW_COMMANDS tool gains an optional ``background`` boolean."""
+    for name in sorted(SLOW_COMMANDS):
+        params = _params_of(mcp, name)
+        props = params["properties"]
+        assert props["background"]["type"] == "boolean"
+        assert props["background"].get("default") is False
+        # Optional: must not be in the required list.
+        assert "background" not in params.get("required", [])
+
+
+def test_non_slow_command_schema_has_no_background(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """Read-only / instant tools keep a clean schema (no ``background``)."""
+    for name in ("whoami", "list_hosts", "add_host"):
+        props = _params_of(mcp, name).get("properties", {})
+        assert "background" not in props
+
+
+def test_make_wrapper_adds_background_param_only_for_slow_commands() -> None:
+    """The synthesised signature carries ``background`` iff the command is slow."""
+    import inspect
+
+    from mtui.mcp.tools import _make_wrapper
+
+    session_stub = MagicMock()
+
+    run_parser = Command.registry["run"].argparser(__import__("sys"))
+    run_wrapper = _make_wrapper(Command.registry["run"], run_parser, session_stub)
+    run_sig = inspect.signature(run_wrapper)
+    assert "background" in run_sig.parameters
+    bg = run_sig.parameters["background"]
+    assert bg.kind is inspect.Parameter.KEYWORD_ONLY
+    assert bg.default is False
+    assert bg.annotation is bool
+
+    who_parser = Command.registry["whoami"].argparser(__import__("sys"))
+    who_wrapper = _make_wrapper(Command.registry["whoami"], who_parser, session_stub)
+    assert "background" not in inspect.signature(who_wrapper).parameters
+
+
+def test_slow_command_background_true_starts_job(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """Calling a slow tool with ``background=True`` returns a job-id message.
+
+    The backgrounded ``run`` starts an asyncio task; the wrapper returns
+    immediately with a poll/fetch hint instead of the command's stdout.
+    Driven with no hosts so the underlying ``run`` finishes fast.
+    """
+    tool = mcp._tool_manager.get_tool("run")  # noqa: SLF001
+    assert tool is not None
+
+    async def _call() -> str:
+        return await tool.fn(command=["true"], hosts=[], background=True)
+
+    out = asyncio.run(_call())
+    assert "started background job" in out
+    assert "run-1" in out
+    assert "job_status" in out
+    assert "job_result" in out


### PR DESCRIPTION
## Summary

Slow `mtui-mcp` host commands (`run`, `update`, `downgrade`, `prepare`, `install`, `uninstall`, `set_repo`, `reboot`) gain a `background=true` flag. Instead of holding the request open for the minutes the operation takes, the call returns a **job id immediately** and runs the command in an asyncio task that still acquires the session lock for its duration — so it serialises against the session's other mutating calls exactly like a foreground call. The client polls the job and meanwhile keeps issuing other tool calls.

This is adapted from the background-jobs commit of #216, extracted as a standalone change. The `workspace` selector that the #216 job tools were written against is **stripped** here to match the current per-client session model on `main` (`resolve_session` is 2-arg; there is no workspace concept yet). Jobs are scoped to the per-call session: one process under stdio, the caller's isolated session under http.

## Tools

Four new control tools drive a backgrounded job:

- **`job_list`** — every job in the session and its state.
- **`job_status(job_id=…)`** — one job's state (`running`/`done`/`failed`/`cancelled`) and elapsed time.
- **`job_result(job_id=…)`** — a finished job's captured stdout. Errors while the job is still running (points the caller at `job_status`) and surfaces the command's failure envelope (stdout, error, exit code) if it failed — exactly as a foreground failure would have.
- **`job_cancel(job_id=…)`** — cancel a running job.

`job_list` / `job_status` / `job_result` carry `readOnlyHint=true`; `job_cancel` does not.

## Implementation notes

- **`mtui/mcp/session.py`** — per-session job table (`_jobs`, `_job_counter`) plus `start_job` (background runner that holds `_lock` and runs the body in `asyncio.to_thread`), `job_list`, `job_status`, `job_result`, `job_cancel`. The read methods are synchronous and lock-free so they work while the backgrounded task holds the lock; `job_cancel` awaits the cancelled task but does not take the lock, so it cannot deadlock against the running job.
- **`mtui/mcp/tools.py`** — `SLOW_COMMANDS` set; the `background: bool = False` parameter is injected into those tools' synthesised signatures only (read-only / instant tools keep a clean schema); the wrapper branches to `start_job` when `background` is set. `register_job_tools` registers the four tools. `Context` is bound into module globals **unconditionally** (not `setdefault`) so a stale stand-in left in globals by an earlier caller never shadows the real SDK type.
- **`mtui/mcp/main.py`** — registers the job tools alongside the existing tool sets.

## Caveat

Cancellation detaches the awaiter, but a job already executing on a host (an SSH command or subprocess) may keep running to completion on that host even after `job_cancel` returns — the same caveat as interrupting a foreground `run` with Ctrl-C. Documented in the tool description, the `job_cancel` docstring, and `Documentation/mcp.rst`. The in-memory job table is unbounded for the session's lifetime; under http the registry's idle-TTL sweep drops the whole session (and its jobs) when it goes quiet.

## Tests & gates

- New `tests/test_mcp_jobs.py` — lifecycle: done / failed / still-running / unknown-id / list / cancel.
- `tests/test_mcp_tools.py` — job-tool registration, read-only hints, `background` flag presence on slow commands / absence on others, and the `start_job` branch.
- Full local gates green: `ruff format --check`, `ruff check`, `ty check`, `pytest` (**1447 passed, 0 warnings**), and `sphinx-build -W` (docs).

Docs updated in `Documentation/mcp.rst` ("Background jobs" subsection) and `CHANGELOG.md` under `[Unreleased]`.