### PR TITLE
fix(oscqam): detach osc stdin and cap runtime so approve can't deadlock mtui-mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `assign`/`approve`/`reject`/`comment` no longer hang the mtui-mcp server. The
+  `osc qam` subprocess inherited the server's stdin — under mtui-mcp that is the
+  MCP stdio JSON-RPC pipe — so an interactive `osc` prompt (e.g. an approve
+  confirmation) blocked reading it forever and, because the server serialises
+  calls through one lock, every subsequent tool call wedged behind it. `osc` now
+  runs with stdin detached (`DEVNULL`) and a 180s timeout, so it either completes
+  or fails cleanly instead of deadlocking the session.
 - Desktop notifications (the `notify` extra) work again. They imported the
   long-dead `pynotify` PyGTK binding, which is unavailable on Python 3.13+, so
   the REPL's update-finished/update-failed toasts were a silent no-op; the

--- a/mtui/data_sources/oscqam.py
+++ b/mtui/data_sources/oscqam.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from shlex import join as shlex_join
 from shlex import quote
-from subprocess import CalledProcessError, check_call
+from subprocess import DEVNULL, CalledProcessError, TimeoutExpired, check_call
 
 from ..support.config import Config
 from ..types.enums import RequestKind
@@ -95,7 +95,12 @@ class OSC:
         logger.debug("Executing command: %s", shlex_join(command))
 
         try:
-            check_call(command)
+            # Never let osc inherit the server's stdin: under mtui-mcp that stdin is
+            # the MCP stdio JSON-RPC pipe, so an interactive osc prompt (e.g. an
+            # approve confirmation) would block reading it forever and deadlock the
+            # single-threaded server. Feed EOF instead, and cap the runtime so a
+            # stalled osc can never wedge the whole session.
+            check_call(command, stdin=DEVNULL, timeout=180)
 
         except CalledProcessError:
             logger.error(
@@ -103,6 +108,13 @@ class OSC:
                 operation,
             )
             logger.debug("Call stack trace:", stack_info=True)
+
+        except TimeoutExpired:
+            logger.error(
+                "'%s' operation timed out after 180s; osc did not return "
+                "(likely an interactive prompt with no input).",
+                operation,
+            )
 
         except FileNotFoundError:
             logger.error("'osc' command not found. Is it installed and in your PATH?")

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -119,6 +119,29 @@ class TestOSCOperations:
         osc.approve(["qam-sle"])  # should not raise
 
     @patch("mtui.data_sources.oscqam.check_call")
+    def test_stdin_detached_and_timed_out(self, mock_check_call, osc):
+        """osc must not inherit our stdin (the MCP pipe) and must be time-capped.
+
+        Otherwise an interactive osc prompt blocks reading the JSON-RPC stdin
+        forever and deadlocks the single-threaded mtui-mcp server.
+        """
+        from subprocess import DEVNULL
+
+        osc.approve(["qam-sle"])
+
+        kwargs = mock_check_call.call_args.kwargs
+        assert kwargs.get("stdin") is DEVNULL
+        assert kwargs.get("timeout")
+
+    @patch("mtui.data_sources.oscqam.check_call")
+    def test_timeoutexpired_logged(self, mock_check_call, osc):
+        """Test TimeoutExpired is caught and logged (does not raise)."""
+        from subprocess import TimeoutExpired
+
+        mock_check_call.side_effect = TimeoutExpired("osc", 180)
+        osc.approve(["qam-sle"])  # should not raise
+
+    @patch("mtui.data_sources.oscqam.check_call")
     def test_api_url(self, mock_check_call, osc):
         """Test API URL is passed correctly."""
         osc.approve(["qam-sle"])


### PR DESCRIPTION
## Problem

`osc qam {assign,approve,reject,comment}` are run via `check_call(command)` in `mtui/data_sources/oscqam.py` with no `stdin`. Under **mtui-mcp** the server's stdin is the MCP stdio JSON-RPC pipe, so when `osc` prompts interactively (e.g. an approve confirmation for some classic requests) it blocks reading that pipe forever. Because the mtui-mcp server serialises every tool call through one lock, the hung `osc` child wedges **all** subsequent calls — `whoami`, `list_workspaces`, further `approve`s — and the whole session looks stuck. There is no timeout, so it never recovers.

Observed in the wild: three `osc -A https://api.suse.de qam approve` children stuck >1h in `unix_stream_read_generic` (reading the inherited MCP stdin), no pinentry/tty involved; `osc api /about` with stdin closed works instantly, ruling out auth.

## Fix

Run `osc` with `stdin=DEVNULL` and a 180s `timeout`, so it either completes or fails cleanly instead of deadlocking the single-threaded server. `TimeoutExpired` is caught and logged alongside the existing error handling.

Adds regression tests asserting the call is stdin-detached + time-capped and that `TimeoutExpired` is handled.

CHANGELOG updated under `[Unreleased] / Fixed`.