### PR TITLE
fix(oscqam): surface osc failures and signal outcome instead of a bare exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   calls through one lock, every subsequent tool call wedged behind it. `osc` now
   runs with stdin detached (`DEVNULL`) and a 180s timeout, so it either completes
   or fails cleanly instead of deadlocking the session.
+- A failed `assign`/`approve`/`reject`/`comment` now reports *why*. `osc qam` is
+  run with its output captured, so a non-zero exit logs osc's actual stderr
+  (e.g. "request already accepted", "user not assigned") instead of a bare "the
+  command returned a non-zero exit code", and the `OSC` methods now return a
+  success/failure boolean to the caller. When the failure followed a
+  `-G/--group` call, the error adds an actionable hint: that path triggers an
+  interactive osc confirmation which cannot be answered headless (e.g. under
+  mtui-mcp), so the operation should be re-run without `-G/--group` to act on the
+  review assigned to you.
 - Desktop notifications (the `notify` extra) work again. They imported the
   long-dead `pynotify` PyGTK binding, which is unavailable on Python 3.13+, so
   the REPL's update-finished/update-failed toasts were a silent no-op; the

--- a/mtui/data_sources/oscqam.py
+++ b/mtui/data_sources/oscqam.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from shlex import join as shlex_join
 from shlex import quote
-from subprocess import DEVNULL, CalledProcessError, TimeoutExpired, check_call
+from subprocess import DEVNULL, CalledProcessError, TimeoutExpired, run
 
 from ..support.config import Config
 from ..types.enums import RequestKind
@@ -12,6 +12,24 @@ from ..types.rrid import RequestReviewID
 logger = getLogger("mtui.connector.oscqam")
 
 API = "https://api.suse.de"
+
+
+def _tail(text: str | None, limit: int = 2000) -> str:
+    """Trim captured osc output to its last ``limit`` chars for logging.
+
+    Args:
+        text: Captured stdout/stderr, possibly ``None``.
+        limit: Maximum number of characters to keep.
+
+    Returns:
+        The stripped text, truncated from the front (prefixed with an
+        ellipsis) when longer than ``limit``; ``""`` when ``text`` is empty.
+
+    """
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return "…" + text[-limit:]
 
 
 class OSC:
@@ -35,7 +53,7 @@ class OSC:
         reason: str = "",
         message: str = "",
         comment: str = "",
-    ) -> None:
+    ) -> bool:
         """Constructs and executes `osc qam` commands safely.
 
         This method builds the command as a list of arguments to
@@ -47,6 +65,11 @@ class OSC:
             reason: The reason for a rejection.
             message: The message to include with the operation.
             comment: A comment to add to the request.
+
+        Returns:
+            ``True`` when osc exited cleanly, ``False`` on any failure
+            (non-zero exit, timeout, or osc not found). Failures are logged
+            with osc's captured stderr so the caller learns *why*.
 
         """
         # Start with the base command components that are always present.
@@ -98,16 +121,36 @@ class OSC:
             # Never let osc inherit the server's stdin: under mtui-mcp that stdin is
             # the MCP stdio JSON-RPC pipe, so an interactive osc prompt (e.g. an
             # approve confirmation) would block reading it forever and deadlock the
