### PR TITLE
fix(refhost): match base=<extension> testplatforms against host addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable user-visible changes to MTUI are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]:
+
+### Fixed
+
+- A testplatform `base=<extension>` (e.g. `base=SLES-LTSS`, `base=sle-ha`,
+  `base=SLES_SAP`, `base=SLE_RT`) now resolves to refhosts that carry that
+  product as an **addon** on a SLES/SLED base, not only to hosts whose base
+  product is literally that name. In the refhosts-ng schema a single host has
+  one base (`SLES`) with LTSS/HA/SAP recorded as addons, so the previous
+  base-only match found nothing — `add_host` reported "No refhosts to add" for
+  every LTSS/HA/SAP incident even though matching hosts existed.
+
 ## 18.2.0 - 2026-06-23
 
 ### Added

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -91,14 +91,37 @@ class Refhosts:
         if attribute.arch and attribute.arch != candidate.arch:
             return False
 
-        if attribute.product is not None and not self._product_matches(
-            candidate.product, attribute.product
+        if attribute.product is not None and not self._product_satisfied(
+            candidate, attribute.product
         ):
             return False
 
         return not (
             attribute.addons
             and not self._addons_match(candidate.addons, attribute.addons)
+        )
+
+    @staticmethod
+    def _product_satisfied(candidate: Host, query: Product) -> bool:
+        """Return True iff ``candidate`` provides the queried base product.
+
+        A testplatform ``base=<name>`` is satisfied when the host's base
+        product matches, **or** when the host carries that product as an
+        addon. Extension products (``SLES-LTSS``, ``sle-ha``, ``SLES_SAP``,
+        ``SLE_RT``, …) ship on a ``SLES``/``SLED`` base and are recorded as
+        addons in the refhosts-ng schema — one physical host can only have a
+        single base, so e.g. ``base=SLES-LTSS`` must still resolve to a
+        ``SLES`` host that has the ``SLES-LTSS`` extension installed.
+        """
+        if Refhosts._product_matches(candidate.product, query):
+            return True
+        return any(
+            addon.name == query.name
+            and (
+                query.version is None
+                or Refhosts._version_matches(addon.version, query.version)
+            )
+            for addon in candidate.addons
         )
 
     @staticmethod

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -630,3 +630,65 @@ class TestRefhostsFactory:
         cfg = _make_config(refhosts_resolvers="invalid_a,invalid_b")
         with pytest.raises(refhost.RefhostsResolveFailedError):
             factory(cfg)
+
+
+# ---------------------------------------------------------------------------
+# base=<extension> matching (SLES-LTSS / sle-ha / SLES_SAP carried as addons)
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionBaseMatching:
+    """A ``base=<extension>`` testplatform resolves to hosts carrying the
+    extension as an addon.
+
+    Extension products (SLES-LTSS, sle-ha, SLES_SAP, SLE_RT, …) ship on a
+    SLES/SLED base and are recorded as addons in the refhosts-ng schema, so a
+    single host can only have one base. ``base=SLES-LTSS`` must therefore match
+    a SLES host that has the SLES-LTSS extension installed — previously only the
+    base product was checked, yielding "No refhosts to add" for every
+    LTSS/HA/SAP incident.
+    """
+
+    @staticmethod
+    def _attr(testplatform):
+        return refhost.Attributes.from_testplatform(testplatform)[0]
+
+    @staticmethod
+    def _host(*, base_minor="SP6", ltss_minor="SP6", with_ltss=True):
+        addons = ()
+        if with_ltss:
+            addons = (
+                refhost.Addon(
+                    name="SLES-LTSS",
+                    version=refhost.Version(major=15, minor=ltss_minor),
+                ),
+            )
+        return refhost.Host(
+            name="ltss-x86",
+            arch="x86_64",
+            product=refhost.Product(
+                name="SLES", version=refhost.Version(major=15, minor=base_minor)
+            ),
+            addons=addons,
+        )
+
+    def test_base_extension_matches_host_with_addon(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attr = self._attr("base=SLES-LTSS(major=15,minor=SP6);arch=[x86_64]")
+        assert rh.is_candidate_match(self._host(), attr)
+
+    def test_base_extension_no_match_when_addon_absent(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attr = self._attr("base=SLES-LTSS(major=15,minor=SP6);arch=[x86_64]")
+        assert not rh.is_candidate_match(self._host(with_ltss=False), attr)
+
+    def test_base_extension_version_must_match_addon(self):
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attr = self._attr("base=SLES-LTSS(major=15,minor=SP6);arch=[x86_64]")
+        assert not rh.is_candidate_match(self._host(ltss_minor="SP5"), attr)
+
+    def test_base_still_matches_real_base_product(self):
+        """The addon fallback must not regress plain base-product matching."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
+        attr = self._attr("base=SLES(major=15,minor=SP6);arch=[x86_64]")
+        assert rh.is_candidate_match(self._host(), attr)


### PR DESCRIPTION
## Problem

`mtui -a <RRID>` + `add_host` for an incident shipping to an **extension** product reports **"No refhosts to add"** even though suitable hosts exist. Example testplatforms (SLES-LTSS / sle-ha kernel-style incident on 15-SP6):

```
base=sle-ha(major=15,minor=SP6);arch=[ppc64le,x86_64]
base=SLES-LTSS(major=15,minor=SP6);arch=[aarch64,ppc64le,s390x,x86_64]
base=SLES_SAP(major=15,minor=SP6);arch=[ppc64le,x86_64]
```

## Cause

`is_candidate_match` checks a `base=<name>` term **only** against the host's base product (`_product_matches(candidate.product, …)`). In the refhosts-ng schema a host has a single base (`SLES`/`SLED`) with LTSS/HA/SAP/RT recorded as **addons** — one physical box is SLES + LTSS + HA at once, so it can only have one base. So `base=SLES-LTSS` is compared to base `SLES` and never matches, despite the host carrying the `SLES-LTSS` extension.

## Fix

`is_candidate_match` now treats a `base=<name>` query as satisfied when the host's base product matches **or** the host carries that product (with a compatible version) as an addon, via a new `_product_satisfied` helper. Plain base-product matching is unchanged, so existing matches and the `addon=` term are unaffected.

Verified against a live `refhosts.yml`: `base=SLES-LTSS(15-SP6)` now resolves to the 11 expected hosts (argo, barbara, dubai, fiorino, frankfurt, halley, kevin, malaga, skovde, whale-29, whale-31) and `base=sle-ha(15-SP6)` to the ppc64le host carrying the HA extension. `base=SLES_SAP(15-SP6)` correctly stays empty — no 15-SP6 host advertises an `SLES_SAP` product (a refhost-inventory gap, not a matcher issue).

## Tests

Adds `TestExtensionBaseMatching` in `tests/test_refhost.py`: addon match, absent-addon negative, addon version-mismatch negative, and a base-product regression guard. Full `ruff format`/`ruff check`/`ty`/`pytest` pass locally.