### PR TITLE
fix(smelt): use prd as the classic Maintenance deadline when crd is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The SMELT deadline shown for a **classic Maintenance** incident (on `assign`
+  pickup and in `smelt_update`) no longer prints `?` when a real deadline
+  exists. mtui read the incident's `crd` (customer-required date), which is
+  `null` for most incidents, instead of `prd` (the planned release date SMELT
+  displays as the deadline). It now uses `crd` when set and falls back to
+  `prd`, and `smelt_update` shows both raw dates. SLFO updates were already
+  correct — the REST v2 API exposes a dedicated `deadline` field.
 - A testplatform `base=<extension>` (e.g. `base=SLES-LTSS`, `base=sle-ha`,
   `base=SLES_SAP`, `base=SLE_RT`) now resolves to refhosts that carry that
   product as an **addon** on a SLES/SLED base, not only to hosts whose base
@@ -81,13 +88,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- The SMELT deadline shown for a **classic Maintenance** incident (on `assign`
-  pickup and in `smelt_update`) no longer prints `?` when a real deadline
-  exists. mtui read the incident's `crd` (customer-required date), which is
-  `null` for most incidents, instead of `prd` (the planned release date SMELT
-  displays as the deadline). It now uses `crd` when set and falls back to
-  `prd`, and `smelt_update` shows both raw dates. SLFO updates were already
-  correct — the REST v2 API exposes a dedicated `deadline` field.
 - A failed `update` now reports the outcome of **every** host instead of only the
   first failure. The post-update check aborted on the first host that failed, so a
   parallel update that broke on several hosts surfaced just one `UpdateError` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The SMELT deadline shown for a **classic Maintenance** incident (on `assign`
+  pickup and in `smelt_update`) no longer prints `?` when a real deadline
+  exists. mtui read the incident's `crd` (customer-required date), which is
+  `null` for most incidents, instead of `prd` (the planned release date SMELT
+  displays as the deadline). It now uses `crd` when set and falls back to
+  `prd`, and `smelt_update` shows both raw dates. SLFO updates were already
+  correct — the REST v2 API exposes a dedicated `deadline` field.
 - A failed `update` now reports the outcome of **every** host instead of only the
   first failure. The post-update check aborted on the first host that failed, so a
   parallel update that broke on several hosts surfaced just one `UpdateError` and

--- a/mtui/commands/smelt.py
+++ b/mtui/commands/smelt.py
@@ -86,7 +86,9 @@ class SmeltUpdate(Command):
             self.println(f"status   : {(node.get('status') or {}).get('name')}")
             self.println(f"rating   : {(node.get('rating') or {}).get('name')}")
             self.println(f"priority : {node.get('priority')}")
+            self.println(f"deadline : {node.get('crd') or node.get('prd')}")
             self.println(f"crd      : {node.get('crd')}")
+            self.println(f"prd      : {node.get('prd')}")
         else:
             self.println("SMELT detail is not available for this request kind")
 

--- a/mtui/data_sources/smelt.py
+++ b/mtui/data_sources/smelt.py
@@ -177,8 +177,11 @@ class Smelt:
         """Return ``(priority, deadline)`` for a request, dispatching on kind.
 
         SLFO uses the REST v2 update (``priority``/``deadline``); classic
-        Maintenance uses the GraphQL incident (``priority``/``crd``). Anything
-        else, or any lookup failure, yields ``(None, None)``.
+        Maintenance uses the GraphQL incident (``priority`` and, for the
+        deadline, ``crd`` when a customer-required date is set, else ``prd``,
+        the planned release date SMELT shows as the deadline — ``crd`` is null
+        for most incidents). Anything else, or any lookup failure, yields
+        ``(None, None)``.
         """
         if not self.configured:
             return None, None
@@ -192,5 +195,5 @@ class Smelt:
             node = self.incident(rrid.maintenance_id)
             if not node:
                 return None, None
-            return node.get("priority"), node.get("crd")
+            return node.get("priority"), node.get("crd") or node.get("prd")
         return None, None

--- a/tests/test_cmd_smelt.py
+++ b/tests/test_cmd_smelt.py
@@ -56,6 +56,41 @@ def test_smelt_update_not_configured(mock_config):
     assert "not configured" in sysmock.stdout.getvalue()
 
 