-            # single-threaded server. Feed EOF instead, and cap the runtime so a
-            # stalled osc can never wedge the whole session.
-            check_call(command, stdin=DEVNULL, timeout=180)
-
-        except CalledProcessError:
-            logger.error(
-                "'%s' operation failed. The command returned a non-zero exit code.",
-                operation,
+            # single-threaded server. Feed EOF instead, cap the runtime so a stalled
+            # osc can never wedge the session, and capture output so a failure can
+            # report osc's actual reason instead of a bare exit code.
+            proc = run(
+                command,
+                stdin=DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=180,
+                check=True,
             )
+
+        except CalledProcessError as e:
+            detail = _tail(e.stderr) or _tail(e.stdout) or f"exit code {e.returncode}"
+            logger.error("'%s' operation failed: %s", operation, detail)
+            if groups:
+                # `osc qam <op> -G` first asks an interactive confirmation; with
+                # stdin detached that prompt EOFs, so the -G path can only fail
+                # headless. The group review reassigned to you on pickup is a plain
+                # user review — approve/assign it without -G.
+                logger.error(
+                    "'%s' was called with -G/--group, whose osc confirmation prompt "
+                    "cannot be answered without a terminal (e.g. under mtui-mcp). "
+                    "Re-run '%s' without -G/--group to act on the review assigned "
+                    "to you.",
+                    operation,
+                    operation,
+                )
             logger.debug("Call stack trace:", stack_info=True)
+            return False
 
         except TimeoutExpired:
             logger.error(
@@ -115,47 +158,66 @@ class OSC:
                 "(likely an interactive prompt with no input).",
                 operation,
             )
+            return False
 
         except FileNotFoundError:
             logger.error("'osc' command not found. Is it installed and in your PATH?")
+            return False
 
-    def approve(self, group: list[str]) -> None:
+        out = _tail(proc.stdout)
+        if out:
+            logger.info("'%s' succeeded: %s", operation, out)
+        return True
+
+    def approve(self, group: list[str]) -> bool:
         """Approves a review request for one or more groups.
 
         Args:
             group: A list of group names to approve the request for.
 
-        """
-        self.__operation("approve", group)
+        Returns:
+            ``True`` if osc approved cleanly, ``False`` otherwise.
 
-    def assign(self, group: list[str]) -> None:
+        """
+        return self.__operation("approve", group)
+
+    def assign(self, group: list[str]) -> bool:
         """Assigns a review request to one or more groups.
 
         Args:
             group: A list of group names to assign the request to.
 
-        """
-        self.__operation("assign", group)
+        Returns:
+            ``True`` if osc assigned cleanly, ``False`` otherwise.
 
-    def unassign(self, group: list[str]) -> None:
+        """
+        return self.__operation("assign", group)
+
+    def unassign(self, group: list[str]) -> bool:
         """Unassigns a review request from one or more groups.
 
         Args:
             group: A list of group names to unassign the request from.
 
-        """
-        self.__operation("unassign", group)
+        Returns:
+            ``True`` if osc unassigned cleanly, ``False`` otherwise.
 
-    def comment(self, comment: str) -> None:
+        """
+        return self.__operation("unassign", group)
+
+    def comment(self, comment: str) -> bool:
         """Adds a comment to a review request.
 
         Args:
             comment: The comment to add.
 
-        """
-        self.__operation("comment", [], comment=comment)
+        Returns:
+            ``True`` if osc recorded the comment cleanly, ``False`` otherwise.
 
-    def reject(self, group: list[str], reason: str, message: str) -> None:
+        """
+        return self.__operation("comment", [], comment=comment)
+
+    def reject(self, group: list[str], reason: str, message: str) -> bool:
         """Rejects a review request.
 
         Args:
@@ -163,5 +225,8 @@ class OSC:
             reason: The reason for the rejection.
             message: The rejection message.
 
+        Returns:
+            ``True`` if osc rejected cleanly, ``False`` otherwise.
+
         """
-        self.__operation("reject", group, reason=reason, message=message)
+        return self.__operation("reject", group, reason=reason, message=message)

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -1,5 +1,12 @@
 """Tests for the mtui connector oscqam module."""
 
+import logging
+from subprocess import (
+    DEVNULL,
+    CalledProcessError,
+    CompletedProcess,
+    TimeoutExpired,
+)
 from unittest.mock import patch
 
 import pytest
@@ -7,11 +14,28 @@ import pytest
 from mtui.data_sources.oscqam import OSC
 from mtui.types import RequestKind
 
+_LOGGER = "mtui.connector.oscqam"
+
 
 @pytest.fixture
 def osc(mock_config, mock_rrid):
     """Create an OSC instance with mock config and rrid."""
     return OSC(mock_config, mock_rrid)
+
+
+@pytest.fixture
+def mock_run():
+    """Patch ``run`` in oscqam with a clean, empty-output success by default.
+
+    Tests that need a failure set ``mock_run.side_effect`` to the relevant
+    exception; the empty ``stdout``/``stderr`` keeps the success path from
+    blowing up on the captured-output logging.
+    """
+    with patch("mtui.data_sources.oscqam.run") as m:
+        m.return_value = CompletedProcess(
+            args=["osc"], returncode=0, stdout="", stderr=""
+        )
+        yield m
 
 
 class TestOSCInit:
@@ -21,132 +45,161 @@ class TestOSCInit:
         assert osc.rrid is mock_rrid
 
 
-class TestOSCOperations:
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_approve(self, mock_check_call, osc):
+class TestOSCCommandBuilding:
+    def test_approve(self, mock_run, osc):
         """Test approve builds correct command."""
         osc.approve(["qam-sle"])
 
-        mock_check_call.assert_called_once()
-        cmd = mock_check_call.call_args[0][0]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         assert cmd[0] == "osc"
         assert "approve" in cmd
         assert "-G" in cmd
         assert "qam-sle" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_assign(self, mock_check_call, osc):
+    def test_assign(self, mock_run, osc):
         """Test assign builds correct command."""
         osc.assign(["qam-sle"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "assign" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_unassign(self, mock_check_call, osc):
+    def test_unassign(self, mock_run, osc):
         """Test unassign builds correct command."""
         osc.unassign(["qam-sle"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "unassign" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_reject_with_reason_and_message(self, mock_check_call, osc):
+    def test_reject_with_reason_and_message(self, mock_run, osc):
         """Test reject includes reason and message."""
         osc.reject(["qam-sle"], "bug found", "details here")
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "reject" in cmd
         assert "-R" in cmd
         assert "bug found" in cmd
         assert "-M" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_comment(self, mock_check_call, osc):
+    def test_comment(self, mock_run, osc):
         """Test comment builds correct command."""
         osc.comment("test comment")
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "comment" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_multiple_groups(self, mock_check_call, osc):
+    def test_multiple_groups(self, mock_run, osc):
         """Test command with multiple groups adds -G for each."""
         osc.approve(["qam-sle", "qam-kernel"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         g_indices = [i for i, x in enumerate(cmd) if x == "-G"]
         assert len(g_indices) == 2
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_empty_groups(self, mock_check_call, osc):
+    def test_empty_groups(self, mock_run, osc):
         """Test command with no groups omits -G."""
         osc.comment("hello")
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "-G" not in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_skip_template_for_pi(self, mock_check_call, osc):
+    def test_skip_template_for_pi(self, mock_run, osc):
         """Test --skip-template is added for PI kind."""
         osc.rrid.kind = RequestKind.PI
         osc.approve(["qam-sle"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "--skip-template" in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_no_skip_template_for_sle(self, mock_check_call, osc):
+    def test_no_skip_template_for_sle(self, mock_run, osc):
         """Test --skip-template is NOT added for non-PI/non-SLFO kinds."""
         osc.rrid.kind = RequestKind.MAINTENANCE
         osc.approve(["qam-sle"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "--skip-template" not in cmd
 
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_calledprocesserror_logged(self, mock_check_call, osc):
-        """Test CalledProcessError is caught and logged."""
-        from subprocess import CalledProcessError
-
-        mock_check_call.side_effect = CalledProcessError(1, "osc")
-        osc.approve(["qam-sle"])  # should not raise
-
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_filenotfounderror_logged(self, mock_check_call, osc):
-        """Test FileNotFoundError is caught and logged."""
-        mock_check_call.side_effect = FileNotFoundError("osc not found")
-        osc.approve(["qam-sle"])  # should not raise
-
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_stdin_detached_and_timed_out(self, mock_check_call, osc):
-        """osc must not inherit our stdin (the MCP pipe) and must be time-capped.
-
-        Otherwise an interactive osc prompt blocks reading the JSON-RPC stdin
-        forever and deadlocks the single-threaded mtui-mcp server.
-        """
-        from subprocess import DEVNULL
-
-        osc.approve(["qam-sle"])
-
-        kwargs = mock_check_call.call_args.kwargs
-        assert kwargs.get("stdin") is DEVNULL
-        assert kwargs.get("timeout")
-
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_timeoutexpired_logged(self, mock_check_call, osc):
-        """Test TimeoutExpired is caught and logged (does not raise)."""
-        from subprocess import TimeoutExpired
-
-        mock_check_call.side_effect = TimeoutExpired("osc", 180)
-        osc.approve(["qam-sle"])  # should not raise
-
-    @patch("mtui.data_sources.oscqam.check_call")
-    def test_api_url(self, mock_check_call, osc):
+    def test_api_url(self, mock_run, osc):
         """Test API URL is passed correctly."""
         osc.approve(["qam-sle"])
 
-        cmd = mock_check_call.call_args[0][0]
+        cmd = mock_run.call_args[0][0]
         assert "-A" in cmd
         api_index = cmd.index("-A")
         assert cmd[api_index + 1] == "https://api.suse.de"
+
+
+class TestOSCInvocation:
+    def test_stdin_detached_captured_and_timed(self, mock_run, osc):
+        """osc must not inherit our stdin, must capture output, and be time-capped.
+
+        Detaching stdin (the MCP JSON-RPC pipe) keeps an interactive osc prompt
+        from deadlocking the single-threaded server; capturing output lets a
+        failure report osc's real reason; the timeout is the backstop.
+        """
+        osc.approve(["qam-sle"])
+
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs.get("stdin") is DEVNULL
+        assert kwargs.get("capture_output") is True
+        assert kwargs.get("text") is True
+        assert kwargs.get("check") is True
+        assert kwargs.get("timeout")
+
+
+class TestOSCOutcome:
+    def test_returns_true_on_success(self, mock_run, osc):
+        """A clean osc exit reports success to the caller."""
+        assert osc.approve(["qam-sle"]) is True
+
+    def test_returns_false_on_calledprocesserror(self, mock_run, osc):
+        """A non-zero osc exit reports failure to the caller (no raise)."""
+        mock_run.side_effect = CalledProcessError(1, "osc", stderr="boom")
+        assert osc.approve(["qam-sle"]) is False
+
+    def test_returns_false_on_timeout(self, mock_run, osc):
+        """A timed-out osc reports failure to the caller (no raise)."""
+        mock_run.side_effect = TimeoutExpired("osc", 180)
+        assert osc.approve(["qam-sle"]) is False
+
+    def test_returns_false_when_osc_missing(self, mock_run, osc):
+        """A missing osc binary reports failure to the caller (no raise)."""
+        mock_run.side_effect = FileNotFoundError("osc not found")
+        assert osc.approve(["qam-sle"]) is False
+
+
+class TestOSCErrorReporting:
+    def test_failure_surfaces_osc_stderr(self, mock_run, osc, caplog):
+        """The captured osc stderr is logged so the caller learns *why*."""
+        mock_run.side_effect = CalledProcessError(
+            1, "osc", stderr="Error: request 414975 already accepted"
+        )
+        with caplog.at_level(logging.ERROR, logger=_LOGGER):
+            osc.approve([])  # no group -> isolates the stderr-surfacing path
+        assert "already accepted" in caplog.text
+
+    def test_group_failure_adds_headless_hint(self, mock_run, osc, caplog):
+        """A failed -G call hints to re-run without -G (the interactive trap)."""
+        mock_run.side_effect = CalledProcessError(1, "osc", stderr="EOFError")
+        with caplog.at_level(logging.ERROR, logger=_LOGGER):
+            osc.approve(["qam-sle"])
+        assert "without -G" in caplog.text
+
+    def test_no_group_failure_omits_hint(self, mock_run, osc, caplog):
+        """A failure without -G must not emit the -G hint."""
+        mock_run.side_effect = CalledProcessError(1, "osc", stderr="nope")
+        with caplog.at_level(logging.ERROR, logger=_LOGGER):
+            osc.comment("hi")
+        assert "without -G" not in caplog.text
+
+    def test_success_logs_osc_stdout(self, mock_run, osc, caplog):
+        """A clean run logs osc's confirmation output."""
+        mock_run.return_value = CompletedProcess(
+            args=["osc"],
+            returncode=0,
+            stdout="Approving 414975 for Martin Pluskal (qam-sle).",
+            stderr="",
+        )
+        with caplog.at_level(logging.INFO, logger=_LOGGER):
+            assert osc.approve([]) is True
+        assert "Approving 414975" in caplog.text


### PR DESCRIPTION
## Problem

`osc qam {assign,approve,reject,comment}` runs through `OSC.__operation`, which (after #228) calls `osc` with `stdin=DEVNULL` + a 180s timeout — that fixed the *deadlock*, but osc's stdout/stderr still went straight to the server's console and were never captured. So a failure logged only:

```
ERROR: 'approve' operation failed. The command returned a non-zero exit code.
```

The actual reason — *request already accepted*, *user not assigned*, a test-result mismatch, or an EOF'd interactive prompt — was invisible to an `mtui-mcp` caller, who then has to go run `osc request show` by hand to find out what happened. `__operation` also returned `None` whether osc succeeded or failed, so callers had no programmatic signal.

A specific trap: `osc qam <op> -G/--group` first asks an interactive `"…Abort?"` confirmation (`oscqam/cli_approve.py`). With stdin detached that prompt EOFs, so the `-G` path can only fail headless — and the bare "non-zero exit code" gave no clue why.

## Change

- Run osc with `capture_output=True` (keeping `stdin=DEVNULL` + the 180s timeout). On a non-zero exit, log osc's real stderr (trimmed) instead of the generic message.
- Return a success/failure `bool` from `__operation` and the public `approve`/`assign`/`unassign`/`comment`/`reject` methods, so callers can tell what happened.
- When the failed call used `-G/--group`, add an actionable hint: that path is interactive and can't run headless (e.g. under mtui-mcp); re-run without `-G/--group` to act on the review assigned to you.
- On success, log osc's confirmation line.

I chose a **contextual hint on failure** over a pre-emptive `isatty()` guard — it can't false-block a legitimate call and needs no fragile terminal heuristic. The deadlock itself remains fixed by #228; this PR is purely visibility + outcome signalling, and the behaviour benefits all four `osc qam` operations since they share `__operation`.

## Tests

`tests/test_oscqam.py` reworked onto a `run()` fixture; added coverage for the outcome bool, stderr surfacing, the `-G` hint (and its absence without `-G`), timeout / missing-binary → `False`, and success-stdout logging. Local gates green: `ruff format --check`, `ruff check`, `ty check` (clean for changed files), `pytest` (full fast suite passes).