### PR TITLE
fix(notify): replace dead pynotify backend with notify-py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Desktop notifications (the `notify` extra) work again. They imported the
+  long-dead `pynotify` PyGTK binding, which is unavailable on Python 3.13+, so
+  the REPL's update-finished/update-failed toasts were a silent no-op; the
+  extra also pinned an unrelated, Python 2-only package literally named
+  `notify`. Notifications are now backed by
+  [notify-py](https://pypi.org/project/notify-py/) (pure-Python DBus on Linux,
+  no system GTK/libnotify needed), fire only in an interactive desktop REPL
+  session (piped/cron/CI/MCP runs are skipped), and the notification class is
+  no longer mistakenly passed as the icon name.
 - `reject -m <message>` no longer aborts with `TypeError: expected string or
   bytes-like object, got 'list'` before the rejection is sent. `--message` uses
   `nargs=REMAINDER`, so it arrives as a list of words; `reject` passed it

--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -82,8 +82,11 @@ The following extras can be combined (for example
     storing credentials in the OS keyring instead of plain text.
 
 ``notify``
-    Adds `notify <https://pypi.org/project/notify/>`_ for desktop
-    notifications.
+    Adds `notify-py <https://pypi.org/project/notify-py/>`_ for desktop
+    notifications in the interactive REPL. On Linux it talks to the
+    freedesktop DBus notification service via pure-Python ``jeepney``, so no
+    system GTK/libnotify bindings are required. Notifications are skipped
+    automatically when not attached to an interactive desktop session.
 
 ``completion``
     Adds `argcomplete <https://pypi.org/project/argcomplete/>`_ to

--- a/mtui/cli/notification.py
+++ b/mtui/cli/notification.py
@@ -1,40 +1,93 @@
-"""A simple desktop notification system using pynotify."""
+"""A simple desktop notification system backed by :mod:`notifypy`.
 
+Desktop notifications are an opt-in feature (the ``notify`` extra pulls in
+`notify-py <https://pypi.org/project/notify-py/>`_). When the dependency is
+absent, or the process is not attached to an interactive desktop session,
+:func:`display` degrades to a quiet no-op so headless, piped, cron, and MCP
+runs never attempt to pop a toast. ``notify-py`` talks to the freedesktop
+DBus notification service via pure-Python ``jeepney`` on Linux, so no system
+GTK/libnotify Python bindings are required.
+"""
+
+import os
+import sys
 from logging import getLogger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from notifypy import Notify  # ty: ignore[unresolved-import]
 
 logger = getLogger("mtui.notifications")
 
-__impl = None
+#: Resolved ``notifypy.Notify`` class, or ``None`` when unavailable.
+_notify_cls: "type[Notify] | None" = None
+#: Whether an import has already been attempted (so a missing extra costs a
+#: single debug-logged attempt rather than retrying on every notification).
+_resolved = False
+
+
+def _resolve() -> "type[Notify] | None":
+    """Returns the ``notifypy.Notify`` class, or ``None`` when unavailable."""
+    global _notify_cls, _resolved
+    if not _resolved:
+        _resolved = True
+        try:
+            from notifypy import Notify  # ty: ignore[unresolved-import]
+        except ImportError:
+            logger.debug("notify-py not installed. notification disabled.")
+        else:
+            _notify_cls = Notify
+
+    return _notify_cls
+
+
+def _desktop_available() -> bool:
+    """Reports whether a desktop notification can plausibly be shown.
+
+    Notifications are a REPL-only courtesy. A toast only makes sense when a
+    user is sitting at an interactive terminal with a graphical session, so
+    this guards against piped/cron/CI/MCP runs that would otherwise attempt
+    (and fail at) a desktop pop-up.
+    """
+    if not sys.stdin.isatty():
+        return False
+
+    if sys.platform == "darwin":
+        return True
+
+    # Linux/BSD: a freedesktop notification needs a graphical session.
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
 def display(
-    summary: str | None = None, text: str | None = None, icon: str = "stock_dialog-info"
+    summary: str | None = None,
+    text: str | None = None,
+    icon: str | None = None,
 ) -> None:
     """Displays a desktop notification.
 
     Args:
-        summary: The summary text of the notification.
+        summary: The summary (title) text of the notification.
         text: The body text of the notification.
-        icon: The icon to display in the notification.
+        icon: Path to an icon image to display, or ``None`` for the default.
 
     """
-    global __impl
-    if __impl is None:
-        try:
-            import pynotify as __impl  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
-        except ImportError:
-            __impl = False
-            logger.debug("pynotify not installed. notification disabled.")
-        else:
-            if not __impl.init("mtui"):
-                __impl = False
-                logger.debug("failed to initialize pynotify")
+    if not _desktop_available():
+        return
 
-    if not __impl:
+    notify_cls = _resolve()
+    if notify_cls is None:
         return
 
     logger.debug('displaying notify message "%s"', text)
     try:
-        __impl.Notification(summary, text, icon).show()
+        notification = notify_cls(default_application_name="mtui")
+        if summary is not None:
+            notification.title = summary
+        if text is not None:
+            notification.message = text
+        if icon:
+            notification.icon = icon
+        notification.send(block=False)
     except Exception:
         logger.debug("failed to display notification")

--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -225,10 +225,13 @@ class CommandPrompt:
 
         Args:
             msg: The message to display.
-            class_: The notification class.
+            class_: The notification class. ``"stock_dialog-error"`` (the
+                historical error class) maps to the freedesktop ``dialog-error``
+                icon; any other value uses the default icon.
 
         """
-        notification.display("MTUI", msg, class_)
+        icon = "dialog-error" if class_ == "stock_dialog-error" else None
+        notification.display("MTUI", msg, icon)
 
     def println(self, msg: str = "", eol: str = "\n") -> None:
         """Prints a message to the output stream.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ mtui-mcp = "mtui.mcp.main:main"
 keyring = ["keyring"]
 mcp = ["mcp[cli]>=1.2"]
 norpm = ["version_utils"]
-notify = ["notify"]
+notify = ["notify-py"]
 rpm = ["rpm"]
 completion = ["argcomplete>=3.0"]
 
@@ -138,6 +138,17 @@ include = ["mtui/types/**", "mtui/data_sources/**"]
 
 [tool.ty.overrides.rules]
 all = "error"
+
+# Desktop notifications are an optional extra (`notify-py`). CI runs `ty`
+# without that extra installed, so the lazy ``from notifypy import Notify``
+# is legitimately unresolved and needs ``# ty: ignore[unresolved-import]``.
+# When a developer *does* install the extra the module resolves and the
+# suppression becomes "unused"; don't let that flip the gate red.
+[[tool.ty.overrides]]
+include = ["mtui/cli/notification.py"]
+
+[tool.ty.overrides.rules]
+unused-ignore-comment = "ignore"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,47 +1,105 @@
-import sys
 from unittest.mock import MagicMock
+
+import pytest
 
 from mtui.cli import notification
 
 
+@pytest.fixture(autouse=True)
+def _reset_resolver(monkeypatch):
+    """Each test starts from a clean, un-attempted resolver state."""
+    monkeypatch.setattr(notification, "_notify_cls", None)
+    monkeypatch.setattr(notification, "_resolved", False)
+
+
 def test_display_success(monkeypatch):
-    """Test display when pynotify is available and works."""
-    mock_pynotify = MagicMock()
-    # Bypass the import/init logic by setting __impl directly
-    monkeypatch.setattr(notification, "__impl", mock_pynotify)
+    """A title/message are set and the notification is sent."""
+    monkeypatch.setattr(notification, "_desktop_available", lambda: True)
+    notify_instance = MagicMock()
+    notify_cls = MagicMock(return_value=notify_instance)
+    # Pretend notify-py resolved to our fake Notify class.
+    monkeypatch.setattr(notification, "_notify_cls", notify_cls)
+    monkeypatch.setattr(notification, "_resolved", True)
 
     notification.display("test summary", "test text")
 
-    mock_pynotify.Notification.assert_called_with(
-        "test summary", "test text", "stock_dialog-info"
-    )
-    mock_pynotify.Notification.return_value.show.assert_called_once()
+    notify_cls.assert_called_once_with(default_application_name="mtui")
+    assert notify_instance.title == "test summary"
+    assert notify_instance.message == "test text"
+    notify_instance.send.assert_called_once_with(block=False)
+
+
+def test_display_sets_icon_when_given(monkeypatch):
+    """An explicit icon is forwarded; otherwise it is left untouched."""
+    monkeypatch.setattr(notification, "_desktop_available", lambda: True)
+    notify_instance = MagicMock()
+    notify_cls = MagicMock(return_value=notify_instance)
+    monkeypatch.setattr(notification, "_notify_cls", notify_cls)
+    monkeypatch.setattr(notification, "_resolved", True)
+
+    notification.display("s", "t", "dialog-error")
+
+    assert notify_instance.icon == "dialog-error"
 
 
 def test_display_import_error(monkeypatch):
-    """Test display when pynotify is not installed."""
-    # Reset state to ensure the import logic is triggered
-    monkeypatch.setattr(notification, "__impl", None)
-    # Make the import fail
-    monkeypatch.setitem(sys.modules, "pynotify", None)
+    """A missing notify-py extra is a quiet no-op, not an exception."""
+    monkeypatch.setattr(notification, "_desktop_available", lambda: True)
+    # Force the resolver to report notify-py as unavailable.
+    monkeypatch.setattr(notification, "_resolve", lambda: None)
 
-    # Should execute quietly without raising an exception
+    # Should execute quietly without raising.
     notification.display("test summary", "test text")
 
 
-def test_display_init_fails(monkeypatch):
-    """Test display when pynotify is installed but fails to initialize."""
-    # Reset state to ensure the import logic is triggered
-    monkeypatch.setattr(notification, "__impl", None)
-
-    mock_pynotify = MagicMock()
-    mock_pynotify.init.return_value = False
-
-    # Make the import succeed but return our mock
-    monkeypatch.setitem(sys.modules, "pynotify", mock_pynotify)
+def test_display_skipped_when_not_interactive(monkeypatch):
+    """Without an interactive desktop session, nothing is constructed."""
+    monkeypatch.setattr(notification, "_desktop_available", lambda: False)
+    notify_cls = MagicMock()
+    monkeypatch.setattr(notification, "_notify_cls", notify_cls)
+    monkeypatch.setattr(notification, "_resolved", True)
 
     notification.display("test summary", "test text")
 
-    # Assert that initialization was attempted but showing a notification was not
-    mock_pynotify.init.assert_called_once_with("mtui")
-    mock_pynotify.Notification.assert_not_called()
+    notify_cls.assert_not_called()
+
+
+def test_display_send_failure_swallowed(monkeypatch):
+    """A backend failure during send must never propagate."""
+    monkeypatch.setattr(notification, "_desktop_available", lambda: True)
+    notify_instance = MagicMock()
+    notify_instance.send.side_effect = RuntimeError("dbus exploded")
+    notify_cls = MagicMock(return_value=notify_instance)
+    monkeypatch.setattr(notification, "_notify_cls", notify_cls)
+    monkeypatch.setattr(notification, "_resolved", True)
+
+    # Should swallow the error.
+    notification.display("test summary", "test text")
+
+    notify_instance.send.assert_called_once_with(block=False)
+
+
+def test_desktop_available_requires_tty(monkeypatch):
+    """Non-tty stdin disables notifications regardless of platform."""
+    monkeypatch.setattr(notification.sys.stdin, "isatty", lambda: False)
+    assert notification._desktop_available() is False
+
+
+def test_desktop_available_linux_needs_display(monkeypatch):
+    """On Linux a graphical session (DISPLAY/WAYLAND) is required."""
+    monkeypatch.setattr(notification.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(notification.sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    assert notification._desktop_available() is False
+
+    monkeypatch.setenv("DISPLAY", ":0")
+    assert notification._desktop_available() is True
+
+
+def test_desktop_available_darwin_always_ok(monkeypatch):
+    """macOS has Notification Center; a tty is sufficient."""
+    monkeypatch.setattr(notification.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(notification.sys, "platform", "darwin")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    assert notification._desktop_available() is True

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -405,12 +405,21 @@ def test_cmdloop_drives_real_session_via_pipe_input(monkeypatch):
 
 
 def test_notify_user_calls_notification_display(monkeypatch):
-    """``notify_user`` is a thin wrapper around ``notification.display``."""
+    """``notify_user`` wraps ``notification.display``; a plain class has no icon."""
     p = _make_prompt()
     display = MagicMock()
     monkeypatch.setattr(repl.notification, "display", display)
     p.notify_user("hello", class_="info")
-    display.assert_called_once_with("MTUI", "hello", "info")
+    display.assert_called_once_with("MTUI", "hello", None)
+
+
+def test_notify_user_maps_error_class_to_icon(monkeypatch):
+    """The historical error class maps to a freedesktop icon name."""
+    p = _make_prompt()
+    display = MagicMock()
+    monkeypatch.setattr(repl.notification, "display", display)
+    p.notify_user("boom", class_="stock_dialog-error")
+    display.assert_called_once_with("MTUI", "boom", "dialog-error")
 
 
 def test_postcmd_short_circuits_for_null_test_report():

--- a/uv.lock
+++ b/uv.lock
@@ -48,15 +48,6 @@ wheels = [
 ]
 
 [[package]]
-name = "app-version"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/07/1089c21119a1ea49326779d9e89dc57845a785f91cd52561f3492def4049/app_version-1.0.1.tar.gz", hash = "sha256:c21f6ea7e97092ba9a28dd6f884766647888273cbda8bde8f108f9657d5b4bff", size = 11155, upload-time = "2017-07-14T11:25:16.398Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/03/5eeff1025f889d8d85738078c4f48e806aafe27c93ed1a52f3fbec029b06/app_version-1.0.1-py3-none-any.whl", hash = "sha256:c38bd6931565b9a972961ef19f1ab8aa80748d68c0153000116800b7ce5678a8", size = 7887, upload-time = "2017-07-14T11:25:25.959Z" },
-]
-
-[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -575,6 +566,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/1f/d3818863e4be96bd641c4643c535a98f0fa2a12efa7c8ba35f763fa778ee/loguru-0.6.0.tar.gz", hash = "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c", size = 123158, upload-time = "2022-01-29T13:47:31.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/21/e1d1da2586865a159fc73b611f36bdd50b6c4043cb6132d3d5e972988028/loguru-0.6.0-py3-none-any.whl", hash = "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3", size = 58317, upload-time = "2022-01-29T13:47:29.921Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -725,7 +729,7 @@ norpm = [
     { name = "version-utils" },
 ]
 notify = [
-    { name = "notify" },
+    { name = "notify-py" },
 ]
 rpm = [
     { name = "rpm" },
@@ -750,7 +754,7 @@ requires-dist = [
     { name = "argcomplete", marker = "extra == 'completion'", specifier = ">=3.0" },
     { name = "keyring", marker = "extra == 'keyring'" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.2" },
-    { name = "notify", marker = "extra == 'notify'" },
+    { name = "notify-py", marker = "extra == 'notify'" },
     { name = "openqa-client" },
     { name = "paramiko" },
     { name = "prompt-toolkit" },
@@ -794,14 +798,17 @@ wheels = [
 ]
 
 [[package]]
-name = "notify"
-version = "0.3.1"
+name = "notify-py"
+version = "0.3.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "app-version" },
-    { name = "validate-email" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "loguru" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/ee/392ea0366a8d1389e6321697b26b3d98f0d828161a0a2ead4d1fa21dfc44/notify-0.3.1.tar.gz", hash = "sha256:89dcebec89e2d82afae43687ad3dab343a94ce79e5af7b652f1f7961135955b9", size = 10879, upload-time = "2019-02-16T12:16:28.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/2b/fc68aeed5108185922c5469484e15c192dff01d61eddfab0c1c256e4f54c/notify_py-0.3.43.tar.gz", hash = "sha256:16ee146d48f16bae5dad233db66014a387efd2c6ed2c4caf1e08aef432070513", size = 648145, upload-time = "2024-06-05T14:40:38.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/b4/649f16520ed0a64c275861dcaf9c1291d079f742aa2bf9102fdd168e4197/notify_py-0.3.43-py3-none-any.whl", hash = "sha256:90da686b480bf05d033b21fb5118662bb7a4c68e68cb21d93a048ca7b867f9b4", size = 649803, upload-time = "2024-06-05T14:40:36.733Z" },
+]
 
 [[package]]
 name = "openqa-client"
@@ -1338,8 +1345,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -1555,12 +1562,6 @@ wheels = [
 ]
 
 [[package]]
-name = "validate-email"
-version = "1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/a0/cb53fb64b52123513d04f9b913b905f3eb6fda7264e639b4573cc715c29f/validate_email-1.3.tar.gz", hash = "sha256:784719dc5f780be319cdd185dc85dd93afebdb6ebb943811bc4c7c5f9c72aeaf", size = 4694, upload-time = "2015-03-23T04:22:45.115Z" }
-
-[[package]]
 name = "version-utils"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1576,4 +1577,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
## What

Desktop notifications were silently broken. `mtui/cli/notification.py` imported the long-dead **`pynotify`** PyGTK binding, which is unavailable on Python 3.13+, so the REPL's *update-finished* / *update-failed* toasts were a permanent no-op. The `notify` extra also pinned an **unrelated, Python 2-only** package literally named `notify` (last released 2019) that never provided the `pynotify` module the code imported.

This PR backs desktop notifications with **[notify-py](https://pypi.org/project/notify-py/)** and restricts them to interactive REPL use, as intended.

## Changes

- **Backend swap** — `notify` extra now pulls `notify-py` (was `notify`). `notify-py` has a synchronous API and uses pure-Python DBus (`jeepney`) on Linux, so **no system GTK/libnotify Python bindings are required** — the whole reason the old binding was unusable.
- **REPL-only guard** — `display()` short-circuits when stdin is not a tty, or (on Linux) when there is no `DISPLAY`/`WAYLAND_DISPLAY`. Piped, cron, CI, and MCP runs never attempt a desktop pop-up. macOS is always allowed (Notification Center).
- **Graceful degradation preserved** — a missing extra or a backend failure stays a quiet, debug-logged no-op (never raises), matching prior behavior.
- **Latent bug fix** — `CommandPrompt.notify_user` previously passed the notification *class* (`"info"`, `"stock_dialog-error"`) straight into the **icon** argument. The error class now maps to the freedesktop `dialog-error` icon; other classes use the default.
- **MCP unchanged** — `McpSession.notify_user` already only logs (correct; MCP must not pop desktop UI).
- **`ty`** — the lazy `from notifypy import Notify` is legitimately unresolved when the optional extra is absent (CI's `ty` job), so it keeps `# ty: ignore[unresolved-import]`; a scoped `ty` override silences the "unused suppression" warning for developers who *do* install the extra. Verified green in **both** configurations.

## Tests / gates

All CI gates pass locally (`uv` matching CI):

- `ruff format --check .` ✅ · `ruff check .` ✅
- `ty check` ✅ — both with and without the `notify` extra installed
- `pytest` ✅ — **1464 passed**
- `sphinx-build -W` ✅

`tests/test_notification.py` was rewritten for the `notify-py` surface (success, icon forwarding, missing-extra, non-interactive guard, send-failure, and `_desktop_available` platform cases). `tests/test_prompt.py` updated for the class→icon mapping plus a new error-class case.

## Docs / changelog

- `Documentation/installation.rst` — `notify` extra now documents `notify-py` and the no-libnotify / REPL-only behavior.
- `CHANGELOG.md` `[Unreleased] → Fixed` documents the restoration.