+def _prompt_maintenance() -> MagicMock:
+    p = MagicMock()
+    p.metadata.__bool__ = lambda self: True
+    p.metadata.rrid = MagicMock()
+    p.metadata.rrid.kind = RequestKind.MAINTENANCE
+    p.metadata.rrid.maintenance_id = "44997"
+    return p
+
+
+def test_smelt_update_maintenance_deadline_falls_back_to_prd(mock_config):
+    """Classic incident: the deadline shows ``prd`` when ``crd`` is null, and both
+    raw dates are printed."""
+    prompt = _prompt_maintenance()
+    sysmock = _sysmock()
+    with patch("mtui.commands.smelt.Smelt") as cls:
+        smelt = cls.return_value
+        smelt.configured = True
+        smelt.incident.return_value = {
+            "incidentId": 44997,
+            "status": {"name": "active"},
+            "rating": {"name": "important"},
+            "priority": 357,
+            "crd": None,
+            "prd": "2026-07-06",
+        }
+        SmeltUpdate(Namespace(), mock_config, sysmock, prompt)()
+    out = sysmock.stdout.getvalue()
+    assert "incident : 44997" in out
+    assert "priority : 357" in out
+    assert "deadline : 2026-07-06" in out  # crd null -> prd
+    assert "crd      : None" in out
+    assert "prd      : 2026-07-06" in out
+    smelt.incident.assert_called_once_with("44997")
+
+
 def test_smelt_updates_pending_filter(mock_config):
     sysmock = _sysmock()
     args = Namespace(

--- a/tests/test_smelt.py
+++ b/tests/test_smelt.py
@@ -117,6 +117,60 @@ def test_priority_deadline_maintenance_via_graphql():
 
 
 @responses.activate
+def test_priority_deadline_maintenance_falls_back_to_prd():
+    """``crd`` is null on most incidents; the deadline then comes from ``prd``
+    (the planned release date SMELT shows), not ``?``.
+    """
+    responses.add(
+        responses.POST,
+        f"{SMELT}/graphql/",
+        json={
+            "data": {
+                "incidents": {
+                    "edges": [
+                        {"node": {"priority": 357, "crd": None, "prd": "2026-07-06"}}
+                    ]
+                }
+            }
+        },
+        status=200,
+    )
+    s = Smelt(_cfg())
+    prio, deadline = s.priority_deadline(
+        RequestReviewID("SUSE:Maintenance:44997:414920")
+    )
+    assert (prio, deadline) == (357, "2026-07-06")
+
+
+@responses.activate
+def test_priority_deadline_maintenance_prefers_crd_over_prd():
+    """A set customer-required date takes precedence over the planned date."""
+    responses.add(
+        responses.POST,
+        f"{SMELT}/graphql/",
+        json={
+            "data": {
+                "incidents": {
+                    "edges": [
+                        {
+                            "node": {
+                                "priority": 9,
+                                "crd": "2026-08-01",
+                                "prd": "2026-09-01",
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        status=200,
+    )
+    s = Smelt(_cfg())
+    prio, deadline = s.priority_deadline(RequestReviewID("SUSE:Maintenance:1:2"))
+    assert (prio, deadline) == (9, "2026-08-01")
+
+
+@responses.activate
 def test_v2_transport_error_returns_none():
     responses.add(responses.GET, f"{V2}/updates/x", status=500)
     assert Smelt(_cfg()).update("x") is None


### PR DESCRIPTION
## Problem

On `assign` pickup (and in `smelt_update`), the SMELT line for a **classic Maintenance** incident prints `deadline ?` even when the incident has a real deadline:

```
SMELT: priority 357, deadline ?
```

…while the SMELT web UI shows a deadline for the same incident.

## Cause

`Smelt.priority_deadline` reads the GraphQL incident's **`crd`** (customer-required date) as the deadline. `crd` is `null` for most incidents — the date SMELT displays as the deadline is **`prd`** (planned release date). The query already fetches `prd`, it just wasn't used.

Verified against incident 44997:

```json
{ "priority": 357, "crd": null, "prd": "2026-07-06T10:05:58+00:00", "status": {"name": "active"}, "rating": {"name": "important"} }
```

## Fix

`priority_deadline` (Maintenance branch) now returns `crd` when a customer-required date is set and falls back to `prd` otherwise. `smelt_update` shows a unified `deadline` line plus both raw `crd`/`prd` values.

## SLFO ("new SMELT") is unaffected

The REST v2 update exposes a dedicated, populated `deadline` field, which mtui already reads. Confirmed against live v2 data (e.g. SLFO #5222 → `2026-07-06`, #5230 → `2026-07-20`); it is `null` only for priority-0 updates that genuinely have no deadline yet. No change needed there.

## Tests

Adds `test_priority_deadline_maintenance_falls_back_to_prd` (crd null → prd) and `test_priority_deadline_maintenance_prefers_crd_over_prd`. Full `ruff format`/`ruff check`/`ty`/`pytest` pass locally.