### PR TITLE
feat(mcp): testreport_fill — bulk-set per-bug placeholder tokens

### DIFF
--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import tempfile
 from logging import getLogger
 from pathlib import Path
@@ -399,6 +400,130 @@ async def testreport_write(
 
 
 # --------------------------------------------------------------------------- #
+# Bulk placeholder fill                                                        #
+# --------------------------------------------------------------------------- #
+
+#: The exact placeholder tokens the QAM testreport template ships with, one per
+#: line, that a tester otherwise has to flip one `testreport_patch` at a time.
+#: Each regex captures the label+padding as ``pre`` so the replacement keeps the
+#: template's column alignment; the value part is matched verbatim so an
+#: already-filled line (e.g. ``STATUS:             SKIPPED``) is never touched —
+#: the fill is idempotent and safe to re-run.
+_SUMMARY_PLACEHOLDER = re.compile(r"^(?P<pre>\s*SUMMARY:\s*)PASSED/FAILED\s*$")
+_REPRODUCER_PLACEHOLDER = re.compile(r"^(?P<pre>\s*REPRODUCER_PRESENT:\s*)YES/NO\s*$")
+_STATUS_PLACEHOLDER = re.compile(
+    r"^(?P<pre>\s*STATUS:\s*)"
+    r"FIXED/NOT_FIXED/HYPOTHETICAL/NOT_REPRODUCIBLE/"
+    r"NO_ENVIRONMENT/TOO_COMPLEX/SKIPPED/OTHER\s*$"
+)
+
+#: Valid single-value codes for the per-bug ``STATUS:`` field.
+_STATUS_CODES = frozenset(
+    {
+        "FIXED",
+        "NOT_FIXED",
+        "HYPOTHETICAL",
+        "NOT_REPRODUCIBLE",
+        "NO_ENVIRONMENT",
+        "TOO_COMPLEX",
+        "SKIPPED",
+        "OTHER",
+    }
+)
+
+
+async def testreport_fill(
+    session: McpSession,
+    reproducer: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+    status: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+    summary: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+) -> dict[str, Any]:
+    """Bulk-fill the repetitive placeholder tokens left by ``export``.
+
+    A freshly exported QAM testreport carries one ``REPRODUCER_PRESENT: YES/NO``
+    + ``STATUS: FIXED/.../OTHER`` placeholder per referenced bug (a CVE-heavy
+    update can have 15+), plus the top ``SUMMARY: PASSED/FAILED``. Flipping each
+    by hand with :func:`testreport_patch` is slow and error-prone on a live
+    report. This sets them all in one atomic write.
+
+    Only the **exact** template placeholder strings are replaced, so the call is
+    idempotent and never clobbers a value you already filled in (e.g. a bug you
+    set to ``REPRODUCER_PRESENT: YES`` / ``STATUS: FIXED`` by hand stays put).
+    Typical use on a security update: ``reproducer="NO", status="SKIPPED",
+    summary="PASSED"`` to clear every CVE placeholder at once, then override the
+    handful of non-security bugs individually with :func:`testreport_patch`. The
+    regression / build-log / source sections are still filled separately.
+
+    Args:
+        reproducer: ``YES`` or ``NO`` to set every unfilled
+            ``REPRODUCER_PRESENT:`` line; ``None`` leaves them.
+        status: a single ``STATUS:`` code (see :data:`_STATUS_CODES`) to set
+            every unfilled templated ``STATUS:`` line; ``None`` leaves them.
+        summary: ``PASSED`` or ``FAILED`` for the top ``SUMMARY:`` line;
+            ``None`` leaves it.
+
+    Returns:
+        ``path``, a ``filled`` breakdown (how many of each token were set),
+        ``bytes_written`` and ``line_count``.
+
+    """
+    if reproducer is not None and reproducer not in ("YES", "NO"):
+        raise McpCommandError(
+            "", f"reproducer must be YES or NO, got {reproducer!r}", 1
+        )
+    if status is not None and status not in _STATUS_CODES:
+        raise McpCommandError(
+            "", f"status must be one of {sorted(_STATUS_CODES)}, got {status!r}", 1
+        )
+    if summary is not None and summary not in ("PASSED", "FAILED"):
+        raise McpCommandError(
+            "", f"summary must be PASSED or FAILED, got {summary!r}", 1
+        )
+    if reproducer is None and status is None and summary is None:
+        raise McpCommandError(
+            "", "nothing to fill: pass at least one of reproducer/status/summary", 1
+        )
+
+    await _heartbeat(ctx, "testreport_fill: waiting for session lock")
+    async with session._lock:
+        path = _resolve_testreport_path(session)
+        content = path.read_text(encoding="utf-8", errors="replace")
+        lines = content.splitlines(keepends=True)
+        counts = {"summary": 0, "reproducer": 0, "status": 0}
+        for i, line in enumerate(lines):
+            nl = "\n" if line.endswith("\n") else ""
+            body = line[:-1] if nl else line
+            if summary is not None:
+                m = _SUMMARY_PLACEHOLDER.match(body)
+                if m:
+                    lines[i] = f"{m.group('pre')}{summary}{nl}"
+                    counts["summary"] += 1
+                    continue
+            if reproducer is not None:
+                m = _REPRODUCER_PLACEHOLDER.match(body)
+                if m:
+                    lines[i] = f"{m.group('pre')}{reproducer}{nl}"
+                    counts["reproducer"] += 1
+                    continue
+            if status is not None:
+                m = _STATUS_PLACEHOLDER.match(body)
+                if m:
+                    lines[i] = f"{m.group('pre')}{status}{nl}"
+                    counts["status"] += 1
+                    continue
+        new_text = "".join(lines)
+        bytes_written = _atomic_write_text(path, new_text)
+
+    return {
+        "path": str(path),
+        "filled": counts,
+        "bytes_written": bytes_written,
+        "line_count": _count_lines(new_text),
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Registration                                                                #
 # --------------------------------------------------------------------------- #
 
@@ -468,6 +593,17 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         session = await resolve_session(provider, ctx)
         return await testreport_write(session, content, ctx=ctx)
 
+    async def _fill(
+        reproducer: str | None = None,
+        status: str | None = None,
+        summary: str | None = None,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        session = await resolve_session(provider, ctx)
+        return await testreport_fill(
+            session, reproducer=reproducer, status=status, summary=summary, ctx=ctx
+        )
+
     read_desc = (
         "Read the currently loaded testreport file. Returns the path, total "
         "line count, and content (utf-8, errors replaced). By default returns "
@@ -498,6 +634,19 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         "e.g. 'build_checks/<pkg>.<arch>.log', 'install_logs/<host>.log', "
         "'source.diff' or 'patchinfo.xml'. The path may not escape the checkout "
         "directory. Returns path, line count and full content."
+    )
+    fill_desc = (
+        "Bulk-set the repetitive per-bug placeholder tokens an exported "
+        "testreport ships with, in one atomic write. `reproducer` (YES/NO) sets "
+        "every unfilled `REPRODUCER_PRESENT:` line; `status` (one of FIXED, "
+        "NOT_FIXED, HYPOTHETICAL, NOT_REPRODUCIBLE, NO_ENVIRONMENT, TOO_COMPLEX, "
+        "SKIPPED, OTHER) sets every unfilled templated `STATUS:` line; `summary` "
+        "(PASSED/FAILED) sets the top `SUMMARY:` line. Only exact template "
+        "placeholders are touched, so it is idempotent and never overwrites a "
+        "value you already set by hand. Ideal for CVE-heavy updates: call with "
+        "reproducer=NO, status=SKIPPED (security policy), then override any "
+        "non-security bug individually with testreport_patch. Returns a `filled` "
+        "count per token. Still fill regression/build-log/source sections yourself."
     )
 
     specs = (
@@ -530,6 +679,12 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
             _write,
             write_desc,
             ToolAnnotations(),
+        ),
+        (
+            "testreport_fill",
+            _fill,
+            fill_desc,
+            ToolAnnotations(idempotentHint=True),
         ),
     )
 

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -343,6 +343,7 @@ def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
     names = tt.register_testreport_tools(mcp, sess)
 
     assert names == [
+        "testreport_fill",
         "testreport_logs",
         "testreport_patch",
         "testreport_read",
@@ -361,7 +362,7 @@ def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
         assert tools[n].annotations is not None
         assert tools[n].annotations.readOnlyHint is True
         assert tools[n].annotations.idempotentHint is True
-    for n in ("testreport_patch", "testreport_write"):
+    for n in ("testreport_patch", "testreport_write", "testreport_fill"):
         if tools[n].annotations is not None:
             assert tools[n].annotations.readOnlyHint is not True
 
@@ -574,3 +575,100 @@ def test_two_ctx_keys_read_their_own_template(tmp_path: Path) -> None:
     # Re-reading ctx_a must still hit file_a (cached session, not file_b).
     assert third["content"] == "alpha\n"
     assert third["path"] == str(file_a)
+
+
+# --------------------------------------------------------------------------- #
+# testreport_fill — bulk placeholder fill                                     #
+# --------------------------------------------------------------------------- #
+
+_FILL_TEMPLATE = (
+    "SUMMARY: PASSED/FAILED\n"
+    "\n"
+    'bnc#1 ("a"):\n'
+    "REPRODUCER_PRESENT: YES/NO\n"
+    "STATUS:             FIXED/NOT_FIXED/HYPOTHETICAL/NOT_REPRODUCIBLE/"
+    "NO_ENVIRONMENT/TOO_COMPLEX/SKIPPED/OTHER\n"
+    "\n"
+    'bnc#2 ("b"):\n'
+    "REPRODUCER_PRESENT: YES/NO\n"
+    "STATUS:             SKIPPED\n"  # already filled -> must stay
+    "\n"
+    'bnc#3 ("c"):\n'
+    "REPRODUCER_PRESENT: YES\n"  # already filled -> must stay
+    "STATUS:             FIXED/NOT_FIXED/HYPOTHETICAL/NOT_REPRODUCIBLE/"
+    "NO_ENVIRONMENT/TOO_COMPLEX/SKIPPED/OTHER\n"
+)
+
+
+def test_fill_sets_unfilled_placeholders_only(tmp_path: Path) -> None:
+    """Fill flips every *unfilled* token; already-set values are untouched."""
+    file = tmp_path / "report.txt"
+    file.write_text(_FILL_TEMPLATE, encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    res = asyncio.run(
+        tt.testreport_fill(sess, reproducer="NO", status="SKIPPED", summary="PASSED")  # ty: ignore[invalid-argument-type]
+    )
+    # summary x1; the two unfilled REPRODUCER lines; the two templated STATUS lines.
+    assert res["filled"] == {"summary": 1, "reproducer": 2, "status": 2}
+
+    out = file.read_text(encoding="utf-8")
+    assert out.startswith("SUMMARY: PASSED\n")
+    assert "PASSED/FAILED" not in out
+    assert "YES/NO" not in out
+    assert "FIXED/NOT_FIXED/" not in out
+    # bug#3's hand-set REPRODUCER stays YES; bug#2's hand-set STATUS stays SKIPPED.
+    assert "REPRODUCER_PRESENT: YES\n" in out
+    # column alignment of STATUS is preserved.
+    assert "STATUS:             SKIPPED\n" in out
+
+
+def test_fill_is_idempotent(tmp_path: Path) -> None:
+    """A second identical fill changes nothing (no placeholders left)."""
+    file = tmp_path / "report.txt"
+    file.write_text(_FILL_TEMPLATE, encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    asyncio.run(
+        tt.testreport_fill(sess, reproducer="NO", status="SKIPPED", summary="PASSED")  # ty: ignore[invalid-argument-type]
+    )
+    after_first = file.read_text(encoding="utf-8")
+    res2 = asyncio.run(
+        tt.testreport_fill(sess, reproducer="NO", status="SKIPPED", summary="PASSED")  # ty: ignore[invalid-argument-type]
+    )
+    assert res2["filled"] == {"summary": 0, "reproducer": 0, "status": 0}
+    assert file.read_text(encoding="utf-8") == after_first
+
+
+def test_fill_partial_only_requested_tokens(tmp_path: Path) -> None:
+    """Passing only `reproducer` leaves SUMMARY and STATUS placeholders alone."""
+    file = tmp_path / "report.txt"
+    file.write_text(_FILL_TEMPLATE, encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    res = asyncio.run(tt.testreport_fill(sess, reproducer="NO"))  # ty: ignore[invalid-argument-type]
+    assert res["filled"] == {"summary": 0, "reproducer": 2, "status": 0}
+    out = file.read_text(encoding="utf-8")
+    assert "SUMMARY: PASSED/FAILED\n" in out  # untouched
+    assert "FIXED/NOT_FIXED/" in out  # untouched
+
+
+def test_fill_rejects_bad_values(tmp_path: Path) -> None:
+    """Invalid enum values and an empty call are rejected with a message."""
+    file = tmp_path / "report.txt"
+    file.write_text(_FILL_TEMPLATE, encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_fill(sess, reproducer="MAYBE"))  # ty: ignore[invalid-argument-type]
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_fill(sess, status="DONE"))  # ty: ignore[invalid-argument-type]
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_fill(sess, summary="OK"))  # ty: ignore[invalid-argument-type]
+    with pytest.raises(McpCommandError):
+        # nothing to fill
+        asyncio.run(tt.testreport_fill(sess))  # ty: ignore[invalid-argument-type]
+
+
+def test_fill_refuses_without_loaded_report(tmp_path: Path) -> None:
+    """``testreport_fill`` raises on a NullTestReport session."""
+    sess = _null_session(tmp_path)
+    with pytest.raises(McpCommandError):
+        asyncio.run(tt.testreport_fill(sess, reproducer="NO"))


### PR DESCRIPTION
## What

Adds a `testreport_fill` MCP tool that bulk-sets the repetitive placeholder
tokens an exported QAM testreport ships with, in one atomic write:

- `reproducer` (YES/NO) → every unfilled `REPRODUCER_PRESENT:` line
- `status` (FIXED/NOT_FIXED/HYPOTHETICAL/NOT_REPRODUCIBLE/NO_ENVIRONMENT/TOO_COMPLEX/SKIPPED/OTHER) → every unfilled templated `STATUS:` line
- `summary` (PASSED/FAILED) → the top `SUMMARY:` line

## Why

A CVE-heavy update (e.g. an apache2 or openssl rebase) carries 15+ per-bug
`REPRODUCER_PRESENT: YES/NO` + `STATUS: …/OTHER` placeholders. Flipping each
one with `testreport_patch` is many round-trips and error-prone on a live
report (line-number drift). For a security update the answer is uniform
(`REPRODUCER_PRESENT: NO`, `STATUS: SKIPPED` per policy), so one call clears
them all; the tester then overrides any non-security bug individually.

## Safety

- Only the **exact** template placeholder strings are replaced, so the call is
  **idempotent** and never overwrites a value already filled in by hand.
- `STATUS` column alignment is preserved (label+padding captured via regex).
- Args are enum-validated; an empty call is refused.

## Tests

5 new tests (sets-unfilled-only, idempotent, partial, rejects-bad-values,
refuses-without-loaded-report); registration test updated. `pytest`/`ruff`/`ty`
all green.

Independent of #216 (different file, no workspace/pool/job dependency).