### PR TITLE
fix(run,lrun): shell-quote arguments so sh -c bodies survive

### DIFF
--- a/mtui/commands/localrun.py
+++ b/mtui/commands/localrun.py
@@ -1,5 +1,6 @@
 """The `lrun` command."""
 
+import shlex
 import subprocess
 from argparse import REMAINDER
 from logging import getLogger
@@ -39,7 +40,11 @@ class LocalRun(Command):
             logger.error("Missing argument")
             return
 
-        cmd = " ".join(self.args.command)
+        # Quote each argument so a token with shell metacharacters (e.g.
+        # ``sh -c "VAR=x; echo $VAR"``) keeps its quoting instead of being
+        # re-split by the ``shell=True`` shell. Shell operators (pipes,
+        # redirection) belong inside an explicit ``sh -c '...'``.
+        cmd = shlex.join(self.args.command)
 
         # Default to the safe (current) streaming behaviour if a caller
         # forgets to set ``interactive`` on the prompt.

--- a/mtui/commands/run.py
+++ b/mtui/commands/run.py
@@ -1,5 +1,6 @@
 """The `run` command."""
 
+import shlex
 from argparse import REMAINDER
 from logging import getLogger
 
@@ -47,12 +48,13 @@ class Run(Command):
         if not targets:
             raise NoRefhostsDefinedError
 
-        command: str = ""
-
-        for i in self.args.command:
-            command += i + " "
-
-        command = command.rstrip(" ")
+        # Quote each argument so a single token that contains shell
+        # metacharacters (e.g. ``sh -c "VAR=x; echo $VAR"`` or ``$(...)``)
+        # survives the trip to the remote shell intact. A plain space-join
+        # would let the remote shell re-split the script body, dropping the
+        # quoting -- so ``sh -c "a; b"`` ran as ``sh -c a`` with ``; b`` leaking
+        # into the outer shell, and ``$VAR``/``$(...)`` expanded empty.
+        command = shlex.join(self.args.command)
         output: list[str] = []
         try:
             with LockedTargets(list(targets.values())):

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -60,6 +60,33 @@ def test_run_empty_targets_raises(mock_config):
         Run(args, mock_config, MagicMock(), prompt)()
 
 
+def test_run_quotes_shell_metacharacters(mock_config):
+    """A single argument with shell metacharacters must reach the host intact.
+
+    Pre-fix the args were space-joined without quoting, so
+    ``sh -c "VAR=x; echo $VAR"`` went on the wire as ``sh -c VAR=x; echo $VAR``
+    -- the remote shell then ran ``sh -c VAR=x`` and leaked ``; echo $VAR`` into
+    the outer shell, where ``$VAR`` expanded empty. ``shlex.join`` keeps the
+    script body as one quoted argument.
+    """
+    t = _target("h1")
+    prompt = _prompt(HostsGroup([t]))
+    args = Namespace(command=["sh", "-c", "VAR=x; echo $VAR"], hosts=None)
+
+    @contextmanager
+    def noop_ctx(_):
+        yield
+
+    with (
+        patch("mtui.commands.run.LockedTargets", noop_ctx),
+        patch("mtui.commands.run.page"),
+        patch.object(HostsGroup, "run") as hg_run,
+    ):
+        Run(args, mock_config, MagicMock(), prompt)()
+
+    hg_run.assert_called_once_with("sh -c 'VAR=x; echo $VAR'")
+
+
 def test_run_target_locked_returns_without_unbound_local(mock_config):
     """A ``TargetLockedError`` during locking must not crash with ``UnboundLocalError``.
 


### PR DESCRIPTION
## Problem

`run` and `lrun` build the command string by space-joining the argument list **without quoting**, then hand it to the remote (`run`) or local (`lrun`, `shell=True`) shell. A single argument containing shell metacharacters loses its quoting on the way to the shell:

- `run ["sh","-c","VAR=x; echo $VAR"]` goes on the wire as `sh -c VAR=x; echo $VAR`. The shell runs `sh -c VAR=x` (sets nothing) and then `; echo $VAR` in the **outer** shell, where `$VAR` is unset → empty output.
- `run ["sh","-c","cp a b"]`-style bodies collapse: `sh -c cp` runs `cp` with **no arguments** (`cp: missing file operand`).
- `$(...)` command substitutions and `for ...; do ...; done` bodies passed as one argument are mangled the same way.

This is the long-standing "wrap it in `sh -c` but the body still gets eaten" behaviour.

## Fix

Join with `shlex.join`, which quotes each argument as needed:

- Simple commands are unchanged: `["uname","-a"]` → `uname -a`.
- A script body passed as one argument stays intact: `["sh","-c","VAR=x; echo $VAR"]` → `sh -c 'VAR=x; echo $VAR'`.

Shell operators (pipes, redirection) are expected inside an explicit `sh -c '...'` (documented in the docstrings).

## Tests

- New `test_run_quotes_shell_metacharacters` asserts the quoted form reaches `HostsGroup.run`.
- Existing `run`/`lrun` tests still pass unchanged (simple commands are identical under `shlex.join`).
- Full suite: 1650 passed; `ruff` and `ty check` clean.