### PR TITLE
fix(removehost): release the in-process pool-arbitration claim

### DIFF
--- a/mtui/commands/removehost.py
+++ b/mtui/commands/removehost.py
@@ -32,6 +32,11 @@ class RemoveHost(Command):
 
         """
         self.targets[target].close()
+        # Drop the in-process pool-arbitration claim too. close() only removes
+        # the remote lock files; the process-global HostArbiter would otherwise
+        # keep this host marked busy for the server's lifetime (no unload over
+        # MCP, so the template stays loaded). See TestReport.release_pool_claim.
+        self.metadata.release_pool_claim(target)
         self.targets.pop(target)
         if target in self.metadata.systems:
             del self.metadata.systems[target]

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -918,6 +918,31 @@ class TestReport(ABC):
         if self._arbiter is not None and self._owner is not None:
             self._arbiter.release_owner(self._owner)
 
+    def release_pool_claim(self, host: str) -> None:
+        """Release one host's in-process arbiter claim.
+
+        Per-host analogue of :meth:`release_pool_claims`, called from
+        ``remove_host`` so a disconnected refhost does not stay claimed in the
+        process-global :class:`HostArbiter` for the rest of the server's
+        lifetime (there is no ``unload`` over MCP, so the template stays
+        loaded). ``Target.close()`` already drops the remote operation/pool
+        lock files; this clears the in-process ownership that those locks and
+        the ``--free`` probe never see. Idempotent and safe when pool
+        selection was never used (``_arbiter``/``_owner`` are then ``None``).
+        """
+        self._pool_claims.discard(host)
+        # Drop only this host from each slot's candidate list -- siblings stay
+        # available as backup-refhost fallbacks (RFC 5.7). Prune a slot only
+        # once it has no candidates left. (``release_pool_claims`` clears the
+        # whole map because it tears the entire report down.)
+        for slot, candidates in list(self._slot_candidates.items()):
+            if host in candidates:
+                candidates.remove(host)
+                if not candidates:
+                    del self._slot_candidates[slot]
+        if self._arbiter is not None and self._owner is not None:
+            self._arbiter.release(host, self._owner)
+
     def autoconnect(self) -> None:
         """Connect refhosts for a freshly loaded (manual-fallback) template.
 

--- a/tests/test_cmd_removehost.py
+++ b/tests/test_cmd_removehost.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +52,10 @@ def test_remove_host_happy_closes_and_pops(mock_config):
         RemoveHost(args, mock_config, MagicMock(), prompt)()
 
     t.close.assert_called_once_with()
+    # the in-process pool-arbiter claim must be released too (close() only drops
+    # the remote lock files) -- otherwise the host stays "busy" for the server's
+    # lifetime. See TestReport.release_pool_claim.
+    prompt.metadata.release_pool_claim.assert_called_once_with("h1")
     assert "h1" not in hg
     assert "h1" not in systems
 
@@ -62,3 +67,83 @@ def test_remove_host_unknown_propagates(mock_config):
     args = Namespace(hosts=["ghost"])
     with pytest.raises(HostIsNotConnectedError):
         RemoveHost(args, mock_config, MagicMock(), prompt)()
+
+
+def test_release_pool_claim_frees_host_for_next_owner():
+    """remove_host's release_pool_claim drops the in-process arbiter claim so a
+    later template (a different owner) can acquire the host.
+
+    Regression for the stale-claim bug: remove_host removed the remote lock
+    files but left HostArbiter._owner mapping the host to the old template, so
+    the scarce ppc64le/s390x slots stayed "all candidates busy" until the
+    mtui-mcp server was restarted.
+    """
+    from types import SimpleNamespace
+
+    from mtui.hosts.host_arbiter import HostArbiter
+    from mtui.test_reports.testreport import TestReport
+
+    arb = HostArbiter()
+    owner_a = ("regA", "SUSE:SLFO:1.2:1")
+    owner_b = ("regB", "SUSE:SLFO:1.2:2")
+    assert arb.acquire_any(["bianca"], owner_a) == "bianca"
+    # while owner_a holds it, owner_b cannot get it
+    assert arb.acquire_any(["bianca"], owner_b, wait=0) is None
+
+    report = SimpleNamespace(
+        _pool_claims={"bianca"},
+        _slot_candidates={("SLES", "16-0", "ppc64le", ()): ["bianca"]},
+        _arbiter=arb,
+        _owner=owner_a,
+    )
+    TestReport.release_pool_claim(cast(TestReport, report), "bianca")
+
+    assert arb.owner_of("bianca") is None
+    assert report._pool_claims == set()
+    assert report._slot_candidates == {}
+    # the next template/owner can now claim the freed host
+    assert arb.acquire_any(["bianca"], owner_b) == "bianca"
+
+
+def test_release_pool_claim_noop_without_pool_selection():
+    """Safe/idempotent when pool selection was never used (arbiter/owner None)."""
+    from types import SimpleNamespace
+
+    from mtui.test_reports.testreport import TestReport
+
+    report = SimpleNamespace(
+        _pool_claims=set(), _slot_candidates={}, _arbiter=None, _owner=None
+    )
+    TestReport.release_pool_claim(cast(TestReport, report), "h1")  # must not raise
+    assert report._pool_claims == set()
+    assert report._slot_candidates == {}
+
+
+def test_release_pool_claim_keeps_sibling_candidates():
+    """Removing one host drops only it from the slot; siblings stay as backups.
+
+    The slot is pruned only once empty, so a backup-refhost fallback for the
+    same slot is still possible after one candidate is removed.
+    """
+    from types import SimpleNamespace
+
+    from mtui.hosts.host_arbiter import HostArbiter
+    from mtui.test_reports.testreport import TestReport
+
+    arb = HostArbiter()
+    owner = ("regA", "SUSE:SLFO:1.2:1")
+    slot = ("SLES", "16-0", "ppc64le", ())
+    assert arb.acquire_any(["bianca"], owner) == "bianca"
+
+    report = SimpleNamespace(
+        _pool_claims={"bianca"},
+        _slot_candidates={slot: ["bianca", "rosa"]},
+        _arbiter=arb,
+        _owner=owner,
+    )
+    TestReport.release_pool_claim(cast(TestReport, report), "bianca")
+
+    # only "bianca" is gone; the sibling "rosa" remains a fallback candidate
+    assert report._slot_candidates == {slot: ["rosa"]}
+    assert report._pool_claims == set()
+    assert arb.owner_of("bianca") is None


### PR DESCRIPTION
## Problem

`remove_host` disconnected a refhost and dropped the remote operation/pool lock files, but never released the **in-process** `HostArbiter` claim. Because templates stay loaded for the `mtui-mcp` server's lifetime (there is no `unload` over MCP), the disconnected host's `(registry_id, rrid)` entry persisted in the process-global `HostArbiter._owner` indefinitely.

Result: the host stayed "busy" to every *other* loaded template until the server was restarted. The scarce 2-host `ppc64le`/`s390x` pools became unselectable — `no free pool host for slot ... all N candidates busy` — even though `list_refhosts --free` reported the host **free** (that probe reads the remote `/var/lock/mtui*.lock` files, which `close()` already removed, not the in-process owner map). A server restart "fixed" it because `get_arbiter()` is a process-global singleton.

## Fix

- Add `TestReport.release_pool_claim(host)` — the per-host analogue of the existing `release_pool_claims()` — which clears `_pool_claims`/`_slot_candidates` and calls `HostArbiter.release(host, owner)` (which only deletes if held by this owner and wakes waiters).
- Call it from `RemoveHost._remove_target` after `target.close()`.

Idempotent and a no-op when pool selection was never used (`_arbiter`/`_owner` are `None`).

## Tests

- `remove_host` releases the claim and a *second* owner can then `acquire_any` the freed host (regression for the stale-claim bug).
- No-op-without-pool-selection guard.
- Existing happy-path test now asserts `release_pool_claim` is called.

Full suite green locally (1514 passed; the 4 unrelated `responses`-dep collection errors are pre-existing).