### PR TITLE
docs(agents): restructure AGENTS.md to spec order + add Definition of Done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,47 @@
 # Agent Notes
 
-## Scope
-- Primary issue tracker for project work is https://progress.opensuse.org. GitHub issue forms disable blank issues; security reports follow `SECURITY.md`.
+## Overview
+- MTUI (Maintenance Test Update Installer) is the SUSE QE tool for validating maintenance updates: load a request by RRID, install/test it on reference hosts over SSH, and approve/reject. It drives `osc`/`svn`/Gitea under the hood.
+- Two driving surfaces: the interactive REPL (`uv run mtui --help`) and the `mtui-mcp` MCP server. Keep both working when touching command or entrypoint code.
+- Primary issue tracker is https://progress.opensuse.org (GitHub blank issues are disabled); security reports follow `SECURITY.md`.
 
-## Project Shape
-- Python package entrypoint is `mtui.main:main`; run it from the checkout with `uv run python -m mtui --help` or `uv run mtui --help`.
-- `mtui/commands/` is imported as a package; every `Command` subclass auto-registers via `Command.__init_subclass__` into `Command.registry`. Add one command module per interactive command; modules starting with `_` are skipped.
-- Commands subclass `mtui.commands._command.Command`, set `command`, implement `_add_arguments()` when needed, and implement `__call__()`.
-- Main runtime wiring is `mtui/main.py` -> `mtui/cli/prompt.py` -> `mtui.commands.registry`.
-- Config is INI from `MTUI_CONF`, explicit `--config`, or `/etc/mtui.cfg` plus `~/.mtuirc`; `TEMPLATE_DIR`, `TMPDIR`, and `GITEA_TOKEN` are also read.
-
-## Development Commands
-- Setup: `uv sync --extra norpm --extra mcp --group dev` (matches CI). The `norpm` extra avoids requiring system `rpm` Python bindings by using `version_utils`; the `mcp` extra provides `mcp`/`pydantic`, without which the `test_mcp_*` suites fail to import.
-- Full local gates matching CI: `uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check`, `uv run pytest`.
+## Setup & Commands
+- Setup (matches CI): `uv sync --extra norpm --extra mcp --group dev`. The `norpm` extra swaps the system `rpm` bindings for `version_utils`; the `mcp` extra provides `mcp`/`pydantic`, without which the `test_mcp_*` suites fail to import.
+- Run it: `uv run mtui --help` or `uv run python -m mtui --help` (entrypoint is `mtui.main:main`).
 - Auto-fix style: `uv run ruff format .` then `uv run ruff check --fix .`.
 - Coverage run: `uv run pytest -v --cov=./mtui --cov-report=xml --cov-report=term`.
-- Docs build with warnings as errors: `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html`.
+- Docs build (warnings are errors): `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html`.
 
 ## Testing
-- Pytest only collects `tests/`; registered strict markers are `slow`, `integration`, and `network`.
+- Pytest only collects `tests/`; strict markers are `slow`, `integration`, `network`.
 - Focus a test with `uv run pytest tests/test_file.py::test_name`; skip costly/external tests with `uv run pytest -m 'not slow and not network'`.
-- HTTP tests use `responses`; shared mock fixtures live in `tests/conftest.py`.
-- CLI smoke tests invoke `python -m mtui`; keep that path working when touching entrypoint or argument parsing code.
+- HTTP is mocked with `responses`; shared fixtures live in `tests/conftest.py`.
 
-## Type And Style Quirks
-- Supported Python is 3.13 and 3.14 (`requires-python = ">=3.13"`); `ty` is pinned to 3.13 (lowest supported) and treats warnings as errors. CI runs the pytest matrix across both versions but only one ty job.
-- `mtui/types/**` and `mtui/data_sources/**` have stricter `ty` rules (`all = "error"`).
-- Ruff enforces import sorting, pyupgrade for py311+, no `print`, and specific `# ty: ignore[...]` codes via `PGH003`.
-- Tests have relaxed Ruff ignores for asserts/private access; do not copy those assumptions into package code.
+## Architecture (non-obvious bits)
+- `mtui/commands/` is a package; every `Command` subclass **auto-registers** via `Command.__init_subclass__` into `Command.registry`. One module per interactive command; modules starting with `_` are skipped.
+- A command subclasses `mtui.commands._command.Command`, sets `command`, implements `_add_arguments()` when needed, and implements `__call__()`.
+- Config is INI from `MTUI_CONF`, explicit `--config`, or `/etc/mtui.cfg` plus `~/.mtuirc`; `TEMPLATE_DIR`, `TMPDIR`, and `GITEA_TOKEN` are also read.
+
+## Type & Style Quirks
+- Supported Python is 3.13 and 3.14; `ty` is pinned to 3.13 (lowest supported) and treats warnings as errors. CI runs the pytest matrix on both versions but only one `ty` job.
+- `mtui/types/**` and `mtui/data_sources/**` carry stricter `ty` rules (`all = "error"`).
+- Suppress a type error with a specific `# ty: ignore[<code>]` (bare ignores are rejected by Ruff `PGH003`).
+- Tests have relaxed Ruff ignores for asserts/private access; do not copy those into package code.
 
 ## Change Workflow
 - User-visible changes belong in `CHANGELOG.md` under `[Unreleased]`; internal-only refactors usually do not.
