### PR TITLE
feat(updates): expose and filter queue by assignee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Maintenance updates in QAM testing. Optional `--review-group`/`--status`/
   `--limit` filters. This is the TeReGen-backed replacement for the removed
   `smelt_updates`/`smelt_requests` commands.
+- `updates` gained assignment exposure (restoring functionality dropped with
+  SMELT): `--assignee <user>` and `--mine` (the current session user) filter the
+  queue to updates assigned to that user, `--unassigned` to updates with no
+  assignee, and `--show-assignment` annotates every row with its assignee
+  without filtering. Requires the matching TeReGen `/updates` assignment support.
 - New `checkers` command — lists the build-check (checker) result runs for the
   loaded update, fetched live from the TeReGen report API
   (`GET /reports/{id}/checkers`). This is the TeReGen-backed replacement for the

--- a/mtui/commands/updates.py
+++ b/mtui/commands/updates.py
@@ -43,11 +43,47 @@ class Updates(Command):
             default=0,
             help="cap the number of rows (0 = all)",
         )
+        # --assignee/--mine/--unassigned select at most one assignment view;
+        # argparse rejects any combination of the three for us.
+        assignment = parser.add_mutually_exclusive_group()
+        assignment.add_argument(
+            "--assignee",
+            default=None,
+            help="filter to updates assigned to this user (any qam group)",
+        )
+        assignment.add_argument(
+            "--mine",
+            action="store_true",
+            help="filter to updates assigned to the current session user",
+        )
+        assignment.add_argument(
+            "--unassigned",
+            action="store_true",
+            help="filter to updates with no assignee",
+        )
+        parser.add_argument(
+            "--show-assignment",
+            action="store_true",
+            help="show the assignee on each row without filtering",
+        )
 
     def __call__(self) -> None:
         """Fetch and print the update queue from TeReGen."""
+        assignee = self.args.assignee
+        if self.args.mine:
+            assignee = self.config.session_user
+
+        # Any assignment-related flag means rows should carry assignment info.
+        want_assignment = bool(
+            assignee or self.args.unassigned or self.args.show_assignment
+        )
+
         updates = TeReGen(self.config).updates(
-            review_group=self.args.review_group, status=self.args.status
+            review_group=self.args.review_group,
+            status=self.args.status,
+            assignee=assignee,
+            unassigned=self.args.unassigned,
+            with_assignment=want_assignment,
         )
         if not updates:
             self.println("No updates in the queue")
@@ -63,16 +99,29 @@ class Updates(Command):
                 continue
             # deadline is an ISO timestamp; the date alone is enough for a row.
             deadline = (u.get("deadline") or "")[:10] or "-"
-            self.println(
+            row = (
                 f"  prio={u.get('priority', '?')!s:<5} "
                 f"{u.get('status', '?')!s:<10} "
                 f"{u.get('kind', '?')!s:<12} "
                 f"{deadline:<11} {u.get('id', '?')}"
             )
+            if want_assignment:
+                row += f" assignee={u.get('assignee') or 'unassigned'}"
+            self.println(row)
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("--review-group",), ("--status",), ("--limit",)], line, text
+            [
+                ("--review-group",),
+                ("--status",),
+                ("--limit",),
+                ("--assignee",),
+                ("--mine",),
+                ("--unassigned",),
+                ("--show-assignment",),
+            ],
+            line,
+            text,
         )

--- a/mtui/data_sources/teregen.py
+++ b/mtui/data_sources/teregen.py
@@ -104,15 +104,45 @@ class TeReGen:
         return d.get("checkers") if isinstance(d, dict) else None
 
     def updates(
-        self, review_group: str | None = None, status: str | None = None
+        self,
+        review_group: str | None = None,
+        status: str | None = None,
+        assignee: str | None = None,
+        unassigned: bool = False,
+        with_assignment: bool = False,
+        no_cache: bool = False,
     ) -> list[Any] | None:
         """The unreleased update queue (live from SMELT), or ``None``.
 
         Optional ``review_group`` / ``status`` narrow the queue server-side.
+
+        Assignment exposure (each maps to a query param of the same name):
+
+        - ``assignee``: keep only updates assigned to that user (any qam group);
+          implies server-side ``status=testing``.
+        - ``unassigned``: keep only updates with no assignee; implies
+          ``status=testing``.
+        - ``with_assignment``: include assignment on every row without
+          filtering; implies ``status=testing``.
+        - ``no_cache``: bypass the server's short assignment cache (use for the
+          pickup moment).
         """
         params = {
-            k: v for k, v in (("review_group", review_group), ("status", status)) if v
+            k: v
+            for k, v in (
+                ("review_group", review_group),
+                ("status", status),
+                ("assignee", assignee),
+            )
+            if v
         }
+        for flag, name in (
+            (unassigned, "unassigned"),
+            (with_assignment, "with_assignment"),
+            (no_cache, "no_cache"),
+        ):
+            if flag:
+                params[name] = "1"
         d = self._get("updates", params=params or None)
         return d.get("updates") if isinstance(d, dict) else None
 

--- a/tests/test_cmd_updates.py
+++ b/tests/test_cmd_updates.py
@@ -6,6 +6,9 @@ import io
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from mtui.cli.argparse import ArgsParseFailureError, ArgumentParser
 from mtui.commands.updates import Updates
 
 
@@ -16,9 +19,23 @@ def _sysmock() -> MagicMock:
 
 
 def _args(**kw) -> Namespace:
-    base = {"review_group": None, "status": None, "limit": 0}
+    base = {
+        "review_group": None,
+        "status": None,
+        "limit": 0,
+        "assignee": None,
+        "mine": False,
+        "unassigned": False,
+        "show_assignment": False,
+    }
     base.update(kw)
     return Namespace(**base)
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(prog="updates", sys_=_sysmock())
+    Updates._add_arguments(parser)
+    return parser
 
 
 def test_updates_lists_queue(mock_config):
@@ -43,7 +60,13 @@ def test_updates_lists_queue(mock_config):
         ]
         Updates(_args(review_group="qam-sle"), mock_config, sysmock, MagicMock())()
 
-    teregen.updates.assert_called_once_with(review_group="qam-sle", status=None)
+    teregen.updates.assert_called_once_with(
+        review_group="qam-sle",
+        status=None,
+        assignee=None,
+        unassigned=False,
+        with_assignment=False,
+    )
     out = sysmock.stdout.getvalue()
     assert "SUSE:SLFO:1.2:5444" in out
     assert "653" in out
@@ -62,3 +85,72 @@ def test_updates_limit(mock_config):
 
     out = sysmock.stdout.getvalue()
     assert "Update queue (1)" in out
+
+
+def test_updates_show_assignment_renders_assignee(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = [
+            {"id": "SUSE:SLFO:1.2:1", "assignee": "alice"},
+            {"id": "SUSE:SLFO:1.2:2", "assignee": None},
+        ]
+        Updates(_args(show_assignment=True), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status=None,
+        assignee=None,
+        unassigned=False,
+        with_assignment=True,
+    )
+    out = sysmock.stdout.getvalue()
+    assert "assignee=alice" in out
+    assert "assignee=unassigned" in out
+
+
+def test_updates_mine_maps_to_session_user(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = []
+        Updates(_args(mine=True), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status=None,
+        assignee="testuser",
+        unassigned=False,
+        with_assignment=True,
+    )
+
+
+def test_updates_unassigned_passes_through(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = []
+        Updates(_args(unassigned=True), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status=None,
+        assignee=None,
+        unassigned=True,
+        with_assignment=True,
+    )
+
+
+def test_updates_mine_and_assignee_are_mutually_exclusive():
+    with pytest.raises(ArgsParseFailureError):
+        _parser().parse_args(["--mine", "--assignee", "bob"])
+
+
+def test_updates_unassigned_with_assignee_errors():
+    with pytest.raises(ArgsParseFailureError):
+        _parser().parse_args(["--unassigned", "--assignee", "bob"])
+
+
+def test_updates_mine_and_unassigned_are_mutually_exclusive():
+    with pytest.raises(ArgsParseFailureError):
+        _parser().parse_args(["--mine", "--unassigned"])

--- a/tests/test_teregen.py
+++ b/tests/test_teregen.py
@@ -109,6 +109,51 @@ def test_updates_passes_query_filters(mock_config):
 
 
 @responses.activate
+def test_updates_passes_assignee(mock_config):
+    responses.add(responses.GET, f"{API}/updates", json={"updates": []})
+    assert _client(mock_config).updates(assignee="mpluskal", status="testing") == []
+    qs = responses.calls[0].request.url or ""
+    assert "assignee=mpluskal" in qs
+    assert "status=testing" in qs
+
+
+@responses.activate
+def test_updates_passes_unassigned_flag(mock_config):
+    responses.add(responses.GET, f"{API}/updates", json={"updates": []})
+    _client(mock_config).updates(unassigned=True)
+    qs = responses.calls[0].request.url or ""
+    assert "unassigned=1" in qs
+
+
+@responses.activate
+def test_updates_passes_with_assignment_flag(mock_config):
+    responses.add(responses.GET, f"{API}/updates", json={"updates": []})
+    _client(mock_config).updates(with_assignment=True)
+    qs = responses.calls[0].request.url or ""
+    assert "with_assignment=1" in qs
+
+
+@responses.activate
+def test_updates_passes_no_cache_flag(mock_config):
+    responses.add(responses.GET, f"{API}/updates", json={"updates": []})
+    _client(mock_config).updates(assignee="mpluskal", no_cache=True)
+    qs = responses.calls[0].request.url or ""
+    assert "no_cache=1" in qs
+    assert "assignee=mpluskal" in qs
+
+
+@responses.activate
+def test_updates_omits_unset_assignment_flags(mock_config):
+    responses.add(responses.GET, f"{API}/updates", json={"updates": []})
+    _client(mock_config).updates()
+    url = responses.calls[0].request.url or ""
+    assert "unassigned" not in url
+    assert "with_assignment" not in url
+    assert "no_cache" not in url
+    assert "assignee" not in url
+
+
+@responses.activate
 def test_regenerate_returns_json_body(mock_config):
     responses.add(
         responses.POST,


### PR DESCRIPTION
## What

Restores assignment visibility/filtering to the `updates` command. The old
`--unassigned`/`--show-assignment` were dropped when SMELT was removed
(#236); this brings the capability back on top of the TeReGen `/updates` API.

### TeReGen client (`mtui/data_sources/teregen.py`)

`updates()` gains four optional keyword params mapping 1:1 to the new
`GET /api/v1/updates` query params:

- `assignee=<user>` — filter to updates assigned to that user (any qam group).
- `unassigned=1` — filter to updates with no assignee.
- `with_assignment=1` — include assignment on each row without filtering.
- `no_cache=1` — bypass the server's short assignment cache.

All three booleans are only sent when `True`; `assignee` only when truthy.

### `updates` command (`mtui/commands/updates.py`)

New flags:

- `--assignee <user>` — filter to updates assigned to that user.
- `--mine` — shorthand for `--assignee <current session user>`.
- `--unassigned` — only updates with no assignee.
- `--show-assignment` — annotate every row with its assignee, no filtering.

`--mine`/`--assignee` are mutually exclusive, and `--unassigned` cannot be
combined with `--assignee`/`--mine`. Whenever any assignment flag is given the
client is called with `with_assignment=True`, and rows render
` assignee=<user>` (`assignee=unassigned` when none).

### Tests

Client-level tests assert the right query params are sent; command-level tests
cover `--show-assignment` rendering, `--mine` -> session user, `--unassigned`
pass-through, and the mutually-exclusive validation errors.

## Note

Depends on the TeReGen `/updates` assignment MR (assignee/unassigned/
with_assignment/no_cache params + assignees/assignee fields); will work once
TeReGen is deployed.