### PR TITLE
feat(commands): fan out set_workflow, add_host, remove_host across templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `list_locks`). `unlock --pool --force` removes a pool claim held by another
   user or template.
 
+### Changed
+
+- `set_workflow`, `add_host`, and `remove_host` now fan out across all loaded
+  templates by default (each acting on that template's own report and host
+  list), matching the other action commands. Use `-T RRID`/`--template RRID` to
+  scope a single command to one loaded template, or `--all-templates` to request
+  fan-out explicitly.
+
 ### Removed
 
 - SMELT support has been removed; report data is now sourced from the TeReGen

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -67,12 +67,12 @@ report, for report-scoped commands). The fan-out commands are: ``run``,
 ``set_repo``, ``reboot``, ``put``, ``get``, ``commit``, ``checkout``,
 ``approve``, ``assign``, ``unassign``, ``reject``, ``comment``, ``show_diff``,
 ``analyze_diff``, ``reload_openqa``, ``openqa_overview``, ``openqa_jobs``,
-``checkers``, the report-bound inspection commands
+``checkers``, ``set_workflow``, the report-bound inspection commands
 ``list_metadata``, ``list_bugs``, ``list_update_commands``, ``list_versions``,
-``list_packages``, and ``show_update_repos``, the host-locking commands
-``lock`` and ``unlock``, and the host-listing commands ``list_hosts``,
-``list_locks``, ``list_timeout``, ``list_sessions``, ``show_log``, and
-``list_history``. Output for each template is prefixed with an
+``list_packages``, and ``show_update_repos``, the host-management commands
+``add_host``, ``remove_host``, ``lock`` and ``unlock``, and the host-listing
+commands ``list_hosts``, ``list_locks``, ``list_timeout``, ``list_sessions``,
+``show_log``, and ``list_history``. Output for each template is prefixed with an
 ``=== <RRID> ===`` banner so results stay attributable. The queue-browsing
 ``updates`` command is not template-scoped and does not fan out. ``regenerate``
 acts on the active template by default (use ``-T``/``--all-templates`` to
@@ -109,10 +109,14 @@ add_host
 
 ::
 
-  add_host [-t HOST] [-k]
+  add_host [-t HOST] [-k] [-T RRID | --all-templates]
 
 Adds another machine to the target host list.
 Without parameter adds all hosts from testplatform.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_), adding the host(s) to each template's
+own host list. Use ``-T RRID`` to scope to a single template.
 
 When adding hosts from a testplatform, mtui connects **one** reference host
 per test-target slot (product + version + arch + addons) rather than every
@@ -145,9 +149,13 @@ remove_host
 
 ::
 
-  remove_host [-t HOST]
+  remove_host [-t HOST] [-T RRID | --all-templates]
 
 Disconnects from given refhost(s) and removes them from the target host list.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_), removing the host(s) from each
+template's own host list. Use ``-T RRID`` to scope to a single template.
 
 .. warning::
   When used without parameters, the command removes all hosts.
@@ -522,12 +530,16 @@ set_workflow
 
 ::
   
-  set_workflow {auto,manual,kernel}
+  set_workflow {auto,manual,kernel} [-T RRID | --all-templates]
 
 Sets workflow and reload data from openQA.
 
 'auto' workflow will be automatically set to manual if openQA install tests
 missing or have failed state
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_), reloading openQA data for each. Use
+``-T RRID`` to scope to a single template.
 
 .. option:: workflow
 

--- a/mtui/commands/addhost.py
+++ b/mtui/commands/addhost.py
@@ -3,7 +3,7 @@
 import concurrent.futures
 from logging import getLogger
 
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from ..support.concurrency import ContextExecutor
 from ..types import Workflow
 from . import Command
