### PR TITLE
fix(repo_manager): refresh transactional hosts via transactional-update

### DIFF
--- a/mtui/hosts/target/repo_manager.py
+++ b/mtui/hosts/target/repo_manager.py
@@ -101,4 +101,32 @@ class RepoManager:
                 sorted(str(p) for p in t.system.flatten()),
             )
 
-        t.run("zypper -n ref")
+        # Refresh repo metadata. On a transactional (read-only root) host this
+        # must go through transactional-update: a `zypper ref` of a signed repo
+        # whose signing key is not yet trusted imports that key into the rpmdb,
+        # which fails on the read-only /usr/lib/sysimage/rpm ("can't create
+        # transaction lock ... Read-only file system") and aborts the refresh --
+        # breaking prepare/update before the package step. Routing it through
+        # `transactional-update --continue run` gives zypper a writable rpmdb in
+        # a snapshot (activated by the reboot the prepare/update flow already
+        # performs for transactional hosts), and --gpg-auto-import-keys lets it
+        # import the repo key non-interactively. The package step uses
+        # `transactional-update -C` (continue), so it stacks on this snapshot.
+        if t.transactional:
+            ref = (
+                "transactional-update --continue --non-interactive run "
+                "zypper --gpg-auto-import-keys -n ref"
+            )
+        else:
+            ref = "zypper -n ref"
+        t.run(ref)
+        # Surface a failed refresh instead of returning silent success.
+        if t.lastexit() not in (0, "0"):
+            err = t.lasterr().strip() or t.lastout().strip()
+            logger.warning(
+                "refreshing repos on %s failed: %s exited %s%s",
+                t.hostname,
+                ref,
+                t.lastexit(),
+                f" ({err.splitlines()[-1]})" if err else "",
+            )

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -139,6 +139,32 @@ def test_run_zypper_warns_when_no_product_matches(mock_target, mock_rrid, caplog
     ), [r.message for r in caplog.records]
 
 
+def test_run_zypper_transactional_routes_ref_through_transactional_update(
+    mock_target, mock_rrid
+):
+    """On a transactional host the final refresh is wrapped in transactional-update.
+
+    A plain ``zypper ref`` of a signed repo whose key is not yet trusted imports
+    that key into the read-only rpmdb and fails; routing it through
+    ``transactional-update --continue run zypper --gpg-auto-import-keys ref``
+    gives zypper a writable snapshot and lets it import the key.
+    """
+    mock_target.state = "enabled"
+    mock_target.transactional = True
+    mock_target.connection.run.return_value = 0
+    mock_target.connection.stdout = ""
+    mock_target.connection.stderr = ""
+    mock_target.system = MagicMock()
+    mock_target.system.flatten.return_value = {Product("SL-Micro", "6-1", "x86_64")}
+    repos = {Product("SL-Micro", "6-1", "x86_64"): "https://example/repo"}
+    mock_target.repo_manager.run_zypper("ar", repos, mock_rrid)
+    commands = [c[0][0] for c in mock_target.connection.run.call_args_list]
+    assert commands[-1] == (
+        "transactional-update --continue --non-interactive run "
+        "zypper --gpg-auto-import-keys -n ref"
+    )
+
+
 def test_run_zypper_ar_warns_on_zypper_failure(mock_target, mock_rrid, caplog):
     """A non-zero ``zypper ar`` exit is surfaced as a WARNING, not swallowed."""
     import logging


### PR DESCRIPTION
## Problem

On a **transactional** (read-only root) host, the trailing `zypper -n ref` in `RepoManager.run_zypper` fails whenever a configured repo's signing key is not yet trusted. zypper tries to import the key into the read-only rpmdb at `/usr/lib/sysimage/rpm`, which can't take the `.rpm.lock`:

```
error: can't create transaction lock on /usr/lib/sysimage/rpm/.rpm.lock (Read-only file system)
Repository 'qa:16.0::pool' is invalid.
 - Signature verification failed for repomd.xml
```

The refresh then aborts — so `prepare`/`update` die before the package step. This is what breaks `mtui prepare` on SL Micro / SLFO:1.1 hosts. Reproduced on `qa:16.0::pool` (QA:SLE16.0), whose repomd is signed by the **QA OBS Project key** (`19d1909a`) that the host had not yet imported — and a read-only host can't import it at refresh time.

The package-mutating verbs already route through `transactional-update` for transactional hosts (the `('slmicro', True)` doer templates); only the repo refresh did not.

## Fix

Route the refresh through `transactional-update --continue --non-interactive run zypper --gpg-auto-import-keys -n ref` when `target.transactional`:

- the snapshot gives zypper a **writable rpmdb**, so it can import the repo key;
- `--gpg-auto-import-keys` imports it non-interactively;
- the package step uses `transactional-update -C` (continue), so it **stacks on this snapshot**, and the reboot the prepare/update flow already performs for transactional hosts activates everything.

Non-transactional hosts keep the plain `zypper -n ref` (unchanged). Also surface a non-zero refresh exit as a WARNING instead of swallowing it (matching the existing `ar` branch).

## Validated on a live SL-Micro 6.1 host

`transactional-update --continue run zypper --gpg-auto-import-keys -n ref` imported `gpg-pubkey-19d1909a` into a snapshot; after the reboot, a plain gpg-checked `zypper refresh --force qa:16.0::pool` **succeeds** on the live system (previously failed with the `.rpm.lock` error). Full suite: 1665 passed; `ruff` + `ty check` clean.