### PR TITLE
Multi-template host fan-out, host-pool arbitration, and refhosts simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Loading a template no longer connects to *every* matching reference host when a
+  testplatform resolves to several candidates on the same architecture. The
+  autoconnect that runs during `load_template` was happening before the host
+  arbiter was wired, so it fell back to the legacy "connect all candidates" path;
+  it now draws exactly one host per test-target slot (product + version + arch +
+  addons). If that host fails to connect, mtui automatically falls back to a
+  backup candidate from the same slot, and only warns once when every candidate
+  for a slot is unreachable.
 - `assign`/`approve`/`reject`/`comment` no longer hang the mtui-mcp server. The
   `osc qam` subprocess inherited the server's stdin — under mtui-mcp that is the
   MCP stdio JSON-RPC pipe — so an interactive `osc` prompt (e.g. an approve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (and the `:name` suffix it added to the prompt string) have been removed. They
   are redundant now that multiple templates can be loaded at once and the toolbar
   shows the active template's RRID alongside the loaded-template count.
+- The `-c`/`--clean-hosts` flag on `load_template` has been removed. Host
+  carry-over between templates no longer happens (each template owns its own
+  hosts), so the flag that toggled it is obsolete.
 
 ### Fixed
 
@@ -118,6 +121,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   connects only the arbiter-chosen host per slot. The host drawn for each slot
   (and the backup-on-failure order) is chosen at random among the free
   candidates so load is spread across interchangeable refhosts.
+- `load_template` no longer reconnects the previously active template's hosts
+  onto the newly loaded one. Each loaded template now owns its own reference
+  hosts: loading a second template (e.g. after `add_host` had switched the
+  first to the manual workflow and connected its testplatform hosts) connects
+  only the new template's own hosts and leaves the first template's hosts and
+  pool claims untouched. This carry-over was a leftover from the pre-1.0,
+  single-template world where loading *replaced* the session.
 - `assign`/`approve`/`reject`/`comment` no longer hang the mtui-mcp server. The
   `osc qam` subprocess inherited the server's stdin — under mtui-mcp that is the
   MCP stdio JSON-RPC pipe — so an interactive `osc` prompt (e.g. an approve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,18 +38,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Tab completion for the `-T/--template` and `--all-templates` flags on every
   fan-out command, completing the loaded template RRIDs as values (like `switch`
   and `unload`).
-- Opt-in host arbitration for multi-template fan-out (`refhosts.pool_select`,
-  default off). When enabled, each loaded template draws a *distinct* free
-  reference host per test-target slot (product + version + arch + addons) from
-  the shared pool, arbitrated in-process so two templates never collide on the
-  same host; claimed hosts carry an identifying `mtui pool <RRID> [<owner>]`
-  remote-lock comment and are released on `unload`/`quit` and when an mtui-mcp
-  session closes. New `lock.wait` / `lock.wait_poll` options make a busy host
-  *queue* (polling) instead of failing immediately, so several fanned-out
-  templates wait politely on an exhausted pool. With `pool_select` off (the
-  default), host selection and locking are byte-for-byte unchanged; fan-out may
-  then open separate SSH sessions to an overlapping host, so use `pool_select`,
-  disjoint host sets, or `-T` when that matters.
+- Host arbitration for multi-template fan-out. Each loaded template draws a
+  *distinct* free reference host per test-target slot (product + version + arch
+  + addons) from the shared pool, arbitrated in-process so two templates never
+  collide on the same host; claimed hosts carry an identifying `mtui pool <RRID>
+  [<owner>]` remote-lock comment and are released on `unload`/`quit` and when an
+  mtui-mcp session closes. New `lock.wait` / `lock.wait_poll` options make a busy
+  host *queue* (polling) instead of failing immediately, so several fanned-out
+  templates wait politely on an exhausted pool. This arbitration is always on;
+  scope a command with `-T` to act on a single template.
 - mtui-mcp gained multi-template parity. Fan-out action tools expose optional
   `template` (scope the call to one loaded RRID) and `all_templates` parameters;
   a call without them fans out across the session's loaded templates. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   addons). If that host fails to connect, mtui automatically falls back to a
   backup candidate from the same slot, and only warns once when every candidate
   for a slot is unreachable.
+- `add_host` without `--target` (selecting hosts from the testplatform) now
+  connects exactly one host per test-target slot. Two problems caused several
+  machines on the same architecture/product to be connected: (1) in automatic
+  mode the reference hosts pre-loaded from the template were still connected
+  alongside the pool-selected host, and (2) the per-slot grouping keyed on every
+  module a host happened to have installed, so two otherwise-interchangeable
+  hosts that differed by a single installed module were treated as separate
+  slots and both connected. Selection now groups by what the testplatform
+  actually requests (base product + version + arch + the requested addons) and
+  connects only the arbiter-chosen host per slot. The host drawn for each slot
+  (and the backup-on-failure order) is chosen at random among the free
+  candidates so load is spread across interchangeable refhosts.
 - `assign`/`approve`/`reject`/`comment` no longer hang the mtui-mcp server. The
   `osc qam` subprocess inherited the server's stdin — under mtui-mcp that is the
   MCP stdio JSON-RPC pipe — so an interactive `osc` prompt (e.g. an approve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Removed
 
+- Location support has been removed. The `set_location` command, the
+  `-l`/`--location` command-line option (both `mtui` and `mtui-mcp`), and the
+  `mtui.location` configuration option no longer exist. Legacy `refhosts.yml`
+  files that group hosts under top-level location keys are still read: every
+  group is now merged into a single host pool. A stray `location =` line in an
+  existing config is harmless and simply ignored.
 - The `set_session_name` command and the `session` field in the bottom toolbar
   (and the `:name` suffix it added to the prompt string) have been removed. They
   are redundant now that multiple templates can be loaded at once and the toolbar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The `-c`/`--clean-hosts` flag on `load_template` has been removed. Host
   carry-over between templates no longer happens (each template owns its own
   hosts), so the flag that toggled it is obsolete.
+- The SSH password fallback has been removed. When public-key authentication to
+  a host fails, mtui no longer prompts for a root password; the connection is
+  reported as failed instead. This removes a rarely-used fallback whose prompt
+  got overwritten by sibling hosts' output when connecting a group of hosts in
+  parallel, leaving an unclear UI. Set up working SSH key authentication to the
+  target (verify with `ssh root@<host>`).
 
 ### Fixed
 
@@ -96,14 +102,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Pool claims are now reliably removed on disconnect (`remove_host`, `quit`,
   `unload`, and MCP session teardown), so hosts are not left claimed after a
   session releases them.
-- The SSH password fallback prompt now renders correctly inside the interactive
-  REPL. Previously, when key authentication failed, the password prompt was read
-  with `getpass`, which does not cooperate with the prompt_toolkit session that
-  drives the REPL: the prompt was never shown and mtui appeared to hang silently.
-  The prompt now goes through the same prompt_toolkit-backed, masked,
-  cross-thread-serialised path as other interactive prompts, and names the user
-  and host it is asking for (`root@<host>'s password: `).
-- Authentication failures (wrong password, generic SSH errors) now print a
+- Authentication failures (failed key auth, generic SSH errors) now print a
   single clear error line instead of dumping a raw paramiko traceback and a
   duplicate message. The full traceback is still available with `--debug`.
 - Loading a template no longer connects to *every* matching reference host when a
@@ -397,11 +396,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Running under MCP (`mtui-mcp`) no longer hangs when a refhost's SSH key
   authentication fails. Previously the connect path fell back to an interactive
-  `getpass` root-password prompt, which has no TTY in MCP mode (stdin is the
-  JSON-RPC pipe) and blocked the session indefinitely. Non-interactive sessions
-  now skip the prompt and fail fast with a single actionable WARNING naming the
-  fix (set up working SSH key auth, verify with `ssh root@<host>`); the affected
-  host is reported as unreachable instead of stalling the whole client.
+  root-password prompt, which has no TTY in MCP mode (stdin is the JSON-RPC pipe)
+  and blocked the session indefinitely. The connect path now fails fast with a
+  single actionable WARNING naming the fix (set up working SSH key auth, verify
+  with `ssh root@<host>`); the affected host is reported as unreachable instead
+  of stalling the whole client.
 - A failed Gitea API call caused by TLS certificate verification (common when
   the SUSE root CA is not in the system trust store) now logs a single,
   actionable message naming the two remedies — install the SUSE CA or set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   backgrounded fanned-out slow command now mints one job per template (visible in
   `job_list`, individually pollable and cancellable) instead of a single job for
   the whole fan-out.
+- `list_locks` and `unlock` gained a `-p`/`--pool` flag to act on host pool
+  claims instead of the zypper/operation lock. By default both commands operate
+  on the zypper/operation lock only (pool claims are no longer shown by
+  `list_locks`). `unlock --pool --force` removes a pool claim held by another
+  user or template.
 
 ### Removed
 
@@ -69,6 +74,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Host *pool* claims and the zypper/operation lock are now fully independent.
+  Previously both shared a single lock file (`/var/lock/mtui.lock`), so a pool
+  claim taken during host selection blocked subsequent zypper operations
+  (`install`, `uninstall`, `update`, `prepare`, `downgrade`) with "Hosts
+  locked", and `list_locks` showed pool claims mixed in with operation locks.
+  Pool claims now live in their own file (`/var/lock/mtui-pool.lock`) and never
+  interfere with operation locks.
+- A host pool-claimed by the current template no longer prevents that template
+  from (re)connecting to it, even across `mtui` restarts (pool-claim ownership
+  is now identified by template RRID + user instead of process PID). A host
+  claimed by a different user or template still correctly blocks connection.
+- Pool claims are now reliably removed on disconnect (`remove_host`, `quit`,
+  `unload`, and MCP session teardown), so hosts are not left claimed after a
+  session releases them.
 - The SSH password fallback prompt now renders correctly inside the interactive
   REPL. Previously, when key authentication failed, the password prompt was read
   with `getpass`, which does not cooperate with the prompt_toolkit session that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The SSH password fallback prompt now renders correctly inside the interactive
+  REPL. Previously, when key authentication failed, the password prompt was read
+  with `getpass`, which does not cooperate with the prompt_toolkit session that
+  drives the REPL: the prompt was never shown and mtui appeared to hang silently.
+  The prompt now goes through the same prompt_toolkit-backed, masked,
+  cross-thread-serialised path as other interactive prompts, and names the user
+  and host it is asking for (`root@<host>'s password: `).
+- Authentication failures (wrong password, generic SSH errors) now print a
+  single clear error line instead of dumping a raw paramiko traceback and a
+  duplicate message. The full traceback is still available with `--debug`.
 - Loading a template no longer connects to *every* matching reference host when a
   testplatform resolves to several candidates on the same architecture. The
   autoconnect that runs during `load_template` was happening before the host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `list_update_commands`, `list_versions`, `list_packages`, and
   `show_update_repos` now fan out across every loaded template too (previously
   they only reported the active one), and accept the same `-T/--template` and
-  `--all-templates` flags. Host-listing commands (`list_hosts`, `list_locks`,
-  `list_timeout`, `list_sessions`, `show_log`, `list_history`) remain scoped to
-  the active template.
+  `--all-templates` flags.
+- Host-locking commands `lock` and `unlock` and host-listing commands
+  `list_hosts`, `list_locks`, `list_timeout`, `list_sessions`, `show_log`, and
+  `list_history` now fan out across every loaded template by default (previously
+  they acted on the active template only), each acting on that template's own
+  hosts with the output prefixed by an `=== <RRID> ===` banner. They accept the
+  same `-T/--template` and `--all-templates` flags to scope a single template or
+  force fan-out explicitly.
 - Tab completion for the `-T/--template` and `--all-templates` flags on every
   fan-out command, completing the loaded template RRIDs as values (like `switch`
   and `unload`).

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -86,7 +86,7 @@ becomes ours, or is reaped as stale; a warning is logged when the wait
 starts and again if it times out (after which the usual "locked" error is
 raised). A value of ``0`` (the default) preserves the historical
 fail-fast behaviour. This is what lets several fanned-out templates queue
-politely on an exhausted shared host pool (see ``refhosts.pool_select``).
+politely on an exhausted shared host pool.
 
 ``lock.wait_poll``
 ~~~~~~~~~~~~~~~~~~
@@ -334,28 +334,6 @@ The ``https`` resolver fetches the refhost database from this URL.
 The ``path`` resolver uses the refhost database at this location.
 
 
-``refhosts.pool_select``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-  | **type**
-  |     bool
-  | **default**
-  |     ``False``
-
-Opt-in refhost-pool parallelism for multi-template fan-out. When enabled,
-each loaded template draws **one distinct free host per test-target slot**
-(product + version + arch + addons) from the shared reference-host pool,
-arbitrated in-process so two templates never draw the same host. Claimed
-hosts take the remote lock with an identifying ``mtui pool <RRID>
-[<owner>]`` comment, and are released (in-process and on the remote lock)
-on ``unload`` / ``quit`` and when an ``mtui-mcp`` session closes. When all
-candidates for a slot are busy, the claim queues per ``lock.wait`` /
-``lock.wait_poll``.
-
-When ``False`` (the default), host selection is byte-for-byte the legacy
-single-host-per-arch path and no pool claims are taken; fan-out across
-templates may then open separate SSH sessions to an overlapping host (see
-the caveat in ``Documentation/user.rst``).
-
 ``refhosts.resolvers``
 ~~~~~~~~~~~~~~~~~~~~~~
   | **type**
@@ -459,7 +437,6 @@ Example
   resolvers = https
   https_uri = https://qam.suse.de/refhosts/refhosts.yml
   path = /usr/share/qam-metadata/refhosts.yml
-  pool_select = false
   
 
   [url]

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -140,26 +140,6 @@ Name of directory for storing install logs
 Please don't change it
 
 
-``mtui.location``
-~~~~~~~~~~~~~~~~~
-  | **type**
-  |     enum: locations defined in `refhosts.yml`_
-  | **default**
-  |     ``default``
-
-.. _refhosts.yml: https://gitlab.suse.de/qa-maintenance/metadata/blob/master/refhosts.yml
-
-.. tip:: View valid locations using ``refdb``:
-
-    ::
-
-        refdb -p location | sort | uniq
-
-MTUI will limit reference hosts to those found in ``mtui.location``.
-If a required system cannot be found in ``mtui.location``, it will be loaded
-from ``default``.
-
-
 ``mtui.ssh_strict_host_key_checking``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   | **type**
@@ -468,7 +448,6 @@ Example
 
   [mtui]
   user = <your username>
-  location = <your location>
   template_dir = /path/to/where/you/want/to/store/test-reports
   
 

--- a/Documentation/cli.rst
+++ b/Documentation/cli.rst
@@ -81,12 +81,6 @@ MTUI will display a short description of its options, operands and their usage,
 and exit.
 
 
-``-l SITE, --location SITE``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Overrides the ``mtui.location`` configuration.
-
-
 ``-s SPEC, --sut SPEC``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/faq.rst
+++ b/Documentation/faq.rst
@@ -10,21 +10,6 @@
 Running MTUI
 ############
 
-How do I change the default refhosts location?
-==============================================
-
-In case you don't want to use the default refhost location, i.e. if
-you have a local or virtual set of refhosts, you can set your personal
-location in the ``~/.mtuirc`` configuration file.
-This eliminates the need to use the ``-l`` (``--location``) option.
-
-Example::
-
-  # cat ~/.mtuirc
-  # MTUI user configuration file
-  [mtui]
-  location=nuremberg
-
 Can I set the template directory without passing it as a command line parameter every time?
 ===========================================================================================
 
@@ -329,18 +314,6 @@ Example::
 
   mtui> add_host -t craig.qam.suse.cz
   info: connecting to craig.qam.suse.cz
-
-
-Can I use refhosts from another location?
-=========================================
-
-Changing the current location is possible using the ``set_location``
-command.
-
-Example::
-
-  mtui> set_location nuremberg
-  info: changed location from 'prague' to 'nuremberg'
 
 
 How can I override refhosts mentioned in the test report?

--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -25,10 +25,8 @@ This pulls in mtui together with all required dependencies.
 
 .. note::
 
-  After installation, you'll need to configure at least your `location`_
-  and you will likely want to customize `template_dir`_ as well.
+  After installation, you will likely want to customize `template_dir`_.
 
-.. _location: ./cfg.html#mtui-location
 .. _template_dir: ./cfg.html#mtui-template-dir
 
 

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -111,7 +111,7 @@ add_host
   add_host [-t HOST] [-k]
 
 Adds another machine to the target host list.
-Without parameter adds all hosts from testplatform based on location
+Without parameter adds all hosts from testplatform.
 
 If the session is in automatic mode, running ``add_host`` switches it to
 the manual workflow (adding hosts by hand is a manual action), updating
@@ -211,7 +211,7 @@ list_refhosts
 ::
 
   list_refhosts [-T QUERY] [-n GLOB] [-a ARCH] [-p PRODUCT]
-                [--version VERSION] [--addon ADDON] [-l LOCATION]
+                [--version VERSION] [--addon ADDON]
                 [--pool] [--json] [--free] [-v]
 
 Queries and searches the reference-host inventory **offline** — no SSH
@@ -220,10 +220,9 @@ connection, no lock, and no loaded test report. It reads the same source
 manual users can find refhosts through mtui instead of parsing
 ``refhosts.yml`` by hand.
 
-With no filters, every known refhost is listed. Location is **not** used to
-scope the search by default: every location is searched and results are
-de-duplicated by host name. Only ``--free`` goes on the wire — it probes each
-matched host's live mtui-lock state.
+With no filters, every known refhost is listed; results are de-duplicated by
+host name. Only ``--free`` goes on the wire — it probes each matched host's
+live mtui-lock state.
 
 **Options:**
 
@@ -252,10 +251,6 @@ matched host's live mtui-lock state.
 .. option:: --addon ADDON
 
   Addon-name substring. Can be used multiple times.
-
-.. option:: -l LOCATION, --location LOCATION
-
-  Restrict to a single location (the default searches all locations).
 
 .. option:: --pool
 
@@ -1124,22 +1119,6 @@ and thus can be especially useful for longer running commands.
 .. option:: loglevel
 
   Log level of MTUI: ``warning``, ``info`` or ``debug``
-
-set_location
-++++++++++++
-
-::
-
-    set_location site
-
-Changes current refhost location to another site.
-
-**Options:**
-
-.. option:: site
-
-  Location name.
-
 
 config
 ++++++

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -115,11 +115,13 @@ Without parameter adds all hosts from testplatform.
 When adding hosts from a testplatform, mtui connects **one** reference host
 per test-target slot (product + version + arch + addons) rather than every
 matching candidate — so a testplatform that resolves to several hosts on the
-same architecture no longer fans out across all of them. If the chosen host
-fails to connect, mtui automatically tries a backup candidate from the same
-slot; only when every candidate for a slot is unreachable is a single warning
-logged and that slot left unconnected. The same one-per-slot selection and
-backup applies to the autoconnect that runs when a template is loaded.
+same architecture no longer fans out across all of them. The host drawn for
+each slot is chosen at random among the free candidates (load is spread across
+interchangeable refhosts). If the chosen host fails to connect, mtui
+automatically tries another candidate from the same slot; only when every
+candidate for a slot is unreachable is a single warning logged and that slot
+left unconnected. The same one-per-slot selection and backup applies to the
+autoconnect that runs when a template is loaded.
 
 If the session is in automatic mode, running ``add_host`` switches it to
 the manual workflow (adding hosts by hand is a manual action), updating

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -88,13 +88,12 @@ a failure on one template does not abort the others.
 
 .. note::
 
-   Enable ``refhosts.pool_select`` to have fan-out draw a **distinct** free
-   reference host per test-target slot from the shared pool, so two templates
-   never collide on the same host (queueing on an exhausted pool per
-   ``lock.wait``). With it off (the default), two loaded templates that point at
-   overlapping reference hosts can each open their own SSH session to the same
-   host; when that matters, enable ``pool_select``, load templates with disjoint
-   host sets, or scope the command with ``-T``.
+   Fan-out always draws a **distinct** free reference host per test-target slot
+   (product + version + arch + addons) from the shared pool, arbitrated
+   in-process so two templates never collide on the same host. When every
+   candidate for a slot is busy, the claim queues on an exhausted pool per
+   ``lock.wait`` / ``lock.wait_poll``. Scope a command with ``-T`` to act on a
+   single template.
 
 
 Commands

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -112,6 +112,15 @@ add_host
 Adds another machine to the target host list.
 Without parameter adds all hosts from testplatform.
 
+When adding hosts from a testplatform, mtui connects **one** reference host
+per test-target slot (product + version + arch + addons) rather than every
+matching candidate — so a testplatform that resolves to several hosts on the
+same architecture no longer fans out across all of them. If the chosen host
+fails to connect, mtui automatically tries a backup candidate from the same
+slot; only when every candidate for a slot is unreachable is a single warning
+logged and that slot left unconnected. The same one-per-slot selection and
+backup applies to the autoconnect that runs when a template is loaded.
+
 If the session is in automatic mode, running ``add_host`` switches it to
 the manual workflow (adding hosts by hand is a manual action), updating
 the prompt accordingly. Pass ``-k``/``--keep-mode`` to add a host without

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -935,23 +935,21 @@ load_template
 
 ::
 
-    load_template (-a RequestReviewID | -k RequestReviewID) [-c] 
+    load_template (-a RequestReviewID | -k RequestReviewID)
 
 Loads a QA Maintenance template by its RRID identifier. The template is
 *added* to the session: previously loaded templates stay loaded and the newly
 loaded one becomes active. Loading an RRID that is already loaded reloads and
-replaces its stored report (and makes it active). The active template's
-connected hosts are kept and extended by the reference hosts defined in the
-template file. `-a` and `-k` options are mutually exclusive.
+replaces its stored report (and makes it active). Each loaded template owns its
+own reference hosts: the newly loaded template connects only the hosts defined
+in its own template file (or selected from its testplatforms) and never
+reconnects hosts that belong to another loaded template. `-a` and `-k` options
+are mutually exclusive.
 
 Use `list_templates`_ to see all loaded templates, `switch`_ to change the
 active one, and `unload`_ to drop one.
 
 **Options:**
-
-.. option:: -c, --clean-hosts
-
-  Cleans up old hosts.
 
 .. option:: -a RequestReviewID
 

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -67,14 +67,15 @@ report, for report-scoped commands). The fan-out commands are: ``run``,
 ``set_repo``, ``reboot``, ``put``, ``get``, ``commit``, ``checkout``,
 ``approve``, ``assign``, ``unassign``, ``reject``, ``comment``, ``show_diff``,
 ``analyze_diff``, ``reload_openqa``, ``openqa_overview``, ``openqa_jobs``,
-``smelt_update``, ``smelt_checkers``, and the report-bound inspection commands
+``smelt_update``, ``smelt_checkers``, the report-bound inspection commands
 ``list_metadata``, ``list_bugs``, ``list_update_commands``, ``list_versions``,
-``list_packages``, and ``show_update_repos``. Output for each template is
-prefixed with an ``=== <RRID> ===`` banner so results stay attributable.
-Queue-browsing SMELT commands (``smelt_requests``, ``smelt_updates``) are not
-template-scoped and do not fan out. Host-listing commands (``list_hosts``,
-``list_locks``, ``list_timeout``, ``list_sessions``, ``show_log``,
-``list_history``) act on the active template only.
+``list_packages``, and ``show_update_repos``, the host-locking commands
+``lock`` and ``unlock``, and the host-listing commands ``list_hosts``,
+``list_locks``, ``list_timeout``, ``list_sessions``, ``show_log``, and
+``list_history``. Output for each template is prefixed with an
+``=== <RRID> ===`` banner so results stay attributable. Queue-browsing SMELT
+commands (``smelt_requests``, ``smelt_updates``) are not template-scoped and do
+not fan out.
 
 Use ``-T RRID``/``--template RRID`` to run such a command against a single
 loaded template instead, or ``--all-templates`` to request fan-out explicitly.
@@ -161,10 +162,14 @@ list_hosts
 
 ::
 
-  list_hosts
+  list_hosts [-T RRID | --all-templates]
 
 Lists all connected hosts, including the system types and their current
 state: ``enabled``, ``disabled`` or ``dryrun``.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 
 list_history
@@ -172,11 +177,15 @@ list_history
 
 ::
 
-  list_history [-e EVENT] [-t HOST]
+  list_history [-e EVENT] [-t HOST] [-T RRID | --all-templates]
 
 Lists a history of MTUI events on the target hosts, such as installing or
 updating packages. Date, username and event is shown. Events can be
 filtered with the ``EVENT`` parameter.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 **Options:**
 
@@ -190,7 +199,7 @@ list_locks
 
 ::
 
-  list_locks [-p]
+  list_locks [-p] [-T RRID | --all-templates]
 
 Lists lock state of all connected hosts.
 
@@ -198,6 +207,10 @@ By default only the zypper/operation locks (set by ``lock`` and the
 install/update/prepare/downgrade flows) are shown. Use ``-p``/``--pool`` to
 instead list the host *pool* claims taken during pool selection. The two
 lock mechanisms are independent and use separate lock files on the hosts.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 
 list_products
@@ -576,10 +589,14 @@ lock
 
 ::
 
-    lock [-t HOST]
+    lock [-t HOST] [-c COMMENT] [-T RRID | --all-templates]
 
 Locks host for exclusive usage. This locks all repository transactions, such as
 enabling or disabling the testing repository on the target hosts.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope the lock to
+a single template.
 
 .. caution::
   The hosts are locked with a timestamp, the UID and PID of the session.
@@ -614,9 +631,13 @@ list_timeout
 
 ::
 
-    list_timeout
+    list_timeout [-T RRID | --all-templates]
 
 Prints the current timeout values per host in seconds.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 
 unlock
@@ -624,13 +645,17 @@ unlock
 
 ::
 
-    unlock [-f] [-p] [-t HOST]
+    unlock [-f] [-p] [-t HOST] [-T RRID | --all-templates]
 
 Unlocks given targets. Unlocks all if used without arguments.
 
 By default this removes the zypper/operation lock. Use ``-p``/``--pool`` to
 instead remove the host *pool* claim. The two lock mechanisms are
 independent and use separate lock files on the hosts.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope the unlock
+to a single template.
 
 **Options:**
 
@@ -921,11 +946,15 @@ show_log
 
 ::
 
-    show_log [-t HOST]
+    show_log [-t HOST] [-T RRID | --all-templates]
 
 Prints the command protocol from the specified hosts. This might be
 handy for the tester, as one can simply dump the command history
 to the reproducer section of the template.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 Metadata Commands
 *****************
@@ -1092,9 +1121,13 @@ list_sessions
 
 ::
 
-    list_sessions [-t HOST]
+    list_sessions [-t HOST] [-T RRID | --all-templates]
 
 Lists current active ssh sessions on target hosts.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_). Use ``-T RRID`` to scope to a
+single template.
 
 
 analyze_diff

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -188,9 +188,14 @@ list_locks
 
 ::
 
-  list_locks
+  list_locks [-p]
 
 Lists lock state of all connected hosts.
+
+By default only the zypper/operation locks (set by ``lock`` and the
+install/update/prepare/downgrade flows) are shown. Use ``-p``/``--pool`` to
+instead list the host *pool* claims taken during pool selection. The two
+lock mechanisms are independent and use separate lock files on the hosts.
 
 
 list_products
@@ -617,16 +622,26 @@ unlock
 
 ::
 
-    unlock [-f] [-t HOST]
+    unlock [-f] [-p] [-t HOST]
 
 Unlocks given targets. Unlocks all if used without arguments.
+
+By default this removes the zypper/operation lock. Use ``-p``/``--pool`` to
+instead remove the host *pool* claim. The two lock mechanisms are
+independent and use separate lock files on the hosts.
 
 **Options:**
 
 
 .. option:: -f, --force
 
-  Force unlock - removes locks set by other users or sessions.
+  Force unlock - removes locks set by other users or sessions (or, with
+  ``--pool``, by other templates).
+
+
+.. option:: -p, --pool
+
+  Remove the pool claim instead of the zypper/operation lock.
 
 
 Update Management

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -99,7 +99,7 @@ Flags mirror :doc:`cli` for the configuration surface that
 ``--color {auto,always,never}``
     Control coloured log output; default ``auto``.
 
-``-l, --location``, ``-t, --template_dir``, ``-g, --gitea_token``, ``-w, --connection_timeout``
+``-t, --template_dir``, ``-g, --gitea_token``, ``-w, --connection_timeout``
     Configuration overrides identical to ``mtui``.
 
 ``-V, --version``

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -311,6 +311,12 @@ knowing:
 Where the REPL would otherwise prompt, pass the matching flag
 explicitly from the MCP client so the behaviour is unambiguous.
 
+SSH authentication is public-key only. If key authentication to a
+target fails, the connection error is reported (the host is marked
+unreachable) -- mtui never falls back to a password prompt, in either
+the REPL or under MCP. Set up working SSH key auth to the target and
+verify it with ``ssh root@<host>``.
+
 
 Testreport editing tools
 ========================

--- a/mtui/cli/args.py
+++ b/mtui/cli/args.py
@@ -65,9 +65,6 @@ def get_parser(sys) -> ArgumentParser:
     """
     parser = ArgumentParser(sys_=sys)
     parser.add_argument(
-        "-l", "--location", type=str, help="override config mtui.location"
-    )
-    parser.add_argument(
         "-t", "--template_dir", type=Path, help="override config mtui.template_dir"
     )
     parser.add_argument(

--- a/mtui/cli/prompter.py
+++ b/mtui/cli/prompter.py
@@ -20,30 +20,74 @@ import threading
 from collections.abc import Callable
 
 
+def _default_password_reader(text: str) -> str:
+    """Read a password masked, safe inside a prompt_toolkit REPL.
+
+    A bare :func:`getpass.getpass` performs a raw terminal read that does
+    not cooperate with the surrounding prompt_toolkit ``PromptSession``
+    that drives the mtui REPL: the terminal is left in prompt_toolkit's
+    half-configured state, so the prompt text is never rendered and the
+    read appears to hang silently (the reported "silent wait" bug). Going
+    through a fresh ``PromptSession`` saves and restores the terminal
+    state correctly -- the same pattern :func:`mtui.cli.term._read_line`
+    uses for visible prompts.
+
+    The prompt text (``user@host's password: ``) is shown while the user
+    types and the characters are masked with ``*``. ``erase_when_done``
+    wipes the whole prompt line once Enter is pressed, so the terminal is
+    not left with a leftover ``user@host's password: *********`` line --
+    matching the clean behaviour of :func:`getpass.getpass`.
+    """
+    # Imported lazily so importing Prompter (e.g. under mtui-mcp, which
+    # has no TTY) never drags in prompt_toolkit's terminal machinery.
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import InMemoryHistory
+
+    session: PromptSession[str] = PromptSession(
+        message=text,
+        is_password=True,
+        erase_when_done=True,
+        history=InMemoryHistory(),
+    )
+    return session.prompt()
+
+
 class Prompter:
-    """Serialise interactive :func:`input` calls across worker threads.
+    """Serialise interactive prompts across worker threads.
 
-    The instance owns one lock. :meth:`ask` acquires it, calls the
-    injected reader (default :func:`input`), releases the lock in a
-    ``finally``. Callers from any thread are safe to call concurrently;
-    they observe strictly sequential prompts in lock-acquisition order.
+    The instance owns one lock. :meth:`ask` (visible input) and
+    :meth:`ask_password` (masked input) both acquire it for the duration
+    of the read and release it in a ``finally``, so callers from any
+    thread are safe to call concurrently; they observe strictly
+    sequential prompts in lock-acquisition order.
 
-    The reader is injectable to keep the class unit-testable without
-    going through real ``stdin``.
+    Both readers are injectable to keep the class unit-testable without
+    going through a real ``stdin`` / terminal.
     """
 
-    __slots__ = ("_lock", "_reader")
+    __slots__ = ("_lock", "_password_reader", "_reader")
 
-    def __init__(self, reader: Callable[[str], str] = input) -> None:
+    def __init__(
+        self,
+        reader: Callable[[str], str] = input,
+        password_reader: Callable[[str], str] = _default_password_reader,
+    ) -> None:
         """Initialise the prompter.
 
         Args:
-            reader: Callable invoked with the prompt text; must return
-                the user's response. Defaults to :func:`input`.
+            reader: Callable invoked with the prompt text for visible
+                input; must return the user's response. Defaults to
+                :func:`input`.
+            password_reader: Callable invoked with the prompt text for
+                masked (non-echoing) input; must return the user's
+                response. Defaults to a prompt_toolkit-backed reader that
+                masks input and is safe to call between the REPL's own
+                ``PromptSession`` reads.
 
         """
         self._lock = threading.Lock()
         self._reader = reader
+        self._password_reader = password_reader
 
     def ask(self, text: str) -> str:
         """Prompt the user with ``text`` and return the typed response.
@@ -61,3 +105,20 @@ class Prompter:
         """
         with self._lock:
             return self._reader(text)
+
+    def ask_password(self, text: str) -> str:
+        """Prompt for a password with ``text``, returning the typed value.
+
+        Like :meth:`ask`, the read is fenced by the prompter's lock so
+        parallel workers cannot race for the terminal, but the typed
+        characters are not echoed.
+
+        Args:
+            text: The prompt text shown to the user.
+
+        Returns:
+            The password the user typed.
+
+        """
+        with self._lock:
+            return self._password_reader(text)

--- a/mtui/cli/prompter.py
+++ b/mtui/cli/prompter.py
@@ -20,57 +20,23 @@ import threading
 from collections.abc import Callable
 
 
-def _default_password_reader(text: str) -> str:
-    """Read a password masked, safe inside a prompt_toolkit REPL.
-
-    A bare :func:`getpass.getpass` performs a raw terminal read that does
-    not cooperate with the surrounding prompt_toolkit ``PromptSession``
-    that drives the mtui REPL: the terminal is left in prompt_toolkit's
-    half-configured state, so the prompt text is never rendered and the
-    read appears to hang silently (the reported "silent wait" bug). Going
-    through a fresh ``PromptSession`` saves and restores the terminal
-    state correctly -- the same pattern :func:`mtui.cli.term._read_line`
-    uses for visible prompts.
-
-    The prompt text (``user@host's password: ``) is shown while the user
-    types and the characters are masked with ``*``. ``erase_when_done``
-    wipes the whole prompt line once Enter is pressed, so the terminal is
-    not left with a leftover ``user@host's password: *********`` line --
-    matching the clean behaviour of :func:`getpass.getpass`.
-    """
-    # Imported lazily so importing Prompter (e.g. under mtui-mcp, which
-    # has no TTY) never drags in prompt_toolkit's terminal machinery.
-    from prompt_toolkit import PromptSession
-    from prompt_toolkit.history import InMemoryHistory
-
-    session: PromptSession[str] = PromptSession(
-        message=text,
-        is_password=True,
-        erase_when_done=True,
-        history=InMemoryHistory(),
-    )
-    return session.prompt()
-
-
 class Prompter:
     """Serialise interactive prompts across worker threads.
 
-    The instance owns one lock. :meth:`ask` (visible input) and
-    :meth:`ask_password` (masked input) both acquire it for the duration
-    of the read and release it in a ``finally``, so callers from any
+    The instance owns one lock. :meth:`ask` acquires it for the duration
+    of the read and releases it in a ``finally``, so callers from any
     thread are safe to call concurrently; they observe strictly
     sequential prompts in lock-acquisition order.
 
-    Both readers are injectable to keep the class unit-testable without
+    The reader is injectable to keep the class unit-testable without
     going through a real ``stdin`` / terminal.
     """
 
-    __slots__ = ("_lock", "_password_reader", "_reader")
+    __slots__ = ("_lock", "_reader")
 
     def __init__(
         self,
         reader: Callable[[str], str] = input,
-        password_reader: Callable[[str], str] = _default_password_reader,
     ) -> None:
         """Initialise the prompter.
 
@@ -78,16 +44,10 @@ class Prompter:
             reader: Callable invoked with the prompt text for visible
                 input; must return the user's response. Defaults to
                 :func:`input`.
-            password_reader: Callable invoked with the prompt text for
-                masked (non-echoing) input; must return the user's
-                response. Defaults to a prompt_toolkit-backed reader that
-                masks input and is safe to call between the REPL's own
-                ``PromptSession`` reads.
 
         """
         self._lock = threading.Lock()
         self._reader = reader
-        self._password_reader = password_reader
 
     def ask(self, text: str) -> str:
         """Prompt the user with ``text`` and return the typed response.
@@ -105,20 +65,3 @@ class Prompter:
         """
         with self._lock:
             return self._reader(text)
-
-    def ask_password(self, text: str) -> str:
-        """Prompt for a password with ``text``, returning the typed value.
-
-        Like :meth:`ask`, the read is fenced by the prompter's lock so
-        parallel workers cannot race for the terminal, but the typed
-        characters are not echoed.
-
-        Args:
-            text: The prompt text shown to the user.
-
-        Returns:
-            The password the user typed.
-
-        """
-        with self._lock:
-            return self._password_reader(text)

--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -472,4 +472,8 @@ class CommandPrompt:
         self.templates.add(tr)
         if str(tr.id):
             self.templates.set_active(str(tr.id))
+        # Run the deferred autoconnect now that ``add`` has wired the host
+        # arbiter, so refhosts are drawn one-per-slot (with backup) instead of
+        # connecting every candidate. No-op unless autoconnect was requested.
+        tr.autoconnect()
         self.set_prompt()

--- a/mtui/commands/__init__.py
+++ b/mtui/commands/__init__.py
@@ -31,6 +31,6 @@ for _modinfo in pkgutil.iter_modules(__path__):
         continue
 
 #: Public alias for :attr:`Command.registry`. Keys are the user-facing command
-#: strings (e.g. ``"set_location"``), values are the concrete
+#: strings (e.g. ``"set_log_level"``), values are the concrete
 #: :class:`Command` subclasses.
 registry = Command.registry

--- a/mtui/commands/hostslock.py
+++ b/mtui/commands/hostslock.py
@@ -2,7 +2,7 @@
 
 from argparse import REMAINDER
 
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from . import Command
 
 
@@ -24,6 +24,7 @@ class HostLock(Command):
     """
 
     command = "lock"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser) -> None:
@@ -32,6 +33,7 @@ class HostLock(Command):
         parser.add_argument(
             "-c", "--comment", action="append", nargs=REMAINDER, help="lock comment"
         )
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `lock` command."""
@@ -43,7 +45,7 @@ class HostLock(Command):
     def complete(state, text, line, begidx, endidx):
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-t", "--target"), ("-c", "--comment")],
+            [("-t", "--target"), ("-c", "--comment"), *template_completion(state)],
             line,
             text,
             state["hosts"].names(),

--- a/mtui/commands/hostsunlock.py
+++ b/mtui/commands/hostsunlock.py
@@ -8,7 +8,10 @@ from . import Command
 class HostsUnlock(Command):
     """Unlocks a host that was previously locked.
 
-    The unlock can be forced by using the `-f` or `--force` parameter.
+    By default this removes the zypper/operation lock. Use ``-p``/``--pool``
+    to instead remove the host *pool* claim. The unlock can be forced by
+    using the ``-f``/``--force`` parameter, which also removes locks set by
+    other users or sessions (or, with ``--pool``, by other templates).
     """
 
     command = "unlock"
@@ -22,17 +25,29 @@ class HostsUnlock(Command):
             action="store_true",
             help="force unlock - remove locks set by other users or sessions",
         )
+        parser.add_argument(
+            "-p",
+            "--pool",
+            action="store_true",
+            help="remove the pool claim instead of the zypper/operation lock",
+        )
 
         cls._add_hosts_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `unlock` command."""
         hosts = self.parse_hosts()
-        hosts.unlock(force=self.args.force)
+        if self.args.pool:
+            hosts.pool_unlock(force=self.args.force)
+        else:
+            hosts.unlock(force=self.args.force)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-f", "--force"), ("-t", "--target")], line, text, state["hosts"].names()
+            [("-f", "--force"), ("-p", "--pool"), ("-t", "--target")],
+            line,
+            text,
+            state["hosts"].names(),
         )

--- a/mtui/commands/hostsunlock.py
+++ b/mtui/commands/hostsunlock.py
@@ -1,7 +1,7 @@
 """The `unlock` command."""
 
 from ..cli.argparse import ArgumentParser
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from . import Command
 
 
@@ -15,6 +15,7 @@ class HostsUnlock(Command):
     """
 
     command = "unlock"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -33,6 +34,7 @@ class HostsUnlock(Command):
         )
 
         cls._add_hosts_arg(parser)
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `unlock` command."""
@@ -46,7 +48,12 @@ class HostsUnlock(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-f", "--force"), ("-p", "--pool"), ("-t", "--target")],
+            [
+                ("-f", "--force"),
+                ("-p", "--pool"),
+                ("-t", "--target"),
+                *template_completion(state),
+            ],
             line,
             text,
             state["hosts"].names(),

--- a/mtui/commands/list_refhosts.py
+++ b/mtui/commands/list_refhosts.py
@@ -6,10 +6,9 @@ Reads the refhost inventory (the same source ``add_host`` resolves through
 lets fleet maintenance and manual users find refhosts through mtui instead of
 parsing ``refhosts.yml`` by hand.
 
-Location is **not** used to scope the search by default (it is being retired):
-every location is searched and results are de-duplicated by host name. The
-optional ``--free`` flag additionally connects to the matched hosts to report
-their live mtui-lock state (the only part that goes on the wire).
+Results are de-duplicated by host name. The optional ``--free`` flag
+additionally connects to the matched hosts to report their live mtui-lock
+state (the only part that goes on the wire).
 """
 
 import concurrent.futures