-- Conventional Commits are expected. Existing docs mention `bsc#NNNN` / `boo#NNNN` for SUSE Bugzilla references when applicable.
-- When adding an interactive command, also add focused tests and document the command in `Documentation/iui.rst`.
+- Conventional Commits are expected; reference SUSE Bugzilla as `bsc#NNNN` / `boo#NNNN` when applicable.
+- When adding an interactive command, also add focused tests and document it in `Documentation/iui.rst`.
+
+## Definition of Done (hard rules)
+- Run the full gate set on the **whole repo** (`.`), never a subset, before pushing or claiming done: `uv run ruff format --check .` **and** `uv run ruff check .` **and** `uv run ty check` **and** `uv run pytest`. CI lints `tests/` too, so formatting only `mtui/` is the most common way to red the pipeline.
+- "Done" means CI is observed green, not predicted green. Report status from the actual run.
+- New/changed lines need >=80% patch coverage (`codecov.yml` `patch.target: 80`). If a branch is genuinely un-coverable (e.g. best-effort network/error paths), add a focused test or a justified `# pragma: no cover` -- never leave `codecov/patch` silently red.
+- Rebase on `upstream/main` and squash to a coherent commit set before requesting review (see `CONTRIBUTING.md`).
 
 ## External Runtime Dependencies
-- Source installs are not from PyPI. `uv` is the expected dev path; `pip install -e '.[norpm]'` is documented as an alternative.
-- MTUI shells out to `osc` for OBS/IBS actions and expects `svn` for test report checkouts/commits; SSH connections are handled through `paramiko`.
+- Source installs are not from PyPI. `uv` is the expected dev path; `pip install -e '.[norpm]'` is a documented alternative.
+- MTUI shells out to `osc` for OBS/IBS actions and `svn` for test report checkouts/commits; SSH connections go through `paramiko`.
 
 ## Further Reading
-- `CONTRIBUTING.md` covers branching/PR/commit conventions; `Documentation/developer.rst` is the deeper architectural reference. `Documentation/iui.rst` documents interactive commands and must be updated when adding one.
+- `CONTRIBUTING.md` covers branching/PR/commit conventions; `Documentation/developer.rst` is the deeper architectural reference; `Documentation/iui.rst` documents interactive commands and must be updated when adding one.


### PR DESCRIPTION
Reworks `AGENTS.md` to follow the converged community guidance for agent context files and the empirical finding that the file is loaded into **every** agent session (so density beats coverage — see the Feb-2026 *AGENTbench* study and the agents.md spec).

## What changes
- **New Project Overview** — what mtui is, who uses it, and the two driving surfaces (interactive REPL + `mtui-mcp`). This was missing entirely.
- **Canonical section order** — Overview → Setup & Commands → Testing → Architecture → Type & Style Quirks → Change Workflow → Definition of Done → External Runtime Dependencies → Further Reading.
- **New Definition of Done (hard rules)** — codifies the discipline that has tripped us up:
  - run the full gate set (`ruff format --check`, `ruff check`, `ty check`, `pytest`) on the **whole repo** (`.`), never a subset — CI lints `tests/` too, so formatting only `mtui/` is the #1 way to red the pipeline;
  - "done" means CI **observed** green, not predicted;
  - new/changed lines need >=80% patch coverage (per `codecov.yml`), with a test or a justified `# pragma: no cover` for genuinely un-coverable network/error paths;
  - rebase on `upstream/main` and squash before review.
- **Pruning** — removed content agents discover for themselves (the `main.py → prompt.py → registry` wiring map) or that linters enforce deterministically (the ruff import-sort/pyupgrade/no-print bullet); kept only genuine, non-discoverable gotchas (the `__init_subclass__` auto-registration, the `ty` 3.13 pin, per-dir `all="error"`, the `# ty: ignore[<code>]`/`PGH003` rule).

Net: 47 lines (was 42), well under the ~150-line soft cap, with higher signal density. Docs-only.