### PR TITLE
fix(mcp): drop active-template semantics that MCP clients cannot address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   list), matching the other action commands. Use `-T RRID`/`--template RRID` to
   scope a single command to one loaded template, or `--all-templates` to request
   fan-out explicitly.
+- Over `mtui-mcp`, tools that previously acted on the "active" template now fan
+  out across every loaded template when more than one is loaded and no
+  `template`/`-T` is given, since MCP has no client-addressable active pointer
+  (`switch` is REPL-only). Pass `template=RRID` to scope a call to a single
+  template. `list_templates` no longer shows the `*` active marker over MCP
+  (the marker remains in the interactive REPL).
 
 ### Removed
 

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -252,7 +252,11 @@ class Command(ABC):
         1. ``-T/--template RRID`` → exactly that template (raises
            :class:`TemplateNotLoadedError` if it is not loaded).
         2. ``--all-templates`` or ``scope == "fanout"`` → every loaded template.
-        3. otherwise → the active template only.
+        3. otherwise → the active template only, **except** under MCP (a
+           non-interactive prompt) with more than one template loaded, where
+           there is no client-addressable "active" pointer (``switch`` is a
+           REPL-only command), so the call fans out across every loaded
+           template instead.
 
         The fan-out branches fall back to the active template when the registry
         is empty so an unloaded session behaves exactly like the historical
@@ -267,6 +271,13 @@ class Command(ABC):
 
         if getattr(self.args, "all_templates", False) or self.scope == "fanout":
             return self.templates.all() or [self.templates.active]
+
+        # Under MCP there is no interactive ``switch``, so the active pointer is
+        # hidden, unaddressable state. With several templates loaded, default an
+        # otherwise-unscoped call to fanout instead of silently picking the
+        # last-loaded one. The REPL keeps its active-template behaviour.
+        if not getattr(self.prompt, "interactive", True) and len(self.templates) > 1:
+            return self.templates.all()
 
         return [self.templates.active]
 

--- a/mtui/commands/templates.py
+++ b/mtui/commands/templates.py
@@ -7,8 +7,10 @@ class ListTemplates(Command):
     """Lists all loaded templates, marking the active one.
 
     For each loaded template the RRID, connected host count and workflow
-    mode are shown. The active template (the one plain action commands act
-    on) is marked with a leading ``*``.
+    mode are shown. In the REPL the active template (the one plain action
+    commands act on) is marked with a leading ``*``. Under MCP there is no
+    client-addressable active pointer (``switch`` is REPL-only), so the
+    marker is omitted.
     """
 
     command = "list_templates"
@@ -20,9 +22,13 @@ class ListTemplates(Command):
             self.println("No templates loaded.")
             return
 
+        # The active pointer is only meaningful in the interactive REPL, where
+        # ``switch`` can move it. Under MCP it is hidden state the client cannot
+        # address, so do not advertise it with a marker.
+        interactive = getattr(self.prompt, "interactive", True)
         active = self.templates.active
         for report in reports:
-            marker = "*" if report is active else " "
+            marker = "*" if interactive and report is active else " "
             hosts = len(report.targets)
             mode = report.workflow.value
             self.println(f"{marker} {report.id}  hosts: {hosts}  mode: {mode}")

--- a/tests/test_cmd_templates.py
+++ b/tests/test_cmd_templates.py
@@ -33,9 +33,10 @@ def _registry(*reports):
     return reg
 
 
-def _prompt(registry):
+def _prompt(registry, *, interactive=True):
     p = MagicMock()
     p.templates = registry
+    p.interactive = interactive
     return p
 
 
@@ -68,3 +69,17 @@ def test_list_templates_marks_active(mock_config):
     assert lines[1].startswith("* SUSE:Maintenance:2:2")
     assert "hosts: 1" in lines[1]
     assert "mode: kernel" in lines[1]
