### PR TITLE
fix(templates): never register the NullTestReport sentinel on a failed load

### DIFF
--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -465,6 +465,11 @@ class CommandPrompt:
             self.interactive,
             prompter=self.prompter,
         )
+        # A failed load returns a NullTestReport sentinel (empty RRID); ``add``
+        # ignores it, and we skip the active-pointer move so the registry (and
+        # any already-loaded templates) are left untouched rather than gaining
+        # a phantom empty-RRID entry that breaks fan-out.
         self.templates.add(tr)
-        self.templates.set_active(str(tr.id))
+        if str(tr.id):
+            self.templates.set_active(str(tr.id))
         self.set_prompt()

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -370,8 +370,13 @@ class McpSession:
             self.interactive,
             prompter=self.prompter,
         )
+        # A failed load returns a NullTestReport sentinel (empty RRID).
+        # ``add`` ignores it; skip the active-pointer move too so a failed
+        # load leaves the registry and active template untouched instead of
+        # planting a phantom entry that breaks fan-out.
         self.templates.add(tr)
-        self.templates.set_active(str(tr.id))
+        if str(tr.id):
+            self.templates.set_active(str(tr.id))
         # Re-apply the non-interactive flag after the testreport swap so
         # the fresh HostsGroup inherits the session's headless mode.
         self.targets.interactive = False

--- a/mtui/template_registry.py
+++ b/mtui/template_registry.py
@@ -70,8 +70,16 @@ class TemplateRegistry:
 
         The first template added becomes active. Re-adding an existing RRID
         replaces the stored report but does not change the active pointer.
+
+        A :class:`NullTestReport` (empty RRID) is the sentinel a *failed* load
+        returns; it is never keyed into the collection. Keying it would leave a
+        phantom empty-RRID entry that breaks every unscoped fan-out with
+        ``TestReportNotLoadedError``. Such a report is silently ignored here so
+        a failed load leaves the registry unchanged.
         """
         rrid = str(report.id)
+        if not rrid:
+            return
         # Wire host-arbitration ownership so connect_targets can draw distinct
         # pool hosts; reports stay legacy (remote-lock-only) until this is set.
         report._arbiter = self.arbiter  # noqa: SLF001

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -72,6 +72,25 @@ def test_add_second_does_not_change_active(registry):
     assert registry.active is r1
 
 
+def test_add_ignores_empty_rrid_sentinel(registry):
+    # A NullTestReport (failed load) has an empty RRID; it must never be keyed
+    # into the registry, else it becomes a phantom entry that breaks fan-out.
+    null = make_report("")
+    registry.add(null)
+    assert len(registry) == 0
+    assert not registry
+    assert "" not in registry
+
+
+def test_add_sentinel_does_not_disturb_loaded_templates(registry):
+    r = make_report("SUSE:Maintenance:1:1")
+    registry.add(r)
+    registry.add(make_report(""))  # failed load mid-session
+    assert len(registry) == 1
+    assert registry.active is r
+    assert registry.rrids() == ["SUSE:Maintenance:1:1"]
+
+
 def test_get_returns_report(registry):
     r = make_report("SUSE:Maintenance:1:1")
     registry.add(r)


### PR DESCRIPTION
## Problem

A failed `load_template` (testreport doesn't exist, Gitea error, etc.) makes `make_testreport` return a `NullTestReport` sentinel with an **empty RRID**. Both `load_update` paths (REPL `CommandPrompt` and `McpSession`) then call `templates.add(tr)` + `set_active(str(tr.id))` unconditionally, so the sentinel gets keyed into the registry under `''`.

Before multi-template this was a harmless single-slot swap. With the `TemplateRegistry` + fan-out it leaves a **phantom empty-RRID entry**: every later *unscoped* fan-out (the default for action/inspection tools) iterates it and aborts with

```
FanOutError([('', TestReportNotLoadedError())])
```

so after a single mistyped or not-yet-generated RRID the whole session can only run `-T`/`template=` scoped calls. Reproduced over mtui-mcp: one `load_template` of an ungenerated SLFO report poisoned every subsequent bare `assign`/`list_metadata`/`openqa_overview`.

## Fix

- `TemplateRegistry.add` ignores an empty-RRID (sentinel) report — it is never keyed in.
- Both `load_update` paths skip the `set_active` move when the load returned the sentinel, so a failed load leaves the registry **and** the active pointer untouched (a failed load mid-session no longer disturbs already-loaded templates).
- The CLI `does not exist` exit path (`main.py` `isinstance(..., NullTestReport)` on the empty-registry active fallback) is preserved.

## Tests

Added two regression tests (`add()` ignores the empty-RRID sentinel; a failed load mid-session keeps loaded templates intact). Full suite green locally (1453 passed; the 4 `responses`-dependent connector modules are unrelated pre-existing collection errors), ruff clean.