### PR TITLE
feat(dashboard): enable AUTOMATIC mode for SLFO updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- SLFO updates now run in AUTOMATIC mode. Their openQA install jobs
+  (`qam-incidentinstall-SLFO`) were previously excluded from the auto workflow,
+  forcing every SLFO update to fall back to manual; they are now recognised and
+  their install logs fetched from the correct artifact
+  (`SLFO_update_install-zypper.log`, distinct from the classic
+  `update_install-zypper.log`) via a job-name to log-filename mapping shared by
+  both auto connectors (poo#200832).
 - `mtui-mcp` now disconnects every loaded template's hosts when a session is
   closed (idle-TTL eviction or shutdown), not just the active template's. A
   session can hold several templates at once, each owning its own host group;

--- a/mtui/data_sources/openqa/standard.py
+++ b/mtui/data_sources/openqa/standard.py
@@ -5,6 +5,7 @@ from os.path import join
 from typing import Self, override
 
 from ...types.urls import URLs
+from ..openqa_install import install_logfile_for
 from .base import OpenQA
 
 logger = getLogger("mtui.connector.openqa.standard")
@@ -36,7 +37,12 @@ class AutoOpenQA(OpenQA):
         return all(
             normalize(y["result"])
             for y in jobs
-            if y["test"] in ["qam-incidentinstall", "qam-incidentinstall-ha"]
+            if y["test"]
+            in [
+                "qam-incidentinstall",
+                "qam-incidentinstall-ha",
+                "qam-incidentinstall-SLFO",
+            ]
         )
 
     @override
@@ -100,12 +106,17 @@ class AutoOpenQA(OpenQA):
                     "tests",
                     str(job["id"]),
                     "file",
-                    self.config.openqa_install_logs,
+                    install_logfile_for(job["test"], self.config.openqa_install_logs),
                 ),
                 job["result"],
             )
             for job in jobs
-            if job["test"] in ["qam-incidentinstall", "qam-incidentinstall-ha"]
+            if job["test"]
+            in [
+                "qam-incidentinstall",
+                "qam-incidentinstall-ha",
+                "qam-incidentinstall-SLFO",
+            ]
         ]
 
     @override

--- a/mtui/data_sources/openqa_install.py
+++ b/mtui/data_sources/openqa_install.py
@@ -1,0 +1,44 @@
+"""Resolution of openQA install-test job names to their log filenames.
+
+Different install-test scenarios publish their zypper install log under
+different filenames. The classic ``qam-incidentinstall`` (and the HA
+variant ``qam-incidentinstall-ha``) jobs publish ``update_install-zypper.log``
+-- the value carried by the ``[openqa] install_logfile`` config option. SLFO
+jobs (``qam-incidentinstall-SLFO``) instead publish
+``SLFO_update_install-zypper.log``.
+
+A single config value cannot express this per-job-name divergence, so the
+URL builders in the auto connectors consult :func:`install_logfile_for`,
+which maps a job name to its log filename and falls back to the configured
+default for the classic case.
+"""
+
+# Map a job-name marker to the install log filename that job publishes.
+# The classic jobs are intentionally absent: they fall back to the
+# configured ``[openqa] install_logfile`` default via the ``default``
+# argument of :func:`install_logfile_for`.
+_INSTALL_LOGFILES: dict[str, str] = {
+    "-SLFO": "SLFO_update_install-zypper.log",
+}
+
+
+def install_logfile_for(test_name: str, default: str) -> str:
+    """Return the install-log filename for an openQA install-test job.
+
+    Args:
+        test_name: The openQA job/test name (e.g. ``qam-incidentinstall``
+            or ``qam-incidentinstall-SLFO``).
+        default: The fallback filename for jobs with no specific mapping
+            (the resolved ``[openqa] install_logfile`` config value).
+
+    Returns:
+        The log filename the job publishes. Matching is by marker
+        substring so name variants (e.g. ``qam-incidentinstall-SLFO-ha``)
+        resolve to the same SLFO log; unknown names return ``default``.
+
+    """
+    name = test_name or ""
+    for marker, logfile in _INSTALL_LOGFILES.items():
+        if marker in name:
+            return logfile
+    return default

--- a/mtui/data_sources/qem_dashboard/dashboard_openqa.py
+++ b/mtui/data_sources/qem_dashboard/dashboard_openqa.py
@@ -7,6 +7,7 @@ from typing import Any, Self
 
 from ...support.concurrency import ContextExecutor
 from ...types import RequestReviewID, URLs
+from ..openqa_install import install_logfile_for
 from .client import _FUTURE_TIMEOUT, FAILED_RESULTS
 from .incident import QEMIncident
 
@@ -182,14 +183,15 @@ class DashboardAutoOpenQA:
                     "tests",
                     str(job["id"]),
                     "file",
-                    self.config.openqa_install_logs,
+                    install_logfile_for(
+                        job.get("test", "") or "", self.config.openqa_install_logs
+                    ),
                 ),
                 str(job.get("result", "") or ""),
             )
             for job in jobs
             if (
                 "qam-incidentinstall" in (job.get("test", "") or "")
-                and "SLFO" not in (job.get("test", "") or "")
                 and self._normalize_result(job.get("result"))
             )
         ]

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -98,6 +98,10 @@ class AutoExport(BaseExport):
         auto = self.openqa.auto
         if auto is None:
             return []
+        # Ensure the install_logs directory exists before writing. SLFO load
+        # paths may not have pre-created it, and writing a log into a missing
+        # directory raises FileNotFoundError.
+        filepath.mkdir(parents=True, exist_ok=True)
         ilogs = zip_longest(
             auto.results,
             map(self._openqa_installog_to_template, auto.results),

--- a/tests/test_export_auto_download.py
+++ b/tests/test_export_auto_download.py
@@ -130,3 +130,30 @@ def test_download_ssl_verify_false_skips_verification(mock_config):
 
     assert out == ["x\n"]
     bs.assert_called_once_with(False)
+
+
+def test_get_logs_creates_install_logs_dir(mock_config, tmp_path):
+    """``get_logs`` creates the install_logs directory before writing.
+
+    Regression: SLFO load paths may not pre-create
+    ``template_dir/<rrid>/install_logs``; writing a log into a missing
+    directory raised ``FileNotFoundError``.
+    """
+    mock_config.template_dir = tmp_path
+    rrid = "SUSE:SLFO:1.2:5295"
+    exporter = AutoExport(mock_config, MagicMock(), FileList([]), False, rrid, False)
+    exporter.openqa = MagicMock()
+    exporter.openqa.auto.results = [_url()]
+
+    target_dir = tmp_path / rrid / mock_config.install_logs
+    assert not target_dir.exists()
+
+    with patch.object(
+        AutoExport, "_openqa_installog_to_template", return_value=["log line\n"]
+    ):
+        filenames = exporter.get_logs()
+
+    assert target_dir.is_dir()
+    assert len(filenames) == 1
+    written = target_dir / "sle_15-SP7_x86_64.log"
+    assert written.is_file()

--- a/tests/test_openqa_connector.py
+++ b/tests/test_openqa_connector.py
@@ -46,6 +46,21 @@ class TestHasPassedInstallJobs:
         ]
         assert auto_oqa._has_passed_install_jobs(jobs) is True
 
+    def test_slfo_install_job_counted(self, auto_oqa):
+        """SLFO install jobs participate in the pass/fail decision."""
+        assert (
+            auto_oqa._has_passed_install_jobs(
+                [{"test": "qam-incidentinstall-SLFO", "result": "passed"}]
+            )
+            is True
+        )
+        assert (
+            auto_oqa._has_passed_install_jobs(
+                [{"test": "qam-incidentinstall-SLFO", "result": "failed"}]
+            )
+            is False
+        )
+
     def test_failed_install_job(self, auto_oqa):
         """Test failed install job returns False."""
         jobs = [
@@ -164,6 +179,26 @@ class TestGetLogsUrl:
         assert len(result) == 1
         assert "123" in result[0].url
         assert result[0].result == "passed"
+
+    def test_slfo_install_job_uses_slfo_logfile(self, auto_oqa):
+        """SLFO install jobs are recognised and use the SLFO install log."""
+        jobs = [
+            {
+                "id": 789,
+                "test": "qam-incidentinstall-SLFO",
+                "result": "passed",
+                "settings": {
+                    "HDD_1": "SLFO-16.0-x86_64-Build1.qcow2",
+                    "ARCH": "x86_64",
+                    "VERSION": "16.0",
+                },
+            },
+        ]
+        result = auto_oqa._get_logs_url(jobs)
+
+        assert len(result) == 1
+        assert "789" in result[0].url
+        assert result[0].url.endswith("SLFO_update_install-zypper.log")
 
 
 # --- AutoOpenQA.run ---

--- a/tests/test_openqa_install_map.py
+++ b/tests/test_openqa_install_map.py
@@ -1,0 +1,33 @@
+"""Tests for the openQA install-job log filename resolution."""
+
+from mtui.data_sources.openqa_install import install_logfile_for
+
+DEFAULT = "update_install-zypper.log"
+
+
+def test_classic_job_uses_default():
+    """A classic install job falls back to the configured default."""
+    assert install_logfile_for("qam-incidentinstall", DEFAULT) == DEFAULT
+    assert install_logfile_for("qam-incidentinstall-ha", DEFAULT) == DEFAULT
+
+
+def test_slfo_job_uses_slfo_logfile():
+    """SLFO install jobs resolve to the SLFO install log filename."""
+    assert (
+        install_logfile_for("qam-incidentinstall-SLFO", DEFAULT)
+        == "SLFO_update_install-zypper.log"
+    )
+
+
+def test_slfo_marker_matches_variants():
+    """The SLFO marker matches name variants by substring."""
+    assert (
+        install_logfile_for("qam-incidentinstall-SLFO-ha", DEFAULT)
+        == "SLFO_update_install-zypper.log"
+    )
+
+
+def test_unknown_and_empty_names_use_default():
+    """Unknown or empty job names fall back to the default."""
+    assert install_logfile_for("qam-somethingelse", DEFAULT) == DEFAULT
+    assert install_logfile_for("", DEFAULT) == DEFAULT

--- a/tests/test_qem_dashboard_connector.py
+++ b/tests/test_qem_dashboard_connector.py
@@ -719,3 +719,43 @@ def test_get_logs_url_tolerates_missing_test_field(mock_config):
     urls = dashboard._get_logs_url(jobs)
     assert urls is not None
     assert len(urls) == 1  # only the matching job, no crash on the None one
+
+
+def test_get_logs_url_includes_slfo_jobs_with_slfo_logfile(mock_config):
+    """SLFO install jobs are included and point at the SLFO install log.
+
+    Regression: ``_get_logs_url`` used to drop any job whose name contained
+    ``SLFO`` (the poo#200832 workaround) and always built the URL with the
+    classic ``install_logfile`` name. SLFO jobs (``qam-incidentinstall-SLFO``)
+    must now be included with ``SLFO_update_install-zypper.log``, while classic
+    jobs keep the configured default.
+    """
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        {
+            "test": "qam-incidentinstall-SLFO",
+            "result": "passed",
+            "id": 10,
+            "settings": {"DISTRI": "sle", "ARCH": "x86_64", "VERSION": "16.0"},
+        },
+        {
+            "test": "qam-incidentinstall",
+            "result": "passed",
+            "id": 11,
+            "settings": {"DISTRI": "sle", "ARCH": "x86_64", "VERSION": "15-SP5"},
+        },
+    ]
+    urls = dashboard._get_logs_url(jobs)
+    assert urls is not None
+    assert len(urls) == 2
+    by_id = {u.url.rsplit("/tests/", 1)[1].split("/")[0]: u.url for u in urls}
+    assert by_id["10"].endswith("SLFO_update_install-zypper.log")
+    assert by_id["11"].endswith(mock_config.openqa_install_logs)
+
+
+def test_has_passed_install_jobs_counts_slfo_jobs(mock_config):
+    """SLFO install jobs participate in the pass/fail decision."""
+    jobs = [{"test": "qam-incidentinstall-SLFO", "result": "passed"}]
+    assert DashboardAutoOpenQA._has_passed_install_jobs(jobs) is True
+    failed = [{"test": "qam-incidentinstall-SLFO", "result": "failed"}]
+    assert DashboardAutoOpenQA._has_passed_install_jobs(failed) is False


### PR DESCRIPTION
## What

Enables AUTOMATIC mode for SLFO updates, which previously always fell back to manual install testing.

## Why

[poo#200832](https://progress.opensuse.org/issues/200832) (the openQA-side blocker) is now resolved. SLFO install jobs run under the scenario name `qam-incidentinstall-SLFO` and publish their log as `SLFO_update_install-zypper.log`. mtui still carried the poo#200832 workaround that excluded any job whose name contained `SLFO` from the auto workflow, so every SLFO update was forced into manual install testing despite working openQA results being available.

Example job: https://openqa.suse.de/tests/22820441

## Changes

- **New `mtui/data_sources/openqa_install.py`** — `install_logfile_for()` maps a job name to its install-log filename via an `-SLFO` marker (covering variants like `-SLFO-ha`); classic jobs keep the configured `[openqa] install_logfile` default.
- **`DashboardAutoOpenQA._get_logs_url`** — removes the `"SLFO" not in test` exclusion; resolves the log filename per job via the mapping.
- **Classic `AutoOpenQA`** — recognises `qam-incidentinstall-SLFO` in both the pass/fail check and the URL builder; resolves the filename via the mapping.
- **`AutoExport.get_logs`** — creates the `install_logs` directory once before writing, fixing `FileNotFoundError: .../install_logs` on SLFO load paths that did not pre-create it.
- Tests for the mapping, both connectors, and the directory creation; `CHANGELOG.md` entry under `[Unreleased]`.

## Testing

Full gate green on the whole repo:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 1649 passed