### PR TITLE
fix(parsers): normalise absolute baseproduct symlink target to basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   one base (`SLES`) with LTSS/HA/SAP recorded as addons, so the previous
   base-only match found nothing — `add_host` reported "No refhosts to add" for
   every LTSS/HA/SAP incident even though matching hosts existed.
+- The product/refhost check no longer misreports a healthy host as having a
+  dangling `/etc/products.d/baseproduct` symlink when that symlink uses an
+  **absolute** target (`/etc/products.d/SLES.prod`) rather than a bare
+  `SLES.prod`. The target was concatenated onto `/etc/products.d/`, producing
+  `/etc/products.d//etc/products.d/SLES.prod`, which failed to open and was
+  reported as dangling (also mis-classifying the real base product as an
+  unexpected addon). The symlink target is now reduced to its basename, so
+  both relative and absolute forms resolve.
 
 ## 18.2.0 - 2026-06-23
 

--- a/mtui/hosts/target/parsers/system.py
+++ b/mtui/hosts/target/parsers/system.py
@@ -1,5 +1,6 @@
 """A parser for the system information of a target host."""
 
+import posixpath
 from logging import getLogger
 
 from ....types import Product
@@ -49,6 +50,14 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
             return (System(Product(name, version, arch)), False)
 
         basefile = sftp.readlink("/etc/products.d/baseproduct")
+        if basefile:
+            # The symlink target may be absolute (``/etc/products.d/SLES.prod``)
+            # or relative (``SLES.prod``). Product files are looked up by
+            # basename within ``/etc/products.d``, so normalise either form to
+            # the basename. Without this an absolute target was concatenated
+            # into ``/etc/products.d//etc/products.d/SLES.prod`` on ``open()``,
+            # which raised ``OSError`` and was misreported as a dangling symlink.
+            basefile = posixpath.basename(basefile)
         if basefile and basefile in files:
             files.remove(basefile)
 

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -339,6 +339,44 @@ class TestParseSystem:
         mock_product_module.parse_product.assert_not_called()
 
     @patch("mtui.hosts.target.parsers.system.product")
+    def test_parse_absolute_baseproduct_symlink(self, mock_product_module):
+        """An absolute baseproduct symlink target resolves, not false-dangling.
+
+        Some hosts have ``/etc/products.d/baseproduct`` pointing at the
+        absolute path ``/etc/products.d/SLES.prod`` rather than the bare
+        ``SLES.prod``. The target file exists, so parse_system must read it
+        normally (not concatenate it into ``/etc/products.d/<abspath>`` and
+        misreport a dangling symlink).
+        """
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = ["SLES.prod"]
+        sftp.readlink.return_value = "/etc/products.d/SLES.prod"
+
+        def _open(path, *args, **kwargs):
+            p = str(path)
+            # Only the correctly-normalised path exists; a doubled path
+            # (the pre-fix bug) raises OSError like a real dangling target.
+            if p == "/etc/products.d/SLES.prod":
+                return MagicMock()
+            if "transactional-update.conf" in p:
+                raise FileNotFoundError(p)
+            raise OSError(f"no such file: {p}")
+
+        sftp.open.side_effect = _open
+        mock_product_module.parse_product.side_effect = [
+            ("SLES", "15-SP6", "x86_64"),
+        ]
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        system, transactional = parse_system(conn)
+
+        assert system.dangling_base is False
+        assert system.get_base().name == "SLES"
+        assert system.get_base().version == "15-SP6"
+        assert transactional is False
+
+    @patch("mtui.hosts.target.parsers.system.product")
     def test_parse_missing_baseproduct_symlink(self, mock_product_module):
         """An absent/empty baseproduct symlink degrades instead of crashing."""
         conn, sftp = _mock_connection_with_sftp()


### PR DESCRIPTION
## Problem

`parse_system` reads the base product by following `/etc/products.d/baseproduct` and opening the target file in `/etc/products.d/`. It assumed the symlink target is a bare basename (e.g. `SLES.prod`):

```python
basefile = sftp.readlink("/etc/products.d/baseproduct")
...
with sftp.open(f"/etc/products.d/{basefile}") as f:
```

Some hosts have the symlink pointing at an **absolute** path instead — `/etc/products.d/baseproduct -> /etc/products.d/SLES.prod`. There the open path becomes `/etc/products.d//etc/products.d/SLES.prod`, which raises `OSError` and is caught as a *dangling baseproduct symlink* — even though the target file exists and the host is perfectly healthy. As a side effect the real base product is then mis-classified as an unexpected addon, so the refhost product-drift check reports bogus differences.

Found on a live refhost whose `baseproduct` symlink (created with an absolute target) tripped the connect-time product check.

## Change

Reduce the `readlink` result to its basename with `posixpath.basename(...)` before the membership check and the open, so both relative (`SLES.prod`) and absolute (`/etc/products.d/SLES.prod`) targets resolve to the file in `/etc/products.d/`.

## Tests

Adds `test_parse_absolute_baseproduct_symlink` (an absolute target resolves and is **not** reported dangling) — verified it fails before the fix and passes after. Existing dangling/missing/relative cases still pass. Local gates green: `ruff format --check`, `ruff check`, `ty check`, full fast `pytest`.