### PR TITLE
fix(reject): join REMAINDER --message before sending it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `reject -m <message>` no longer aborts with `TypeError: expected string or
+  bytes-like object, got 'list'` before the rejection is sent. `--message` uses
+  `nargs=REMAINDER`, so it arrives as a list of words; `reject` passed it
+  unjoined to `osc.reject`/`gitea.reject`, which hand it to `shlex.quote` (a
+  list crashes it). The message is now joined to a single string first (matching
+  `commit`), so a reject reason actually reaches the maintainer. Rejecting with a
+  bare reason and no message was unaffected.
 - The SMELT deadline shown for a **classic Maintenance** incident (on `assign`
   pickup and in `smelt_update`) no longer prints `?` when a real deadline
   exists. mtui read the incident's `crd` (customer-required date), which is

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -234,18 +234,30 @@ class Reject(BaseApiCall):
             + "Always as last of command, it takes remainder of command",
         )
 
+    @property
+    def _message(self) -> str:
+        """The rejection message as a single string.
+
+        ``--message`` uses ``nargs=REMAINDER``, so ``self.args.message`` is a
+        list of words (or ``None`` when omitted). It must be joined before it
+        reaches ``osc.reject``/``gitea.reject``, which pass it to
+        ``shlex.quote`` — handing those a list raises ``TypeError`` and aborts
+        the reject before it is sent.
+        """
+        return " ".join(self.args.message) if self.args.message else ""
+
     def osc(self) -> None:
         """Rejects the request in OSC."""
         logger.info("Reject request %s", self.metadata.rrid.review_id)
         osc = OSC(self.config, self.metadata.rrid)
-        osc.reject(self.args.group, self.args.reason, self.args.message)
+        osc.reject(self.args.group, self.args.reason, self._message)
 
     def gitea(self) -> None:
         """Rejects the pull request in Gitea."""
         logger.info("Reject PR %s", self.metadata.id)
         try:
             gitea = Gitea(self.config, self.metadata.giteaprapi)
-            gitea.reject(self.args.reason, self.args.user, self.args.message)
+            gitea.reject(self.args.reason, self.args.user, self._message)
         except GiteaError as e:
             logger.error(e)
 

--- a/tests/test_cmd_apicall.py
+++ b/tests/test_cmd_apicall.py
@@ -93,6 +93,61 @@ def test_end_of_testing_pi_unlocks(mock_config, cls, extra):
 
 
 # ---------------------------------------------------------------------------
+# reject joins its REMAINDER --message into a single string before sending it.
+# A bare list reaches shlex.quote() in oscqam.__operation and aborts the reject
+# with TypeError("expected string or bytes-like object, got 'list'").
+# ---------------------------------------------------------------------------
+
+
+def test_reject_osc_joins_message_into_string(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()  # MAINTENANCE -> osc path
+    args = Namespace(
+        group=["qam-sle"],
+        reason="build_problem",
+        message=["dependency", "issues", "bsc#1234"],
+        user="",
+    )
+
+    with patch("mtui.commands.apicall.OSC") as osc_cls:
+        Reject(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.reject.assert_called_once_with(
+        ["qam-sle"], "build_problem", "dependency issues bsc#1234"
+    )
+
+
+def test_reject_gitea_joins_message_into_string(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+    prompt.metadata.rrid.kind = RequestKind.SLFO  # -> gitea path
+    args = Namespace(
+        group=["qam-sle"],
+        reason="build_problem",
+        message=["dependency", "issues"],
+        user="someone",
+    )
+
+    with patch("mtui.commands.apicall.Gitea") as gitea_cls:
+        Reject(args, mock_config, MagicMock(), prompt)()
+
+    gitea_cls.return_value.reject.assert_called_once_with(
+        "build_problem", "someone", "dependency issues"
+    )
+
+
+def test_reject_without_message_sends_empty_string(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], reason="admin", message=None, user="")
+
+    with patch("mtui.commands.apicall.OSC") as osc_cls:
+        Reject(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.reject.assert_called_once_with(["qam-sle"], "admin", "")
+
+
+# ---------------------------------------------------------------------------
 # Comment reads the body through ask_user (not the bare input() that
 # would block / echo ^M between two prompt_toolkit sessions)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`reject -m <message>` aborts before the rejection is sent:

```
TypeError: expected string or bytes-like object, got 'list'
```

So a reject can currently only be issued with a bare reason — any explanatory message crashes the command (REPL and MCP alike).

## Cause

`reject`'s `--message` uses `nargs=REMAINDER`, so `self.args.message` is a **list** of words. `Reject.osc()` / `Reject.gitea()` passed that list straight through:

```python
osc.reject(self.args.group, self.args.reason, self.args.message)   # message: list
```

`oscqam.__operation` then does `message_args = ["-M", quote(message)]` with `shlex.quote`, which requires a `str` — quoting a list raises the `TypeError`. The `commit` command takes the same `REMAINDER` pattern but joins it first (`" ".join(...)`); `reject` simply didn't.

## Fix

Join the message into a single string before handing it to `osc.reject` / `gitea.reject`, via a small `_message` property. Rejecting with no message is unaffected (now sends `""`).

## Why it wasn't caught

The only existing test that rejects with a message (`test_end_of_testing_pi_unlocks`) runs under `patch("mtui.commands.apicall.OSC")`, so `osc.reject` is a mock and the real `__operation`/`quote()` path is never exercised; it only asserts the unlock side-effect. This PR adds command-level tests asserting `osc.reject` / `gitea.reject` receive the **joined string** (and `""` when no message is given).

Full `ruff format`/`ruff check`/`ty`/`pytest` pass locally.