### PR TITLE
fix(gitea): allow re-review of a rebuilt PR after a stale decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the teardown previously reaped only the active template's connections,
   leaking the others' SSH sessions. This now mirrors the REPL `quit` command,
   which already closed every template's hosts.
+- `approve`, `reject`, and `assign` no longer refuse a Gitea PR whose review was
+  re-requested after an earlier decision (e.g. the package was rebuilt following
+  a `REQUEST_CHANGES`). The "already approved/rejected" guard scanned the
+  append-only comment history and so honoured a stale decision forever; it now
+  treats a pending review request for the group as superseding the old decision,
+  letting the group review the rebuilt PR again.
 - Host *pool* claims and the zypper/operation lock are now fully independent.
   Previously both shared a single lock file (`/var/lock/mtui.lock`), so a pool
   claim taken during host selection blocked subsequent zypper operations

--- a/mtui/data_sources/gitea.py
+++ b/mtui/data_sources/gitea.py
@@ -282,11 +282,24 @@ class Gitea:
         return False
 
     def __is_done(self) -> bool:
-        """Checks if the pull request has been approved or rejected."""
+        """Checks if the group's review has been decided and still stands.
+
+        The decision is recorded as a magic PR comment
+        (``@<group>-review: LGTM/approved/declined``). That history is
+        append-only, so a stale decision lingers after a rebuild re-requests
+        the group's review. Treat a pending re-request as superseding the old
+        decision: only report "done" when a decision comment exists *and* the
+        group is not currently a requested reviewer.
+        """
         comments = sorted(self.__get_all_comments())
 
         done = re.compile(f"@{self.group}-review: (LGTM|approved?|declined?)")
-        return any(done.match(c.body) for c in comments)
+        if not any(done.match(c.body) for c in comments):
+            return False
+        # A decision comment exists, but a pending re-request (e.g. a rebuild
+        # that re-requested the group's review) supersedes it -- the group must
+        # review the new state again.
+        return not self.__has_review()
 
     def approve(self, other: str | None = None) -> None:
         """Approves the PR by posting a comment.

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -215,6 +215,73 @@ class TestGiteaOperations:
         assert "LGTM" in str(posts[0].request.body)
 
     @responses.activate
+    def test_approve_after_rebuild_rerequest_posts_comment(self, gitea):
+        """A re-requested review supersedes a stale decision -> approve proceeds.
+
+        After a rebuild re-requests the group's review, an earlier decline
+        comment lingers in the (append-only) history. approve() must still post
+        a fresh LGTM rather than refuse with GiteaNoReviewError.
+        """
+        me = self._make_comment(
+            1,
+            gitea.ASSIGN_TEMPLATE % (gitea.user, gitea.group),
+            "2024-01-01T00:00:00+00:00",
+        )
+        stale_decline = self._make_comment(
+            2,
+            f"@{gitea.group}-review: decline",
+            "2024-01-02T00:00:00+00:00",
+        )
+        comments = [me, stale_decline]
+        # check_assign -> the session user is the assignee
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        # is_done -> a decision comment exists ...
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        # ... but the group's review is requested again -> not done
+        responses.add(
+            responses.GET,
+            gitea.pr,
+            json={"requested_reviewers": [{"login": f"{gitea.group}-review"}]},
+            status=200,
+        )
+        responses.add(responses.POST, gitea.prissues, json={"id": 3}, status=201)
+
+        gitea.approve()
+
+        posts = [c for c in responses.calls if c.request.method == "POST"]
+        assert len(posts) == 1
+        assert "LGTM" in str(posts[0].request.body)
+
+    @responses.activate
+    def test_approve_when_already_decided_raises(self, gitea):
+        """A standing decision with no pending re-request still blocks approve."""
+        me = self._make_comment(
+            1,
+            gitea.ASSIGN_TEMPLATE % (gitea.user, gitea.group),
+            "2024-01-01T00:00:00+00:00",
+        )
+        decision = self._make_comment(
+            2,
+            f"@{gitea.group}-review: LGTM",
+            "2024-01-02T00:00:00+00:00",
+        )
+        comments = [me, decision]
+        # check_assign -> assigned to the session user
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        # is_done -> decision comment exists ...
+        responses.add(responses.GET, gitea.prissues, json=comments, status=200)
+        # ... and no pending re-request -> done
+        responses.add(
+            responses.GET,
+            gitea.pr,
+            json={"requested_reviewers": []},
+            status=200,
+        )
+
+        with pytest.raises(GiteaNoReviewError):
+            gitea.approve()
+
+    @responses.activate
     def test_assign_no_review_raises(self, gitea):
         """Test assign raises GiteaNoReviewError when no review exists."""
         responses.add(


### PR DESCRIPTION
## Problem

`approve`, `reject`, and `assign` refuse a Gitea-backed PR with `GiteaNoReviewError("PR was already approved/rejected")` once *any* decision comment (`@<group>-review: LGTM/approved/declined`) exists for the group.

The guard `Gitea.__is_done()` scans the PR's **append-only comment history**, so a decision lingers forever. When a package is **rebuilt after a `REQUEST_CHANGES`**, the bot re-requests the group's review (the group is back in `requested_reviewers`, the old review goes stale), but mtui still sees the old `decline`/`LGTM` comment and won't let the group review the rebuilt PR — there is no way to approve/reject it through mtui.

Seen in practice: an update rejected by `qam-sle-review`, fixed, rebuilt, and re-requested could not be approved via mtui.

## Fix

Make `__is_done()` re-request-aware: a pending review request for the group supersedes any earlier decision. It now reports "done" only when a decision comment exists **and** the group is **not** currently a requested reviewer, reusing the existing `__has_review()` / `requested_reviewers` signal.

Comment history is still checked first, so:
- **fresh PR** (no decision comment) → unchanged, no extra PR lookup;
- **decided, not re-requested** → still blocked (duplicate-decision protection preserved);
- **decided, then rebuilt/re-requested** → proceeds (mtui posts a fresh comment; the bot's latest-comment-wins logic supersedes the stale one).

This fixes `approve`, `reject`, and `assign` together (all gate on `__is_done()`).

## Tests

- `test_approve_after_rebuild_rerequest_posts_comment` — stale decline + pending re-request ⇒ `approve()` posts `LGTM` (the regression).
- `test_approve_when_already_decided_raises` — standing decision, no re-request ⇒ still raises `GiteaNoReviewError` (guards the preserved behavior, previously untested).

Full suite green (`1618 passed`), ruff clean. CHANGELOG updated.