@@ -32,8 +31,7 @@ class ListRefhosts(Command):
     With no filters every known refhost is listed. Filter by hostname glob,
     arch, base product, version, or addon — or pass a full ``--testplatform``
     query (same syntax ``add_host`` matches on). ``--pool`` groups the result
-    by test-target slot (one candidate per arch/codestream). Location is
-    ignored by default.
+    by test-target slot (one candidate per arch/codestream).
     """
 
     command = "list_refhosts"
@@ -66,11 +64,6 @@ class ListRefhosts(Command):
             "--addon", action="append", help="addon-name substring (repeatable)"
         )
         parser.add_argument(
-            "-l",
-            "--location",
-            help="restrict to a single location (default: search all locations)",
-        )
-        parser.add_argument(
             "--pool",
             action="store_true",
             help="group by test-target slot (product+version+arch+addons)",
@@ -96,14 +89,13 @@ class ListRefhosts(Command):
         return f"{version.major}-{version.minor}"
 
     @classmethod
-    def _record(cls, host, location: str | None, slot: str | None) -> dict:
+    def _record(cls, host, slot: str | None) -> dict:
         return {
             "name": host.name,
             "arch": host.arch,
             "product": host.product.name,
             "version": cls._ver_str(host.product.version),
             "addons": [a.name for a in host.addons],
-            "location": location,
             "slot": slot,
         }
 
@@ -114,7 +106,6 @@ class ListRefhosts(Command):
         if a.testplatform:
             hits = refhosts.query(
                 attributes=Attributes.from_testplatform(a.testplatform),
-                location=a.location,
             )
         else:
             hits = refhosts.query(
@@ -123,17 +114,16 @@ class ListRefhosts(Command):
                 product=a.product,
                 version=a.version,
                 addon=a.addon,
-                location=a.location,
             )
         records: list[dict] = []
-        for host, loc in hits:
+        for host in hits:
             # Reuse Refhosts.slot_of for the test-target identity so the
             # command and the host-arbitration pool agree on what a "slot" is.
             slot = None
             if a.pool:
                 name, ver, arch, _addons = refhosts.slot_of(host)
                 slot = f"{name}-{ver} {arch}"
-            records.append(self._record(host, loc, slot))
+            records.append(self._record(host, slot))
         return records
 
     def _probe_locks(self, records: list[dict]) -> None:
@@ -182,8 +172,6 @@ class ListRefhosts(Command):
         def fmt(r: dict) -> str:
             prod = f"{r['product']} {r['version']}".strip()
             cols = [f"{r['name']:<34}", f"{prod:<22}", f"{r['arch']:<8}"]
-            if not self.args.pool:
-                cols.append(f"{r['location'] or '':<10}")
             if free:
                 cols.append(f"{r.get('lock', ''):<22}")
             if verbose:
@@ -215,7 +203,6 @@ class ListRefhosts(Command):
                 ("-p", "--product"),
                 ("--version",),
                 ("--addon",),
-                ("-l", "--location"),
                 ("--pool",),
                 ("--json",),
                 ("--free",),

--- a/mtui/commands/loadtemplate.py
+++ b/mtui/commands/loadtemplate.py
@@ -13,9 +13,10 @@ class LoadTemplate(Command):
     All changes and logs from an already loaded template are lost if
     not saved previously.
 
-    Already connected hosts are kept and extended by the reference
-    hosts defined in the template file. This behavior can be changed
-    with the -c/--clean-hosts parameter.
+    Each loaded template owns its own reference hosts. Loading a template
+    never reconnects hosts that belong to another loaded template; the new
+    template connects only the reference hosts defined in its own template
+    file (or selected from its testplatforms).
     """
 
     command = "load_template"
@@ -40,13 +41,6 @@ class LoadTemplate(Command):
             help="OBS kernel/live-patch request review id\nexample: SUSE:Maintenance:1:1",
             dest="update",
         )
-        parser.add_argument(
-            "-c",
-            "--clean-hosts",
-            dest="chosts",
-            action="store_false",
-            help="clean up old hosts",
-        )
 
     def __call__(self):
         """Executes the `load_template` command.
@@ -55,36 +49,23 @@ class LoadTemplate(Command):
         current session. Loading an RRID that is already loaded replaces its
         stored report (``TemplateRegistry.add`` is keyed by RRID) and makes it
         active; previously loaded templates are left untouched.
+
+        The newly loaded template connects only its own reference hosts. Hosts
+        belonging to other loaded templates are left alone -- each template
+        owns its own hosts and pool claims.
         """
         if self.args.update.kind not in ("kernel", "auto"):
             raise TestReportNotLoadedError
 
-        # Snapshot the currently active template's hosts *before* loading so
-        # the -c/--clean-hosts carry-over can reconnect them to the new
-        # template. We do not close the old template's connections any more:
-        # the old report stays in the registry with its own hosts.
-        re_add = list(self.targets.keys()) if self.args.chosts else []
-
         # Workflow mode (auto/kernel) is seeded onto the TestReport by
         # make_testreport when load_update runs below.
         self.prompt.load_update(self.args.update, autoconnect=True)
