### PR TITLE
refactor: move workflow mode from global Config to per-TestReport Workflow enum

### DIFF
--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -25,6 +25,7 @@ from .. import commands
 from ..commands import Command, CommandAlreadyBoundError
 from ..support import messages
 from ..test_reports.null_report import NullTestReport
+from ..types import Workflow
 from . import notification
 from ._completer import MtuiCompleter
 from ._history import default_history_path, get_history
@@ -180,9 +181,9 @@ class CommandPrompt:
 
         Rendered fields:
 
-        * ``mode`` — ``kernel`` when :attr:`config.kernel` is set
-          (kernel-update workflow), ``auto`` when only :attr:`config.auto`
-          is set (automatic-update workflow), ``manual`` otherwise.
+        * ``mode`` — the active report's :attr:`workflow`
+          (:class:`~mtui.types.Workflow`): ``kernel``, ``auto``, or
+          ``manual``.
         * ``session`` — resolved in precedence order: an explicit name
           set via ``set_session_name`` (:attr:`self.session`) wins; else
           the loaded test report's :attr:`id` (its RRID); else the
@@ -205,12 +206,7 @@ class CommandPrompt:
             spaces so it reads naturally inside the reverse-video bar.
 
         """
-        if self.config.kernel:
-            mode = "kernel"
-        elif self.config.auto:
-            mode = "auto"
-        else:
-            mode = "manual"
+        mode = self.metadata.workflow.value
 
         sess = self.session if getattr(self, "session", None) else ""
         if not sess:
@@ -436,10 +432,8 @@ class CommandPrompt:
         self.session = session
         session = ":" + str(session) if session else ""
         mode = "mtui"
-        if self.config.auto and not self.config.kernel:
-            mode += "-auto"
-        elif self.config.kernel:
-            mode += "-kernel"
+        if self.metadata.workflow is not Workflow.MANUAL:
+            mode += f"-{self.metadata.workflow.value}"
         self.prompt = f"{mode}{session}> "
 
     if TYPE_CHECKING:

--- a/mtui/commands/addhost.py
+++ b/mtui/commands/addhost.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 from ..cli.completion import complete_choices
 from ..support.concurrency import ContextExecutor
+from ..types import Workflow
 from . import Command
 
 logger = getLogger("mtui.commands.addhost")
@@ -40,10 +41,9 @@ class AddHost(Command):
         # automatic mode the user almost certainly meant to test manually
         # (and just forgot to switch), so move to the manual workflow --
         # unless --keep-mode was given.
-        if self.config.auto and not self.args.keep_mode:
+        if self.metadata.workflow is Workflow.AUTO and not self.args.keep_mode:
             logger.info("add_host: switching from automatic to manual workflow")
-            self.config.auto = False
-            self.config.kernel = False
+            self.metadata.workflow = Workflow.MANUAL
             self.prompt.set_prompt(self.prompt.session)
 
         if not self.args.target:

--- a/mtui/commands/export.py
+++ b/mtui/commands/export.py
@@ -7,6 +7,7 @@ from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices_filelist
 from ..data_sources.qem_dashboard import DashboardAutoOpenQA
 from ..support.misc import requires_update
+from ..types import Workflow
 from ..types.filelist import FileList
 from ..update_workflow.export import AutoExport, KernelExport, ManualExport
 from ..update_workflow.export.base import BaseExport
@@ -46,12 +47,12 @@ class Export(Command):
         """Executes the `export` command."""
         targets: list[str] = list(self.parse_hosts().keys())
         filename = self.args.filename or Path(self.metadata.path)
-        exporters: dict[tuple[bool, bool], type[BaseExport]] = {
-            (True, False): AutoExport,
-            (False, True): KernelExport,
-            (False, False): ManualExport,
+        exporters: dict[Workflow, type[BaseExport]] = {
+            Workflow.AUTO: AutoExport,
+            Workflow.KERNEL: KernelExport,
+            Workflow.MANUAL: ManualExport,
         }
-        exporter = exporters[(self.config.auto, self.config.kernel)]
+        exporter = exporters[self.metadata.workflow]
         if issubclass(exporter, ManualExport) and not self.metadata.openqa.auto:
             self.metadata.openqa.auto = DashboardAutoOpenQA(
                 self.config,

--- a/mtui/commands/loadtemplate.py
+++ b/mtui/commands/loadtemplate.py
@@ -66,15 +66,11 @@ class LoadTemplate(Command):
             self.targets[target].close()
             del self.targets[target]
 
-        if self.args.update.kind == "kernel":
-            self.config.kernel = True
-            self.config.auto = False
-        elif self.args.update.kind == "auto":
-            self.config.kernel = False
-            self.config.auto = True
-        else:
+        if self.args.update.kind not in ("kernel", "auto"):
             raise TestReportNotLoadedError
 
+        # Workflow mode (auto/kernel) is seeded onto the TestReport by
+        # make_testreport when load_update runs below.
         self.prompt.load_update(self.args.update, autoconnect=True)
 
         # Reload hosts to which we already have a connection

--- a/mtui/commands/reloadoqa.py
+++ b/mtui/commands/reloadoqa.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from ..data_sources.openqa import KernelOpenQA
 from ..data_sources.qem_dashboard import DashboardAutoOpenQA
 from ..support.misc import requires_update
+from ..types import Workflow
 from . import Command
 
 logger = getLogger("mtui.commands.reloadopenqa")
@@ -18,7 +19,7 @@ class ReloadOpenQA(Command):
     @requires_update
     def __call__(self) -> None:
         """Executes the `reload_openqa` command."""
-        if self.config.kernel:
+        if self.metadata.workflow is Workflow.KERNEL:
             if self.metadata.openqa.kernel == []:
                 logger.info("Getting data from kernel openQA")
                 self.metadata.openqa.kernel.append(

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -9,6 +9,7 @@ from ..data_sources.qem_dashboard import DashboardAutoOpenQA
 from ..hosts.refhost import RefhostsFactory
 from ..support import messages
 from ..support.misc import requires_update
+from ..types import Workflow
 from . import Command
 
 logger = logging.getLogger("mtui.commands.simplesets")
@@ -190,15 +191,14 @@ class SetWorkflow(Command):
         state: str = self.args.workflow
 
         if state == "kernel":
-            if self.config.kernel:
+            if self.metadata.workflow is Workflow.KERNEL:
                 logger.info("Desired workflow %s is same as current", state)
                 self.metadata.openqa.auto.run()
                 for oq in self.metadata.openqa.kernel:
                     oq.run()
                 return
             logger.info("Setting workflow to '%s'", state)
-            self.config.auto = False
-            self.config.kernel = True
+            self.metadata.workflow = Workflow.KERNEL
             self.metadata.openqa.auto = DashboardAutoOpenQA(
                 self.config,
                 self.config.openqa_instance,
@@ -224,13 +224,12 @@ class SetWorkflow(Command):
             )
             return
         if state == "auto":
-            if self.config.auto:
+            if self.metadata.workflow is Workflow.AUTO:
                 logger.info("Desired workflow %s is same as current", state)
                 self.metadata.openqa.auto.run()
                 return
             logger.info("Setting workflow to '%s'", state)
-            self.config.auto = True
-            self.config.kernel = False
+            self.metadata.workflow = Workflow.AUTO
             self.metadata.openqa.auto = DashboardAutoOpenQA(
                 self.config,
                 self.config.openqa_instance,
@@ -241,15 +240,14 @@ class SetWorkflow(Command):
             if self.metadata.openqa.auto.results is None:
                 logger.warning("No install jobs or install jobs failed")
                 logger.info("Switch mode to manual")
-                self.config.auto = False
+                self.metadata.workflow = Workflow.MANUAL
             return
-        if not self.config.auto and not self.config.kernel:
+        if self.metadata.workflow is Workflow.MANUAL:
             logger.info("Desired workflow %s is same as current", state)
             self.metadata.openqa.auto.run()
             return
         logger.info("Setting workflow to '%s'", state)
-        self.config.auto = False
-        self.config.kernel = False
+        self.metadata.workflow = Workflow.MANUAL
         self.metadata.openqa.auto.run()
         self.metadata.openqa.kernel = []
         return

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -14,7 +14,7 @@ from ...support.messages import (
     MissingPreparerError,
     MissingUpdaterError,
 )
-from ...types import Package
+from ...types import Package, Workflow
 from ...types.rpmver import RPMVersion
 from ...update_workflow.hooks import CompareScript, PostScript, PreScript
 from . import Target
@@ -560,7 +560,7 @@ class HostsGroup(UserDict[str, Target]):
 
         package_check()
 
-        if "noscript" not in params and not testreport.config.auto:
+        if "noscript" not in params and testreport.workflow is not Workflow.AUTO:
             testreport.run_scripts(PreScript, self)
 
         self.update_lock()
@@ -633,7 +633,7 @@ class HostsGroup(UserDict[str, Target]):
 
             package_check(True)
 
-            if "noscript" not in params and not testreport.config.auto:
+            if "noscript" not in params and testreport.workflow is not Workflow.AUTO:
                 testreport.run_scripts(PostScript, self)
                 testreport.run_scripts(CompareScript, self)
         except BaseException:

--- a/mtui/main.py
+++ b/mtui/main.py
@@ -61,8 +61,6 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
         logger.setLevel(level=logging.DEBUG)
 
     config.merge_args(args)
-    config.kernel = False
-    config.auto = False
 
     config.distro, config.distro_ver, config.distro_kernel = detect_system()
 
@@ -72,14 +70,8 @@ def run_mtui(config: Config, logger: logging.Logger, args: Namespace) -> Literal
     prompter = Prompter()
     prompt = CommandPrompt(config, logger, sys, CommandPromptDisplay, prompter=prompter)
     if args.update:
-        if args.update.kind == "kernel":
-            config.kernel = True
-            config.auto = False
-        elif args.update.kind == "auto":
-            config.auto = True
-            config.kernel = False
-        else:
-            pass
+        # Workflow mode (auto/kernel) is now seeded onto the TestReport by
+        # make_testreport when load_update runs; no global config flags here.
         try:
             prompt.load_update(args.update, autoconnect=not bool(args.sut))
         except (

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -76,19 +76,17 @@ def build_session(cfg: Config, log: Logger) -> McpSession:
     """Construct a fresh :class:`McpSession` from ``cfg`` and ``log``.
 
     Each session gets its **own** shallow copy of ``cfg`` so the
-    per-client isolation extends to the mutable workflow flags that
-    commands flip in place — ``config.auto`` / ``config.kernel`` (set
-    by ``load_template`` / ``add_host`` / ``set_mode``) and
-    ``config.location`` (``set_location``). A shallow copy is the right
-    tool: those attributes are scalars, so each session rebinds its own
-    while the heavy read-only members (the parsed ``ConfigParser``, the
-    refhosts factory) stay shared. Without the copy, every http client
-    would share one ``Config`` and clobber each other's workflow mode.
+    per-client isolation extends to the mutable scalars that commands
+    flip in place — notably ``config.location`` (``set_location``). A
+    shallow copy is the right tool: those attributes are scalars, so
+    each session rebinds its own while the heavy read-only members (the
+    parsed ``ConfigParser``, the refhosts factory) stay shared. Without
+    the copy, every http client would share one ``Config`` and clobber
+    each other's mutable state.
 
-    The workflow flags are seeded to ``False`` here, matching the REPL's
-    boot defaults in :func:`mtui.main.main`: ``add_host`` (and other
-    commands) read ``config.auto`` *before* any ``load_template`` runs,
-    so an unset attribute would raise ``AttributeError``.
+    Workflow mode (``auto`` / ``kernel``) now lives on the loaded
+    :class:`TestReport`, not on ``config``, so no per-session seeding of
+    those flags is needed here.
 
     Args:
         cfg: The base application configuration (already merged with
@@ -103,10 +101,6 @@ def build_session(cfg: Config, log: Logger) -> McpSession:
 
     """
     session_cfg = copy.copy(cfg)
-    # Match the REPL boot defaults (mtui.main.main); commands read these
-    # before any template is loaded.
-    session_cfg.kernel = False
-    session_cfg.auto = False
     return McpSession(session_cfg, log)
 
 

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -112,8 +112,6 @@ class Config:
     mcp_session_idle_timeout: int
 
     # -- Attributes set externally in main.py --
-    kernel: bool
-    auto: bool
     distro: str
     distro_ver: str
     distro_kernel: str

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -28,7 +28,7 @@ from ..support.exceptions import InvalidGiteaHashError, UpdateError
 from ..support.fileops import ensure_dir_exists
 from ..support.messages import MetadataNotLoadedError
 from ..support.paths import scripts_path
-from ..types import OpenQAResults, Product, TargetMeta
+from ..types import OpenQAResults, Product, TargetMeta, Workflow
 from .metadata_parsers import patchinfo_titles
 from .svn_io import (
     TemplateFormatError,
@@ -88,6 +88,9 @@ class TestReport(ABC):
         """
         self.config: Config = config
         self._prompter = prompter
+
+        # Per-report workflow mode (previously global config.auto / config.kernel).
+        self.workflow: Workflow = Workflow.MANUAL
 
         self._scripts_src_dir: Path = scripts_src_dir or scripts_path()
 

--- a/mtui/types/__init__.py
+++ b/mtui/types/__init__.py
@@ -5,7 +5,14 @@ throughout the application.
 """
 
 from .commandlog import CommandLog
-from .enums import ExecutionMode, RequestKind, TargetState, assignment, method
+from .enums import (
+    ExecutionMode,
+    RequestKind,
+    TargetState,
+    Workflow,
+    assignment,
+    method,
+)
 from .filelist import FileList
 from .hostlog import HostLog
 from .oqaresults import OpenQAOverviewResult, OpenQAResult, OpenQAResults
@@ -36,6 +43,7 @@ __all__ = [
     "TargetState",
     "Test",
     "URLs",
+    "Workflow",
     "assignment",
     "method",
 ]

--- a/mtui/types/enums.py
+++ b/mtui/types/enums.py
@@ -52,6 +52,24 @@ class ExecutionMode(Enum):
     SERIAL = "serial"
 
 
+class Workflow(StrEnum):
+    """Per-report update workflow mode.
+
+    Replaces the previous pair of mutually-dependent booleans
+    (``report.auto`` / ``report.kernel``), making the three modes
+    mutually exclusive by construction -- there is no longer an
+    invalid ``auto and kernel`` state to represent.
+
+    :class:`StrEnum` so the values match ``set_workflow``'s CLI choices
+    (``auto`` / ``manual`` / ``kernel``) and any string comparison or
+    serialization stays byte-identical.
+    """
+
+    AUTO = "auto"
+    MANUAL = "manual"
+    KERNEL = "kernel"
+
+
 class RequestKind(Enum):
     """Kind component of an OBS Request Review ID.
 

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -33,7 +33,7 @@ from ..test_reports.sl_report import SLTestReport
 from ..test_reports.svn_io import TemplateIOError, testreport_svn_checkout
 from ..test_reports.testreport import TestReport
 from . import RequestReviewID
-from .enums import RequestKind
+from .enums import RequestKind, Workflow
 
 logger = getLogger("mtui.types.updateid")
 
@@ -221,6 +221,8 @@ class AutoOBSUpdateID(UpdateID):
         except TestReportNotLoadedError:
             return NullTestReport(config, prompter=prompter)
 
+        tr.workflow = Workflow.AUTO
+
         self._create_installogs_dir(config)
         tr.incident = QEMIncident(
             self.id,
@@ -239,7 +241,7 @@ class AutoOBSUpdateID(UpdateID):
         if tr.openqa.auto.results is None:
             logger.warning("No install jobs or install jobs failed")
             logger.info("Switch mode to manual")
-            tr.config.auto = False
+            tr.workflow = Workflow.MANUAL
 
             if autoconnect:
                 logger.info("Connect refhosts from testreport")
@@ -308,6 +310,8 @@ class KernelOBSUpdateID(UpdateID):
             tr = self._checkout(config, interactive, prompter=prompter)
         except TestReportNotLoadedError:
             return NullTestReport(config, prompter=prompter)
+
+        tr.workflow = Workflow.KERNEL
 
         self._create_installogs_dir(config)
         self.create_results_dir(config)

--- a/tests/test_cmd_addhost.py
+++ b/tests/test_cmd_addhost.py
@@ -8,11 +8,13 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.addhost import AddHost
+from mtui.types import Workflow
 
 
 def _prompt() -> MagicMock:
     p = MagicMock()
     p.metadata = MagicMock()
+    p.metadata.workflow = Workflow.MANUAL
     p.metadata.testplatforms = ["base=sles(major=15);arch=[x86_64]"]
     p.display = MagicMock()
     p.targets = MagicMock()
@@ -72,15 +74,13 @@ def test_add_host_without_targets_uses_testplatforms(mock_config):
 
 def test_add_host_in_automatic_mode_switches_to_manual(mock_config):
     """Running add_host while in automatic mode switches to the manual workflow."""
-    mock_config.auto = True
-    mock_config.kernel = False
     prompt = _prompt()
+    prompt.metadata.workflow = Workflow.AUTO
     args = Namespace(target=None, keep_mode=False)
 
     AddHost(args, mock_config, MagicMock(), prompt)()
 
-    assert mock_config.auto is False
-    assert mock_config.kernel is False
+    assert prompt.metadata.workflow is Workflow.MANUAL
     # Prompt indicator refreshed (drops the "-auto" marker).
     prompt.set_prompt.assert_called_once_with(prompt.session)
     # The hosts are still added.
@@ -89,14 +89,13 @@ def test_add_host_in_automatic_mode_switches_to_manual(mock_config):
 
 def test_add_host_keep_mode_stays_automatic(mock_config):
     """--keep-mode leaves automatic mode untouched even though a host is added."""
-    mock_config.auto = True
-    mock_config.kernel = False
     prompt = _prompt()
+    prompt.metadata.workflow = Workflow.AUTO
     args = Namespace(target=None, keep_mode=True)
 
     AddHost(args, mock_config, MagicMock(), prompt)()
 
-    assert mock_config.auto is True  # still automatic
+    assert prompt.metadata.workflow is Workflow.AUTO  # still automatic
     prompt.set_prompt.assert_not_called()
     # The hosts are still added.
     prompt.metadata.connect_targets.assert_called_once_with()
@@ -135,8 +134,8 @@ def test_add_host_does_not_echo_product_warnings_to_stdout(mock_config):
 
 def test_add_host_in_manual_mode_does_not_switch(mock_config):
     """In manual mode add_host leaves the workflow untouched."""
-    mock_config.auto = False
     prompt = _prompt()
+    prompt.metadata.workflow = Workflow.MANUAL
     args = Namespace(target=None, keep_mode=False)
 
     AddHost(args, mock_config, MagicMock(), prompt)()

--- a/tests/test_cmd_export.py
+++ b/tests/test_cmd_export.py
@@ -11,12 +11,14 @@ import pytest
 
 from mtui.commands.export import Export
 from mtui.support.messages import TestReportNotLoadedError
+from mtui.types import Workflow
 
 
 def _prompt() -> MagicMock:
     p = MagicMock()
     p.metadata = MagicMock()
     p.metadata.__bool__ = lambda self: True
+    p.metadata.workflow = Workflow.MANUAL
     p.metadata.path = "/tmp/log"
     p.metadata.openqa = MagicMock()
     p.metadata.openqa.auto = MagicMock()  # truthy -> skips DashboardAutoOpenQA branch
@@ -38,8 +40,6 @@ def _filelist_ctx() -> MagicMock:
 
 def test_export_manual_branch_instantiates_manual_exporter(mock_config):
     prompt = _prompt()
-    mock_config.auto = False
-    mock_config.kernel = False
     args = Namespace(filename=None, hosts=None, force=False)
 
     # ManualExport must be a real class so the `issubclass()` check inside
@@ -65,8 +65,6 @@ def test_export_manual_branch_instantiates_manual_exporter(mock_config):
 def test_export_logs_exception_on_filelist_failure(mock_config, caplog):
     """Inner-block exceptions are caught and `logger.exception` logs them."""
     prompt = _prompt()
-    mock_config.auto = False
-    mock_config.kernel = False
     args = Namespace(filename=Path("/nonexistent"), hosts=None, force=False)
     caplog.set_level(logging.ERROR, logger="mtui.commands.export")
 

--- a/tests/test_cmd_loadtemplate.py
+++ b/tests/test_cmd_loadtemplate.py
@@ -20,8 +20,12 @@ def _prompt(metadata_truthy: bool = False) -> MagicMock:
     return p
 
 
-def test_load_template_auto_kind_sets_config_and_loads(mock_config):
-    """No prior metadata, kind=auto -> config.auto=True and prompt.load_update."""
+def test_load_template_auto_kind_loads(mock_config):
+    """No prior metadata, kind=auto -> prompt.load_update is called.
+
+    Workflow mode (auto/kernel) is now seeded onto the TestReport by
+    ``make_testreport`` during ``load_update``, not by this command.
+    """
     prompt = _prompt(metadata_truthy=False)
     update = MagicMock()
     update.kind = "auto"
@@ -29,8 +33,6 @@ def test_load_template_auto_kind_sets_config_and_loads(mock_config):
 
     LoadTemplate(args, mock_config, MagicMock(), prompt)()
 
-    assert mock_config.auto is True
-    assert mock_config.kernel is False
     prompt.load_update.assert_called_once_with(update, autoconnect=True)
 
 

--- a/tests/test_export_openqa.py
+++ b/tests/test_export_openqa.py
@@ -14,6 +14,7 @@ from mtui.types import (
     OpenQAResults,
     RequestReviewID,
     URLs,
+    Workflow,
 )
 from mtui.update_workflow.export.auto import AutoExport
 from mtui.update_workflow.export.base import BaseExport
@@ -100,13 +101,12 @@ def test_manual_export_loads_dashboard_results_before_export(mock_config, tmp_pa
     prompt.metadata.incident = MagicMock()
     prompt.metadata.openqa = OpenQAResults()
     prompt.metadata.path = filename
+    prompt.metadata.workflow = Workflow.MANUAL
     prompt.metadata.report_results.return_value = []
     prompt.display = MagicMock()
     prompt.targets.select.return_value.values.return_value = []
 
     args = Namespace(filename=Path(filename), force=False, hosts=None)
-    mock_config.auto = False
-    mock_config.kernel = False
 
     with patch("mtui.commands.export.DashboardAutoOpenQA") as dashboard:
         dashboard.return_value.run.return_value = MagicMock()

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -10,6 +10,7 @@ from mtui.hosts.target.hostgroup import HostsGroup
 from mtui.hosts.target.locks import TargetLockedError
 from mtui.support.exceptions import UpdateError
 from mtui.support.messages import HostIsNotConnectedError
+from mtui.types import Workflow
 
 
 def _stub_target(
@@ -736,7 +737,7 @@ def test_perform_update_runs_full_flow_with_noprepare_and_noscript(mock_run):
     t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     t1.check.return_value = MagicMock()
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -766,7 +767,7 @@ def test_perform_update_runs_pre_post_and_compare_scripts(mock_run):
     t1.check.return_value = MagicMock()
     t1.lasterr.return_value = ""
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -785,7 +786,7 @@ def test_perform_update_unlocks_when_run_fails(mock_run):
     t1.packages = {}
     t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -814,7 +815,7 @@ def test_perform_update_reports_all_host_failures(
             side_effect=UpdateError("Dependency Error", host)
         )
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -855,7 +856,7 @@ def test_perform_update_single_failure_reraises_original(
     t1.check.return_value = MagicMock(side_effect=orig)
     t2.check.return_value = MagicMock()  # h2 passes
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -878,7 +879,7 @@ def test_perform_update_removes_repos_at_end(mock_run, mock_fanout):
     t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     t1.check.return_value = MagicMock()
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"
@@ -900,7 +901,7 @@ def test_perform_update_keeps_repos_when_run_fails(mock_run, mock_fanout):
     t1.packages = {}
     t1.doer.return_value = _doer_dict(command="zypper up", reboot="")
     testreport = MagicMock()
-    testreport.config.auto = False
+    testreport.workflow = Workflow.MANUAL
     testreport.get_package_list.return_value = ["pkg"]
     testreport.rrid.maintenance_id = "1"
     testreport.rrid.review_id = "2"

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -38,6 +38,7 @@ from mtui.mcp.registry import (
     _session_key,
 )
 from mtui.mcp.session import McpSession
+from mtui.types import Workflow
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -80,6 +81,7 @@ class _RealishConfig:
         self.chdir_to_template_dir = False
         self.connection_timeout = 30
         self.session_user = "testuser"
+        self.location = "nuremberg"
 
 
 def _registry(
@@ -438,46 +440,46 @@ def test_aclose_cancels_sweeper_and_closes_all(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# build_session: workflow-flag seeding + per-session config isolation         #
+# build_session: default workflow mode + per-session config isolation         #
 # --------------------------------------------------------------------------- #
 
 
-def test_build_session_seeds_workflow_flags_false(tmp_path: Path) -> None:
-    """A fresh session must expose ``config.auto`` / ``config.kernel`` as False.
+def test_build_session_defaults_to_manual_mode(tmp_path: Path) -> None:
+    """A fresh session's (null) report defaults to manual workflow.
 
-    Regression guard: ``add_host`` (and other commands) read
-    ``config.auto`` *before* any ``load_template`` runs. Phase A removed
-    the boot-time defaults, which made ``add_host`` on a fresh MCP
-    session raise ``AttributeError: 'Config' object has no attribute
-    'auto'``. ``build_session`` now seeds both flags.
+    Workflow mode now lives on the loaded :class:`TestReport` as a
+    :class:`~mtui.types.Workflow` enum, not on ``config``. A fresh
+    session holds a ``NullTestReport`` whose ``workflow`` defaults to
+    ``Workflow.MANUAL``, and ``build_session`` no longer seeds any mode
+    flags onto ``config``.
     """
     session = build_session(_RealishConfig(tmp_path), _LOG)  # ty: ignore[invalid-argument-type]
-    assert session.config.auto is False
-    assert session.config.kernel is False
+    assert session.metadata.workflow is Workflow.MANUAL
+    # The mode is no longer carried by config.
+    assert not hasattr(session.config, "auto")
+    assert not hasattr(session.config, "kernel")
+    assert not hasattr(session.config, "workflow")
 
 
 def test_build_session_copies_config_per_session(tmp_path: Path) -> None:
-    """Each session gets its own config copy; workflow flips don't leak.
+    """Each session gets its own config copy; mutable scalars don't leak.
 
     Under http every session is minted from one base ``cfg``; a shallow
-    copy per session keeps the mutable workflow flags
-    (``auto``/``kernel``/``location``) independent so one client's
-    ``load_template`` cannot flip another client's workflow mode.
+    copy per session keeps mutable scalars (such as ``location``)
+    independent so one client's ``set_location`` cannot change another
+    client's location.
     """
     base = _RealishConfig(tmp_path)
     a = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
     b = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
 
     assert a.config is not b.config
-    # Simulate client A loading a kernel template.
-    a.config.auto = True
-    a.config.kernel = True
+    # Simulate client A changing its location.
+    a.config.location = "prague"
     # Client B must be unaffected.
-    assert b.config.auto is False
-    assert b.config.kernel is False
+    assert b.config.location == "nuremberg"
     # And the shared base config must never have been mutated.
-    assert not hasattr(base, "auto")
-    assert not hasattr(base, "kernel")
+    assert base.location == "nuremberg"
 
 
 def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
@@ -494,5 +496,5 @@ def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
 
     a, b = asyncio.run(driver())
     assert a.config is not b.config
-    a.config.kernel = True
-    assert b.config.kernel is False
+    a.config.location = "prague"
+    assert b.config.location == "nuremberg"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -19,6 +19,7 @@ from mtui.cli import repl
 from mtui.cli.argparse import ArgsParseFailureError
 from mtui.support import messages
 from mtui.test_reports.null_report import NullTestReport
+from mtui.types import Workflow
 
 
 def _bind_do(p: repl.CommandPrompt, name: str, handler: Any) -> None:
@@ -34,8 +35,7 @@ def _bind_do(p: repl.CommandPrompt, name: str, handler: Any) -> None:
 
 def _make_prompt(
     *,
-    auto: bool = False,
-    kernel: bool = False,
+    workflow: Workflow = Workflow.MANUAL,
     pipe_input=None,
 ) -> repl.CommandPrompt:
     """Build a ``CommandPrompt`` with stock magic-mocked collaborators.
@@ -45,12 +45,10 @@ def _make_prompt(
     session machinery without touching the controlling TTY.
     """
     config = MagicMock()
-    config.auto = auto
-    config.kernel = kernel
     log = MagicMock()
     sys = MagicMock()
     display_factory = MagicMock()
-    return repl.CommandPrompt(
+    p = repl.CommandPrompt(
         config,
         log,
         sys,
@@ -58,6 +56,9 @@ def _make_prompt(
         _input=pipe_input,
         _output=DummyOutput() if pipe_input is not None else None,
     )
+    # Workflow mode now lives on the active TestReport, not on config.
+    p.metadata.workflow = workflow
+    return p
 
 
 # --------------------------------------------------------------------------- #
@@ -425,6 +426,7 @@ def test_postcmd_updates_prompt_when_metadata_loaded():
     """With a real test report, ``postcmd`` refreshes the prompt with the session."""
     p = _make_prompt()
     p.metadata = MagicMock()  # not a NullTestReport
+    p.metadata.workflow = Workflow.MANUAL
     p.session = "sess1"
     p.postcmd(False, "noop")
     assert p.prompt == "mtui:sess1> "
@@ -444,15 +446,15 @@ def test_set_prompt_normal_mode():
 
 
 def test_set_prompt_auto_mode():
-    """``config.auto`` (and not kernel) renders the ``mtui-auto`` prefix."""
-    p = _make_prompt(auto=True, kernel=False)
+    """``Workflow.AUTO`` renders the ``mtui-auto`` prefix."""
+    p = _make_prompt(workflow=Workflow.AUTO)
     p.set_prompt("s1")
     assert p.prompt == "mtui-auto:s1> "
 
 
 def test_set_prompt_kernel_mode():
-    """``config.kernel`` overrides auto-mode and renders ``mtui-kernel``."""
-    p = _make_prompt(auto=True, kernel=True)
+    """``Workflow.KERNEL`` renders the ``mtui-kernel`` prefix."""
+    p = _make_prompt(workflow=Workflow.KERNEL)
     p.set_prompt(None)
     assert p.prompt == "mtui-kernel> "
 
@@ -470,15 +472,15 @@ def test_bottom_toolbar_manual_mode_empty_session_zero_hosts():
     assert p._bottom_toolbar() == " mode: manual  session: empty  hosts: 0 "
 
 
-def test_bottom_toolbar_kernel_mode_takes_precedence_over_auto():
-    """``config.kernel`` wins the mode coin-flip even when auto is also set."""
-    p = _make_prompt(auto=True, kernel=True)
+def test_bottom_toolbar_kernel_mode():
+    """``Workflow.KERNEL`` renders the ``kernel`` mode label."""
+    p = _make_prompt(workflow=Workflow.KERNEL)
     assert " mode: kernel " in p._bottom_toolbar()
 
 
 def test_bottom_toolbar_auto_mode():
-    """``config.auto`` (without kernel) renders the ``auto`` label."""
-    p = _make_prompt(auto=True, kernel=False)
+    """``Workflow.AUTO`` renders the ``auto`` mode label."""
+    p = _make_prompt(workflow=Workflow.AUTO)
     assert " mode: auto " in p._bottom_toolbar()
 
 

--- a/tests/test_reloadoqa.py
+++ b/tests/test_reloadoqa.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.reloadoqa import ReloadOpenQA
-from mtui.types import OpenQAResults, RequestReviewID
+from mtui.types import OpenQAResults, RequestReviewID, Workflow
 
 
 def _build_prompt() -> MagicMock:
@@ -21,6 +21,7 @@ def _build_prompt() -> MagicMock:
     prompt.metadata.id = "SUSE:Maintenance:12358:199773"
     prompt.metadata.rrid = RequestReviewID("SUSE:Maintenance:12358:199773")
     prompt.metadata.incident = MagicMock()
+    prompt.metadata.workflow = Workflow.MANUAL
     prompt.metadata.openqa = OpenQAResults()
     prompt.display = MagicMock()
     prompt.targets = MagicMock()
@@ -35,7 +36,7 @@ def test_reload_openqa_kernel_first_call_appends_both_to_kernel_list(mock_config
     `KernelOBSUpdateID.make_testreport` does).
     """
     prompt = _build_prompt()
-    mock_config.kernel = True
+    prompt.metadata.workflow = Workflow.KERNEL
     mock_config.openqa_instance = "https://openqa.example.com"
     mock_config.openqa_instance_baremetal = "https://baremetal.example.com"
     args = Namespace()
@@ -74,7 +75,7 @@ def test_reload_openqa_kernel_refresh_calls_run_on_existing(mock_config):
     existing_b = MagicMock(name="existing_b")
     prompt.metadata.openqa.kernel = [existing_a, existing_b]
     prompt.metadata.openqa.auto = MagicMock(name="existing_auto")
-    mock_config.kernel = True
+    prompt.metadata.workflow = Workflow.KERNEL
     args = Namespace()
 
     with (
@@ -94,7 +95,7 @@ def test_reload_openqa_kernel_refresh_calls_run_on_existing(mock_config):
 def test_reload_openqa_auto_only_when_kernel_disabled(mock_config):
     """With kernel disabled, only the auto branch runs."""
     prompt = _build_prompt()
-    mock_config.kernel = False
+    prompt.metadata.workflow = Workflow.MANUAL
     args = Namespace()
 
     with (

--- a/tests/test_simpleset.py
+++ b/tests/test_simpleset.py
@@ -2,7 +2,7 @@ from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
 from mtui.commands.simpleset import SetLocation, SetWorkflow
-from mtui.types import OpenQAResults, RequestReviewID
+from mtui.types import OpenQAResults, RequestReviewID, Workflow
 
 
 class _FakeConfig:
@@ -48,12 +48,11 @@ def test_set_workflow_auto_uses_rrid(mock_config):
     prompt.metadata.rrid = RequestReviewID("SUSE:Maintenance:12358:199773")
     prompt.metadata.incident = MagicMock()
     prompt.metadata.openqa = OpenQAResults()
+    prompt.metadata.workflow = Workflow.MANUAL
     prompt.display = MagicMock()
     prompt.targets = MagicMock()
 
     args = Namespace(workflow="auto")
-    mock_config.auto = False
-    mock_config.kernel = False
 
     with patch("mtui.commands.simpleset.DashboardAutoOpenQA") as dashboard:
         dashboard.return_value.run.return_value.results = []

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -32,6 +32,19 @@ def _make(tmp_path: Path) -> OBSTestReport:
 
 
 # ---------------------------------------------------------------------------
+# Workflow mode is per-report (previously global config.auto / config.kernel)
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_mode_defaults_to_manual(tmp_path: Path) -> None:
+    """A freshly built report's workflow defaults to manual."""
+    from mtui.types import Workflow
+
+    r = _make(tmp_path)
+    assert r.workflow is Workflow.MANUAL
+
+
+# ---------------------------------------------------------------------------
 # Package list aggregation + dedup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Workflow mode (auto / kernel / manual) was global state on `Config`, set in `main.py` and mutated in place across commands. This made it a per-template concern masquerading as global config — and the second hidden lock blocking multi-template support.

Move it onto each `TestReport` as a single `Workflow` StrEnum (`AUTO` / `MANUAL` / `KERNEL`), replacing the prior pair of mutually-dependent booleans so the invalid "auto and kernel" state is unrepresentable. `make_testreport` seeds the mode at load time; every read/write site now goes through `report.workflow`.

## Changes

- **New `Workflow` StrEnum** — `mtui/types/enums.py`: mutually exclusive `AUTO`, `MANUAL`, `KERNEL` values matching CLI choices
- **`TestReport.workflow`** — per-report mode attribute, defaults to `MANUAL`
- **`Config` cleanup** — removed `auto` and `kernel` attributes; removed boot-time seeding in `main.py` and MCP `build_session`
- **Command updates** — `addhost`, `export`, `loadtemplate`, `reloadoqa`, `simpleset`, `hostgroup` now read/write `metadata.workflow`
- **MCP session** — `build_session` docstring updated; workflow no longer carried by config
- **Prompt rendering** — bottom toolbar and prompt prefix read from `metadata.workflow`
- **Tests** — all test fixtures updated to set `metadata.workflow`; new `test_workflow_mode_defaults_to_manual` test

## Breaking Changes

- **`Config.auto` and `Config.kernel` removed** — external code or custom commands reading these attributes will raise `AttributeError`. Migration: read `TestReport.workflow` instead.
- **`build_session` no longer seeds `config.auto`/`config.kernel`** — MCP sessions that expect these on config must migrate to `session.metadata.workflow`.

## Testing

- All existing tests pass with updated fixtures using `Workflow` enum
- New test: `test_workflow_mode_defaults_to_manual` verifies default state
- Test coverage updated across 14 test files (addhost, export, loadtemplate, hostgroup, MCP registry, prompt, reloadoqa, simpleset, testreport)

## Related

Step toward multi-template support — workflow mode is now scoped per loaded test report rather than global.