@@ -18,6 +18,7 @@ class AddHost(Command):
     """
 
     command = "add_host"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser) -> None:
@@ -34,6 +35,7 @@ class AddHost(Command):
             action="store_true",
             help="do not switch to the manual workflow when in automatic mode",
         )
+        cls._add_template_arg(parser)
 
     def __call__(self) -> None:
         """Executes the `add_host` command."""
@@ -61,4 +63,8 @@ class AddHost(Command):
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
-        return complete_choices([("-t", "--target"), ("-k", "--keep-mode")], line, text)
+        return complete_choices(
+            [("-t", "--target"), ("-k", "--keep-mode"), *template_completion(state)],
+            line,
+            text,
+        )

--- a/mtui/commands/removehost.py
+++ b/mtui/commands/removehost.py
@@ -3,7 +3,7 @@
 import concurrent.futures
 
 from ..cli.argparse import ArgumentParser
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from ..support.concurrency import ContextExecutor
 from . import Command
 
@@ -18,11 +18,13 @@ class RemoveHost(Command):
     """
 
     command = "remove_host"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
         """Adds arguments to the command's argument parser."""
         cls._add_hosts_arg(parser)
+        cls._add_template_arg(parser)
 
     def _remove_target(self, target) -> None:
         """Removes a single target host.
@@ -53,5 +55,8 @@ class RemoveHost(Command):
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
         return complete_choices(
-            [("-t", "--target")], line, text, state["hosts"].names()
+            [("-t", "--target"), *template_completion(state)],
+            line,
+            text,
+            state["hosts"].names(),
         )

--- a/mtui/commands/simpleset.py
+++ b/mtui/commands/simpleset.py
@@ -3,7 +3,7 @@
 import logging
 
 from ..cli.argparse import ArgumentParser
-from ..cli.completion import complete_choices
+from ..cli.completion import complete_choices, template_completion
 from ..data_sources.openqa import KernelOpenQA
 from ..data_sources.qem_dashboard import DashboardAutoOpenQA
 from ..support.misc import requires_update
@@ -107,6 +107,7 @@ class SetWorkflow(Command):
     """
 
     command = "set_workflow"
+    scope = "fanout"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -114,6 +115,7 @@ class SetWorkflow(Command):
         parser.add_argument(
             "workflow", choices=["auto", "manual", "kernel"], help="desired workflow"
         )
+        cls._add_template_arg(parser)
 
     @requires_update
     def __call__(self) -> None:
@@ -185,4 +187,8 @@ class SetWorkflow(Command):
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:
         """Provides tab completion for the command."""
-        return complete_choices([("auto",), ("manual",), ("kernel",)], line, text)
+        return complete_choices(
+            [("auto",), ("manual",), ("kernel",), *template_completion(state)],
+            line,
+            text,
+        )

--- a/tests/test_cmd_addhost.py
+++ b/tests/test_cmd_addhost.py
@@ -141,3 +141,33 @@ def test_add_host_in_manual_mode_does_not_switch(mock_config):
     AddHost(args, mock_config, MagicMock(), prompt)()
 
     prompt.set_prompt.assert_not_called()
+
+
+def test_add_host_is_fanout():
+    """add_host fans out across every loaded template by default."""
+    assert AddHost.scope == "fanout"
+
+
+def test_add_host_accepts_template_flag():
+    ns = AddHost.parse_args("-T SUSE:Maintenance:1:1", sys)
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+def test_add_host_accepts_all_templates_flag():
+    ns = AddHost.parse_args("--all-templates", sys)
+    assert ns.all_templates is True
+    assert ns.template is None
+
+
+def test_add_host_defaults_have_template_flags():
+    default = AddHost.parse_args("", sys)
+    assert default.template is None
+    assert default.all_templates is False
+
+
+def test_add_host_complete_offers_template_rrids():
+    templates = MagicMock()
+    templates.rrids.return_value = ["SUSE:Maintenance:1:1"]
+    out = AddHost.complete({"hosts": [], "templates": templates}, "", "add_host ", 9, 9)
+    assert "SUSE:Maintenance:1:1" in out

--- a/tests/test_cmd_removehost.py
+++ b/tests/test_cmd_removehost.py
@@ -147,3 +147,31 @@ def test_release_pool_claim_keeps_sibling_candidates():
     assert report._slot_candidates == {slot: ["rosa"]}
     assert report._pool_claims == set()
     assert arb.owner_of("bianca") is None
+
+
+def test_remove_host_is_fanout():
+    """remove_host fans out across every loaded template by default."""
+    assert RemoveHost.scope == "fanout"
+
+
+def test_remove_host_accepts_template_flag():
+    ns = RemoveHost.parse_args("-T SUSE:Maintenance:1:1", MagicMock())
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+def test_remove_host_accepts_all_templates_flag():
+    ns = RemoveHost.parse_args("--all-templates", MagicMock())
+    assert ns.all_templates is True
+    assert ns.template is None
+
+
+def test_remove_host_complete_offers_template_rrids():
+    templates = MagicMock()
+    templates.rrids.return_value = ["SUSE:Maintenance:1:1"]
+    hosts = MagicMock()
+    hosts.names.return_value = []
+    out = RemoveHost.complete(
+        {"hosts": hosts, "templates": templates}, "", "remove_host ", 12, 12
+    )
+    assert "SUSE:Maintenance:1:1" in out

--- a/tests/test_simpleset.py
+++ b/tests/test_simpleset.py
@@ -27,3 +27,28 @@ def test_set_workflow_auto_uses_rrid(mock_config):
         prompt.metadata.incident,
         prompt.metadata.rrid,
     )
+
+
+def test_set_workflow_is_fanout():
+    """set_workflow fans out across every loaded template by default."""
+    assert SetWorkflow.scope == "fanout"
+
+
+def test_set_workflow_accepts_template_flag():
+    ns = SetWorkflow.parse_args("-T SUSE:Maintenance:1:1 manual", MagicMock())
+    assert ns.workflow == "manual"
+    assert ns.template == "SUSE:Maintenance:1:1"
+    assert ns.all_templates is False
+
+
+def test_set_workflow_accepts_all_templates_flag():
+    ns = SetWorkflow.parse_args("--all-templates manual", MagicMock())
+    assert ns.all_templates is True
+    assert ns.template is None
+
+
+def test_set_workflow_complete_offers_template_rrids():
+    templates = MagicMock()
+    templates.rrids.return_value = ["SUSE:Maintenance:1:1"]
+    out = SetWorkflow.complete({"templates": templates}, "", "set_workflow ", 13, 13)
+    assert "SUSE:Maintenance:1:1" in out


### PR DESCRIPTION
## Summary

Three REPL commands mutated per-template state but were stuck on the default `active` scope, so in a multi-template session they silently acted on the **active template only** — an inconsistent gap in the fan-out model the rest of the action commands already follow.

This brings them in line:

| Command | Was | Now |
|---|---|---|
| `set_workflow` | set `metadata.workflow` + openQA reload on the active template | fans out across all loaded templates |
| `add_host` | added hosts to the active template's host group | adds to every loaded template's own group |
| `remove_host` | removed from the active template only | removes from every loaded template |

Each gained `scope = "fanout"` plus `-T/--template` and `--all-templates` (via `_add_template_arg`), and template-RRID tab completion. Per-template `=== <RRID> ===` banners and per-template error isolation (`FanOutError` aggregate) come for free from the base `run()` dispatcher.

## Changes

- `mtui/commands/simpleset.py` — `SetWorkflow` fan-out + template flag/completion
- `mtui/commands/addhost.py` — `AddHost` fan-out + template flag/completion
- `mtui/commands/removehost.py` — `RemoveHost` fan-out + template flag/completion
- `tests/test_simpleset.py`, `tests/test_cmd_addhost.py`, `tests/test_cmd_removehost.py` — 12 new tests (scope, `-T`/`--all-templates` parsing, defaults, RRID completion)
- `Documentation/iui.rst` — added the three to the fan-out command list and documented per-command behaviour
- `CHANGELOG.md` — new `### Changed` entry under `[Unreleased]`

## Behaviour change note

For multi-template sessions, `remove_host` with no args now means "remove all hosts across all loaded templates" by default (was: active template only). Documented in the changelog and `iui.rst`. Scope to one with `-T RRID`.

## Verification (whole repo, all green)

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — **1680 passed**
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html` — build succeeded