-
-        # Reconnect the hosts we were already connected to, adding them to the
-        # freshly loaded testreport so they get connected to again.
-        # This feature comes from pre-1.0 versions.
-        # NOTE: the only reason we need to reconnect seems to be that
-        # when the L{Target} object is created, it is passed a list of
-        # packages, which changes with the testreport change. So this
-        # may go away when refactored.
-        for target in re_add:
-            self.prompt.metadata.add_target(target)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
             [
-                ("-c", "--clean-hosts"),
                 ("SUSE:Maintenance:", "openSUSE:Maintenance:"),
                 ("-a", "--auto-review-id"),
                 ("-k", "--kernel-review-id"),

--- a/mtui/commands/simplelists.py
+++ b/mtui/commands/simplelists.py
@@ -27,13 +27,35 @@ class ListBugs(Command):
 
 
 class ListLocks(Command):
-    """Lists the lock state of all connected hosts."""
+    """Lists the lock state of all connected hosts.
+
+    By default only the zypper/operation locks (set by ``lock`` and the
+    install/update/prepare/downgrade flows) are shown. Use ``-p``/``--pool``
+    to instead list the host *pool* claims taken during pool selection.
+    """
 
     command = "list_locks"
 
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        parser.add_argument(
+            "-p",
+            "--pool",
+            action="store_true",
+            help="list pool-claim locks instead of zypper/operation locks",
+        )
+
     def __call__(self) -> None:
         """Executes the `list_locks` command."""
-        self.targets.select(enabled=True).report_locks(self.display.list_locks)
+        self.targets.select(enabled=True).report_locks(
+            self.display.list_locks, pool=self.args.pool
+        )
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices([("-p", "--pool")], line, text)
 
 
 class ListHosts(Command):

--- a/mtui/commands/simplelists.py
+++ b/mtui/commands/simplelists.py
@@ -3,7 +3,7 @@
 from typing import ClassVar
 
 from ..cli.argparse import ArgumentParser
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from ..cli.term import page
 from ..support.misc import requires_update
 from . import Command
@@ -35,6 +35,7 @@ class ListLocks(Command):
     """
 
     command = "list_locks"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -45,6 +46,7 @@ class ListLocks(Command):
             action="store_true",
             help="list pool-claim locks instead of zypper/operation locks",
         )
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `list_locks` command."""
@@ -55,27 +57,51 @@ class ListLocks(Command):
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
-        return complete_choices([("-p", "--pool")], line, text)
+        return complete_choices(
+            [("-p", "--pool"), *template_completion(state)], line, text
+        )
 
 
 class ListHosts(Command):
     """Lists all connected hosts, including their system types and state."""
 
     command = "list_hosts"
+    scope = "fanout"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `list_hosts` command."""
         self.targets.report_self(self.display.list_host)
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(template_completion(state), line, text)
 
 
 class ListTimeout(Command):
     """Prints the current timeout values per host in seconds."""
 
     command = "list_timeout"
+    scope = "fanout"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `list_timeout` command."""
         self.targets.report_timeout(self.display.list_timeout)
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(template_completion(state), line, text)
 
 
 class ListUpdateCommands(Command):
@@ -98,11 +124,13 @@ class ListSessions(Command):
     """Lists current active SSH sessions on target hosts."""
 
     command = "list_sessions"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
         """Adds arguments to the command's argument parser."""
         cls._add_hosts_arg(parser)
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `list_sessions` command."""
@@ -120,7 +148,10 @@ class ListSessions(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-t", "--target")], line, text, state["hosts"].names()
+            [("-t", "--target"), *template_completion(state)],
+            line,
+            text,
+            state["hosts"].names(),
         )
 
 
@@ -149,11 +180,13 @@ class ListLog(Command):
     """
 
     command = "show_log"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
         """Adds arguments to the command's argument parser."""
         cls._add_hosts_arg(parser)
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `show_log` command."""
@@ -166,7 +199,10 @@ class ListLog(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-t", "--target")], line, text, state["hosts"].names()
+            [("-t", "--target"), *template_completion(state)],
+            line,
+            text,
+            state["hosts"].names(),
         )
 
 
@@ -221,6 +257,7 @@ class ListHistory(Command):
     """
 
     command = "list_history"
+    scope = "fanout"
 
     filters: ClassVar[set[str]] = {
         "connect",
@@ -242,6 +279,7 @@ class ListHistory(Command):
             help="event to list",
         )
         cls._add_hosts_arg(parser)
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `list_history` command."""
@@ -265,5 +303,6 @@ class ListHistory(Command):
             ("update",),
             ("downgrade",),
             ("install",),
+            *template_completion(state),
         ]
         return complete_choices(cstring, line, text, state["hosts"].names())

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -6,53 +6,11 @@ from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
 from ..data_sources.openqa import KernelOpenQA
 from ..data_sources.qem_dashboard import DashboardAutoOpenQA
-from ..hosts.refhost import RefhostsFactory
-from ..support import messages
 from ..support.misc import requires_update
 from ..types import Workflow
 from . import Command
 
 logger = logging.getLogger("mtui.commands.simplesets")
-
-
-class SetLocation(Command):
-    """Changes the current reference host location to another site."""
-
-    command = "set_location"
-
-    @classmethod
-    def _add_arguments(cls, parser: ArgumentParser) -> None:
-        """Adds arguments to the command's argument parser."""
-        parser.add_argument(
-            "site", action="store", type=str, nargs=1, help="location name"
-        )
-
-    def __call__(self) -> None:
-        """Executes the `set_location` command."""
-        old: str = self.config.location
-        new: str = self.args.site[0]
-        self.config.location = new
-        if self.config.location != new:
-            # The config setter rejected the location (and logged why);
-            # leave the working refhost set untouched.
-            return
-
-        # A manual location change resets the working refhost selection:
-        # drop hosts inherited from the testreport template and from the
-        # previously configured location so a subsequent ``add_host``
-        # derives hosts only from the newly selected location. The
-        # per-testplatform fallback to the ``default`` location in
-        # ``Refhosts.search`` still applies.
-        self.metadata.hostnames.clear()
-        logger.info(messages.LocationChangedMessage(old, new))
-
-    @staticmethod
-    def complete(state, text, line, begidx, endidx) -> list[str]:
-        """Provides tab completion for the command."""
-        loc = RefhostsFactory(state["config"]).get_locations()
-        locations = [tuple(loc)]
-
-        return complete_choices(locations, line, text)
 
 
 class SetLogLevel(Command):

--- a/mtui/hosts/connection/__init__.py
+++ b/mtui/hosts/connection/__init__.py
@@ -6,11 +6,10 @@ internal leaf-module split.
 """
 
 from .connection import Connection
-from .timeout import CommandTimeoutError, NonInteractiveAuthRequired, policy_from_config
+from .timeout import CommandTimeoutError, policy_from_config
 
 __all__ = [
     "CommandTimeoutError",
     "Connection",
-    "NonInteractiveAuthRequired",
     "policy_from_config",
 ]

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -6,7 +6,6 @@ remote shells on a remote host.
 """
 
 import errno
-import getpass
 import logging
 import select
 import stat
@@ -24,7 +23,7 @@ from paramiko import Channel, SFTPClient, SFTPFile, SSHClient, SSHConfig
 
 from ...cli.term import termsize
 from ...support.messages import ReConnectFailed
-from .timeout import CommandTimeoutError, NonInteractiveAuthRequired
+from .timeout import CommandTimeoutError
 
 logger = getLogger("mtui.connection")
 RETRIES: int = 5
@@ -43,7 +42,6 @@ class Connection:
 
     __slots__ = [
         "_interactive",
-        "_password_prompt",
         "_policy",
         "_timeout_prompt",
         "client",
@@ -63,13 +61,13 @@ class Connection:
         timeout: int,
         missing_host_key_policy: paramiko.MissingHostKeyPolicy | None = None,
         timeout_prompt: Callable[[str], str] | None = None,
-        password_prompt: Callable[[str], str] | None = None,
         interactive: bool = True,
     ) -> None:
         """Opens an SSH channel to the specified host.
 
-        This method tries to authenticate using SSH keys and falls back to
-        password authentication if key-based authentication fails.
+        Authentication is SSH public-key only. If key auth fails the
+        connection error propagates to the caller -- there is no password
+        fallback (set up working SSH key auth to the target instead).
 
         Args:
             hostname: The hostname or IP address of the remote host.
@@ -89,27 +87,15 @@ class Connection:
                 :class:`mtui.cli.prompter.Prompter`'s ``ask`` method here
                 to surface a serialised, race-free prompt to the user
                 when multiple targets run a command in parallel.
-            password_prompt: Optional callable invoked with prompt text
-                when key authentication fails and a password is needed.
-                Returns the user's typed password. When ``None`` (the
-                default) the fallback uses :func:`getpass.getpass`, which
-                works for a plain terminal but renders nothing when called
-                between the REPL's prompt_toolkit ``PromptSession`` reads
-                (the prompt silently hangs). Wire a
-                :class:`mtui.cli.prompter.Prompter`'s ``ask_password``
-                method here so the masked prompt is rendered correctly
-                and serialised across parallel targets.
             interactive: Whether a TTY-backed user is available to answer
-                an SSH password prompt. ``True`` (the default) preserves
-                the legacy behaviour: if key auth fails, fall back to
-                :func:`getpass.getpass`. ``False`` (e.g. under
-                ``mtui-mcp``, which has no TTY) skips the prompt and
-                raises :class:`NonInteractiveAuthRequired` instead of
-                blocking forever on an invisible password prompt.
+                the command-timeout prompt raised by :meth:`run`. ``True``
+                (the default) lets a timed-out command ask the user
+                whether to keep waiting. ``False`` (e.g. under
+                ``mtui-mcp``, which has no TTY) makes a silent command
+                timeout abort the run instead of looping forever.
 
         """
         self._timeout_prompt = timeout_prompt
-        self._password_prompt = password_prompt
         self._interactive = interactive
         self.hostname = hostname
 
@@ -186,81 +172,25 @@ class Connection:
             )
 
         except (paramiko.AuthenticationException, paramiko.BadHostKeyException):
-            # public key auth failed. The only remaining fallback is to
-            # ask the user for the root password, which needs a TTY.
-            if not self._interactive:
-                # No TTY (e.g. under mtui-mcp): a getpass prompt would be
-                # invisible to the client and block the process forever.
-                # Fail fast with a clear, actionable message instead.
-                logger.warning(
-                    "Authentication failed on %s: key auth did not succeed and "
-                    "password prompting is unavailable in non-interactive mode. "
-                    "Set up working SSH key authentication for this host "
-                    '(verify with "ssh root@%s").',
-                    self.hostname,
-                    self.hostname,
-                )
-                raise NonInteractiveAuthRequired(
-                    f"key authentication failed on {self.hostname} and no "
-                    "interactive password prompt is available"
-                ) from None
-
-            # Interactive session: fall back to a password prompt. Other
-            # than ssh, mtui asks only once for a password. this could
-            # be changed if there is demand for it.
-            username = opts.get("user", "root")
+            # Public-key authentication failed. There is no password
+            # fallback: MTUI requires working SSH key auth to the target
+            # (set it up and verify with "ssh root@<host>"). Re-raise so
+            # the caller (Target.connect) reports the single user-facing
+            # ConnectingTargetFailedMessage; keep the traceback at DEBUG
+            # (visible with --debug) so only one line surfaces per failure.
             logger.warning(
-                "Authentication failed on %s: AuthKey missing. Make sure your system is set up correctly",
+                "Authentication failed on %s: SSH key authentication did not "
+                'succeed. Set up working SSH key auth (verify with "ssh '
+                'root@%s").',
+                self.hostname,
                 self.hostname,
             )
-            logger.warning("Trying manually, please enter the password")
-            # Explicit, host/user-labelled prompt so the user understands
-            # *why* the terminal is waiting (the old bare getpass() looked
-            # like a silent hang in the REPL).
-            prompt_text = f"{username}@{self.hostname}'s password: "
-            # Prefer the injected password prompt (the REPL wires
-            # Prompter.ask_password, which renders correctly between
-            # prompt_toolkit reads and masks input). Fall back to
-            # getpass.getpass for plain-terminal / test callers that pass
-            # no callback.
-            if self._password_prompt is not None:
-                password = self._password_prompt(prompt_text)
-            else:
-                password = getpass.getpass(prompt_text)
-
-            try:
-                # try again with password auth instead of public/private key
-                self.client.connect(
-                    hostname=(
-                        opts.get("hostname", self.hostname)
-                        if "proxycommand" not in opts
-                        else self.hostname
-                    ),
-                    port=int(opts.get("port", self.port)),
-                    username=username,
-                    password=password,
-                    sock=(
-                        paramiko.ProxyCommand(opts["proxycommand"])
-                        if "proxycommand" in opts
-                        else None
-                    ),
-                    timeout=self.timeout,
-                    banner_timeout=self.timeout,
-                    auth_timeout=self.timeout,
-                )
-            except paramiko.AuthenticationException:
-                # if a wrong password was set, don't connect to the host and
-                # reraise the exception so the caller (Target.connect) reports
-                # the single user-facing ConnectingTargetFailedMessage. Keep
-                # the specific "wrong password" wording and traceback at DEBUG
-                # (visible with --debug) so we don't print two messages for one
-                # failure.
-                logger.debug(
-                    "Authentication failed on %s: wrong password",
-                    self.hostname,
-                    exc_info=True,
-                )
-                raise
+            logger.debug(
+                "Authentication failure detail on %s",
+                self.hostname,
+                exc_info=True,
+            )
+            raise
         except paramiko.SSHException:
             # unspecified general SSHException. the host/sshd is probably not
             # available. As above: one-line error, traceback to DEBUG.

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -43,6 +43,7 @@ class Connection:
 
     __slots__ = [
         "_interactive",
+        "_password_prompt",
         "_policy",
         "_timeout_prompt",
         "client",
@@ -62,6 +63,7 @@ class Connection:
         timeout: int,
         missing_host_key_policy: paramiko.MissingHostKeyPolicy | None = None,
         timeout_prompt: Callable[[str], str] | None = None,
+        password_prompt: Callable[[str], str] | None = None,
         interactive: bool = True,
     ) -> None:
         """Opens an SSH channel to the specified host.
@@ -87,6 +89,16 @@ class Connection:
                 :class:`mtui.cli.prompter.Prompter`'s ``ask`` method here
                 to surface a serialised, race-free prompt to the user
                 when multiple targets run a command in parallel.
+            password_prompt: Optional callable invoked with prompt text
+                when key authentication fails and a password is needed.
+                Returns the user's typed password. When ``None`` (the
+                default) the fallback uses :func:`getpass.getpass`, which
+                works for a plain terminal but renders nothing when called
+                between the REPL's prompt_toolkit ``PromptSession`` reads
+                (the prompt silently hangs). Wire a
+                :class:`mtui.cli.prompter.Prompter`'s ``ask_password``
+                method here so the masked prompt is rendered correctly
+                and serialised across parallel targets.
             interactive: Whether a TTY-backed user is available to answer
                 an SSH password prompt. ``True`` (the default) preserves
                 the legacy behaviour: if key auth fails, fall back to
@@ -97,6 +109,7 @@ class Connection:
 
         """
         self._timeout_prompt = timeout_prompt
+        self._password_prompt = password_prompt
         self._interactive = interactive
         self.hostname = hostname
 
@@ -195,12 +208,25 @@ class Connection:
             # Interactive session: fall back to a password prompt. Other
             # than ssh, mtui asks only once for a password. this could
             # be changed if there is demand for it.
+            username = opts.get("user", "root")
             logger.warning(
                 "Authentication failed on %s: AuthKey missing. Make sure your system is set up correctly",
                 self.hostname,
             )
-            logger.warning("Trying manually, please enter the root password")
-            password = getpass.getpass()
+            logger.warning("Trying manually, please enter the password")
+            # Explicit, host/user-labelled prompt so the user understands
+            # *why* the terminal is waiting (the old bare getpass() looked
+            # like a silent hang in the REPL).
+            prompt_text = f"{username}@{self.hostname}'s password: "
+            # Prefer the injected password prompt (the REPL wires
+            # Prompter.ask_password, which renders correctly between
+            # prompt_toolkit reads and masks input). Fall back to
+            # getpass.getpass for plain-terminal / test callers that pass
+            # no callback.
+            if self._password_prompt is not None:
+                password = self._password_prompt(prompt_text)
+            else:
+                password = getpass.getpass(prompt_text)
 
             try:
                 # try again with password auth instead of public/private key
@@ -211,7 +237,7 @@ class Connection:
                         else self.hostname
                     ),
                     port=int(opts.get("port", self.port)),
-                    username=opts.get("user", "root"),
+                    username=username,
                     password=password,
                     sock=(
                         paramiko.ProxyCommand(opts["proxycommand"])
@@ -224,16 +250,22 @@ class Connection:
                 )
             except paramiko.AuthenticationException:
                 # if a wrong password was set, don't connect to the host and