+
+
+def test_list_templates_omits_active_marker_under_mcp(mock_config):
+    r1 = _report("SUSE:Maintenance:1:1", hosts=2, workflow=Workflow.AUTO)
+    r2 = _report("SUSE:Maintenance:2:2", hosts=1, workflow=Workflow.KERNEL)
+    reg = _registry(r1, r2)
+    reg.set_active("SUSE:Maintenance:2:2")
+    lines = _run(_prompt(reg, interactive=False), mock_config)
+
+    # No '*' marker over MCP: the active pointer is not client-addressable.
+    assert len(lines) == 2
+    assert "*" not in "".join(lines)
+    assert lines[0].startswith("  SUSE:Maintenance:1:1")
+    assert lines[1].startswith("  SUSE:Maintenance:2:2")

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -257,6 +257,9 @@ class _FakeRegistry:
     def get(self, rrid):
         return self._reports[rrid]
 
+    def __len__(self):
+        return len(self._reports)
+
     @property
     def active(self):
         return self._active
@@ -297,13 +300,16 @@ class FailingFanoutCommand(Command):
             raise RuntimeError(f"boom on {rrid}")
 
 
-def _make_cmd(cmd_cls, registry, *, template=None, all_templates=False):
+def _make_cmd(
+    cmd_cls, registry, *, template=None, all_templates=False, interactive=True
+):
     args = Namespace(template=template, all_templates=all_templates)
     prompt = MagicMock()
     prompt.templates = registry
     prompt.metadata = registry.active
     prompt.targets = registry.active.targets
     prompt.display = MagicMock()
+    prompt.interactive = interactive
     return cmd_cls(args, MagicMock(), MagicMock(), prompt)
 
 
@@ -344,6 +350,28 @@ class TestResolveTemplates:
         cmd = _make_cmd(FanoutCommand, reg)
         resolved = cmd._resolve_templates()
         assert resolved == [active]
+
+    def test_mcp_active_scope_fans_out_when_many_loaded(self):
+        # Under MCP (non-interactive) there is no addressable active pointer,
+        # so an unscoped active-scope command fans out across all templates.
+        reg = _FakeRegistry([_FakeReport("A"), _FakeReport("B")])
+        cmd = _make_cmd(CountingCommand, reg, interactive=False)
+        resolved = cmd._resolve_templates()
+        assert [str(r.id) for r in resolved] == ["A", "B"]
+
+    def test_mcp_active_scope_single_template_unchanged(self):
+        # With one template the MCP path is identical to the active fallback.
+        reg = _FakeRegistry([_FakeReport("A")])
+        cmd = _make_cmd(CountingCommand, reg, interactive=False)
+        resolved = cmd._resolve_templates()
+        assert [str(r.id) for r in resolved] == ["A"]
+
+    def test_repl_active_scope_still_returns_active_only(self):
+        # The interactive REPL keeps its active-template behaviour.
+        reg = _FakeRegistry([_FakeReport("A"), _FakeReport("B")])
+        cmd = _make_cmd(CountingCommand, reg, interactive=True)
+        resolved = cmd._resolve_templates()
+        assert [str(r.id) for r in resolved] == ["A"]
 
 
 class TestRun:


### PR DESCRIPTION
## Why

The "active template" pointer is REPL-only state, moved with the interactive `switch` command. MCP clients have no `switch`/`unload` tools (they are denied in `mtui.mcp.deny`), so the active pointer was hidden, unaddressable state set as a side effect of `load_template`.

This leaked into MCP in two ways:
- `list_templates` advertised an active template with a `*` marker the client could never move.
- An unscoped action tool silently acted on whichever template was loaded *last* instead of one the caller chose, making behaviour non-deterministic.

## What changed

- `_resolve_templates()` now defaults to **fanout** for `scope="active"` commands when running under a non-interactive (MCP) prompt with more than one template loaded. This aligns the foreground path with the existing per-template background-job fanout. Pass `template=RRID` / `-T RRID` to scope a single call.
- `list_templates` omits the `*` active marker under MCP; the REPL keeps it.
- `CHANGELOG.md` `[Unreleased]` entry.
- Focused tests for both paths (MCP fanout with many loaded, MCP single-template unchanged, REPL active-only unchanged, and the list_templates marker behaviour in both modes).

The REPL's active-template behaviour and marker are unchanged.

## Verification

Full gate set run on the whole repo, observed green:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 1684 passed
- `sphinx-build -W` — build succeeded (docstrings edited)