### PR TITLE
fix(transactional): install/downgrade all packages in one snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Transactional (read-only-root, SL Micro) hosts now install and downgrade every
+  package in a SINGLE `transactional-update` snapshot. The previous per-package
+  loop ran one `transactional-update pkg in` per package, each opening its own
+  snapshot, so the packages never landed together in the booted snapshot — the
+  prepare/downgrade reported success yet the packages were missing (or stayed at
+  the test version) after reboot. `prepare` and `downgrade` now pass the whole
+  package set to a single fresh-snapshot invocation, dropping the obsolete
+  `--continue`/`-C` chain and the separate init-snapshot/start-command canaries.
 - SLFO updates now run in AUTOMATIC mode. Their openQA install jobs
   (`qam-incidentinstall-SLFO`) were previously excluded from the auto workflow,
   forcing every SLFO update to fall back to manual; they are now recognised and

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -352,11 +352,6 @@ class HostsGroup(UserDict[str, Target]):
                 for t in self.data.values()
                 if t.transactional
             }
-            start = {
-                t.hostname: t.doer("preparer")["start_command"].substitute()
-                for t in self.data.values()
-                if t.transactional
-            }
         except MissingPreparerError as e:
             logger.error("%s", e)
             return
@@ -365,9 +360,10 @@ class HostsGroup(UserDict[str, Target]):
 
         try:
             self._fanout_set_repo(operation, testreport)
-            if start:
-                self.run(start)
 
+            # Abort early if adding/removing the issue repo failed on any host;
+            # installing against a half-configured repo set would only produce a
+            # confusing downstream error.
             for t in self.data.values():
                 if t.lasterr():
                     logger.critical(
@@ -379,14 +375,32 @@ class HostsGroup(UserDict[str, Target]):
                         t.lastexit(),
                     )
                     return
-            for pkg in pkgs:
+
+            if cmd == "installed_only":
+                # Conditional per-package install (only touch already-installed
+                # packages) -- inherently one package at a time.
+                for pkg in pkgs:
+                    command = {
+                        t.hostname: t.doer("preparer", force, testing)[cmd].substitute(
+                            package=pkg
+                        )
+                        for t in self.data.values()
+                    }
+                    self.run(command)
+            elif pkgs:
+                # Install every package in a SINGLE transaction. This is required
+                # for transactional (read-only-root) hosts: a per-package loop
+                # runs one `transactional-update pkg in` per package, each opening
+                # its own snapshot, so the packages never end up together in the
+                # booted snapshot -- the install "succeeds" yet they are missing
+                # after reboot. One call -> one snapshot -> one reboot. (Matches
+                # the comment above and the single-call slm_update patch path.)
                 command = {
                     t.hostname: t.doer("preparer", force, testing)[cmd].substitute(
-                        package=pkg
+                        package=" ".join(pkgs)
                     )
                     for t in self.data.values()
                 }
-
                 self.run(command)
 
             for t in self.data.values():
@@ -427,11 +441,6 @@ class HostsGroup(UserDict[str, Target]):
                 for t in self.data.values()
                 if t.transactional
             }
-            init_snapshot = {
-                t.hostname: t.doer("downgrader")["init_snapshot"].substitute()
-                for t in self.data.values()
-                if t.transactional
-            }
         except MissingDowngraderError as e:
             logger.error("%s", e)
             return
@@ -468,28 +477,61 @@ class HostsGroup(UserDict[str, Target]):
                     version = sorted(release[name], key=RPMVersion, reverse=True)[0]
                     versions.setdefault(hn, {}).update({name: version})
 
-            if init_snapshot:
-                self.run(init_snapshot)
+            transactional_hosts = {h for h, t in self.data.items() if t.transactional}
 
+            # Non-transactional hosts: per-package zypper downgrade (each gated on
+            # the package being installed) -- unchanged behaviour.
             for package in packages:
                 cmd = {
                     h: t.doer("downgrader")["command"].safe_substitute(
                         package=package, version=versions[h][package]
                     )
                     for h, t in self.data.items()
-                    if h in versions and package in versions[h]
+                    if h not in transactional_hosts
+                    and h in versions
+                    and package in versions[h]
                 }
                 if cmd:
                     self.run(cmd)
 