-                # reraise the exception hoping it's catched somewhere in an
-                # upper layer.
-                logger.exception(
-                    "Authentication failed on %s: wrong password", self.hostname
+                # reraise the exception so the caller (Target.connect) reports
+                # the single user-facing ConnectingTargetFailedMessage. Keep
+                # the specific "wrong password" wording and traceback at DEBUG
+                # (visible with --debug) so we don't print two messages for one
+                # failure.
+                logger.debug(
+                    "Authentication failed on %s: wrong password",
+                    self.hostname,
+                    exc_info=True,
                 )
                 raise
         except paramiko.SSHException:
             # unspecified general SSHException. the host/sshd is probably not
-            # available.
-            logger.exception("SSHException while connecting to %s", self.hostname)
+            # available. As above: one-line error, traceback to DEBUG.
+            logger.error("SSHException while connecting to %s", self.hostname)
+            logger.debug("SSHException detail", exc_info=True)
             raise
 
         except OSError:

--- a/mtui/hosts/connection/timeout.py
+++ b/mtui/hosts/connection/timeout.py
@@ -29,22 +29,6 @@ class CommandTimeoutError(Exception):
         return repr(self.command)
 
 
-class NonInteractiveAuthRequired(paramiko.AuthenticationException):
-    """Raised when key auth fails but no interactive password prompt is possible.
-
-    SSH public-key authentication failed and the only remaining fallback
-    is to ask the user for the root password. In a non-interactive
-    session (e.g. ``mtui-mcp``, which has no TTY and whose stdin is the
-    JSON-RPC pipe) that prompt cannot be shown and would block forever,
-    so we raise this instead.
-
-    Subclasses :class:`paramiko.AuthenticationException` so existing
-    ``except (paramiko.)AuthenticationException`` / ``except Exception``
-    handlers in the connect path keep catching it -- the host is simply
-    reported as unreachable rather than hanging the process.
-    """
-
-
 _HOST_KEY_POLICIES: dict[str, type[paramiko.MissingHostKeyPolicy]] = {
     "auto_add": paramiko.AutoAddPolicy,
     "warn": paramiko.WarningPolicy,

--- a/mtui/hosts/refhost/resolvers.py
+++ b/mtui/hosts/refhost/resolvers.py
@@ -32,7 +32,7 @@ class PathResolver(Resolver):
         self.refhosts_factory = refhosts_factory
 
     def resolve(self, config) -> Refhosts:
-        return self.refhosts_factory(config.refhosts_path, config.location)
+        return self.refhosts_factory(config.refhosts_path)
 
 
 class HttpsResolver(Resolver):
@@ -71,7 +71,7 @@ class HttpsResolver(Resolver):
 
     def resolve(self, config) -> Refhosts:
         self._refresh_if_needed(config)
-        return self.refhosts_factory(self.cache_path, config.location)
+        return self.refhosts_factory(self.cache_path)
 
     def _refresh_if_needed(self, config) -> None:
         if self._is_refresh_needed(config.refhosts_https_expiration):

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 
 from ruamel.yaml import YAML
 
-from ...support import messages
 from .models import Addon, Attributes, Host, Product, Version, _host_from_dict
 
 if TYPE_CHECKING:
@@ -28,24 +27,23 @@ logger = getLogger("mtui.refhost")
 class Refhosts:
     """Loads and searches ``refhosts.yml`` for hosts matching :class:`Attributes`."""
 
-    _default_location = "default"
-
-    def __init__(self, hostmap: Path, location: str | None = None) -> None:
+    def __init__(self, hostmap: Path) -> None:
         """Initialize the Refhosts object.
 
         Args:
             hostmap: Path to ``refhosts.yml``.
-            location: Location key to search; defaults to ``"default"``.
 
         """
-        self.location = location if location is not None else self._default_location
         self._parse_refhosts(hostmap)
 
     def _parse_refhosts(self, hostmap: Path) -> None:
         """Load ``hostmap`` and convert each row to a :class:`Host`.
 
-        Malformed rows are logged at ERROR and dropped; YAML parse
-        failures propagate.
+        The legacy ``refhosts.yml`` groups host rows under top-level
+        location keys (``default:``, ``nuremberg:``, …). Location support
+        has been retired, so every group is merged into a single flat list
+        of hosts. Malformed rows are logged at ERROR and dropped; YAML
+        parse failures propagate.
         """
         try:
             with hostmap.open() as f:
@@ -54,36 +52,21 @@ class Refhosts:
             logger.error("failed to parse refhosts.yml")
             raise
 
-        self.data: dict[str, list[Host]] = {}
-        for loc, rows in (raw or {}).items():
-            self.data[loc] = [
+        self.data: list[Host] = []
+        for rows in (raw or {}).values():
+            self.data.extend(
                 h for h in (_host_from_dict(row) for row in rows or []) if h is not None
-            ]
+            )
 
     def search(self, attributes: list[Attributes]) -> list[str]:
-        """Return hostnames matching any of the given :class:`Attributes`.
-
-        For each query attribute, search the configured location first;
-        if it yields no match and the configured location is not
-        ``default``, fall back to ``default``.
-        """
+        """Return hostnames matching any of the given :class:`Attributes`."""
         results: list[str] = []
         for attribute in attributes:
-            host = [
+            results += [
                 candidate.name
-                for candidate in self.data.get(self.location, [])
+                for candidate in self.data
                 if self.is_candidate_match(candidate, attribute)
             ]
-
-            if not host and self.location != self._default_location:
-                host = [
-                    candidate.name
-                    for candidate in self.data.get(self._default_location, [])
-                    if self.is_candidate_match(candidate, attribute)
-                ]
-
-            results += host
-
         return results
 
     def is_candidate_match(self, candidate: Host, attribute: Attributes) -> bool:
@@ -171,18 +154,12 @@ class Refhosts:
     def host_by_name(self, name: str) -> Host | None:
         """Return the refhosts entry whose ``name`` matches, or ``None``.
 
-        Searches the configured location first, then ``default``, then any
-        remaining locations, so a connected host maps back to the metadata
-        row mtui would use for it. Returns ``None`` if no row matches.
+        So a connected host maps back to the metadata row mtui would use
+        for it. Returns ``None`` if no row matches.
         """
-        ordered: list[str] = []
-        for loc in (self.location, self._default_location, *self.data):
-            if loc not in ordered:
-                ordered.append(loc)
-        for loc in ordered:
-            for candidate in self.data.get(loc, []):
-                if candidate.name == name:
-                    return candidate
+        for candidate in self.data:
+            if candidate.name == name:
+                return candidate
         return None
 
     def query(
@@ -194,34 +171,26 @@ class Refhosts:
         product: str | None = None,
         version: str | None = None,
         addon: "list[str] | None" = None,
-        location: str | None = None,
-    ) -> list[tuple[Host, str]]:
-        """Return ``(host, location)`` for refhosts matching the filters.
-
-        Location is **not** used to scope the search by default (it is being
-        retired): every location is scanned and results are de-duplicated by
-        host name (first location wins, preserving first-seen order). Pass
-        ``location`` to restrict to a single one.
+    ) -> list[Host]:
+        """Return refhosts matching the filters, de-duplicated by host name.
 
         ``attributes`` (parsed from a ``testplatform``) and the field filters
         (``name`` glob, ``arch``, ``product`` substring, ``version``,
         ``addon`` substring) are alternatives — when ``attributes`` is given
         the field filters are ignored. With neither, every host is returned.
         """
-        locs = [location] if location is not None else list(self.data)
         seen: set[str] = set()
-        out: list[tuple[Host, str]] = []
-        for loc in locs:
-            for host in self.data.get(loc, []):
-                if host.name in seen:
+        out: list[Host] = []
+        for host in self.data:
+            if host.name in seen:
+                continue
+            if attributes is not None:
+                if not any(self.is_candidate_match(host, a) for a in attributes):
                     continue
-                if attributes is not None:
-                    if not any(self.is_candidate_match(host, a) for a in attributes):
-                        continue
-                elif not self._field_match(host, name, arch, product, version, addon):
-                    continue
-                seen.add(host.name)
-                out.append((host, loc))
+            elif not self._field_match(host, name, arch, product, version, addon):
+                continue
+            seen.add(host.name)
+            out.append(host)
         return out
 
     @staticmethod
@@ -287,29 +256,16 @@ class Refhosts:
     def search_pool(
         self,
         attributes: list[Attributes],
-        *,
-        location: str | None = None,
     ) -> list[tuple[Host, tuple[str, str, str, tuple[str, ...]]]]:
         """Return pool candidates ``(host, slot)`` matching ``attributes``.
 
-        Thin wrapper over :meth:`query`: searches across **all** locations by
-        default (location ignored for pool candidates) and tags each match
-        with its :meth:`slot_of` test-target slot, so the host-arbitration
-        path can group candidates by slot and draw one free host per slot.
+        Thin wrapper over :meth:`query` that tags each match with its
+        :meth:`slot_of` test-target slot, so the host-arbitration path can
+        group candidates by slot and draw one free host per slot.
         """
         return [
-            (host, self.slot_of(host))
-            for host, _loc in self.query(attributes=attributes, location=location)
+            (host, self.slot_of(host)) for host in self.query(attributes=attributes)
         ]
-
-    def check_location_sanity(self, location: str) -> None:
-        """Raise :class:`InvalidLocationError` if ``location`` is unknown."""
-        if location not in self.data:
-            raise messages.InvalidLocationError(location, self.get_locations())
-
-    def get_locations(self) -> set[str]:
-        """Return the set of known location names."""
-        return set(self.data.keys())
 
 
 class RefhostsResolveFailedError(RuntimeError):

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -267,6 +267,60 @@ class Refhosts:
             (host, self.slot_of(host)) for host in self.query(attributes=attributes)
         ]
 
+    @staticmethod
+    def slot_for_query(
+        attribute: Attributes, host: Host
+    ) -> tuple[str, str, str, tuple[str, ...]]:
+        """Return the test-target slot keyed on the *queried* attributes.
+
+        Unlike :meth:`slot_of` — which keys on every module a host happens to
+        have installed — this keys on what the testplatform actually
+        distinguishes: the base product + version it requests, the host's arch
+        (testplatforms fan out one query per arch), and only the addons the
+        testplatform explicitly asked for. Hosts that satisfy the same query
+        are interchangeable for that update and must collapse to one slot, so
+        the arbiter draws a single host per (product, version, arch, requested
+        addons) instead of one per distinct installed-module set.
+        """
+        product = attribute.product
+        if product is None:
+            name, ver_str = "", ""
+        else:
+            name = product.name
+            ver = product.version
+            if ver is None:
+                ver_str = ""
+            elif ver.minor is None or ver.minor == "":
+                ver_str = str(ver.major)
+            else:
+                ver_str = f"{ver.major}-{ver.minor}"
+        addons = tuple(sorted(a.name for a in attribute.addons))
+        return (name, ver_str, host.arch, addons)
+
+    def search_pool_by_query(
+        self,
+        attributes: list[Attributes],
+    ) -> list[tuple[Host, tuple[str, str, str, tuple[str, ...]]]]:
+        """Return pool candidates ``(host, slot)`` keyed on the query slot.
+
+        Like :meth:`search_pool` but tags each match with
+        :meth:`slot_for_query` (the testplatform's requested identity) rather
+        than the host's full installed-module identity, so host-arbitration
+        draws one host per *requested* test-target slot. Each host is tagged
+        with the slot of the first attribute it matches.
+        """
+        out: list[tuple[Host, tuple[str, str, str, tuple[str, ...]]]] = []
+        seen: set[str] = set()
+        for host in self.query(attributes=attributes):
+            if host.name in seen:
+                continue
+            for attribute in attributes:
+                if self.is_candidate_match(host, attribute):
+                    out.append((host, self.slot_for_query(attribute, host)))
+                    seen.add(host.name)
+                    break
+        return out
+
 
 class RefhostsResolveFailedError(RuntimeError):
     """Raised when no resolver can produce a usable ``refhosts.yml`` source."""

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -104,6 +104,12 @@ class HostsGroup(UserDict[str, Target]):
             with suppress(TargetLockedError):
                 x.unlock(*a, **kw)
 
+    def pool_unlock(self, *a, **kw) -> None:
+        """Removes the pool claim on all hosts in the group."""
+        for x in self.data.values():
+            with suppress(TargetLockedError):
+                x.pool_unlock(*a, **kw)
+
     def lock(self, *a, **kw) -> None:
         """Locks all hosts in the group."""
         for x in self.data.values():
@@ -697,15 +703,18 @@ class HostsGroup(UserDict[str, Target]):
         for hn in sorted(self.data.keys()):
             self.data[hn].reporter.history(sink)
 
-    def report_locks(self, sink):
+    def report_locks(self, sink, pool: bool = False):
         """Reports the lock state of all hosts in the group.
 
         Args:
             sink: The function to use for reporting.
+            pool: When True, report the pool-claim locks instead of the
+                zypper/operation locks.
 
         """
         for hn in sorted(self.data.keys()):
-            self.data[hn].reporter.locks(sink)
+            reporter = self.data[hn].reporter
+            (reporter.pool_locks if pool else reporter.locks)(sink)
 
     def report_timeout(self, sink) -> None:
         """Reports the timeout of all hosts in the group.

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -418,3 +418,84 @@ class TargetLock:
         # NOTE: checking pid handles the case where one user is
         # running multiple mtui instances against the same hosts
         return self._lock.pid == self.i_am_pid
+
+
+class PoolLock(TargetLock):
+    """Remote lock for refhost *pool* claims, separate from the zypper lock.
+
+    A pool claim marks a reference host as taken by a particular template
+    (RRID) so a different user/template does not connect to the same host,
+    while the host-arbitration pool selection runs. It lives in its own
+    remote file (:attr:`filename`) so it never collides with the operation
+    lock taken around zypper transactions (``lock``/``unlock``,
+    ``update_lock``, ``LockedTargets``) -- the two mechanisms are fully
+    independent.
+
+    Ownership differs from :class:`TargetLock` deliberately: a pool lock is
+    "mine" when it was taken by the **same template (RRID) and user**,
+    regardless of PID. The pool lock outlives the process that took it (a
+    tester may reconnect from a fresh ``mtui`` invocation), so a PID-based
+    identity -- as the base class uses for the per-process operation lock --
+    would wrongly block a session from reconnecting to a host it already
+    claimed.
+
+    The RRID is stored in the lock comment as ``mtui pool <RRID> [<owner>]``
+    (see :meth:`mtui.test_reports.testreport.TestReport.connect_target`).
+    """
+
+    filename = Path("/var/lock/mtui-pool.lock")
+
+    def __init__(self, connection: Connection, config: Config, rrid: str = "") -> None:
+        """Initializes the `PoolLock` object.
+
+        Args:
+            connection: The connection to the target host.
+            config: The application configuration.
+            rrid: The RRID of the owning template. When empty (e.g. a
+                directly-constructed report that never uses pool selection),
+                ownership degrades to user-only.
+
+        """
+        super().__init__(connection, config)
+        self.i_am_rrid = rrid
+
+    @staticmethod
+    def _rrid_of(comment: str) -> str:
+        """Extracts the RRID from a ``mtui pool <RRID> [<owner>]`` comment.
+
+        Args:
+            comment: The lock comment.
+
+        Returns:
+            The RRID, or ``""`` when the comment is not a pool comment.
+
+        """
+        parts = comment.split()
+        if len(parts) >= 3 and parts[0] == "mtui" and parts[1] == "pool":
+            return parts[2]
+        return ""
+
+    def is_mine(self) -> bool:
+        """Checks if the pool lock is owned by this template + user.
+
+        Unlike :meth:`TargetLock.is_mine`, ownership ignores the PID and
+        compares the RRID recorded in the lock comment against this
+        session's RRID, so a tester reconnecting from a fresh process is
+        recognized as the owner.
+
+        Returns:
+            True if the lock belongs to this template and user, False
+            otherwise.
+
+        """
+        if not self._lock.user:
+            raise RuntimeError("not locked")
+
+        if self._lock.user != self.i_am_user:
+            return False
+        # Pool locks outlive the process, so identity is RRID-based, not PID.
+        # When this session has no RRID (non-pool report), fall back to
+        # user-only ownership.
+        if not self.i_am_rrid:
+            return True
+        return self._rrid_of(self._lock.comment) == self.i_am_rrid

--- a/mtui/hosts/target/reporter.py
+++ b/mtui/hosts/target/reporter.py
@@ -59,9 +59,14 @@ class Reporter:
         sink(t.hostname, t.system, t.lastout().split("\n"))
 
     def locks(self, sink: Callable[[str, System, "TargetLock"], None]) -> None:
-        """Report the lock object to ``sink``."""
+        """Report the zypper/operation lock object to ``sink``."""
         t = self.target
         sink(t.hostname, t.system, t._lock)  # noqa: SLF001
+
+    def pool_locks(self, sink: Callable[[str, System, "TargetLock"], None]) -> None:
+        """Report the pool-claim lock object to ``sink``."""
+        t = self.target
+        sink(t.hostname, t.system, t._pool_lock)  # noqa: SLF001
 
     def timeout(self, sink: Callable[[str, System, int], None]) -> None:
         """Report the current connection timeout to ``sink``."""

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -107,11 +107,11 @@ class Target:
                 cross-thread serialisation. ``None`` means "no prompt,
                 silently wait on timeout" — see
                 :class:`mtui.connection.Connection`.
-            interactive: Whether a TTY-backed user can answer an SSH
-                password prompt if key auth fails. Forwarded to
+            interactive: Whether a TTY-backed user can answer the
+                command-timeout prompt. Forwarded to
                 :class:`mtui.connection.Connection`; ``False`` (headless,
-                e.g. ``mtui-mcp``) makes a key-auth failure raise rather
-                than block on an invisible password prompt.
+                e.g. ``mtui-mcp``) makes a silent command timeout abort
+                the run rather than wait for an answer that can't come.
             rrid: The owning template's RRID, used as the pool-lock
                 ownership identity (see :class:`PoolLock`). Empty for
                 directly-constructed reports that never use pool selection.
@@ -174,9 +174,6 @@ class Target:
                 self._timeout,
                 missing_host_key_policy=policy_from_config(policy_name),
                 timeout_prompt=self._prompter.ask if self._prompter else None,
-                password_prompt=(
-                    self._prompter.ask_password if self._prompter else None
-                ),
                 interactive=self._interactive,
             )
         except Exception as e:

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -167,6 +167,9 @@ class Target:
                 self._timeout,
                 missing_host_key_policy=policy_from_config(policy_name),
                 timeout_prompt=self._prompter.ask if self._prompter else None,
+                password_prompt=(
+                    self._prompter.ask_password if self._prompter else None
+                ),
                 interactive=self._interactive,
             )
         except Exception as e:

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -2,6 +2,7 @@
 
 import errno
 from collections.abc import Callable
+from contextlib import suppress
 from logging import getLogger
 from pathlib import Path
 from string import Template
@@ -28,6 +29,7 @@ from ...update_workflow.checks import (
 )
 from ..connection import CommandTimeoutError, Connection, policy_from_config
 from . import TargetLock, TargetLockedError
+from .locks import PoolLock
 from .package_querier import PackageQuerier
 from .parsers import parse_system
 from .repo_manager import RepoManager
@@ -86,6 +88,7 @@ class Target:
         connection: type[Connection] = Connection,
         prompter: "Prompter | None" = None,
         interactive: bool = True,
+        rrid: str = "",
     ) -> None:
         """Initializes the `Target` object.
 
@@ -109,6 +112,9 @@ class Target:
                 :class:`mtui.connection.Connection`; ``False`` (headless,
                 e.g. ``mtui-mcp``) makes a key-auth failure raise rather
                 than block on an invisible password prompt.
+            rrid: The owning template's RRID, used as the pool-lock
+                ownership identity (see :class:`PoolLock`). Empty for
+                directly-constructed reports that never use pool selection.
 
         """
         self.config = config
@@ -121,6 +127,7 @@ class Target:
         self.Connection = connection
         self._prompter = prompter
         self._interactive = interactive
+        self._rrid = rrid
 
         self.state: TargetState | str = TargetState(state)
         # default timeout for target, used only on connecting/reconnecting Target
@@ -177,6 +184,9 @@ class Target:
             raise e
 
         self._lock = self.TargetLock(self.connection, self.config)
+        # Pool claims use a separate remote file + RRID-based ownership so they
+        # never collide with the per-process zypper operation lock above.
+        self._pool_lock = PoolLock(self.connection, self.config, self._rrid)
         if self.is_locked() and not self._lock.reap_if_stale():
             logger.warning(self._lock.locked_by_msg())
 
@@ -503,7 +513,7 @@ class Target:
             else.
 
         """
-        return self._lock.try_claim(comment)
+        return self._pool_lock.try_claim(comment)
 
     def unlock(self, force: bool = False) -> None:
         """Unlocks the target.
@@ -515,6 +525,20 @@ class Target:
         """
         try:
             self._lock.unlock(force)
+        except TargetLockedError as e:
+            logger.warning(e)
+            raise
+
+    def pool_unlock(self, force: bool = False) -> None:
+        """Removes this target's pool claim (separate from the zypper lock).
+
+        Args:
+            force: If True, removes a pool claim owned by another
+                user/template too.
+
+        """
+        try:
+            self._pool_lock.unlock(force)
         except TargetLockedError as e:
             logger.warning(e)
             raise
@@ -591,6 +615,12 @@ class Target:
             if self.connection and self.connection.is_active():
                 self.connection.timeout = 15
                 self.unlock()
+                # Best-effort: drop our pool claim on disconnect so a host is
+                # not left claimed after the session releases it. Only removes
+                # a claim owned by this template (force=False); foreign claims
+                # are left untouched.
+                with suppress(TargetLockedError):
+                    self.pool_unlock()
         except Exception:
             # ignore if the connection seems to be lost
             pass

--- a/mtui/mcp/args.py
+++ b/mtui/mcp/args.py
@@ -29,9 +29,6 @@ def get_parser(sys) -> ArgumentParser:
     """
     parser = ArgumentParser(sys_=sys, prog="mtui-mcp")
     parser.add_argument(
-        "-l", "--location", type=str, help="override config mtui.location"
-    )
-    parser.add_argument(
         "-t", "--template_dir", type=Path, help="override config mtui.template_dir"
     )
     parser.add_argument(

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -75,16 +75,15 @@ def _is_clean_shutdown_group(exc: BaseException) -> bool:
 def build_session(cfg: Config, log: Logger) -> McpSession:
     """Construct a fresh :class:`McpSession` from ``cfg`` and ``log``.
 
-    Each session gets its **own** shallow copy of ``cfg`` so the
-    per-client isolation extends to the mutable scalars that commands
-    flip in place — notably ``config.location`` (``set_location``). A
-    shallow copy is the right tool: those attributes are scalars, so
-    each session rebinds its own while the heavy read-only members (the
-    parsed ``ConfigParser``, the refhosts factory) stay shared. Without
-    the copy, every http client would share one ``Config`` and clobber
+    Each session gets its **own** shallow copy of ``cfg`` so per-client
+    isolation extends to any scalar a command might rebind on ``config``
+    in place. A shallow copy is the right tool: scalars are rebound
+    per session while the heavy read-only members (the parsed
+    ``ConfigParser``, the refhosts factory) stay shared. Without the
+    copy, every http client would share one ``Config`` and could clobber
     each other's mutable state.
 
-    Workflow mode (``auto`` / ``kernel``) now lives on the loaded
+    Workflow mode (``auto`` / ``kernel``) lives on the loaded
     :class:`TestReport`, not on ``config``, so no per-session seeding of
     those flags is needed here.
 

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -380,6 +380,10 @@ class McpSession:
         # Re-apply the non-interactive flag after the testreport swap so
         # the fresh HostsGroup inherits the session's headless mode.
         self.targets.interactive = False
+        # Run the deferred autoconnect now that ``add`` has wired the host
+        # arbiter, so refhosts are drawn one-per-slot (with backup) instead of
+        # connecting every candidate. No-op unless autoconnect was requested.
+        tr.autoconnect()
         self.set_prompt()
 
     # ------------------------------------------------------------------

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -106,7 +106,6 @@ class Config:
     lock_pi_autolock: bool
     lock_wait: int
     lock_wait_poll: int
-    refhost_pool_select: bool
 
     # -- mtui-mcp server (http transport) per-client session registry --
     mcp_session_cap: int
@@ -406,7 +405,7 @@ class Config:
                 bool,
                 getboolean,
             ),
-            # Host-arbitration pool queueing (RFC §5.8). When a candidate host
+            # Host-arbitration pool queueing. When a candidate host
             # is busy, a pool claim queues up to ``wait`` seconds, polling
             # every ``wait_poll`` seconds. ``wait <= 0`` (default) fails fast
             # (current behaviour).
@@ -423,17 +422,6 @@ class Config:
                 15,
                 int,
                 getint,
-            ),
-            # Refhost-pool parallelism (RFC §5.7). When enabled, fan-out across
-            # templates draws one *distinct* free host per test-target slot from
-            # the shared pool via the in-process HostArbiter, instead of the
-            # legacy single-host-per-arch path. Default off → unchanged.
-            ConfigOption(
-                "refhost_pool_select",
-                ("refhosts", "pool_select"),
-                False,
-                bool,
-                getboolean,
             ),
             # ``mtui-mcp`` http transport isolates state per client in a
             # session registry (see mtui.mcp.registry). ``session_cap``

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -14,8 +14,6 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
-from ..hosts.refhost import RefhostsFactory, RefhostsResolveFailedError
-from .messages import InvalidLocationError
 from .paths import terms_path
 
 logger = getLogger("mtui.config")
@@ -119,19 +117,15 @@ class Config:
     distro_ver: str
     distro_kernel: str
 
-    def __init__(self, path: Path | None, refhosts=RefhostsFactory) -> None:
+    def __init__(self, path: Path | None) -> None:
         """Initializes the configuration object.
 
         This method reads config files, and sets up options.
 
         Args:
             path: An optional path to a specific config file.
-            refhosts: The factory to use for creating refhosts.
 
         """
-        self.refhosts = refhosts
-        self.__location = "default"
-
         if path:
             self.configfiles = [path]
         elif _pth := getenv("MTUI_CONF"):
@@ -151,30 +145,6 @@ class Config:
             self.config.read(self.configfiles)
         except configparser.Error as e:
             logger.error(e)
-
-    @property
-    def location(self) -> str:
-        """The location property."""
-        return self.__location
-
-    @location.setter
-    def location(self, x: str) -> None:
-        """Sets the location property.
-
-        Args:
-            x: The new location.
-
-        """
-        try:
-            self.refhosts(self).check_location_sanity(x)
-        except InvalidLocationError as e:
-            logger.error(e)
-            return
-        except RefhostsResolveFailedError:
-            logger.error("Can't read `refhosts.yml` file, no valid refhosts database")
-            return
-
-        self.__location = x
 
     def _parse_config(self) -> None:
         """Parses the configuration options from the config files.
@@ -221,7 +191,7 @@ class Config:
 
         def get_connection_timeout(section: str, option: str) -> str:
             # Read from the [connection] section, falling back to the legacy
-            # [mtui] location so existing configs keep working.
+            # [mtui] section so existing configs keep working.
             try:
                 return self.config.get(section, option)
             except (configparser.NoSectionError, configparser.NoOptionError):
@@ -486,19 +456,6 @@ class Config:
                 int,
                 getint,
             ),
-            # ``location`` MUST be parsed last. Assigning it goes through the
-            # ``location`` property setter, which resolves refhosts to validate
-            # the location -- and the resolve reads ``ssl_verify`` and the
-            # ``refhosts_*`` options. Those must already be set on ``self``, so
-            # this option stays at the end of the list. Reordering it earlier
-            # reintroduces ``AttributeError: 'Config' object has no attribute
-            # 'ssl_verify'`` during config parsing.
-            ConfigOption(
-                "location",
-                ("mtui", "location"),
-                "default",
-                getter=get,
-            ),
         ]
 
     def _list_terms(self) -> None:
@@ -537,9 +494,6 @@ class Config:
             args: The parsed command-line arguments.
 
         """
-        if args.location:
-            self.location = args.location
-
         if args.template_dir:
             self.template_dir = args.template_dir
 

--- a/mtui/support/messages.py
+++ b/mtui/support/messages.py
@@ -207,19 +207,6 @@ class CompareScriptCrashedError(CompareScriptError):
         return f"Compare script {self.argv!r} crashed:\n{self.stderr}"
 
 
-class LocationChangedMessage(UserMessage):
-    """A message for when the location changes."""
-
-    def __init__(self, old, new) -> None:
-        self.old = old
-        self.new = new
-
-    @property
-    def message(self):
-        """The message."""
-        return f"changed location from {self.old!r} to {self.new!r}"
-
-
 class MissingDoerError(ErrorMessage):
     """Base class for missing "doer" errors."""
 
@@ -262,18 +249,6 @@ class MissingDowngraderError(MissingDoerError):
     """Raised when a downgrader is missing."""
 
     name = "Downgrader"
-
-
-class InvalidLocationError(UserError):
-    """Raised when an invalid location is specified."""
-
-    _msg = "Invalid location {0!r}. Available locations: {1}"
-
-    def __init__(self, requested, available) -> None:
-        self.requested = requested
-        self.available = available
-
-        self.message = self._msg.format(requested, ", ".join(available))
 
 
 class ReConnectFailed(ErrorMessage):

--- a/mtui/template_registry.py
+++ b/mtui/template_registry.py
@@ -59,7 +59,7 @@ class TemplateRegistry:
         self.id: str = uuid4().hex
         #: Process-global host arbiter shared by every registry (RFC §5.7).
         #: Reports claim distinct refhosts through it keyed on
-        #: ``(self.id, RRID)`` when ``[refhosts] pool_select`` is on.
+        #: ``(self.id, RRID)`` so fan-out never collides on a shared host.
         self.arbiter = get_arbiter()
         self._null: TestReport = null_factory()
         self._entries: dict[str, TestReport] = {}

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -754,7 +754,7 @@ class TestReport(ABC):
     def _pool_select_from_tp(self, refhosts, attributes, testplatform) -> None:
         """Pick one distinct free host per test-target slot via the arbiter.
 
-        Candidates are searched across all locations and grouped by slot
+        Candidates are searched and grouped by slot
         (product+version+arch+addons). For each slot the in-process arbiter
         hands out one host not already claimed by another owner, queueing up
         to ``[lock] wait`` seconds when every candidate is busy. The remote

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -740,12 +740,14 @@ class TestReport(ABC):
         self.hostnames.update(set(hostnames))
 
     def _pool_selection_active(self) -> bool:
-        """True when refhost-pool arbitration should drive host selection."""
-        return bool(
-            self.config.refhost_pool_select
-            and self._arbiter is not None
-            and self._owner is not None
-        )
+        """True when refhost-pool arbitration should drive host selection.
+
+        Active whenever an in-process arbiter and owner are wired up (the
+        fan-out / ``mtui-mcp`` runtime path). When they are absent — e.g. a
+        direct ``add_host`` — selection falls back to the legacy
+        single-host-per-arch ``search()`` path.
+        """
+        return self._arbiter is not None and self._owner is not None
 
     def _pool_owner_label(self) -> str:
         """Human owner stamp for the remote pool lock comment."""

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -603,6 +603,7 @@ class TestReport(ABC):
                 timeout=self.config.connection_timeout,
                 prompter=self._prompter,
                 interactive=self._prompter is not None,
+                rrid=str(self.id),
             )
             target.connect()
             new_system = str(target.system)
@@ -778,6 +779,7 @@ class TestReport(ABC):
                 self.packages,
                 prompter=self._prompter,
                 interactive=self._prompter is not None,
+                rrid=str(self.id),
             )
             self.targets[hostname].connect()
 
@@ -890,7 +892,7 @@ class TestReport(ABC):
             target = self.targets.get(host)
             if target is not None:
                 with suppress(Exception):
-                    target.unlock()
+                    target.pool_unlock()
         self._pool_claims.clear()
         self._slot_candidates.clear()
         if self._arbiter is not None and self._owner is not None:

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -3,6 +3,7 @@
 import concurrent.futures
 import glob
 import os
+import random
 import re
 import shutil
 import stat
@@ -641,7 +642,19 @@ class TestReport(ABC):
         targets: dict[str, Target] = {}
         new_systems: dict[str, str] = {}
         executor = ContextExecutor()
-        hosts: set[str] = {host for host in self.hostnames if host not in self.targets}
+        # Once a testplatform/pool selection has run (``_slot_candidates`` set),
+        # only the arbiter-chosen hosts (one per slot) should be connected.
+        # ``hostnames`` may also hold the full set of template ``reference host:``
+        # candidates (autoconnect pre-loads them), so connecting all of it would
+        # drag in every duplicate per slot -- the regression this guards against.
+        # Before any pool selection (plain template autoconnect / ``add_host
+        # --target``) every requested host in ``hostnames`` connects as before.
+        connectable = (
+            self._pool_claims
+            if self._pool_selection_active() and self._slot_candidates
+            else self.hostnames
+        )
+        hosts: set[str] = {host for host in connectable if host not in self.targets}
 
         if hosts:
             logger.info("Adding %s", hosts)
@@ -841,17 +854,20 @@ class TestReport(ABC):
     def _pool_select_from_tp(self, refhosts, attributes, testplatform) -> None:
         """Pick one distinct free host per test-target slot via the arbiter.
 
-        Candidates are searched and grouped by slot
-        (product+version+arch+addons). For each slot the in-process arbiter
-        hands out one host not already claimed by another owner, queueing up
-        to ``[lock] wait`` seconds when every candidate is busy. The remote
-        lock is taken later at connect time (``connect_target``).
+        Candidates are searched and grouped by the *requested* slot
+        (base product + version + arch + the testplatform's requested addons),
+        so hosts that satisfy the same testplatform collapse to one slot
+        regardless of which extra modules they happen to have installed. For
+        each slot the in-process arbiter hands out one host not already claimed
+        by another owner, queueing up to ``[lock] wait`` seconds when every
+        candidate is busy. The remote lock is taken later at connect time
+        (``connect_target``).
         """
         arbiter = self._arbiter
         owner = self._owner
         if arbiter is None or owner is None:
             return
-        pairs = refhosts.search_pool(attributes)
+        pairs = refhosts.search_pool_by_query(attributes)
         if not pairs:
             logger.warning("nothing found for testplatform %r", testplatform)
             return
@@ -859,7 +875,11 @@ class TestReport(ABC):
         for host, slot in pairs:
             by_slot.setdefault(slot, []).append(host.name)
         for slot, candidates in by_slot.items():
-            # Remember the full candidate list so connect_targets can fall
+            # Pick (and fall back) randomly within a slot so load is spread
+            # across the interchangeable refhosts instead of always hammering
+            # the first one in refhosts.yml order.
+            random.shuffle(candidates)
+            # Remember the (shuffled) candidate list so connect_targets can fall
             # back to a sibling host if the chosen one fails to connect.
             self._slot_candidates[slot] = list(candidates)
             # Skip slots we already hold a host for (across testplatforms).

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -135,6 +135,16 @@ class TestReport(ABC):
         self._owner: tuple[str, str] | None = None
         # Hosts this report has claimed through the arbiter (for release).
         self._pool_claims: set[str] = set()
+        # Per-slot ordered candidate hostnames captured during pool selection,
+        # so connect_targets can fall back to a sibling host when the primary
+        # claim fails to connect (RFC §5.7 backup-refhost).
+        self._slot_candidates: dict[tuple, list[str]] = {}
+        # Set by ``make_testreport`` when a load asked for autoconnect; the
+        # actual connect is deferred to :meth:`autoconnect` so it runs *after*
+        # ``TemplateRegistry.add`` has wired the host arbiter (otherwise the
+        # legacy search() path connects every candidate instead of one per
+        # slot).
+        self._autoconnect_pending = False
         self.bugs: dict[str, str] = {}
         self.jira: dict[str, str] = {}
         self.testplatforms: list[str] = []
@@ -666,6 +676,10 @@ class TestReport(ABC):
             del connections
             del executor
 
+        # For pool slots whose chosen host did not connect, fall back to a
+        # sibling candidate in the same slot (RFC §5.7 backup-refhost).
+        self._connect_pool_backups(hosts, targets, new_systems)
+
         # We need to be sure that only the system property only have the  connected hosts
         self.systems = {host: system for host, system in new_systems.items() if system}
         for t in self.targets.copy():
@@ -675,6 +689,75 @@ class TestReport(ABC):
         self.targets.update(
             {host: target for host, target in targets.items() if target}
         )
+
+    def _connect_pool_backups(
+        self,
+        attempted: set[str],
+        targets: dict[str, Target],
+        new_systems: dict[str, str],
+    ) -> None:
+        """Retry failed pool slots against their remaining candidates.
+
+        A slot whose primary claim failed to connect (and which we did not
+        already connect via another candidate) is retried sequentially: the
+        next free candidate in the slot is claimed through the arbiter and
+        connected, until one succeeds or the slot is exhausted. Mutates
+        ``targets`` / ``new_systems`` in place for any backup that connects.
+
+        Best-effort and a no-op when pool selection is inactive. Failures are
+        rare, so the retry runs serially rather than re-entering the fan-out.
+        """
+        if not self._pool_selection_active() or not self._slot_candidates:
+            return
+        arbiter = self._arbiter
+        owner = self._owner
+        if arbiter is None or owner is None:
+            return
+
+        for slot, candidates in self._slot_candidates.items():
+            # Already have a live connection for this slot? Nothing to do.
+            if any(c in targets for c in candidates):
+                continue
+            # Drop the dead primary claim(s) so a sibling can be tried and the
+            # exhausted-pool wait below reflects real availability.
+            for c in candidates:
+                if c in self._pool_claims and c not in targets:
+                    self._pool_claims.discard(c)
+                    arbiter.release(c, owner)
+
+            remaining = [c for c in candidates if c not in attempted]
+            connected = False
+            while remaining:
+                chosen = arbiter.acquire_any(
+                    remaining,
+                    owner,
+                    wait=self.config.lock_wait,
+                    poll=self.config.lock_wait_poll,
+                )
+                if chosen is None:
+                    break
+                attempted.add(chosen)
+                remaining.remove(chosen)
+                self._pool_claims.add(chosen)
+                self.hostnames.add(chosen)
+                logger.info("Trying backup refhost %s for slot %s", chosen, slot)
+                target, new_system = self.connect_target(chosen)
+                if target is False or new_system is False:
+                    # connect_target already released the in-process claim on a
+                    # remote-lock race; drop it unconditionally so the next
+                    # candidate is free to try.
+                    self._pool_claims.discard(chosen)
+                    arbiter.release(chosen, owner)
+                    continue
+                targets[chosen], new_systems[chosen] = target, new_system
+                connected = True
+                break
+            if not connected:
+                logger.warning(
+                    "no connectable pool host for slot %s (tried %d candidates)",
+                    slot,
+                    len(candidates),
+                )
 
     def add_target(self, hostname: str) -> None:
         """Adds a target to the test report.
@@ -774,6 +857,9 @@ class TestReport(ABC):
         for host, slot in pairs:
             by_slot.setdefault(slot, []).append(host.name)
         for slot, candidates in by_slot.items():
+            # Remember the full candidate list so connect_targets can fall
+            # back to a sibling host if the chosen one fails to connect.
+            self._slot_candidates[slot] = list(candidates)
             # Skip slots we already hold a host for (across testplatforms).
             if any(arbiter.owner_of(c) == owner for c in candidates):
                 continue
@@ -806,8 +892,34 @@ class TestReport(ABC):
                 with suppress(Exception):
                     target.unlock()
         self._pool_claims.clear()
+        self._slot_candidates.clear()
         if self._arbiter is not None and self._owner is not None:
             self._arbiter.release_owner(self._owner)
+
+    def autoconnect(self) -> None:
+        """Connect refhosts for a freshly loaded (manual-fallback) template.
+
+        Deferred from :meth:`UpdateID.make_testreport` so it runs *after*
+        :meth:`TemplateRegistry.add` has wired the host arbiter. With the
+        arbiter in place, :meth:`refhosts_from_tp` takes the pool-selection
+        path and draws one host per test-target slot (instead of the legacy
+        ``search()`` path that connected every candidate per arch).
+
+        No-op unless ``make_testreport`` flagged this report for autoconnect.
+        """
+        if not self._autoconnect_pending:
+            return
+        self._autoconnect_pending = False
+
+        logger.info("Connect refhosts from testreport")
+        self.connect_targets()
+
+        for tp in self.testplatforms:
+            logger.debug("Testplatform: %s", tp)
+            self.refhosts_from_tp(tp)
+
+        logger.info("Connect refhosts from TestPlatform")
+        self.connect_targets()
 
     def list_bugs(self, sink, arg):
         """Lists the bugs for the test report.

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -244,15 +244,11 @@ class AutoOBSUpdateID(UpdateID):
             tr.workflow = Workflow.MANUAL
 
             if autoconnect:
-                logger.info("Connect refhosts from testreport")
-                tr.connect_targets()
-
-                for tp in tr.testplatforms:
-                    logger.debug("Testplatform: %s", tp)
-                    tr.refhosts_from_tp(tp)
-
-                logger.info("Connect refhosts from TestPlatform")
-                tr.connect_targets()
+                # Defer the actual connect to TestReport.autoconnect(), which
+                # the loader calls *after* TemplateRegistry.add wires the host
+                # arbiter -- so refhosts_from_tp draws one host per slot
+                # (with backup) instead of connecting every candidate.
+                tr._autoconnect_pending = True  # noqa: SLF001
 
         return tr
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,9 @@ def mock_target(mock_config, mock_connection, mock_system):
     target._lock = MagicMock()
     target._lock.is_locked.return_value = False
     target._lock.is_mine.return_value = True