-                    for t in self.data.values():
-                        t.check("downgrader")(
-                            t.hostname,
-                            t.lastout(),
-                            t.lastin(),
-                            t.lasterr(),
-                            t.lastexit(),
-                        )
+                    for h, t in self.data.items():
+                        if h not in transactional_hosts:
+                            t.check("downgrader")(
+                                t.hostname,
+                                t.lastout(),
+                                t.lastin(),
+                                t.lasterr(),
+                                t.lastexit(),
+                            )
+
+            # Transactional hosts: downgrade ALL packages in a SINGLE
+            # transaction/snapshot. A per-package loop opens a snapshot per
+            # package and they never land together, so the packages stay at the
+            # test version after reboot (the prepare/newpackage failure mode).
+            combined = {}
+            for h in transactional_hosts:
+                specs = [
+                    f"{p}={versions[h][p]}"
+                    for p in packages
+                    if h in versions and p in versions[h]
+                ]
+                if specs:
+                    combined[h] = (
+                        self.data[h]
+                        .doer("downgrader")["command"]
+                        .safe_substitute(package=" ".join(specs))
+                    )
+            if combined:
+                self.run(combined)
+                for h in combined:
+                    t = self.data[h]
+                    t.check("downgrader")(
+                        t.hostname,
+                        t.lastout(),
+                        t.lastin(),
+                        t.lasterr(),
+                        t.lastexit(),
+                    )
 
             self._reboot(reboot)
         except MissingDowngraderError:

--- a/mtui/update_workflow/actions/downgrade.py
+++ b/mtui/update_workflow/actions/downgrade.py
@@ -48,15 +48,23 @@ done \
 | awk -F "|" '{{ print $2,"=",$4 }}'
 """
 
-    cmd_template = "rpm -q $package &>/dev/null && transactional-update -c pkg in -C --force-resolution --oldpackage -y $package=$version"
+    # Downgrade ALL packages in a single fresh snapshot (no --continue, no
+    # separate init snapshot): ``$package`` carries the whole "name=version ..."
+    # spec list so one transactional-update call lands them together and one
+    # reboot activates them. The previous per-package ``-c ... -C`` chain plus a
+    # ``transactional-update run true`` init snapshot opened a snapshot per
+    # package, which did not accumulate -- the downgrade "succeeded" yet the
+    # packages stayed at the test version after reboot (same failure mode as
+    # prepare/newpackage).
+    cmd_template = (
+        "transactional-update -n pkg in --force-resolution --oldpackage -y $package"
+    )
     reboot = "systemctl reboot"
-    init_snapshot = "transactional-update run true"
 
     return {
         "list_command": Template(list_command_template),
         "command": Template(cmd_template),
         "reboot": Template(reboot),
-        "init_snapshot": Template(init_snapshot),
     }
 
 

--- a/mtui/update_workflow/actions/prepare.py
+++ b/mtui/update_workflow/actions/prepare.py
@@ -61,11 +61,14 @@ def slm_prepare(force: bool = False, testing: bool = False) -> dict[str, Templat
 
     """
     parameter = "--force-resolution" if force else ""
+    # Install in a SINGLE fresh snapshot (no --continue): the caller passes all
+    # packages to one invocation, so they land together and a single reboot
+    # activates them. The previous `--continue` + per-package "start operation"
+    # canary chained a separate snapshot per package, which did not accumulate --
+    # the packages "succeeded" but were missing after reboot. This mirrors the
+    # working single-call slm_update patch path.
     return {
-        "start_command": Template("transactional-update run echo 'start operation'"),
-        "command": Template(
-            f"transactional-update -n -C pkg in -l {parameter} $package"
-        ),
+        "command": Template(f"transactional-update -n pkg in -l {parameter} $package"),
         "installed_only": Template(
             f"if $(rpm -q $package &>/dev/null); then transactional-update -n pkg in -l {parameter} $package ; fi"
         ),

--- a/tests/test_actions_downgrade.py
+++ b/tests/test_actions_downgrade.py
@@ -15,9 +15,15 @@ def test_zypper_downgrade_uses_oldpackage() -> None:
 
 
 def test_slmicro_downgrade_uses_oldpackage() -> None:
-    """The transactional-update downgrade command also allows older versions."""
-    sub = slmicro()["command"].safe_substitute(package="bash", version="1.2-3")
-    assert "transactional-update -c pkg in" in sub
+    """The transactional-update downgrade command allows older versions and takes
+    the full ``name=version`` spec list as ``$package`` so all packages downgrade
+    in a single fresh snapshot (no ``--continue`` / init snapshot, which left
+    packages at the test version after reboot)."""
+    cmds = slmicro()
+    sub = cmds["command"].safe_substitute(package="bash=1.2-3 vim=2.0-1")
+    assert "transactional-update -n pkg in" in sub
+    assert "-C" not in cmds["command"].template
+    assert "init_snapshot" not in cmds
     assert "--oldpackage" in sub
     assert "--force-resolution" in sub
-    assert "bash=1.2-3" in sub
+    assert "bash=1.2-3 vim=2.0-1" in sub

--- a/tests/test_actions_prepare.py
+++ b/tests/test_actions_prepare.py
@@ -33,7 +33,23 @@ def test_slm_prepare_force_adds_force_resolution() -> None:
     sub = cmds["command"].safe_substitute(package="bash")
     assert "--force-resolution" in sub
     assert "reboot" in cmds
-    assert "start_command" in cmds
+
+
+def test_slm_prepare_command_is_single_fresh_snapshot() -> None:
+    """The slmicro prepare command must NOT use ``--continue``/``-C`` and must
+    not rely on a separate ``start_command`` canary: each prepare runs as one
+    fresh ``transactional-update pkg in`` so a one-shot multi-package install
+    lands atomically and survives the reboot. A per-package ``-C`` chain left the
+    packages missing after reboot even though the command "succeeded"."""
+    cmds = slm_prepare()
+    template = cmds["command"].template
+    assert "-C" not in template
+    assert "--continue" not in template
+    assert "start_command" not in cmds
+    sub = cmds["command"].safe_substitute(package="pkg-a pkg-b pkg-c")
+    assert "transactional-update" in sub
+    assert "pkg in" in sub
+    assert "pkg-a pkg-b pkg-c" in sub  # all packages in one invocation
 
 
 def test_slm_prepare_default_no_force() -> None:

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -615,39 +615,39 @@ def test_perform_uninstall_transactional_triggers_reboot(mock_run):
 
 
 @patch("mtui.hosts.target.hostgroup.RunCommand")
-def test_perform_prepare_runs_per_package_command(mock_run):
-    """``perform_prepare`` runs the command-template once per package."""
+def test_perform_prepare_installs_all_packages_in_one_command(mock_run):
+    """``perform_prepare`` installs every package in a SINGLE command (one
+    transaction/snapshot), not one run per package -- the per-package loop left
+    packages missing after reboot on transactional hosts."""
     t1 = _stub_target("h1")
     t1.lasterr.return_value = ""
-    t1.doer.return_value = _doer_dict(
-        command="zypper in $package", reboot="", start_command=""
-    )
+    doer = _doer_dict(command="zypper in $package", reboot="")
+    t1.doer.return_value = doer
     t1.check.return_value = MagicMock()
     hg = HostsGroup([t1])  # type: ignore[arg-type]
     hg.perform_prepare(["pkg-a", "pkg-b"], MagicMock())
-    # 2 packages → 2 RunCommand invocations beyond the lock cleanup.
-    assert mock_run.call_count >= 2
-    t1.unlock.assert_called()
-
-
-@patch("mtui.hosts.target.hostgroup.RunCommand")
-def test_perform_prepare_filters_branding_upstream(mock_run):
-    """The hard-coded ``branding-upstream`` name is excluded from per-pkg cmds."""
-    t1 = _stub_target("h1")
-    t1.lasterr.return_value = ""
-    t1.doer.return_value = _doer_dict(
-        command="zypper in $package", reboot="", start_command=""
-    )
-    t1.check.return_value = MagicMock()
-    hg = HostsGroup([t1])  # type: ignore[arg-type]
-    hg.perform_prepare(["pkg-a", "branding-upstream", "pkg-b"], MagicMock())
-    # 2 surviving packages.
     per_pkg_calls = [
         c
         for c in mock_run.call_args_list
         if isinstance(c.args[1], dict) and "h1" in c.args[1]
     ]
-    assert len(per_pkg_calls) == 2
+    assert len(per_pkg_calls) == 1  # one combined call, not one-per-package
+    doer["command"].substitute.assert_called_once_with(package="pkg-a pkg-b")
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_prepare_filters_branding_upstream(mock_run):
+    """The hard-coded ``branding-upstream`` name is excluded from the combined
+    install command."""
+    t1 = _stub_target("h1")
+    t1.lasterr.return_value = ""
+    doer = _doer_dict(command="zypper in $package", reboot="")
+    t1.doer.return_value = doer
+    t1.check.return_value = MagicMock()
+    hg = HostsGroup([t1])  # type: ignore[arg-type]
+    hg.perform_prepare(["pkg-a", "branding-upstream", "pkg-b"], MagicMock())
+    doer["command"].substitute.assert_called_once_with(package="pkg-a pkg-b")
 
 
 @patch("mtui.hosts.target.hostgroup.RunCommand")
@@ -746,6 +746,31 @@ def test_perform_downgrade_unlocks_on_error(mock_run):
     mock_run.return_value.run.side_effect = RuntimeError("downgrade boom")
     with pytest.raises(RuntimeError, match="downgrade boom"):
         hg.perform_downgrade(["pkg-a"], MagicMock())
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_transactional_combines_packages(mock_run):
+    """A transactional host downgrades EVERY package in a SINGLE command (one
+    transaction/snapshot): the per-package loop opened a snapshot per package and
+    they never landed together, so the packages stayed at the test version after
+    reboot. The combined call must substitute the full ``name=version`` spec list
+    once, and the downgrader check must run for the transactional host."""
+    t1 = _stub_target("h1", transactional=True)
+    # list_command output parsed into versions: pkg-a -> 1.5-1, pkg-b -> 2.0-1.
+    t1.lastout.return_value = "pkg-a = 1.5-1\npkg-b = 2.0-1\n"
+    command = MagicMock(safe_substitute=MagicMock(return_value="tu pkg in ..."))
+    t1.doer.return_value = {
+        **_doer_dict(reboot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
+        "command": command,
+    }
+    t1.check.return_value = MagicMock()
+    hg = HostsGroup([t1])
+    hg.perform_downgrade(["pkg-a", "pkg-b"], MagicMock())
+    # Every spec joined into ONE invocation, not one call per package.
+    command.safe_substitute.assert_called_once_with(package="pkg-a=1.5-1 pkg-b=2.0-1")
+    t1.check.assert_called_with("downgrader")
     t1.unlock.assert_called()
 
 


### PR DESCRIPTION
## Problem

On transactional (read-only-root) hosts (SL Micro), `prepare --newpackage` and `downgrade` opened a **separate `transactional-update` snapshot per package**: a per-package `-C`/`--continue` chain preceded by a `transactional-update run echo 'start operation'` / `run true` canary snapshot. Those snapshots do **not** accumulate, so the operation reports success while:

- **prepare/`--newpackage`**: the new packages are *missing* after reboot, and
- **downgrade**: the packages stay at the *test version* after reboot.

Reproduced on SL-Micro 6.1: `transactional-update run echo start` followed by two sequential `transactional-update -C ...` calls + reboot left **neither** change active. Observed in the wild: `mtui update --newpackage` of a not-installed package reported `update succeeded` but `rpm -q` showed the packages missing on both arches.

The working `slm_update` patch step already uses a **single** `transactional-update pkg in` call (no `-C`), and every manual single-call install behaves correctly — confirming one-call-per-transaction is the right model.

## Fix

Install/downgrade every package in a **single** `transactional-update` call (one snapshot → one reboot):

- **`slm_prepare`**: drop the `start_command` canary and `-C`. `perform_prepare` now substitutes all packages into one command for the `command` path (the `installed_only` per-package path is unchanged). This matches the long-standing "all packages prepared in one step" comment that the per-package loop contradicted.
- **`slmicro` downgrade**: drop `init_snapshot` and `-c ... -C`. `$package` now carries the full `name=version ...` spec list; `perform_downgrade` issues one combined call on transactional hosts. The **non-transactional zypper per-package path is unchanged**.
- The `perform_prepare` set_repo error guard is preserved (moved adjacent to the repo step).

## Tests

Updated the affected unit tests (single-call assertions; no `-C`/canary) and added coverage that the combined command carries all packages. Full suite green: **1666 passed**.

## Note

The fix is unit-tested; end-to-end re-verification on a transactional refhost requires running the patched code (an mtui-mcp restart picks it up).