+    target._pool_lock = MagicMock()
+    target._pool_lock.is_locked.return_value = False
+    target._pool_lock.is_mine.return_value = True
     target.system = mock_system
     target.transactional = False
     target.packages = {
@@ -123,6 +126,9 @@ def mock_target_pair(mock_config, mock_system):
         t._lock = MagicMock()
         t._lock.is_locked.return_value = False
         t._lock.is_mine.return_value = True
+        t._pool_lock = MagicMock()
+        t._pool_lock.is_locked.return_value = False
+        t._pool_lock.is_mine.return_value = True
         t.system = mock_system
         t.transactional = False
         t.packages = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ def mock_config():
     # Matches the production default: verify TLS certificates everywhere
     # unless the user opts out via [mtui] ssl_verify.
     config.ssl_verify = True
-    config.location = "nuremberg"
     config.auto = False
     # Lock-wait queueing defaults (off = legacy fail-fast); see [lock] wait.
     config.lock_wait = 0

--- a/tests/fixtures/mtuirc
+++ b/tests/fixtures/mtuirc
@@ -1,7 +1,6 @@
 # Realistic minimal mtuirc fixture used by tests/test_config.py to exercise
 # the INI parser end-to-end (multiple sections, multiple value types).
 [mtui]
-location = nuremberg
 connection_timeout = 450
 user = qauser
 chdir_to_template_dir = true

--- a/tests/fixtures/refhosts.yml
+++ b/tests/fixtures/refhosts.yml
@@ -1,3 +1,6 @@
+# Legacy refhosts.yml format: hosts grouped under top-level location keys.
+# Location support is retired; Refhosts merges every group into one flat list,
+# so this fixture verifies that hosts from all groups are read and de-duped.
 default:
   - name: host-default-x86
     arch: x86_64

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -27,8 +27,6 @@ def test_get_parser_args():
     # Test short arguments
     parsed_args = parser.parse_args(
         [
-            "-l",
-            "test_location",
             "-t",
             "/test/template_dir",
             "-s",
@@ -45,7 +43,6 @@ def test_get_parser_args():
         ]
     )
 
-    assert parsed_args.location == "test_location"
     assert parsed_args.template_dir == Path("/test/template_dir")
     assert parsed_args.sut[0].print_args() == "-t host1 -t host2"
     assert parsed_args.connection_timeout == 600
@@ -57,8 +54,6 @@ def test_get_parser_args():
     # Test long arguments
     parsed_args = parser.parse_args(
         [
-            "--location",
-            "test_location_long",
             "--template_dir",
             "/test/template_dir_long",
             "--sut",
@@ -75,7 +70,6 @@ def test_get_parser_args():
         ]
     )
 
-    assert parsed_args.location == "test_location_long"
     assert parsed_args.template_dir == Path("/test/template_dir_long")
     assert parsed_args.sut[0].print_args() == "-t host3 -t host4"
     assert parsed_args.connection_timeout == 1200

--- a/tests/test_cmd_hostslock.py
+++ b/tests/test_cmd_hostslock.py
@@ -31,3 +31,19 @@ def test_lock_without_comment_passes_empty_string(mock_config):
     args = Namespace(hosts=None, comment=None)
     HostLock(args, mock_config, MagicMock(), prompt)()
     prompt.targets.select.return_value.lock.assert_called_once_with("")
+
+
+def test_lock_is_fanout():
+    assert HostLock.scope == "fanout"
+
+
+def test_lock_accepts_template_flag():
+    ns = HostLock.parse_args("-T SUSE:Maintenance:1:1", MagicMock())
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+def test_lock_accepts_all_templates_flag():
+    ns = HostLock.parse_args("--all-templates", MagicMock())
+    assert ns.all_templates is True
+    assert ns.template is None

--- a/tests/test_cmd_hostsunlock.py
+++ b/tests/test_cmd_hostsunlock.py
@@ -45,3 +45,19 @@ def test_unlock_pool_with_force(mock_config):
     args = Namespace(hosts=None, force=True, pool=True)
     HostsUnlock(args, mock_config, MagicMock(), prompt)()
     prompt.targets.select.return_value.pool_unlock.assert_called_once_with(force=True)
+
+
+def test_unlock_is_fanout():
+    assert HostsUnlock.scope == "fanout"
+
+
+def test_unlock_accepts_template_flag():
+    ns = HostsUnlock.parse_args("-T SUSE:Maintenance:1:1", MagicMock())
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+def test_unlock_accepts_all_templates_flag():
+    ns = HostsUnlock.parse_args("--all-templates", MagicMock())
+    assert ns.all_templates is True
+    assert ns.template is None

--- a/tests/test_cmd_hostsunlock.py
+++ b/tests/test_cmd_hostsunlock.py
@@ -20,13 +20,28 @@ def _prompt() -> MagicMock:
 
 def test_unlock_default_no_force(mock_config):
     prompt = _prompt()
-    args = Namespace(hosts=None, force=False)
+    args = Namespace(hosts=None, force=False, pool=False)
     HostsUnlock(args, mock_config, MagicMock(), prompt)()
     prompt.targets.select.return_value.unlock.assert_called_once_with(force=False)
 
 
 def test_unlock_with_force(mock_config):
     prompt = _prompt()
-    args = Namespace(hosts=None, force=True)
+    args = Namespace(hosts=None, force=True, pool=False)
     HostsUnlock(args, mock_config, MagicMock(), prompt)()
     prompt.targets.select.return_value.unlock.assert_called_once_with(force=True)
+
+
+def test_unlock_pool_default_no_force(mock_config):
+    prompt = _prompt()
+    args = Namespace(hosts=None, force=False, pool=True)
+    HostsUnlock(args, mock_config, MagicMock(), prompt)()
+    prompt.targets.select.return_value.pool_unlock.assert_called_once_with(force=False)
+    prompt.targets.select.return_value.unlock.assert_not_called()
+
+
+def test_unlock_pool_with_force(mock_config):
+    prompt = _prompt()
+    args = Namespace(hosts=None, force=True, pool=True)
+    HostsUnlock(args, mock_config, MagicMock(), prompt)()
+    prompt.targets.select.return_value.pool_unlock.assert_called_once_with(force=True)

--- a/tests/test_cmd_loadtemplate.py
+++ b/tests/test_cmd_loadtemplate.py
@@ -29,7 +29,7 @@ def test_load_template_auto_kind_loads(mock_config):
     prompt = _prompt(metadata_truthy=False)
     update = MagicMock()
     update.kind = "auto"
-    args = Namespace(update=update, chosts=False)
+    args = Namespace(update=update)
 
     LoadTemplate(args, mock_config, MagicMock(), prompt)()
 
@@ -40,7 +40,7 @@ def test_load_template_unknown_kind_raises(mock_config):
     prompt = _prompt(metadata_truthy=False)
     update = MagicMock()
     update.kind = "unknown"
-    args = Namespace(update=update, chosts=False)
+    args = Namespace(update=update)
 
     with pytest.raises(TestReportNotLoadedError):
         LoadTemplate(args, mock_config, MagicMock(), prompt)()
@@ -57,24 +57,26 @@ def test_load_template_does_not_close_existing_hosts(mock_config):
     prompt.targets = {"h1": existing}
     update = MagicMock()
     update.kind = "auto"
-    # -c not passed -> chosts defaults True (keep/re-add hosts).
-    args = Namespace(update=update, chosts=True)
+    args = Namespace(update=update)
 
     LoadTemplate(args, mock_config, MagicMock(), prompt)()
 
     existing.close.assert_not_called()
     prompt.load_update.assert_called_once_with(update, autoconnect=True)
-    # carry-over re-adds the previously connected host to the new template
-    prompt.metadata.add_target.assert_called_once_with("h1")
 
 
-def test_load_template_clean_hosts_skips_carry_over(mock_config):
-    """With -c/--clean-hosts (chosts False) no host carry-over happens."""
+def test_load_template_never_carries_over_other_templates_hosts(mock_config):
+    """Loading a template must not reconnect hosts owned by another template.
+
+    Each loaded template owns its own hosts: the previously active template's
+    connected hosts are left on that template and never re-added to the newly
+    loaded one.
+    """
     prompt = _prompt(metadata_truthy=True)
-    prompt.targets = {"h1": MagicMock()}
+    prompt.targets = {"h1": MagicMock(), "h2": MagicMock()}
     update = MagicMock()
     update.kind = "auto"
-    args = Namespace(update=update, chosts=False)
+    args = Namespace(update=update)
 
     LoadTemplate(args, mock_config, MagicMock(), prompt)()
 

--- a/tests/test_cmd_simplelists.py
+++ b/tests/test_cmd_simplelists.py
@@ -9,9 +9,13 @@ import pytest
 
 from mtui.commands.simplelists import (
     ListBugs,
+    ListHistory,
     ListHosts,
     ListLocks,
+    ListLog,
     ListMetadata,
+    ListSessions,
+    ListTimeout,
     ListUpdateCommands,
     ListVersions,
 )
@@ -84,6 +88,39 @@ def test_report_bound_command_accepts_template_flag(cmd_cls):
 
 @pytest.mark.parametrize("cmd_cls", _REPORT_BOUND)
 def test_report_bound_command_accepts_all_templates_flag(cmd_cls):
+    sys_mock = MagicMock()
+    ns = cmd_cls.parse_args("--all-templates", sys_mock)
+    assert ns.all_templates is True
+    assert ns.template is None
+
+
+# --- fan-out scope contract for host-listing / host-locking commands ---
+
+_HOST_LISTING = (
+    ListHosts,
+    ListLocks,
+    ListTimeout,
+    ListSessions,
+    ListHistory,
+    ListLog,
+)
+
+
+@pytest.mark.parametrize("cmd_cls", _HOST_LISTING)
+def test_host_listing_command_is_fanout(cmd_cls):
+    assert cmd_cls.scope == "fanout"
+
+
+@pytest.mark.parametrize("cmd_cls", _HOST_LISTING)
+def test_host_listing_command_accepts_template_flag(cmd_cls):
+    sys_mock = MagicMock()
+    ns = cmd_cls.parse_args("-T SUSE:Maintenance:1:1", sys_mock)
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+@pytest.mark.parametrize("cmd_cls", _HOST_LISTING)
+def test_host_listing_command_accepts_all_templates_flag(cmd_cls):
     sys_mock = MagicMock()
     ns = cmd_cls.parse_args("--all-templates", sys_mock)
     assert ns.all_templates is True

--- a/tests/test_cmd_simplelists.py
+++ b/tests/test_cmd_simplelists.py
@@ -35,10 +35,18 @@ def test_list_hosts_calls_report_self(mock_config):
 
 def test_list_locks_filters_enabled_then_reports(mock_config):
     prompt = _prompt()
-    ListLocks(Namespace(), mock_config, MagicMock(), prompt)()
+    ListLocks(Namespace(pool=False), mock_config, MagicMock(), prompt)()
     prompt.targets.select.assert_called_once_with(enabled=True)
     prompt.targets.select.return_value.report_locks.assert_called_once_with(
-        prompt.display.list_locks
+        prompt.display.list_locks, pool=False
+    )
+
+
+def test_list_locks_pool_flag_reports_pool(mock_config):
+    prompt = _prompt()
+    ListLocks(Namespace(pool=True), mock_config, MagicMock(), prompt)()
+    prompt.targets.select.return_value.report_locks.assert_called_once_with(
+        prompt.display.list_locks, pool=True
     )
 
 

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -61,7 +61,6 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("remove_host", "mtui.commands.removehost", "RemoveHost"),
         ("run", "mtui.commands.run", "Run"),
         ("set_host_state", "mtui.commands.hoststate", "HostState"),
-        ("set_location", "mtui.commands.simpleset", "SetLocation"),
         ("set_log_level", "mtui.commands.simpleset", "SetLogLevel"),
         ("set_repo", "mtui.commands.setrepo", "SetRepo"),
         ("set_timeout", "mtui.commands.simpleset", "SetTimeout"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,55 +3,22 @@ from pathlib import Path
 
 import pytest
 
-from mtui.hosts.refhost import RefhostsResolveFailedError
 from mtui.support import config
-from mtui.support.messages import InvalidLocationError
-
-
-class MockRefhosts:
-    def __init__(self, config):
-        pass
-
-    def check_location_sanity(self, location):
-        pass
-
-    def __call__(self, config):
-        return self
-
-
-class RaisingRefhosts:
-    """Refhosts double whose ``check_location_sanity`` raises on demand."""
-
-    exc: Exception | None = None
-
-    def __init__(self, config):
-        pass
-
-    def check_location_sanity(self, location):
-        if self.exc is not None:
-            raise self.exc
-
-    def __call__(self, config):
-        return self
 
 
 def test_default_config(tmpdir):
     """Test default config."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("")
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
-    assert cfg.location == "default"
+    cfg = config.Config(config_file)
     assert cfg.connection_timeout == 300
 
 
 def test_override_default_config(tmpdir):
     """Test override config."""
     config_file = Path(tmpdir.join("test.cfg"))
-    config_file.write_text(
-        "[mtui]\nlocation = test_location\nconnection_timeout = 600\n"
-    )
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
-    assert cfg.location == "test_location"
+    config_file.write_text("[mtui]\nconnection_timeout = 600\n")
+    cfg = config.Config(config_file)
     assert cfg.connection_timeout == 600
 
 
@@ -59,17 +26,17 @@ def test_connection_timeout_from_connection_section(tmpdir):
     """connection_timeout is read from the [connection] section."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("[connection]\nconnection_timeout = 45\n")
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     assert cfg.connection_timeout == 45
 
 
 def test_connection_timeout_connection_section_wins(tmpdir):
-    """[connection] takes precedence over the legacy [mtui] location."""
+    """[connection] takes precedence over the legacy [mtui] section."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text(
         "[mtui]\nconnection_timeout = 600\n[connection]\nconnection_timeout = 45\n"
     )
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     assert cfg.connection_timeout == 45
 
 
@@ -77,14 +44,11 @@ def test_smelt_url_defaults_empty_and_overrides(tmpdir):
     """smelt_url has no default (off unless configured) and reads [smelt] url."""
     empty = Path(tmpdir.join("empty.cfg"))
     empty.write_text("")
-    assert config.Config(empty, refhosts=MockRefhosts).smelt_url == ""
+    assert config.Config(empty).smelt_url == ""
 
     configured = Path(tmpdir.join("smelt.cfg"))
     configured.write_text("[smelt]\nurl = https://smelt.example.com\n")
-    assert (
-        config.Config(configured, refhosts=MockRefhosts).smelt_url
-        == "https://smelt.example.com"
-    )
+    assert config.Config(configured).smelt_url == "https://smelt.example.com"
 
 
 def test_path_options_expand_tilde(tmpdir):
@@ -95,61 +59,27 @@ def test_path_options_expand_tilde(tmpdir):
         "[mtui]\ninstall_logs = ~/logs\n"
         "[target]\ntempdir = ~/scratch\n"
     )
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     assert cfg.refhosts_path == Path.home() / "qam/refhosts.yml"
     assert cfg.install_logs == Path.home() / "logs"
     assert cfg.target_tempdir == Path.home() / "scratch"
     # An absolute path is passed through unchanged.
     abs_cfg = Path(tmpdir.join("abs.cfg"))
     abs_cfg.write_text("[refhosts]\npath = /usr/share/refhosts.yml\n")
-    assert config.Config(abs_cfg, refhosts=MockRefhosts).refhosts_path == Path(
-        "/usr/share/refhosts.yml"
-    )
-
-
-def test_ssl_verify_available_when_location_resolves_during_parse(tmpdir):
-    """Parsing ``location`` triggers the resolve, which reads ``ssl_verify``.
-
-    Regression: ``location`` was parsed before ``ssl_verify``, so the resolve
-    fired by the ``location`` setter raised ``AttributeError: 'Config' object
-    has no attribute 'ssl_verify'``. ``location`` must be parsed last so every
-    option the resolve depends on is already set.
-    """
-    seen: dict[str, object] = {}
-
-    class SslReadingRefhosts:
-        def __init__(self, cfg):
-            self._cfg = cfg
-
-        def check_location_sanity(self, location):
-            # Reading these must not raise during config parsing.
-            seen["ssl_verify"] = self._cfg.ssl_verify
-            seen["refhosts_resolvers"] = self._cfg.refhosts_resolvers
-
-        def __call__(self, cfg):
-            return SslReadingRefhosts(cfg)
-
-    cfg_file = Path(tmpdir.join("test.cfg"))
-    cfg_file.write_text("[mtui]\nlocation = nuremberg\nssl_verify = false\n")
-    cfg = config.Config(cfg_file, refhosts=SslReadingRefhosts(None))
-    assert cfg.location == "nuremberg"
-    assert cfg.ssl_verify is False
-    assert seen["ssl_verify"] is False
+    assert config.Config(abs_cfg).refhosts_path == Path("/usr/share/refhosts.yml")
 
 
 def test_merge_args(tmpdir):
     """Test merge_args."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("")
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     args = Namespace(
-        location="cmd_location",
         template_dir="/cmd/template_dir",
         connection_timeout=1200,
         gitea_token="cmd_gitea_token",
     )
     cfg.merge_args(args)
-    assert cfg.location == "cmd_location"
     assert cfg.template_dir == "/cmd/template_dir"
     assert cfg.connection_timeout == 1200
     assert cfg.qem_dashboard_api == "http://dashboard.qam.suse.de/api"
@@ -160,7 +90,7 @@ def test_ssh_strict_host_key_checking_default(tmpdir):
     """Default value preserves backward-compatible auto-add behaviour."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("")
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     assert cfg.ssh_strict_host_key_checking == "auto_add"
 
 
@@ -168,7 +98,7 @@ def test_ssh_strict_host_key_checking_override(tmpdir):
     """[connection] section in INI overrides the default."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text("[connection]\nssh_strict_host_key_checking = reject\n")
-    cfg = config.Config(config_file, refhosts=MockRefhosts)
+    cfg = config.Config(config_file)
     assert cfg.ssh_strict_host_key_checking == "reject"
 
 
@@ -177,7 +107,7 @@ def test_mtui_conf_env_var_selects_configfile(tmpdir, monkeypatch):
     cfg_file = Path(tmpdir.join("via_env.cfg"))
     cfg_file.write_text("[mtui]\nconnection_timeout = 777\n")
     monkeypatch.setenv("MTUI_CONF", str(cfg_file))
-    cfg = config.Config(None, refhosts=MockRefhosts)
+    cfg = config.Config(None)
     assert cfg.configfiles == [cfg_file]
     assert cfg.connection_timeout == 777
 
@@ -185,7 +115,7 @@ def test_mtui_conf_env_var_selects_configfile(tmpdir, monkeypatch):
 def test_default_configfiles_when_no_path_no_env(monkeypatch):
     """No ``path`` and no ``MTUI_CONF`` falls back to the canonical pair."""
     monkeypatch.delenv("MTUI_CONF", raising=False)
-    cfg = config.Config(None, refhosts=MockRefhosts)
+    cfg = config.Config(None)
     assert cfg.configfiles == [
         Path("/etc/mtui.cfg"),
         Path("~/.mtuirc").expanduser(),
@@ -198,42 +128,13 @@ def test_read_logs_and_swallows_configparser_error(tmpdir, caplog):
     # MissingSectionHeaderError: option line before any [section].
     cfg_file.write_text("connection_timeout = 42\n")
     with caplog.at_level("ERROR", logger="mtui.config"):
-        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+        cfg = config.Config(cfg_file)
     assert any(
         "MissingSectionHeader" in r.message or "section" in r.message.lower()
         for r in caplog.records
     )
     # Defaults still applied; broken file did not poison subsequent steps.
     assert cfg.connection_timeout == 300
-
-
-def test_location_setter_invalid_location_keeps_previous(tmpdir, caplog):
-    """``InvalidLocationError`` is logged and the location is unchanged."""
-    cfg_file = Path(tmpdir.join("loc.cfg"))
-    cfg_file.write_text("")
-    refhosts = RaisingRefhosts
-    cfg = config.Config(cfg_file, refhosts=refhosts)
-    assert cfg.location == "default"
-    refhosts.exc = InvalidLocationError("nowhere", ["here", "there"])
-    with caplog.at_level("ERROR", logger="mtui.config"):
-        cfg.location = "nowhere"
-    assert cfg.location == "default"
-    assert any("nowhere" in r.message for r in caplog.records)
-    refhosts.exc = None  # reset shared class state
-
-
-def test_location_setter_resolve_failed_keeps_previous(tmpdir, caplog):
-    """``RefhostsResolveFailedError`` is logged and the location is unchanged."""
-    cfg_file = Path(tmpdir.join("loc.cfg"))
-    cfg_file.write_text("")
-    refhosts = RaisingRefhosts
-    cfg = config.Config(cfg_file, refhosts=refhosts)
-    refhosts.exc = RefhostsResolveFailedError()
-    with caplog.at_level("ERROR", logger="mtui.config"):
-        cfg.location = "anywhere"
-    assert cfg.location == "default"
-    assert any("refhosts.yml" in r.message for r in caplog.records)
-    refhosts.exc = None
 
 
 @pytest.mark.parametrize(
@@ -258,7 +159,7 @@ def test_fixup_failure_logs_and_falls_back_to_default(
     cfg_file = Path(tmpdir.join("typed.cfg"))
     cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
     with caplog.at_level("ERROR", logger="mtui.config"):
-        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+        cfg = config.Config(cfg_file)
     assert getattr(cfg, attr) == expected_default
     assert any(attr in r.message and ini_value in r.message for r in caplog.records), (
         f"expected an ERROR log line mentioning {attr!r} and the bad value "
@@ -289,7 +190,7 @@ def test_typed_getter_failure_logs_and_falls_back_to_default(
     cfg_file = Path(tmpdir.join("typed.cfg"))
     cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
     with caplog.at_level("ERROR", logger="mtui.config"):
-        cfg = config.Config(cfg_file, refhosts=MockRefhosts)
+        cfg = config.Config(cfg_file)
     assert getattr(cfg, attr) == expected_default
     assert any(attr in r.message for r in caplog.records), (
         f"expected an ERROR log line mentioning {attr!r}; "
@@ -312,10 +213,9 @@ def test_mtuirc_fixture_parses_all_sections():
     assert fixture.is_file(), "tests/fixtures/mtuirc fixture missing"
     assert fixture.stat().st_size > 0, "tests/fixtures/mtuirc must be populated"
 
-    cfg = config.Config(fixture, refhosts=MockRefhosts)
+    cfg = config.Config(fixture)
 
     # String values across multiple sections.
-    assert cfg.location == "nuremberg"
     assert cfg.session_user == "qauser"
     assert cfg.openqa_instance == "https://openqa.example.com"
     assert cfg.openqa_install_distri == "sle"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -512,6 +512,92 @@ def test_connect_wrong_password_reraises(
         Connection("test_host", 22, 300)
 
 
+def test_connection_password_prompt_is_host_labelled(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """The key-auth fallback prompt must name the user and host.
+
+    Regression for the "silent wait" UX: the old bare ``getpass.getpass()``
+    gave no indication of *why* the terminal was blocked. The prompt now
+    embeds ``<user>@<host>'s password: `` so the user understands what is
+    being asked.
+    """
+    mock_ssh_client.connect.side_effect = [
+        paramiko.AuthenticationException,
+        None,  # password attempt succeeds
+    ]
+    with patch("getpass.getpass", return_value="password") as mock_getpass:
+        Connection("test_host", 22, 300)
+
+    mock_getpass.assert_called_once()
+    (prompt_text,) = mock_getpass.call_args.args
+    assert "test_host" in prompt_text
+    assert "root@test_host" in prompt_text
+
+
+def test_connect_wrong_password_logs_only_at_debug(
+    mock_ssh_client, mock_ssh_config, mock_path, caplog
+):
+    """A wrong password emits NO error/critical at the connection layer.
+
+    Regression for the duplicate message: the connection used to log
+    ``error: ...wrong password`` and then ``Target.connect`` logged
+    ``critical: connecting to ... failed``. The connection layer now keeps
+    its specific wording (plus traceback) at DEBUG so only one user-facing
+    line -- ``Target.connect``'s -- is printed.
+    """
+    mock_ssh_client.connect.side_effect = [
+        paramiko.AuthenticationException,
+        paramiko.AuthenticationException,
+    ]
+    with (
+        patch("getpass.getpass", return_value="wrong"),
+        pytest.raises(paramiko.AuthenticationException),
+        caplog.at_level("DEBUG", logger="mtui.connection"),
+    ):
+        Connection("test_host", 22, 300)
+
+    # Nothing surfaces at ERROR or higher from the connection layer.
+    assert not [
+        r
+        for r in caplog.records
+        if r.levelno >= 40  # ERROR/CRITICAL
+    ]
+    # The detail (with traceback) is available at DEBUG for --debug runs.
+    debug_records = [r for r in caplog.records if r.levelname == "DEBUG"]
+    wrong_pw = [r for r in debug_records if "wrong password" in r.getMessage()]
+    assert len(wrong_pw) == 1
+    assert wrong_pw[0].exc_info is not None
+
+
+def test_connection_uses_password_prompt_callback_over_getpass(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """When a ``password_prompt`` callback is wired, it is used (not getpass).
+
+    Regression for the "silent wait": in the prompt_toolkit REPL a bare
+    ``getpass.getpass`` renders nothing. ``Target`` wires
+    ``Prompter.ask_password`` as ``password_prompt`` so the masked prompt is
+    rendered correctly; the callback must take precedence over getpass and
+    receive the host-labelled prompt text.
+    """
+    mock_ssh_client.connect.side_effect = [
+        paramiko.AuthenticationException,
+        None,  # password attempt succeeds
+    ]
+    callback = MagicMock(return_value="secret")
+    with patch("getpass.getpass") as mock_getpass:
+        Connection("test_host", 22, 300, password_prompt=callback)
+
+    mock_getpass.assert_not_called()
+    callback.assert_called_once()
+    (prompt_text,) = callback.call_args.args
+    assert "root@test_host" in prompt_text
+    # The captured password is fed to the retry connect.
+    second_call = mock_ssh_client.connect.call_args_list[1]
+    assert second_call.kwargs["password"] == "secret"
+
+
 def test_connect_sshexception_propagates(
     mock_ssh_client, mock_ssh_config, mock_path, caplog
 ):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,7 +7,6 @@ import pytest
 from mtui.hosts.connection import (
     CommandTimeoutError,
     Connection,
-    NonInteractiveAuthRequired,
     policy_from_config,
 )
 
@@ -74,78 +73,40 @@ def test_connection_init_success(mock_ssh_client, mock_ssh_config, mock_path):
     assert conn.timeout == 300
 
 
-def test_connection_init_auth_fallback(mock_ssh_client, mock_ssh_config, mock_path):
-    """Test password fallback authentication."""
-    mock_ssh_client.connect.side_effect = [
-        paramiko.AuthenticationException,
-        None,  # second call succeeds
-    ]
-    with patch("getpass.getpass", return_value="password") as mock_getpass:
-        Connection("test_host", 22, 300)
-
-        assert mock_getpass.call_count == 1
-        assert mock_ssh_client.connect.call_count == 2
-        mock_ssh_client.connect.assert_any_call(
-            hostname="test_host",
-            port=22,
-            username="root",
-            key_filename=None,
-            sock=None,
-            timeout=300,
-            banner_timeout=300,
-            auth_timeout=300,
-        )
-        mock_ssh_client.connect.assert_any_call(
-            hostname="test_host",
-            port=22,
-            username="root",
-            password="password",
-            sock=None,
-            timeout=300,
-            banner_timeout=300,
-            auth_timeout=300,
-        )
-
-
-def test_connection_noninteractive_auth_fail_raises_without_getpass(
+def test_connection_key_auth_failure_reraises_without_password_prompt(
     mock_ssh_client, mock_ssh_config, mock_path
 ):
-    """Non-interactive: a key-auth failure must NOT prompt for a password.
+    """A key-auth failure re-raises; there is no password fallback.
 
-    Under ``mtui-mcp`` there is no TTY, so ``getpass.getpass`` would block
-    forever on an invisible prompt. With ``interactive=False`` the
-    fallback is skipped entirely and ``NonInteractiveAuthRequired`` is
-    raised instead (the original hang reported against homer.qam.suse.cz).
+    MTUI requires working SSH key authentication. When key auth fails the
+    ``AuthenticationException`` propagates to the caller (Target.connect,
+    which reports ConnectingTargetFailedMessage) -- the connection never
+    prompts for a password. This holds in both interactive and
+    non-interactive sessions.
     """
     mock_ssh_client.connect.side_effect = paramiko.AuthenticationException
 
     with patch("getpass.getpass") as mock_getpass:
-        with pytest.raises(NonInteractiveAuthRequired):
-            Connection("test_host", 22, 300, interactive=False)
+        with pytest.raises(paramiko.AuthenticationException):
+            Connection("test_host", 22, 300)
 
         mock_getpass.assert_not_called()
         # Only the initial key-auth attempt happened; no password retry.
         assert mock_ssh_client.connect.call_count == 1
 
 
-def test_connection_noninteractive_bad_host_key_raises_without_getpass(
-    mock_ssh_client, mock_ssh_config, mock_path
-):
-    """A BadHostKeyException is treated the same as auth failure when headless."""
+def test_connection_bad_host_key_reraises(mock_ssh_client, mock_ssh_config, mock_path):
+    """A BadHostKeyException re-raises just like a plain auth failure."""
     mock_ssh_client.connect.side_effect = paramiko.BadHostKeyException(
         "test_host", MagicMock(), MagicMock()
     )
 
     with patch("getpass.getpass") as mock_getpass:
-        with pytest.raises(NonInteractiveAuthRequired):
-            Connection("test_host", 22, 300, interactive=False)
+        with pytest.raises(paramiko.BadHostKeyException):
+            Connection("test_host", 22, 300)
 
         mock_getpass.assert_not_called()
-
-
-def test_connection_noninteractive_auth_fail_is_paramiko_auth_subclass():
-    """The raised error stays catchable by existing AuthenticationException handlers."""
-    assert issubclass(NonInteractiveAuthRequired, paramiko.AuthenticationException)
+        assert mock_ssh_client.connect.call_count == 1
 
 
 def test_run_command_success(mock_ssh_client, mock_ssh_config, mock_path):
@@ -496,106 +457,36 @@ def test_connect_logs_non_enoent_ssh_config_error(
     assert any("denied" in r.message for r in caplog.records)
 
 
-def test_connect_wrong_password_reraises(
+def test_connect_key_auth_failure_warns_and_logs_detail_at_debug(
     mock_ssh_client, mock_ssh_config, mock_path, caplog
 ):
-    """Failing both key and password auth re-raises the second exception."""
-    mock_ssh_client.connect.side_effect = [
-        paramiko.AuthenticationException,
-        paramiko.AuthenticationException,
-    ]
-    with (
-        patch("getpass.getpass", return_value="wrong"),
-        pytest.raises(paramiko.AuthenticationException),
-        caplog.at_level("ERROR", logger="mtui.connection"),
-    ):
-        Connection("test_host", 22, 300)
+    """A key-auth failure surfaces one WARNING; the traceback stays at DEBUG.
 
-
-def test_connection_password_prompt_is_host_labelled(
-    mock_ssh_client, mock_ssh_config, mock_path
-):
-    """The key-auth fallback prompt must name the user and host.
-
-    Regression for the "silent wait" UX: the old bare ``getpass.getpass()``
-    gave no indication of *why* the terminal was blocked. The prompt now
-    embeds ``<user>@<host>'s password: `` so the user understands what is
-    being asked.
+    The connection layer emits a single actionable WARNING (set up SSH key
+    auth) and keeps the exception detail/traceback at DEBUG so only one
+    user-facing line is printed for a single failure. The exception then
+    propagates to the caller (Target.connect), which reports the
+    user-facing ConnectingTargetFailedMessage.
     """
-    mock_ssh_client.connect.side_effect = [
-        paramiko.AuthenticationException,
-        None,  # password attempt succeeds
-    ]
-    with patch("getpass.getpass", return_value="password") as mock_getpass:
-        Connection("test_host", 22, 300)
+    mock_ssh_client.connect.side_effect = paramiko.AuthenticationException
 
-    mock_getpass.assert_called_once()
-    (prompt_text,) = mock_getpass.call_args.args
-    assert "test_host" in prompt_text
-    assert "root@test_host" in prompt_text
-
-
-def test_connect_wrong_password_logs_only_at_debug(
-    mock_ssh_client, mock_ssh_config, mock_path, caplog
-):
-    """A wrong password emits NO error/critical at the connection layer.
-
-    Regression for the duplicate message: the connection used to log
-    ``error: ...wrong password`` and then ``Target.connect`` logged
-    ``critical: connecting to ... failed``. The connection layer now keeps
-    its specific wording (plus traceback) at DEBUG so only one user-facing
-    line -- ``Target.connect``'s -- is printed.
-    """
-    mock_ssh_client.connect.side_effect = [
-        paramiko.AuthenticationException,
-        paramiko.AuthenticationException,
-    ]
     with (
-        patch("getpass.getpass", return_value="wrong"),
+        patch("getpass.getpass") as mock_getpass,
         pytest.raises(paramiko.AuthenticationException),
         caplog.at_level("DEBUG", logger="mtui.connection"),
     ):
         Connection("test_host", 22, 300)
 
-    # Nothing surfaces at ERROR or higher from the connection layer.
-    assert not [
-        r
-        for r in caplog.records
-        if r.levelno >= 40  # ERROR/CRITICAL
-    ]
+    mock_getpass.assert_not_called()
+    # No password retry: only the single key-auth attempt happened.
+    assert mock_ssh_client.connect.call_count == 1
+    # Nothing surfaces above WARNING from the connection layer.
+    assert not [r for r in caplog.records if r.levelno >= 40]
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("key authentication" in r.getMessage().lower() for r in warnings)
     # The detail (with traceback) is available at DEBUG for --debug runs.
     debug_records = [r for r in caplog.records if r.levelname == "DEBUG"]
-    wrong_pw = [r for r in debug_records if "wrong password" in r.getMessage()]
-    assert len(wrong_pw) == 1
-    assert wrong_pw[0].exc_info is not None
-
-
-def test_connection_uses_password_prompt_callback_over_getpass(
-    mock_ssh_client, mock_ssh_config, mock_path
-):
-    """When a ``password_prompt`` callback is wired, it is used (not getpass).
-
-    Regression for the "silent wait": in the prompt_toolkit REPL a bare
-    ``getpass.getpass`` renders nothing. ``Target`` wires
-    ``Prompter.ask_password`` as ``password_prompt`` so the masked prompt is
-    rendered correctly; the callback must take precedence over getpass and
-    receive the host-labelled prompt text.
-    """
-    mock_ssh_client.connect.side_effect = [
-        paramiko.AuthenticationException,
-        None,  # password attempt succeeds
-    ]
-    callback = MagicMock(return_value="secret")
-    with patch("getpass.getpass") as mock_getpass:
-        Connection("test_host", 22, 300, password_prompt=callback)
-
-    mock_getpass.assert_not_called()
-    callback.assert_called_once()
-    (prompt_text,) = callback.call_args.args
-    assert "root@test_host" in prompt_text
-    # The captured password is fed to the retry connect.
-    second_call = mock_ssh_client.connect.call_args_list[1]
-    assert second_call.kwargs["password"] == "secret"
+    assert any(r.exc_info is not None for r in debug_records)
 
 
 def test_connect_sshexception_propagates(

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -363,7 +363,7 @@ def test_report_self_delegates():
 
 
 def test_report_locks_delegates():
-    """Test report_locks delegates to each target."""
+    """Test report_locks delegates to each target (zypper lock by default)."""
     t1 = MagicMock()
     t1.hostname = "h1"
     sink = MagicMock()
@@ -372,6 +372,31 @@ def test_report_locks_delegates():
     hg.report_locks(sink)
 
     t1.reporter.locks.assert_called_once_with(sink)
+    t1.reporter.pool_locks.assert_not_called()
+
+
+def test_report_locks_pool_delegates_to_pool_locks():
+    """``report_locks(pool=True)`` delegates to the pool reporter."""
+    t1 = MagicMock()
+    t1.hostname = "h1"
+    sink = MagicMock()
+
+    hg = HostsGroup([t1])  # type: ignore[arg-type]
+    hg.report_locks(sink, pool=True)
+
+    t1.reporter.pool_locks.assert_called_once_with(sink)
+    t1.reporter.locks.assert_not_called()
+
+
+def test_pool_unlock_delegates_to_each_target():
+    """``pool_unlock`` calls ``pool_unlock`` on every target, suppressing errors."""
+    t1 = MagicMock()
+    t1.hostname = "h1"
+
+    hg = HostsGroup([t1])  # type: ignore[arg-type]
+    hg.pool_unlock(force=True)
+
+    t1.pool_unlock.assert_called_once_with(force=True)
 
 
 def test_report_timeout_delegates():

--- a/tests/test_list_refhosts.py
+++ b/tests/test_list_refhosts.py
@@ -104,6 +104,64 @@ def test_slot_of_distinguishes_arch_and_version() -> None:
     assert x86[2] != aarch[2]
 
 
+def test_slot_of_distinguishes_installed_addons() -> None:
+    """slot_of keys on the host's full installed addon set (per-host identity)."""
+    rh = _rh()
+    hosts = {h.name: h for h in rh.query()}
+    # Both x86_64 sles 15-SP5, but host-default-x86 has the ``sdk`` addon and
+    # host-nbg-x86 has none -> slot_of treats them as different slots.
+    with_sdk = rh.slot_of(hosts["host-default-x86"])
+    no_addon = rh.slot_of(hosts["host-nbg-x86"])
+    assert with_sdk != no_addon
+    assert with_sdk[3] == ("sdk",)
+    assert no_addon[3] == ()
+
+
+def test_slot_for_query_collapses_same_arch_base_regardless_of_addons() -> None:
+    """The query slot ignores extra installed modules a testplatform did not ask for.
+
+    A testplatform that requests just ``base=sles;arch=x86_64`` (no addon) must
+    treat every x86_64 sles 15-SP5 host as one interchangeable slot, even though
+    one of them happens to have ``sdk`` installed. This is what keeps add_host
+    from connecting several hosts of the same arch/product.
+    """
+    from mtui.hosts.refhost.models import Attributes
+
+    rh = _rh()
+    hosts = {h.name: h for h in rh.query()}
+    attr = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")[0]
+    s_with_sdk = rh.slot_for_query(attr, hosts["host-default-x86"])
+    s_no_addon = rh.slot_for_query(attr, hosts["host-nbg-x86"])
+    assert s_with_sdk == s_no_addon
+    # No requested addons -> empty addon component in the slot.
+    assert s_with_sdk[3] == ()
+
+
+def test_search_pool_by_query_groups_interchangeable_hosts() -> None:
+    """search_pool_by_query tags interchangeable hosts with one shared slot."""
+    from mtui.hosts.refhost.models import Attributes
+
+    attrs = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")
+    pairs = _rh().search_pool_by_query(attrs)
+    by_name = {h.name: slot for h, slot in pairs}
+    assert set(by_name) == {"host-default-x86", "host-nbg-x86"}
+    # Both interchangeable for this query -> identical (single) slot.
+    assert len(set(by_name.values())) == 1
+
+
+def test_slot_for_query_distinguishes_requested_addon() -> None:
+    """Different requested addons on the same arch/base are different slots."""
+    from mtui.hosts.refhost.models import Attributes
+
+    rh = _rh()
+    host = next(h for h in rh.query() if h.name == "host-default-x86")
+    plain = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")[0]
+    with_addon = Attributes.from_testplatform(
+        "base=sles(major=15,minor=5);arch=[x86_64];addon=sdk(major=15,minor=5)"
+    )[0]
+    assert rh.slot_for_query(plain, host) != rh.slot_for_query(with_addon, host)
+
+
 # --------------------------------------------------------------------------- #
 # _version_str_match                                                          #
 # --------------------------------------------------------------------------- #

--- a/tests/test_list_refhosts.py
+++ b/tests/test_list_refhosts.py
@@ -24,15 +24,15 @@ FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
 
 
 def _rh() -> Refhosts:
-    return Refhosts(FIXTURE, location="nuremberg")
+    return Refhosts(FIXTURE)
 
 
 # --------------------------------------------------------------------------- #
 # Refhosts.query                                                              #
 # --------------------------------------------------------------------------- #
-def test_query_no_filter_lists_all_locations_deduped() -> None:
-    names = sorted(h.name for h, _loc in _rh().query())
-    # default + nuremberg, de-duplicated by name (location ignored)
+def test_query_no_filter_lists_all_hosts_deduped() -> None:
+    names = sorted(h.name for h in _rh().query())
+    # every legacy location group merged into one list, de-duplicated by name
     assert names == [
         "host-default-aarch64",
         "host-default-noaddon",
@@ -43,14 +43,14 @@ def test_query_no_filter_lists_all_locations_deduped() -> None:
 
 
 def test_query_arch_filter() -> None:
-    names = {h.name for h, _ in _rh().query(arch=["x86_64"])}
+    names = {h.name for h in _rh().query(arch=["x86_64"])}
     assert names == {"host-default-noaddon", "host-default-x86", "host-nbg-x86"}
 
 
 def test_query_product_substring_and_version() -> None:
     # product substring is case-insensitive; SP optional in version
     hits = _rh().query(product="sles", version="15-SP5")
-    assert {h.name for h, _ in hits} == {
+    assert {h.name for h in hits} == {
         "host-default-aarch64",
         "host-default-x86",
         "host-nbg-only-here",
@@ -60,17 +60,10 @@ def test_query_product_substring_and_version() -> None:
 
 
 def test_query_name_glob() -> None:
-    assert {h.name for h, _ in _rh().query(name="host-nbg-*")} == {
+    assert {h.name for h in _rh().query(name="host-nbg-*")} == {
         "host-nbg-only-here",
         "host-nbg-x86",
     }
-
-
-def test_query_location_scope_restricts() -> None:
-    # explicit location narrows to that location's rows only
-    only_nbg = {h.name for h, _ in _rh().query(location="nuremberg")}
-    assert "host-nbg-only-here" in only_nbg
-    assert "host-default-noaddon" not in only_nbg
 
 
 def test_query_empty_on_no_match() -> None:
@@ -81,19 +74,19 @@ def test_query_by_testplatform_attributes() -> None:
     from mtui.hosts.refhost.models import Attributes
 
     attrs = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")
-    names = {h.name for h, _ in _rh().query(attributes=attrs)}
+    names = {h.name for h in _rh().query(attributes=attrs)}
     assert names == {"host-default-x86", "host-nbg-x86"}
 
 
 # --------------------------------------------------------------------------- #
 # search_pool / slot_of                                                       #
 # --------------------------------------------------------------------------- #
-def test_search_pool_tags_slots_all_locations() -> None:
+def test_search_pool_tags_slots() -> None:
     from mtui.hosts.refhost.models import Attributes
 
     attrs = Attributes.from_testplatform("base=sles(major=15,minor=5);arch=[x86_64]")
     pairs = _rh().search_pool(attrs)
-    # matches both x86 hosts across locations, each tagged with a slot tuple
+    # matches both x86 hosts, each tagged with a slot tuple
     by_name = {h.name: slot for h, slot in pairs}
     assert set(by_name) == {"host-default-x86", "host-nbg-x86"}
     for slot in by_name.values():
@@ -103,7 +96,7 @@ def test_search_pool_tags_slots_all_locations() -> None:
 
 def test_slot_of_distinguishes_arch_and_version() -> None:
     rh = _rh()
-    hosts = {h.name: h for h, _ in rh.query()}
+    hosts = {h.name: h for h in rh.query()}
     x86 = rh.slot_of(hosts["host-default-x86"])
     aarch = rh.slot_of(hosts["host-default-aarch64"])
     # same product/version, different arch -> different slot
@@ -131,9 +124,7 @@ def test_version_str_match_variants() -> None:
 # --------------------------------------------------------------------------- #
 def _cfg() -> SimpleNamespace:
     # makes RefhostsFactory(config) resolve the fixture via the 'path' resolver
-    return SimpleNamespace(
-        refhosts_resolvers="path", refhosts_path=FIXTURE, location="nuremberg"
-    )
+    return SimpleNamespace(refhosts_resolvers="path", refhosts_path=FIXTURE)
 
 
 def _cmd(**args) -> ListRefhosts:
@@ -144,7 +135,6 @@ def _cmd(**args) -> ListRefhosts:
         "product": None,
         "version": None,
         "addon": None,
-        "location": None,
         "pool": False,
         "as_json": False,
         "free": False,

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -9,6 +9,7 @@ import pytest
 
 from mtui.hosts.target.locks import (
     LockedTargets,
+    PoolLock,
     RemoteLock,
     TargetLock,
     TargetLockedError,
@@ -461,3 +462,73 @@ class TestLockedTargets:
             raise ValueError("test error")
 
         t1.unlock.assert_called_once()
+
+
+# --- PoolLock ---
+
+
+class TestPoolLock:
+    @pytest.fixture
+    def pool(self, mock_config):
+        """A PoolLock owned by template SUSE:Maintenance:1:2, user testuser."""
+        mock_config.session_user = "testuser"
+        conn = MagicMock()
+        conn.hostname = "host1.example.com"
+        return PoolLock(conn, mock_config, rrid="SUSE:Maintenance:1:2")
+
+    def test_uses_separate_lockfile(self):
+        """The pool lock lives in its own file, distinct from the zypper lock."""
+        assert PoolLock.filename != TargetLock.filename
+        assert str(PoolLock.filename) == "/var/lock/mtui-pool.lock"
+
+    def test_rrid_of_parses_pool_comment(self):
+        """``mtui pool <RRID> [<owner>]`` yields the RRID."""
+        assert (
+            PoolLock._rrid_of("mtui pool SUSE:Maintenance:1:2 [alice]")
+            == "SUSE:Maintenance:1:2"
+        )
+
+    def test_rrid_of_non_pool_comment_empty(self):
+        """A non-pool comment yields no RRID."""
+        assert PoolLock._rrid_of("testing of something") == ""
+        assert PoolLock._rrid_of("") == ""
+
+    def test_is_mine_same_rrid_ignores_pid(self, pool):
+        """A pool lock by the same template + user is mine regardless of PID."""
+        pool._lock = RemoteLock()
+        pool._lock.user = "testuser"
+        pool._lock.pid = pool.i_am_pid + 1  # different process
+        pool._lock.comment = "mtui pool SUSE:Maintenance:1:2 [alice]"
+        assert pool.is_mine() is True
+
+    def test_is_mine_different_rrid_not_mine(self, pool):
+        """A pool lock by a different template (same user) is not mine."""
+        pool._lock = RemoteLock()
+        pool._lock.user = "testuser"
+        pool._lock.pid = pool.i_am_pid
+        pool._lock.comment = "mtui pool SUSE:Maintenance:9:9 [bob]"
+        assert pool.is_mine() is False
+
+    def test_is_mine_different_user_not_mine(self, pool):
+        """A pool lock by a different user is not mine even with same RRID."""
+        pool._lock = RemoteLock()
+        pool._lock.user = "otheruser"
+        pool._lock.comment = "mtui pool SUSE:Maintenance:1:2 [alice]"
+        assert pool.is_mine() is False
+
+    def test_is_mine_no_rrid_falls_back_to_user(self, mock_config):
+        """With no session RRID, ownership degrades to user-only."""
+        mock_config.session_user = "testuser"
+        conn = MagicMock()
+        conn.hostname = "host1.example.com"
+        pool = PoolLock(conn, mock_config, rrid="")
+        pool._lock = RemoteLock()
+        pool._lock.user = "testuser"
+        pool._lock.comment = "mtui pool SUSE:Maintenance:9:9 [bob]"
+        assert pool.is_mine() is True
+
+    def test_is_mine_raises_when_not_locked(self, pool):
+        """An unlocked pool lock raises, matching TargetLock's contract."""
+        pool._lock = RemoteLock()
+        with pytest.raises(RuntimeError, match="not locked"):
+            pool.is_mine()

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -81,7 +81,6 @@ class _RealishConfig:
         self.chdir_to_template_dir = False
         self.connection_timeout = 30
         self.session_user = "testuser"
-        self.location = "nuremberg"
 
 
 def _registry(
@@ -465,21 +464,20 @@ def test_build_session_copies_config_per_session(tmp_path: Path) -> None:
     """Each session gets its own config copy; mutable scalars don't leak.
 
     Under http every session is minted from one base ``cfg``; a shallow
-    copy per session keeps mutable scalars (such as ``location``)
-    independent so one client's ``set_location`` cannot change another
-    client's location.
+    copy per session keeps mutable scalars independent so one client
+    rebinding a config scalar cannot change another client's config.
     """
     base = _RealishConfig(tmp_path)
     a = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
     b = build_session(base, _LOG)  # ty: ignore[invalid-argument-type]
 
     assert a.config is not b.config
-    # Simulate client A changing its location.
-    a.config.location = "prague"
+    # Simulate client A rebinding a config scalar.
+    a.config.connection_timeout = 999
     # Client B must be unaffected.
-    assert b.config.location == "nuremberg"
+    assert b.config.connection_timeout == 30
     # And the shared base config must never have been mutated.
-    assert base.location == "nuremberg"
+    assert base.connection_timeout == 30
 
 
 def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
@@ -496,8 +494,8 @@ def test_registry_sessions_have_independent_config(tmp_path: Path) -> None:
 
     a, b = asyncio.run(driver())
     assert a.config is not b.config
-    a.config.location = "prague"
-    assert b.config.location == "nuremberg"
+    a.config.connection_timeout = 999
+    assert b.config.connection_timeout == 30
 
 
 def test_registry_sessions_have_distinct_arbiter_owner_keys(tmp_path: Path) -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -189,23 +189,23 @@ def test_set_host_state_schema_carries_enum(
     ]
 
 
-def test_set_location_schema_is_scalar_string(
+def test_nargs_one_positional_schema_is_scalar_string(
     mcp: FastMCP, registered_names: list[str]
 ) -> None:
-    """``set_location`` positional ``nargs=1`` is a required scalar string.
+    """A ``nargs=1`` positional (``put filename``) is a required scalar string.
 
-    Regression for the MCP-side bug where ``{"site": "prague"}`` was
+    Regression for the MCP-side bug where ``{"filename": "x"}`` was
     rejected with ``Input should be a valid list`` because the schema
     demanded an array.
     """
-    params = _params_of(mcp, "set_location")
-    site = params["properties"]["site"]
-    assert site["type"] == "string"
-    assert site.get("description") == "location name"
+    params = _params_of(mcp, "put")
+    filename = params["properties"]["filename"]
+    assert filename["type"] == "string"
+    assert filename.get("description") == "file to upload to all hosts"
     # Scalar field must not carry array-shaped length bounds.
-    assert "minItems" not in site
-    assert "maxItems" not in site
-    assert "site" in params.get("required", [])
+    assert "minItems" not in filename
+    assert "maxItems" not in filename
+    assert "filename" in params.get("required", [])
 
 
 def test_update_schema_exposes_store_const_as_booleans(
@@ -415,18 +415,18 @@ def test_optional_multivalue_flag_round_trip() -> None:
 
 
 def test_nargs_one_positional_accepts_scalar_round_trip() -> None:
-    """``set_location site`` (``nargs=1``) round-trips a scalar string.
+    """``put filename`` (``nargs=1``) round-trips a scalar string.
 
-    Regression for the MCP-side bug where ``{"site": "prague"}`` was
+    Regression for the MCP-side bug where ``{"filename": "x"}`` was
     rejected with ``Input should be a valid list`` because the schema
     demanded an array. The encoder must accept the scalar and argparse
     must still produce its conventional 1-element list.
     """
-    parser = Command.registry["set_location"].argparser(__import__("sys"))
-    argv = kwargs_to_argv(parser, {"site": "prague"})
-    assert argv == ["prague"]
+    parser = Command.registry["put"].argparser(__import__("sys"))
+    argv = kwargs_to_argv(parser, {"filename": "payload.bin"})
+    assert argv == ["payload.bin"]
     parsed = parser.parse_args(argv)
-    assert parsed.site == ["prague"]
+    assert parsed.filename == ["payload.bin"]
 
 
 def test_optional_list_arg_preserves_nonempty_argparse_default() -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -569,7 +569,6 @@ def test_loadtemplate_kernel_id_routes_to_kernel_flag() -> None:
         {
             "kernel_review_id": "SUSE:Maintenance:1:1",
             "auto_review_id": None,
-            "chosts": True,
         },
     )
     assert argv[:2] == ["--kernel-review-id", "SUSE:Maintenance:1:1"]
@@ -585,7 +584,6 @@ def test_loadtemplate_auto_id_routes_to_auto_flag() -> None:
         {
             "auto_review_id": "SUSE:Maintenance:1:1",
             "kernel_review_id": None,
-            "chosts": True,
         },
     )
     assert argv[:2] == ["--auto-review-id", "SUSE:Maintenance:1:1"]
@@ -621,7 +619,6 @@ def test_loadtemplate_rejects_neither_review_id(
         return await tool.fn(
             auto_review_id=None,
             kernel_review_id=None,
-            chosts=True,
         )
 
     with pytest.raises(McpCommandError) as ei:
@@ -643,7 +640,6 @@ def test_loadtemplate_rejects_both_review_ids(
         return await tool.fn(
             auto_review_id="SUSE:Maintenance:1:1",
             kernel_review_id="SUSE:Maintenance:2:2",
-            chosts=True,
         )
 
     with pytest.raises(McpCommandError) as ei:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -46,10 +46,6 @@ def test_messages():
         == "Compare script 'test_argv' crashed:\nstderr"
     )
     assert (
-        str(messages.LocationChangedMessage("old", "new"))
-        == "changed location from 'old' to 'new'"
-    )
-    assert (
         str(messages.MissingPreparerError("test_release"))
         == "Missing Preparer for test_release"
     )
@@ -68,10 +64,6 @@ def test_messages():
     assert (
         str(messages.MissingDowngraderError("test_release"))
         == "Missing Downgrader for test_release"
-    )
-    assert (
-        str(messages.InvalidLocationError("req", ["avail"]))
-        == "Invalid location 'req'. Available locations: avail"
     )
     assert (
         str(messages.ReConnectFailed("test_host"))

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -36,57 +36,6 @@ def test_default_reader_is_input():
     assert p._reader is input  # noqa: SLF001
 
 
-def test_ask_password_uses_injected_password_reader():
-    """``ask_password`` routes through the masked reader, not ``ask``'s."""
-    reader = MagicMock(return_value="visible")
-    pw_reader = MagicMock(return_value="s3cret")
-    p = Prompter(reader=reader, password_reader=pw_reader)
-
-    assert p.ask_password("pw? ") == "s3cret"
-    pw_reader.assert_called_once_with("pw? ")
-    reader.assert_not_called()
-
-
-def test_default_password_reader_is_prompt_toolkit_backed():
-    """The default masked reader must not be the plain visible reader.
-
-    A bare ``input`` would echo the password and hang inside the REPL's
-    prompt_toolkit session; the default must be the dedicated
-    prompt_toolkit-backed reader instead.
-    """
-    p = Prompter()
-    assert p._password_reader is not input  # noqa: SLF001
-    assert p._password_reader is not p._reader  # noqa: SLF001
-
-
-def test_concurrent_ask_and_password_are_serialised():
-    """``ask`` and ``ask_password`` share one lock; they never overlap."""
-    active = 0
-    max_active = 0
-    guard = threading.Lock()
-
-    def _track(_text: str) -> str:
-        nonlocal active, max_active
-        with guard:
-            active += 1
-            max_active = max(max_active, active)
-        time.sleep(0.03)
-        with guard:
-            active -= 1
-        return _text
-
-    p = Prompter(reader=_track, password_reader=_track)
-
-    t1 = threading.Thread(target=lambda: p.ask("visible "))
-    t2 = threading.Thread(target=lambda: p.ask_password("masked "))
-    t1.start()
-    t2.start()
-    t1.join(timeout=5)
-    t2.join(timeout=5)
-
-    assert max_active == 1, f"ask/ask_password overlapped: {max_active}"
-
-
 def test_concurrent_asks_are_serialised():
     """Two concurrent ``ask`` calls never overlap; the lock fences them.
 

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -36,6 +36,57 @@ def test_default_reader_is_input():
     assert p._reader is input  # noqa: SLF001
 
 
+def test_ask_password_uses_injected_password_reader():
+    """``ask_password`` routes through the masked reader, not ``ask``'s."""
+    reader = MagicMock(return_value="visible")
+    pw_reader = MagicMock(return_value="s3cret")
+    p = Prompter(reader=reader, password_reader=pw_reader)
+
+    assert p.ask_password("pw? ") == "s3cret"
+    pw_reader.assert_called_once_with("pw? ")
+    reader.assert_not_called()
+
+
+def test_default_password_reader_is_prompt_toolkit_backed():
+    """The default masked reader must not be the plain visible reader.
+
+    A bare ``input`` would echo the password and hang inside the REPL's
+    prompt_toolkit session; the default must be the dedicated
+    prompt_toolkit-backed reader instead.
+    """
+    p = Prompter()
+    assert p._password_reader is not input  # noqa: SLF001
+    assert p._password_reader is not p._reader  # noqa: SLF001
+
+
+def test_concurrent_ask_and_password_are_serialised():
+    """``ask`` and ``ask_password`` share one lock; they never overlap."""
+    active = 0
+    max_active = 0
+    guard = threading.Lock()
+
+    def _track(_text: str) -> str:
+        nonlocal active, max_active
+        with guard:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.03)
+        with guard:
+            active -= 1
+        return _text
+
+    p = Prompter(reader=_track, password_reader=_track)
+
+    t1 = threading.Thread(target=lambda: p.ask("visible "))
+    t2 = threading.Thread(target=lambda: p.ask_password("masked "))
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert max_active == 1, f"ask/ask_password overlapped: {max_active}"
+
+
 def test_concurrent_asks_are_serialised():
     """Two concurrent ``ask`` calls never overlap; the lock fences them.
 

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from mtui.hosts import refhost
-from mtui.support.messages import InvalidLocationError
 
 REFHOSTS_FIXTURE = Path(__file__).parent / "fixtures" / "refhosts.yml"
 
@@ -208,13 +207,11 @@ class TestFromTestplatform:
 class TestRefhosts:
     """Public-API behaviour of ``Refhosts``."""
 
-    def test_init_defaults_to_default_location(self):
+    def test_init_merges_all_location_groups(self):
+        """Hosts from every legacy location key are merged into one list."""
         rh = refhost.Refhosts(REFHOSTS_FIXTURE)
-        assert rh.location == "default"
-
-    def test_init_with_explicit_location(self):
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
-        assert rh.location == "nuremberg"
+        names = {h.name for h in rh.data}
+        assert {"host-default-x86", "host-nbg-only-here"} <= names
 
     def test_parse_refhosts_propagates_load_failure(self, tmp_path, caplog):
         """A broken yml file is logged at error and re-raised."""
@@ -246,36 +243,23 @@ class TestRefhosts:
         )
         with caplog.at_level("ERROR", logger="mtui.refhost"):
             rh = refhost.Refhosts(bad)
-        assert [h.name for h in rh.data["default"]] == ["good-host"]
+        assert [h.name for h in rh.data] == ["good-host"]
         assert any("dropping malformed host row" in r.message for r in caplog.records)
 
-    def test_get_locations(self):
+    def test_search_finds_host(self):
         rh = refhost.Refhosts(REFHOSTS_FIXTURE)
-        assert rh.get_locations() == {"default", "nuremberg"}
-
-    def test_check_location_sanity_known_location_returns_none(self):
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
-        assert rh.check_location_sanity("nuremberg") is None
-
-    def test_check_location_sanity_unknown_location_raises(self):
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
-        with pytest.raises(InvalidLocationError):
-            rh.check_location_sanity("atlantis")
-
-    def test_search_finds_host_in_current_location(self):
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
         attrs = refhost.Attributes.from_testplatform(
             "base=sles(major=15,minor=5);arch=[x86_64]"
         )
-        assert rh.search(attrs) == ["host-nbg-x86"]
+        # Both former-location x86 hosts match the merged pool.
+        assert set(rh.search(attrs)) == {"host-default-x86", "host-nbg-x86"}
 
-    def test_search_falls_back_to_default_when_location_misses(self):
-        """When the configured location has no match, default location is checked."""
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE, location="nuremberg")
+    def test_search_finds_host_from_any_former_location(self):
+        """A host that lived only under ``default`` is found in the merged pool."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
         attrs = refhost.Attributes.from_testplatform(
             "base=sles(major=12,minor=sp4);arch=[x86_64]"
         )
-        # Only present under ``default``.
         assert rh.search(attrs) == ["host-default-noaddon"]
 
     def test_search_returns_empty_when_no_match_anywhere(self):
@@ -293,24 +277,16 @@ class TestRefhosts:
         )
         assert rh.search(attrs) == ["host-default-x86"]
 
-    def test_search_default_location_no_fallback(self):
-        """The fallback branch is skipped when already searching the default."""
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE)  # default location
-        attrs = refhost.Attributes.from_testplatform(
-            "base=sles(major=99,minor=99);arch=[mips]"
-        )
-        assert rh.search(attrs) == []
-
-    def test_host_by_name_finds_in_default(self):
+    def test_host_by_name_finds_host(self):
         rh = refhost.Refhosts(REFHOSTS_FIXTURE)
         host = rh.host_by_name("host-default-x86")
         assert host is not None
         assert host.name == "host-default-x86"
         assert host.product.name == "sles"
 
-    def test_host_by_name_finds_in_other_location(self):
-        """A host living only under ``nuremberg`` is still found from default."""
-        rh = refhost.Refhosts(REFHOSTS_FIXTURE)  # default location
+    def test_host_by_name_finds_host_from_any_former_location(self):
+        """A host that lived only under ``nuremberg`` is still found."""
+        rh = refhost.Refhosts(REFHOSTS_FIXTURE)
         host = rh.host_by_name("host-nbg-only-here")
         assert host is not None
         assert host.arch == "ppc64le"
@@ -436,7 +412,6 @@ def _make_config(**overrides):
         "refhosts_path": REFHOSTS_FIXTURE,
         "refhosts_https_uri": "https://example.invalid/refhosts.yml",
         "refhosts_https_expiration": 3600,
-        "location": "default",
         "ssl_verify": None,
     }
     base.update(overrides)
@@ -461,9 +436,9 @@ class TestPathResolver:
     def test_resolve_uses_configured_path(self):
         factory_mock = MagicMock()
         resolver = refhost.PathResolver(refhosts_factory=factory_mock)
-        cfg = _make_config(location="nuremberg")
+        cfg = _make_config()
         rh = resolver.resolve(cfg)
-        factory_mock.assert_called_once_with(REFHOSTS_FIXTURE, "nuremberg")
+        factory_mock.assert_called_once_with(REFHOSTS_FIXTURE)
         assert rh is factory_mock.return_value
 
 
@@ -474,10 +449,10 @@ class TestHttpsResolver:
         resolver = _make_https_resolver(
             statter=statter, time_now_getter=MagicMock(return_value=1_000_000)
         )
-        cfg = _make_config(location="nuremberg")
+        cfg = _make_config()
         rh = resolver.resolve(cfg)
         resolver.refhosts_factory.assert_called_once_with(  # ty: ignore[unresolved-attribute]
-            resolver.cache_path, "nuremberg"
+            resolver.cache_path
         )
         assert rh is resolver.refhosts_factory.return_value  # ty: ignore[unresolved-attribute]
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -61,6 +61,15 @@ def test_locks_calls_sink_with_underlying_lock_object(mock_target):
     )
 
 
+def test_pool_locks_calls_sink_with_pool_lock_object(mock_target):
+    """``pool_locks`` exposes the private ``_pool_lock`` to the sink."""
+    sink = MagicMock()
+    mock_target.reporter.pool_locks(sink)
+    sink.assert_called_once_with(
+        mock_target.hostname, mock_target.system, mock_target._pool_lock
+    )
+
+
 def test_timeout_reads_connection_timeout_at_call_time(mock_target):
     """``timeout`` reflects the live ``connection.timeout`` value."""
     mock_target.connection.timeout = 42

--- a/tests/test_simpleset.py
+++ b/tests/test_simpleset.py
@@ -1,45 +1,8 @@
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-from mtui.commands.simpleset import SetLocation, SetWorkflow
+from mtui.commands.simpleset import SetWorkflow
 from mtui.types import OpenQAResults, RequestReviewID, Workflow
-
-
-class _FakeConfig:
-    """Minimal config whose location setter mimics Config's accept/reject."""
-
-    def __init__(self, accept: bool) -> None:
-        self._loc = "foo"
-        self._accept = accept
-
-    @property
-    def location(self) -> str:
-        return self._loc
-
-    @location.setter
-    def location(self, value: str) -> None:
-        # Real Config rejects an unknown location and keeps the old value.
-        if self._accept:
-            self._loc = value
-
-
-def _run_set_location(accept: bool, site: str, initial_hosts):
-    prompt = MagicMock()
-    prompt.metadata.hostnames = set(initial_hosts)
-    SetLocation(Namespace(site=[site]), _FakeConfig(accept), MagicMock(), prompt)()
-    return prompt.metadata
-
-
-def test_set_location_resets_hostnames_on_change():
-    """A successful set_location drops template/old-location refhosts."""
-    meta = _run_set_location(True, "bar", ["foo-host-1", "foo-host-2"])
-    assert meta.hostnames == set()
-
-
-def test_set_location_keeps_hostnames_when_rejected():
-    """A rejected location leaves the working refhost set untouched."""
-    meta = _run_set_location(False, "atlantis", ["foo-host-1"])
-    assert meta.hostnames == {"foo-host-1"}
 
 
 def test_set_workflow_auto_uses_rrid(mock_config):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -330,15 +330,17 @@ def test_set_timeout(mock_config):
 
 
 def test_close_unlocks_and_closes(mock_config):
-    """Test close() unlocks and closes the connection."""
+    """Test close() unlocks both the zypper and pool locks and closes."""
     target = Target(mock_config, "host.example.com")  # type: ignore[arg-type]
     target.connection = MagicMock()
     target.connection.is_active.return_value = True
     target._lock = MagicMock()
+    target._pool_lock = MagicMock()
 
     target.close()
 
     target._lock.unlock.assert_called_once_with(False)
+    target._pool_lock.unlock.assert_called_once_with(False)
     target.connection.close.assert_called_once()
 
 

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -112,6 +112,11 @@ class _FakeRefhosts:
     def search_pool(self, _attributes):
         return self._pairs
 
+    def search_pool_by_query(self, _attributes):
+        # The fake's pairs are already tagged with the (query) slot the test
+        # wants, so the query-keyed pool search returns them unchanged.
+        return self._pairs
+
 
 def _ph(name, slot):
     h = MagicMock()
@@ -197,7 +202,91 @@ def test_pool_records_slot_candidates_for_backup(tmp_path: Path) -> None:
     pairs = [_ph("a-x86", slot), _ph("b-x86", slot)]
     r = _pool_report(tmp_path, pairs)
     r.refhosts_from_tp("tp")
-    assert r._slot_candidates[slot] == ["a-x86", "b-x86"]
+    assert sorted(r._slot_candidates[slot]) == ["a-x86", "b-x86"]
+
+
+def test_pool_selection_ignores_preloaded_template_hostnames(tmp_path: Path) -> None:
+    """Pool selection connects one host per slot, not the template's full list.
+
+    In automatic mode the template parser pre-fills ``hostnames`` with every
+    ``reference host:`` line — multiple candidates per arch/slot. When the user
+    then runs ``add_host`` (no ``--target``) the testplatform/pool path must
+    connect exactly one arbiter-chosen host per slot and must NOT drag the
+    pre-loaded duplicates along (the regression that connected every candidate).
+    """
+    slot_x = ("sles", "15-5", "x86_64", ())
+    slot_a = ("sles", "15-5", "aarch64", ())
+    pairs = [
+        _ph("a-x86", slot_x),
+        _ph("b-x86", slot_x),  # same slot as a-x86
+        _ph("c-arm", slot_a),
+        _ph("d-arm", slot_a),  # same slot as c-arm
+    ]
+    r = _pool_report(tmp_path, pairs)
+    # Template autoconnect already loaded every candidate.
+    r.hostnames = {"a-x86", "b-x86", "c-arm", "d-arm"}
+    _stub_connect(r, {"a-x86", "b-x86", "c-arm", "d-arm"})
+
+    r.refhosts_from_tp("tp")
+    r.connect_targets()
+
+    # Exactly one connected host per slot, drawn from the pool claims.
+    assert len(r.targets) == 2
+    assert set(r.targets) == r._pool_claims
+    # One host from each slot, never two of the same slot.
+    assert len({h for h in r.targets if h.endswith("x86")}) == 1
+    assert len({h for h in r.targets if h.endswith("arm")}) == 1
+
+
+def test_pool_collapses_same_query_slot_across_installed_addons(
+    tmp_path: Path,
+) -> None:
+    """Same arch/base hosts with differing installed modules share one slot.
+
+    ``search_pool_by_query`` tags interchangeable hosts (same requested
+    product/arch/addons) with one shared slot, so the pool draws a single host
+    even when each candidate has a different installed-module set -- the real
+    cause of the multiple-hosts-per-arch regression.
+    """
+    # Both x86_64 sles 15-SP7 candidates, one query slot (no requested addons).
+    slot = ("SLES", "15-SP7", "x86_64", ())
+    pairs = [_ph("host-a", slot), _ph("host-b", slot)]
+    r = _pool_report(tmp_path, pairs)
+    # Automatic mode pre-loaded both into hostnames.
+    r.hostnames = {"host-a", "host-b"}
+    _stub_connect(r, {"host-a", "host-b"})
+
+    r.refhosts_from_tp("tp")
+    r.connect_targets()
+
+    assert len(r.targets) == 1
+    assert set(r.targets) <= {"host-a", "host-b"}
+    assert set(r.targets) == r._pool_claims
+
+
+def test_pool_select_shuffles_candidates(tmp_path: Path) -> None:
+    """Per-slot candidates are shuffled so the chosen host is random."""
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph(f"h{i}", slot) for i in range(5)]
+    r = _pool_report(tmp_path, pairs)
+    with patch("mtui.test_reports.testreport.random.shuffle") as shuffle:
+        r.refhosts_from_tp("tp")
+    shuffle.assert_called_once()
+
+
+def test_pool_select_warns_when_slot_exhausted(tmp_path: Path, caplog) -> None:
+    """All candidates in a slot already held → warn and claim nothing."""
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("a-x86", slot), _ph("b-x86", slot)]
+    r = _pool_report(tmp_path, pairs)
+    # Another owner already holds every candidate for the slot.
+    other = ("reg", "OTHER")
+    assert r._arbiter.try_acquire("a-x86", other)
+    assert r._arbiter.try_acquire("b-x86", other)
+    with caplog.at_level(logging.WARNING, logger="mtui.template.testreport"):
+        r.refhosts_from_tp("tp")
+    assert r._pool_claims == set()
+    assert any("no free pool host for slot" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +385,53 @@ def test_connect_targets_no_backup_when_primary_connects(tmp_path: Path) -> None
     # backup was never attempted (only the primary connect_target call)
     attempted = {c.args[0] for c in r.connect_target.call_args_list}
     assert attempted == {primary}
+
+
+def test_pool_connect_skips_host_locked_by_another_owner(tmp_path: Path) -> None:
+    """The autoconnect/pool path honours the *remote* pool lock.
+
+    A host whose remote lock is held by someone else (``try_claim`` -> False)
+    must not be added; the pool falls back to a free sibling in the same slot.
+    Exercises the real ``connect_target`` lock check (not the ``connect_target``
+    stub), so it guards the load->manual->autoconnect connect flow end to end.
+    """
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("locked-host", slot), _ph("free-host", slot)]
+    r = _pool_report(tmp_path, pairs)
+
+    # Force a deterministic primary so the assertion is stable: "locked-host"
+    # is chosen first, then must yield to the free sibling.
+    with patch(
+        "mtui.test_reports.testreport.random.shuffle",
+        lambda c: c.sort(reverse=True),
+    ):
+        r.refhosts_from_tp("tp")
+    assert "locked-host" in r._pool_claims
+
+    created: dict[str, MagicMock] = {}
+
+    def fake_target(_config, host, *_a, **_kw):
+        t = MagicMock()
+        t.hostname = host
+        t.system = f"sys-{host}"
+        # Remote lock is busy only for the already-locked host.
+        t.try_claim.return_value = host != "locked-host"
+        t.connection.is_active.return_value = True
+        created[host] = t
+        return t
+
+    with patch("mtui.test_reports.testreport.Target", side_effect=fake_target):
+        r.connect_targets()
+
+    # Locked host was connected-then-released; the free sibling is the one kept.
+    assert "free-host" in r.targets
+    assert "locked-host" not in r.targets
+    assert "free-host" in r._pool_claims
+    assert "locked-host" not in r._pool_claims
+    # In-process claim on the locked host was released back to the arbiter.
+    assert r._arbiter.owner_of("locked-host") is None
+    # We actually attempted the remote claim on the locked host.
+    created["locked-host"].try_claim.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -186,7 +186,7 @@ def test_release_pool_claims_unlocks_and_releases(tmp_path: Path) -> None:
     target = MagicMock()
     r.targets[claimed] = target
     r.release_pool_claims()
-    target.unlock.assert_called_once()
+    target.pool_unlock.assert_called_once()
     assert r._pool_claims == set()
     assert r._slot_candidates == {}
     assert r._arbiter.owner_of(claimed) is None

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -188,7 +188,114 @@ def test_release_pool_claims_unlocks_and_releases(tmp_path: Path) -> None:
     r.release_pool_claims()
     target.unlock.assert_called_once()
     assert r._pool_claims == set()
+    assert r._slot_candidates == {}
     assert r._arbiter.owner_of(claimed) is None
+
+
+def test_pool_records_slot_candidates_for_backup(tmp_path: Path) -> None:
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("a-x86", slot), _ph("b-x86", slot)]
+    r = _pool_report(tmp_path, pairs)
+    r.refhosts_from_tp("tp")
+    assert r._slot_candidates[slot] == ["a-x86", "b-x86"]
+
+
+# ---------------------------------------------------------------------------
+# Deferred autoconnect (runs after the arbiter is wired by the registry)
+# ---------------------------------------------------------------------------
+
+
+def test_autoconnect_noop_when_not_pending(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    assert r._autoconnect_pending is False
+    with patch.object(r, "connect_targets") as ct:
+        r.autoconnect()
+    ct.assert_not_called()
+
+
+def test_autoconnect_connects_and_resolves_testplatforms(tmp_path: Path) -> None:
+    r = _make(tmp_path)
+    r._autoconnect_pending = True
+    r.testplatforms = ["tp1", "tp2"]
+    with (
+        patch.object(r, "connect_targets") as ct,
+        patch.object(r, "refhosts_from_tp") as rft,
+    ):
+        r.autoconnect()
+    # connect once for testreport hosts, once after resolving testplatforms
+    assert ct.call_count == 2
+    assert [c.args[0] for c in rft.call_args_list] == ["tp1", "tp2"]
+    # flag cleared so a second call is a no-op
+    assert r._autoconnect_pending is False
+    with patch.object(r, "connect_targets") as ct2:
+        r.autoconnect()
+    ct2.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Connect-time backup refhost (RFC §5.7)
+# ---------------------------------------------------------------------------
+
+
+def _stub_connect(r, connectable: set[str]) -> None:
+    """Patch connect_target so only hosts in ``connectable`` succeed."""
+
+    def fake(host):
+        if host in connectable:
+            t = MagicMock()
+            t.system = f"sys-{host}"
+            return t, str(t.system)
+        return False, False
+
+    r.connect_target = MagicMock(side_effect=fake)
+
+
+def test_connect_targets_falls_back_to_backup_on_primary_failure(
+    tmp_path: Path,
+) -> None:
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("primary", slot), _ph("backup", slot)]
+    r = _pool_report(tmp_path, pairs)
+    r.refhosts_from_tp("tp")
+    primary = next(iter(r._pool_claims))
+    backup = "backup" if primary == "primary" else "primary"
+    # Only the backup is reachable.
+    _stub_connect(r, {backup})
+    r.connect_targets()
+    assert backup in r.targets
+    assert primary not in r.targets
+    assert backup in r._pool_claims
+    assert primary not in r._pool_claims
+
+
+def test_connect_targets_warns_when_all_slot_candidates_down(
+    tmp_path: Path, caplog
+) -> None:
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("h1", slot), _ph("h2", slot)]
+    r = _pool_report(tmp_path, pairs)
+    r.refhosts_from_tp("tp")
+    _stub_connect(r, set())  # nothing reachable
+    with caplog.at_level(logging.WARNING, logger="mtui.template.testreport"):
+        r.connect_targets()
+    assert r.targets == {}
+    assert any(
+        "no connectable pool host for slot" in rec.message for rec in caplog.records
+    )
+
+
+def test_connect_targets_no_backup_when_primary_connects(tmp_path: Path) -> None:
+    slot = ("sles", "15-5", "x86_64", ())
+    pairs = [_ph("primary", slot), _ph("backup", slot)]
+    r = _pool_report(tmp_path, pairs)
+    r.refhosts_from_tp("tp")
+    primary = next(iter(r._pool_claims))
+    _stub_connect(r, {primary})
+    r.connect_targets()
+    assert primary in r.targets
+    # backup was never attempted (only the primary connect_target call)
+    attempted = {c.args[0] for c in r.connect_target.call_args_list}
+    assert attempted == {primary}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -795,8 +795,9 @@ def test_connect_target_exception_returns_false_false(tmp_path: Path) -> None:
 def test_connect_target_noninteractive_when_no_prompter(tmp_path: Path) -> None:
     """No prompter (MCP / headless) -> Target built with interactive=False.
 
-    This is the ``add_host`` path that previously hung: a key-auth failure
-    must not drop into an invisible ``getpass`` prompt under MCP.
+    The flag now governs the command-timeout prompt: under MCP a silent
+    command timeout aborts the run rather than waiting for an answer that
+    cannot come.
     """
     r = _make(tmp_path)
     assert r._prompter is None
@@ -841,8 +842,8 @@ def test_add_target_noninteractive_when_no_prompter(tmp_path: Path) -> None:
     """``add_host -t <host>`` under MCP builds the Target with interactive=False.
 
     ``AddHost.__call__`` dispatches to ``TestReport.add_target`` for each
-    ``--target``; with no prompter the connection must skip the password
-    prompt instead of blocking (the homer.qam.suse.cz hang).
+    ``--target``; with no prompter the connection runs non-interactively
+    so a silent command timeout aborts instead of blocking.
     """
     r = _make(tmp_path)
     assert r._prompter is None

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -109,7 +109,7 @@ class _FakeRefhosts:
     def search(self, _attributes):  # legacy path (should be unused when pooling)
         return [h.name for h, _slot in self._pairs]
 
-    def search_pool(self, _attributes, *, location=None):
+    def search_pool(self, _attributes):
         return self._pairs
 
 

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -123,7 +123,6 @@ def _pool_report(tmp_path, pairs, *, owner=("reg", "RRID")):
     from mtui.hosts.host_arbiter import HostArbiter
 
     r = _make(tmp_path)
-    r.config.refhost_pool_select = True
     r.config.lock_wait = 0
     r.config.lock_wait_poll = 15
     r._arbiter = HostArbiter()
@@ -132,14 +131,16 @@ def _pool_report(tmp_path, pairs, *, owner=("reg", "RRID")):
     return r
 
 
-def test_pool_off_uses_legacy_search(tmp_path: Path) -> None:
+def test_pool_inactive_without_arbiter_uses_legacy_search(tmp_path: Path) -> None:
+    # No arbiter/owner wired up → fall back to the legacy search() path.
     r = _make(tmp_path)
-    r.config.refhost_pool_select = False
+    r._arbiter = None
+    r._owner = None
     r.refhostsFactory = MagicMock(
         return_value=_FakeRefhosts([_ph("h1", ("sles", "15", "x86_64", ()))])
     )
-    with patch.object(type(r), "_pool_selection_active", return_value=False):
-        r.refhosts_from_tp("base=sles(major=15,minor=5);arch=[x86_64]")
+    assert r._pool_selection_active() is False
+    r.refhosts_from_tp("base=sles(major=15,minor=5);arch=[x86_64]")
     assert r.hostnames == {"h1"}
     assert r._pool_claims == set()
 

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -183,6 +183,39 @@ def test_pool_two_reports_draw_distinct_hosts(tmp_path: Path) -> None:
     assert r1._pool_claims.isdisjoint(r2._pool_claims)
 
 
+def test_loading_second_report_keeps_first_reports_hosts(tmp_path: Path) -> None:
+    """A freshly selected report must not disturb an existing report's hosts.
+
+    Reproduces the ``load_template -a RRID1`` -> ``load_template -a RRID2``
+    regression: RRID2 selecting its own pool hosts must leave RRID1's claims
+    and arbiter ownership untouched (each template owns its own hosts).
+    """
+    from mtui.hosts.host_arbiter import HostArbiter
+
+    arb = HostArbiter()
+    pairs = [
+        _ph("a-x86", ("sles", "15-5", "x86_64", ())),
+        _ph("b-x86", ("sles", "15-5", "x86_64", ())),
+    ]
+    r1 = _pool_report(tmp_path, pairs, owner=("reg", "RRID1"))
+    r1._arbiter = arb
+    r1.refhosts_from_tp("tp")
+    r1_claims = set(r1._pool_claims)
+    assert r1_claims
+
+    # Second template loads later, sharing the process-global arbiter.
+    r2 = _pool_report(tmp_path, pairs, owner=("reg", "RRID2"))
+    r2._arbiter = arb
+    r2.refhosts_from_tp("tp")
+
+    # RRID1's claims and arbiter ownership are unchanged.
+    assert r1._pool_claims == r1_claims
+    for h in r1_claims:
+        assert arb.owner_of(h) == ("reg", "RRID1")
+    # RRID2 picked its own, disjoint hosts.
+    assert r2._pool_claims.isdisjoint(r1_claims)
+
+
 def test_release_pool_claims_unlocks_and_releases(tmp_path: Path) -> None:
     pairs = [_ph("a-x86", ("sles", "15-5", "x86_64", ()))]
     r = _pool_report(tmp_path, pairs)


### PR DESCRIPTION
## Summary

This branch reworks how MTUI selects, locks, and connects refhosts, and adds multi-template support for several interactive commands.

### Refhosts & host arbitration
- Remove location support and merge legacy `refhosts.yml` handling (`refhosts`: drop `pool_select` option, make host arbitration always-on).
- Pool-select exactly one host per requested test-target slot, with a backup on connection failure.
- Separate host pool claims from the zypper operation lock so locking semantics are distinct.

### Templates
- Never register the `NullTestReport` sentinel on a failed load.
- Stop reconnecting other templates' hosts on load.

### Commands
- Fan out `lock`, `unlock`, and host-listing commands across templates.

### Connection
- Render the SSH password prompt correctly in the REPL.
- Remove the SSH password fallback.

## Test plan
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest`