### PR TITLE
fix(mcp): close four multi-template correctness hazards in the MCP surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `unload` is now exposed as an `mtui-mcp` tool. It takes an RRID and drops
+  exactly that loaded template (closing only its host connections), leaving the
+  others loaded — the addressable counterpart to `load_template` for MCP
+  clients. It is single-target by design and never fans out, even with several
+  templates loaded. (`switch` stays REPL-only; select a template per call with
+  the `template` parameter.)
 - New `regenerate` command — regenerates the loaded update's test-report
   template via the TeReGen API (`POST /reports/{id}/regenerate`), waits for the
   generation job to finish, and reloads the fresh template. Supports `--force`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Over `mtui-mcp`, a command with a `nargs=REMAINDER` *optional* flag declared
+  before another flag (the shape used by `reject --message`) could have the
+  later flag swallowed into the message when re-encoding a tool call to argv.
+  The REMAINDER optional is now always emitted after every other flag, so the
+  trailing flag is parsed correctly regardless of argument declaration order.
 - Transactional (read-only-root, SL Micro) hosts now install and downgrade every
   package in a SINGLE `transactional-update` snapshot. The previous per-package
   loop ran one `transactional-update pkg in` per package, each opening its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (`switch` is REPL-only). Pass `template=RRID` to scope a call to a single
   template. `list_templates` no longer shows the `*` active marker over MCP
   (the marker remains in the interactive REPL).
+- Over `mtui-mcp`, the testreport file tools (`testreport_read`,
+  `testreport_logs`, `testreport_read_file`, `testreport_patch`,
+  `testreport_write`, `testreport_fill`) gained an optional `template=RRID`
+  parameter selecting which loaded template's checkout to act on. With more than
+  one template loaded they now refuse an unscoped call (naming the loaded RRIDs)
+  instead of silently editing the last-loaded one; single-template sessions are
+  unchanged.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   one template loaded they now refuse an unscoped call (naming the loaded RRIDs)
   instead of silently editing the last-loaded one; single-template sessions are
   unchanged.
+- Over `mtui-mcp`, loading a template (`load_template`, `regenerate`) no longer
+  moves the session's active-template pointer. The active template is REPL-only
+  navigation state; setting it on every load made it hidden, unaddressable
+  state that let unscoped tools silently act on the last-loaded template.
+  Clients now address a template explicitly per call (`template=`/`-T`), and an
+  unscoped action fans out across all loaded templates. A single-template
+  session is unchanged (the registry's active fallback is the only loaded
+  report).
 
 ### Removed
 

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -295,6 +295,11 @@ MCP tool surface. ``mtui/mcp/deny.py`` is the source of truth.
     - Launches local terminal-emulator scripts (``term.<name>.sh``)
       that spawn ``xterm``/``konsole``/etc. on the operator's
       ``$DISPLAY``.
+  * - ``switch``
+    - Moves the session's active-template pointer — REPL-only navigation
+      with no client-addressable equivalent over MCP (tools select a
+      template per call via the ``template`` parameter). ``unload`` is the
+      addressable counterpart and **is** exposed (it names its own RRID).
 
 Interactive-prompt defaults
 ---------------------------
@@ -550,10 +555,12 @@ others and reports an aggregate failure at the end.
 
 .. note::
 
-   ``switch`` and ``unload`` are **not** exposed as tools; moving the
-   active-template pointer is REPL-only navigation. Over MCP you target a
-   specific template per call with the ``template`` parameter instead;
-   ``list_templates`` remains available as a read-only listing.
+   ``switch`` is **not** exposed as a tool; moving the active-template
+   pointer is REPL-only navigation. Over MCP you target a specific template
+   per call with the ``template`` parameter instead. ``unload <rrid>`` **is**
+   exposed — it names its own RRID and drops exactly that template (closing
+   only its host connections), leaving the others loaded. ``list_templates``
+   remains available as a read-only listing.
 
 Background jobs (don't block on a slow host op)
 -----------------------------------------------

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -326,6 +326,15 @@ Three hand-written tools operate on the path tracked by
 ``no testreport loaded; run `load_template` first`` when no test
 report is loaded.
 
+Every testreport tool accepts an optional ``template="<RRID>"`` parameter
+selecting which loaded template's checkout to act on. There is no
+client-addressable active template over MCP (``switch`` is REPL-only), so
+with **more than one** template loaded an unscoped call is refused with
+``multiple templates loaded (...); pass template=<rrid>`` rather than
+silently editing the last-loaded report. With zero or one template loaded
+the parameter may be omitted and behaves as before. An unknown RRID is
+refused with ``template not loaded: <rrid>``.
+
 ``testreport_read(offset: int = None, limit: int = None) -> dict``
     Returns ``{"path": str, "line_count": int, "content": str}``.
     Reads the file as UTF-8 with ``errors="replace"``. Marked

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -43,6 +43,12 @@ class Command(ABC):
     #: action commands that are safe to repeat per template opt into
     #: ``"fanout"``; inherently single-target commands (``load_template``,
     #: ``edit``, ``switch``, ``quit``, …) keep ``"active"``.
+    #:
+    #: ``"single"`` is a stricter variant of ``"active"`` for commands that
+    #: name their own target template and must run **exactly once** regardless
+    #: of how many templates are loaded — e.g. ``unload <rrid>``, which would
+    #: otherwise fan out under MCP (where ``"active"`` defaults to fan-out with
+    #: several loaded) and try to remove the same RRID once per template.
     scope: ClassVar[str] = "active"
 
     #: Auto-populated registry of every concrete ``Command`` subclass that
@@ -268,6 +274,12 @@ class Command(ABC):
                 return [self.templates.get(rrid)]
             except KeyError:
                 raise TemplateNotLoadedError(rrid) from None
+
+        # Inherently single-target commands (``unload <rrid>``) name their own
+        # template and must run exactly once; never auto-fan-out them, not even
+        # under MCP with several loaded.
+        if self.scope == "single":
+            return [self.templates.active]
 
         if getattr(self.args, "all_templates", False) or self.scope == "fanout":
             return self.templates.all() or [self.templates.active]

--- a/mtui/commands/unload.py
+++ b/mtui/commands/unload.py
@@ -1,5 +1,7 @@
 """The `unload` command."""
 
+from typing import ClassVar
+
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
 from ..support.messages import TemplateNotLoadedError
@@ -14,6 +16,12 @@ class Unload(Command):
     """
 
     command = "unload"
+    #: ``unload`` names its own target RRID and removes exactly that template,
+    #: so it must run once regardless of how many templates are loaded. Without
+    #: this it would fan out under MCP (where ``"active"`` defaults to fan-out
+    #: with several loaded) and try to remove the same RRID once per template,
+    #: failing on the second pass with ``TemplateNotLoadedError``.
+    scope: ClassVar[str] = "single"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/mtui/mcp/_argv.py
+++ b/mtui/mcp/_argv.py
@@ -15,7 +15,15 @@ inverse of :func:`mtui.mcp._schema.action_to_parameter`:
   ``[[v1, v2, ...]]`` instead of swallowing a repeated flag as a value.
 * Positional ``nargs=REMAINDER``/``*``/``+`` → append elements verbatim
   at the end (after every flag-shaped argument), preserving order.
-* Optional scalar → emit ``[long_flag, str(value)]``.
+* Optional ``nargs=REMAINDER`` (e.g. ``reject --message``) → emit the
+  flag once followed by every token, but **into the positional tail** so
+  it lands after every other flag. A REMAINDER optional consumes all
+  remaining argv tokens, so emitting a later ``--flag`` behind it would
+  be swallowed as a value; deferring it to the tail keeps it safe
+  regardless of ``parser._actions`` declaration order.
+* Optional scalar / other multi-value (``+``/``*``/N) → emit
+  ``[long_flag, v1, v2, ...]`` (or ``[long_flag, str(value)]`` for a
+  scalar) among the flags.
 * Positional scalar → append ``str(value)`` after the flags.
 
 The function returns a list of strings; callers (notably
@@ -76,9 +84,11 @@ def kwargs_to_argv(
 
     Arguments are emitted in the same order ``parser._actions`` defines
     them so the output is deterministic and easy to read in logs. All
-    optional flags come out first, then positional values — argparse
-    accepts positionals after flags but not interleaved with them when
-    ``nargs=REMAINDER`` is involved.
+    plain optional flags come out first, then the positional tail —
+    argparse accepts positionals after flags but not interleaved with
+    them when ``nargs=REMAINDER`` is involved. A REMAINDER-consuming
+    *optional* (e.g. ``reject --message``) is also deferred to the tail
+    so it is emitted after every other flag and cannot swallow one.
 
     Args:
         parser: The command's :class:`argparse.ArgumentParser`. Used to
@@ -212,8 +222,18 @@ def kwargs_to_argv(
             # token. We must emit ``[--flag, v1, v2, ...]`` once, not
             # ``[--flag, v1, --flag, v2]`` (the latter would be parsed
             # as a single value list ``[v1, '--flag', v2]``).
-            flag_tokens.append(flag)
-            flag_tokens.extend(str(item) for item in value)
+            if action.nargs == argparse.REMAINDER:
+                # A REMAINDER optional swallows *every* remaining token,
+                # including a later ``--flag``. Emitting it inside
+                # ``flag_tokens`` is only safe when it happens to be the
+                # last flag declared; route it into the positional tail so
+                # it is always emitted after every other flag regardless of
+                # ``parser._actions`` order (e.g. ``reject --message``).
+                positional_tail.append(flag)
+                positional_tail.extend(str(item) for item in value)
+            else:
+                flag_tokens.append(flag)
+                flag_tokens.extend(str(item) for item in value)
         else:
             flag_tokens.extend([flag, str(value)])
 

--- a/mtui/mcp/deny.py
+++ b/mtui/mcp/deny.py
@@ -17,12 +17,17 @@ Per-entry rationale:
   already advertises tool descriptions to clients.
 - ``terms``: launches local terminal-emulator scripts (``term.<name>.sh``)
   that spawn ``xterm``/``konsole``/etc. on the operator's ``$DISPLAY``.
-- ``switch``, ``unload``: interactive multi-template navigation that mutates
-  the session's active-template pointer / loaded set. MCP multi-template
-  control is exposed instead through the per-tool ``template`` parameter
-  (Phase 4); ``list_templates`` remains available as a read-only listing.
+- ``switch``: interactive navigation that moves the session's active-template
+  pointer — REPL-only state with no client-addressable equivalent under MCP
+  (tools select a template per call via the ``template`` parameter, and
+  ``list_templates`` remains a read-only listing).
+
+``unload`` is **not** denied: it takes an explicit RRID, mutates only the
+loaded set (closing that template's host connections), needs no TTY, and does
+not call ``sys.exit``, so it is exposed as an MCP tool. It is the addressable
+counterpart to ``load_template`` for dropping one template from a session.
 """
 
 REPL_ONLY: frozenset[str] = frozenset(
-    {"quit", "exit", "EOF", "edit", "shell", "help", "terms", "switch", "unload"}
+    {"quit", "exit", "EOF", "edit", "shell", "help", "terms", "switch"}
 )

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -371,15 +371,22 @@ class McpSession:
             prompter=self.prompter,
         )
         # A failed load returns a NullTestReport sentinel (empty RRID).
-        # ``add`` ignores it; skip the active-pointer move too so a failed
-        # load leaves the registry and active template untouched instead of
-        # planting a phantom entry that breaks fan-out.
+        # ``add`` ignores it; nothing else to do for a failed load.
         self.templates.add(tr)
-        if str(tr.id):
-            self.templates.set_active(str(tr.id))
-        # Re-apply the non-interactive flag after the testreport swap so
-        # the fresh HostsGroup inherits the session's headless mode.
-        self.targets.interactive = False
+        # Deliberately do NOT move the active pointer here. The active template
+        # is REPL-only navigation state (moved by the ``switch`` command, which
+        # is denied over MCP); setting it as a side effect of every load made it
+        # hidden, unaddressable state and let unscoped tools silently act on the
+        # last-loaded template. MCP clients address a template explicitly per
+        # call (``template=``/``-T``); an unscoped action fans out across all
+        # loaded templates (see ``Command._resolve_templates``). The registry's
+        # ``active`` property still falls back to the first-loaded report so a
+        # single-template session behaves exactly as before.
+        #
+        # Re-apply the non-interactive flag on the *freshly loaded* report's
+        # host group (not ``self.targets``, which tracks the active pointer we
+        # no longer move) so it inherits the session's headless mode.
+        tr.targets.interactive = False
         # Run the deferred autoconnect now that ``add`` has wired the host
         # arbiter, so refhosts are drawn one-per-slot (with backup) instead of
         # connecting every candidate. No-op unless autoconnect was requested.

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -66,34 +66,94 @@ _READ_FIRST_WARNING = (
     "to get current line numbers; line numbers shift after every patch."
 )
 
+#: Glued onto every testreport tool description: there is no client-addressable
+#: active template under MCP, so a tool with several templates loaded must be
+#: told which one to act on.
+_TEMPLATE_NOTE = (
+    "Pass `template=<rrid>` to target a specific loaded template; required when "
+    "more than one template is loaded."
+)
+
 
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
 # --------------------------------------------------------------------------- #
 
 
-def _resolve_testreport_path(session: McpSession) -> Path:
-    """Return the loaded testreport's path or raise :class:`McpCommandError`.
+def _resolve_report(session: McpSession, template: str | None):
+    """Return the :class:`TestReport` a tool call should act on.
 
-    Two refusal conditions, both producing the same single-sentence
-    error message so the LLM does not have to disambiguate:
+    Resolution mirrors the auto-generated command tools' ``-T/--template``
+    contract (see :meth:`mtui.commands._command.Command._resolve_templates`)
+    but for the hand-written testreport tools, which act on exactly one file:
 
-    * ``session.metadata`` is a :class:`NullTestReport` (no template
-      ever loaded in this session).
-    * ``session.metadata.path`` is ``None`` (loaded but no on-disk
-      representation, defensive — should not happen in practice).
+    * ``template`` given → that loaded template, via
+      ``session.templates.get(rrid)``; an unknown RRID raises
+      :class:`McpCommandError`.
+    * ``template`` omitted with **more than one** template loaded → refuse and
+      tell the caller to pass ``template=<rrid>``. There is no client-
+      addressable "active" pointer under MCP, so silently picking one would be
+      a wrong-target hazard.
+    * ``template`` omitted with **zero or one** loaded → fall back to
+      ``session.metadata`` (the single loaded report or the
+      :class:`NullTestReport` sentinel), preserving the historical single-
+      template behaviour.
 
     Args:
         session: The active :class:`McpSession`.
+        template: Optional RRID of a loaded template to scope to.
+
+    Returns:
+        The selected :class:`TestReport` (possibly the NullTestReport
+        sentinel when nothing is loaded; the caller's path check rejects it).
+
+    Raises:
+        McpCommandError: When ``template`` names an unloaded RRID, or when it
+            is omitted while several templates are loaded.
+
+    """
+    if template is not None:
+        try:
+            return session.templates.get(template)
+        except KeyError:
+            raise McpCommandError("", f"template not loaded: {template}", 1) from None
+
+    loaded = session.templates.all()
+    if len(loaded) > 1:
+        rrids = ", ".join(str(r.id) for r in loaded)
+        raise McpCommandError(
+            "",
+            f"multiple templates loaded ({rrids}); pass template=<rrid>",
+            1,
+        )
+    return session.metadata
+
+
+def _resolve_testreport_path(session: McpSession, template: str | None = None) -> Path:
+    """Return the loaded testreport's path or raise :class:`McpCommandError`.
+
+    The target report is selected by :func:`_resolve_report` (honouring the
+    optional ``template`` RRID); the path is then validated. Two refusal
+    conditions produce the same single-sentence error message so the LLM does
+    not have to disambiguate:
+
+    * the resolved report is a :class:`NullTestReport` (no template loaded).
+    * its ``path`` is ``None`` (loaded but no on-disk representation,
+      defensive — should not happen in practice).
+
+    Args:
+        session: The active :class:`McpSession`.
+        template: Optional RRID of a loaded template to scope to.
 
     Returns:
         The :class:`pathlib.Path` pointing at the loaded testreport.
 
     Raises:
-        McpCommandError: When no testreport is loaded.
+        McpCommandError: When no testreport is loaded or ``template`` is
+            ambiguous/unknown (see :func:`_resolve_report`).
 
     """
-    metadata = session.metadata
+    metadata = _resolve_report(session, template)
     if isinstance(metadata, NullTestReport) or metadata.path is None:
         raise McpCommandError(
             "",
@@ -103,7 +163,7 @@ def _resolve_testreport_path(session: McpSession) -> Path:
     return Path(metadata.path)
 
 
-def _resolve_template_dir(session: McpSession) -> Path:
+def _resolve_template_dir(session: McpSession, template: str | None = None) -> Path:
     """Return the loaded testreport's checkout directory.
 
     This is the parent of the ``log`` file (``metadata.path``) — the directory
@@ -111,7 +171,7 @@ def _resolve_template_dir(session: McpSession) -> Path:
     ``build_checks/`` and ``install_logs/`` subdirectories. Raises the same
     refusal as :func:`_resolve_testreport_path` when nothing is loaded.
     """
-    return _resolve_testreport_path(session).parent
+    return _resolve_testreport_path(session, template).parent
 
 
 def _safe_template_file(base: Path, relpath: str) -> Path:
@@ -212,6 +272,7 @@ async def testreport_read(
     session: McpSession,
     offset: int = 1,  # noqa: PT028 - tool entrypoint, not a pytest test
     limit: int | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Return the loaded testreport file's content and line count.
@@ -235,7 +296,7 @@ async def testreport_read(
 
     await _heartbeat(ctx, "testreport_read: waiting for session lock")
     async with session._lock:
-        path = _resolve_testreport_path(session)
+        path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
 
     windowed = offset != 1 or limit is not None
@@ -261,6 +322,7 @@ async def testreport_read(
 
 async def testreport_logs(
     session: McpSession,
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """List the auxiliary log files in the loaded testreport's checkout.
@@ -273,7 +335,7 @@ async def testreport_logs(
     """
     await _heartbeat(ctx, "testreport_logs: waiting for session lock")
     async with session._lock:
-        base = _resolve_template_dir(session)
+        base = _resolve_template_dir(session, template)
 
         def listing(sub: str) -> list[dict[str, Any]]:
             d = base / sub
@@ -295,6 +357,7 @@ async def testreport_logs(
 async def testreport_read_file(
     session: McpSession,
     relpath: str,
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Read a file from the loaded testreport's checkout by relative path.
@@ -306,7 +369,7 @@ async def testreport_read_file(
     """
     await _heartbeat(ctx, "testreport_read_file: waiting for session lock")
     async with session._lock:
-        base = _resolve_template_dir(session)
+        base = _resolve_template_dir(session, template)
         target = _safe_template_file(base, relpath)
         if not target.is_file():
             raise McpCommandError(
@@ -327,6 +390,7 @@ async def testreport_patch(
     start_line: int,
     end_line: int,
     replacement: str,
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Replace an inclusive 1-indexed line range with ``replacement``.
@@ -340,7 +404,7 @@ async def testreport_patch(
     """
     await _heartbeat(ctx, "testreport_patch: waiting for session lock")
     async with session._lock:
-        path = _resolve_testreport_path(session)
+        path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
         lines = content.splitlines(keepends=True)
         n = len(lines)
@@ -380,6 +444,7 @@ async def testreport_patch(
 async def testreport_write(
     session: McpSession,
     content: str,
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Overwrite the loaded testreport file with ``content`` atomically.
@@ -390,7 +455,7 @@ async def testreport_write(
     """
     await _heartbeat(ctx, "testreport_write: waiting for session lock")
     async with session._lock:
-        path = _resolve_testreport_path(session)
+        path = _resolve_testreport_path(session, template)
         bytes_written = _atomic_write_text(path, content)
     return {
         "path": str(path),
@@ -437,6 +502,7 @@ async def testreport_fill(
     reproducer: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     status: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     summary: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
+    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
     """Bulk-fill the repetitive placeholder tokens left by ``export``.
@@ -487,7 +553,7 @@ async def testreport_fill(
 
     await _heartbeat(ctx, "testreport_fill: waiting for session lock")
     async with session._lock:
-        path = _resolve_testreport_path(session)
+        path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
         lines = content.splitlines(keepends=True)
         counts = {"summary": 0, "reproducer": 0, "status": 0}
@@ -565,43 +631,59 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
     async def _read(
         offset: int = 1,
         limit: int | None = None,
+        template: str | None = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
-        return await testreport_read(session, offset=offset, limit=limit, ctx=ctx)
+        return await testreport_read(
+            session, offset=offset, limit=limit, template=template, ctx=ctx
+        )
 
-    async def _logs(ctx: Context | None = None) -> dict[str, Any]:
+    async def _logs(
+        template: str | None = None, ctx: Context | None = None
+    ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
-        return await testreport_logs(session, ctx=ctx)
+        return await testreport_logs(session, template=template, ctx=ctx)
 
-    async def _read_file(relpath: str, ctx: Context | None = None) -> dict[str, Any]:
+    async def _read_file(
+        relpath: str, template: str | None = None, ctx: Context | None = None
+    ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
-        return await testreport_read_file(session, relpath, ctx=ctx)
+        return await testreport_read_file(session, relpath, template=template, ctx=ctx)
 
     async def _patch(
         start_line: int,
         end_line: int,
         replacement: str,
+        template: str | None = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
         return await testreport_patch(
-            session, start_line, end_line, replacement, ctx=ctx
+            session, start_line, end_line, replacement, template=template, ctx=ctx
         )
 
-    async def _write(content: str, ctx: Context | None = None) -> dict[str, Any]:
+    async def _write(
+        content: str, template: str | None = None, ctx: Context | None = None
+    ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
-        return await testreport_write(session, content, ctx=ctx)
+        return await testreport_write(session, content, template=template, ctx=ctx)
 
     async def _fill(
         reproducer: str | None = None,
         status: str | None = None,
         summary: str | None = None,
+        template: str | None = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
         return await testreport_fill(
-            session, reproducer=reproducer, status=status, summary=summary, ctx=ctx
+            session,
+            reproducer=reproducer,
+            status=status,
+            summary=summary,
+            template=template,
+            ctx=ctx,
         )
 
     read_desc = (
@@ -610,30 +692,31 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         "the whole file; pass `offset` (1-based first line) and/or `limit` (max "
         "lines) to read a line window instead — use this to page a large report "
         "(a Product Increment log can be thousands of lines) without overflowing. "
-        f"{_READ_FIRST_WARNING}"
+        f"{_READ_FIRST_WARNING} {_TEMPLATE_NOTE}"
     )
     patch_desc = (
         "Splice an inclusive 1-indexed line range in the currently loaded "
         "testreport file. `end_line == start_line - 1` inserts before "
         "`start_line` without replacing anything. The write is atomic. "
-        f"{_READ_FIRST_WARNING}"
+        f"{_READ_FIRST_WARNING} {_TEMPLATE_NOTE}"
     )
     write_desc = (
         "Overwrite the currently loaded testreport file with the given "
         "content. Atomic. Use this as the fallback when patching would "
-        f"require tracking line-number drift across many edits. {_READ_FIRST_WARNING}"
+        f"require tracking line-number drift across many edits. {_READ_FIRST_WARNING} "
+        f"{_TEMPLATE_NOTE}"
     )
     logs_desc = (
         "List the auxiliary log files in the loaded testreport's checkout: the "
         "per-package/arch build-check logs (build_checks/) and the per-refhost "
         "install logs (install_logs/). Returns each file's name and size; fetch "
-        "one with testreport_read_file."
+        f"one with testreport_read_file. {_TEMPLATE_NOTE}"
     )
     read_file_desc = (
         "Read a file from the loaded testreport's checkout by relative path, "
         "e.g. 'build_checks/<pkg>.<arch>.log', 'install_logs/<host>.log', "
         "'source.diff' or 'patchinfo.xml'. The path may not escape the checkout "
-        "directory. Returns path, line count and full content."
+        f"directory. Returns path, line count and full content. {_TEMPLATE_NOTE}"
     )
     fill_desc = (
         "Bulk-set the repetitive per-bug placeholder tokens an exported "
@@ -646,7 +729,8 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         "value you already set by hand. Ideal for CVE-heavy updates: call with "
         "reproducer=NO, status=SKIPPED (security policy), then override any "
         "non-security bug individually with testreport_patch. Returns a `filled` "
-        "count per token. Still fill regression/build-log/source sections yourself."
+        "count per token. Still fill regression/build-log/source sections yourself. "
+        f"{_TEMPLATE_NOTE}"
     )
 
     specs = (

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -406,6 +406,65 @@ def test_unload_removes_only_the_named_template(tmp_path: Path) -> None:
     assert sess.templates.rrids() == ["SUSE:Maintenance:2:1"]
 
 
+def _fake_update(rrid: str) -> MagicMock:
+    """Build a fake OBS update whose ``make_testreport`` yields a report.
+
+    The returned report mock carries an ``id`` (str-able to ``rrid``), a
+    ``targets`` namespace exposing a settable ``interactive`` flag, and a
+    no-op ``autoconnect``.
+    """
+    targets = MagicMock()
+    targets.interactive = True
+    report = MagicMock()
+    report.id = rrid
+    report.targets = targets
+    update = MagicMock()
+    update.make_testreport.return_value = report
+    return update
+
+
+def test_load_update_does_not_move_active_pointer(tmp_path: Path) -> None:
+    """A second ``load_update`` must leave the active pointer on the first load.
+
+    The active template is REPL-only navigation state; over MCP it must not
+    move as a side effect of loading. The registry's ``active`` falls back to
+    the first-loaded report, so it stays put across subsequent loads.
+    """
+    sess = _make_session(tmp_path)
+
+    sess.load_update(_fake_update("SUSE:Maintenance:1:1"), autoconnect=False)
+    # First load is addressable as the active fallback.
+    assert str(sess.templates.active.id) == "SUSE:Maintenance:1:1"
+
+    sess.load_update(_fake_update("SUSE:Maintenance:2:1"), autoconnect=False)
+    # Both loaded, but active is still the first — not the last-loaded.
+    assert sess.templates.rrids() == [
+        "SUSE:Maintenance:1:1",
+        "SUSE:Maintenance:2:1",
+    ]
+    assert str(sess.templates.active.id) == "SUSE:Maintenance:1:1"
+
+
+def test_load_update_sets_headless_on_freshly_loaded_report(tmp_path: Path) -> None:
+    """``interactive=False`` lands on the just-loaded report, not the active one.
+
+    With the active pointer no longer moved on load, the headless flag must be
+    applied to the newly loaded report's own host group, even when a different
+    (first-loaded) template remains active.
+    """
+    sess = _make_session(tmp_path)
+
+    first = _fake_update("SUSE:Maintenance:1:1")
+    sess.load_update(first, autoconnect=False)
+    second = _fake_update("SUSE:Maintenance:2:1")
+    sess.load_update(second, autoconnect=False)
+
+    # The second (non-active) report still got the headless flag applied.
+    second_report = second.make_testreport.return_value
+    assert second_report.targets.interactive is False
+    second_report.autoconnect.assert_called_once()
+
+
 def test_unload_unknown_rrid_raises(tmp_path: Path) -> None:
     """``unload`` on an unloaded RRID surfaces a clean command error."""
     from mtui.commands.unload import Unload

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -385,3 +385,39 @@ def test_dispatch_template_flag_scopes_to_one(tmp_path: Path) -> None:
     finally:
         Command.registry.pop(cls.command, None)
     assert seen == ["SUSE:Maintenance:2:1"]
+
+
+def test_unload_removes_only_the_named_template(tmp_path: Path) -> None:
+    """``unload <rrid>`` runs once and removes exactly that template.
+
+    Regression: ``unload`` has ``scope="single"``, so even with several
+    templates loaded under MCP (where ``scope="active"`` defaults to fan-out)
+    it must not fan out and try to remove the same RRID once per template,
+    which failed the second pass with ``TemplateNotLoadedError``.
+    """
+    from mtui.commands.unload import Unload
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+
+    out = asyncio.run(sess.run_command(Unload, ["SUSE:Maintenance:1:1"]))
+
+    assert out == ""
+    assert sess.templates.rrids() == ["SUSE:Maintenance:2:1"]
+
+
+def test_unload_unknown_rrid_raises(tmp_path: Path) -> None:
+    """``unload`` on an unloaded RRID surfaces a clean command error."""
+    from mtui.commands.unload import Unload
+    from mtui.mcp.session import McpCommandError
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+
+    with pytest.raises(McpCommandError):
+        asyncio.run(sess.run_command(Unload, ["SUSE:Maintenance:9:9"]))
+    # Both templates remain loaded after a failed unload.
+    assert sess.templates.rrids() == [
+        "SUSE:Maintenance:1:1",
+        "SUSE:Maintenance:2:1",
+    ]

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -57,15 +58,55 @@ def _null_session(tmp_path: Path) -> McpSession:
     return McpSession(_config(tmp_path), logging.getLogger("test.mcp.testreport"))
 
 
+class _FakeRegistry:
+    """Minimal stand-in for :class:`mtui.template_registry.TemplateRegistry`.
+
+    Exposes only the surface :func:`mtui.mcp.testreport_tools._resolve_report`
+    reads: ``get(rrid)``, ``all()``. Seeded from an ordered ``{rrid: report}``
+    mapping so single- and multi-template tests can share the fixture.
+    """
+
+    def __init__(self, reports: Mapping[str, object]) -> None:
+        self._entries = dict(reports)
+
+    def get(self, rrid: str) -> object:
+        return self._entries[rrid]
+
+    def all(self) -> list[object]:
+        return list(self._entries.values())
+
+
 def _loaded_session(tmp_path: Path, path: Path) -> SimpleNamespace:
-    """Fake session that only needs the two attributes the tools touch.
+    """Fake session that only needs the attributes the tools touch.
 
     Avoids constructing a full TestReport — we just need ``metadata.path``
     to be a non-None string and ``metadata`` to *not* be a NullTestReport.
     ``_lock`` is a real :class:`asyncio.Lock` so the ``async with`` works.
+    A single-entry ``templates`` registry is provided so ``_resolve_report``
+    resolves to ``metadata`` (zero/one loaded -> active fallback).
     """
-    metadata = SimpleNamespace(path=str(path))
-    return SimpleNamespace(metadata=metadata, _lock=asyncio.Lock())
+    metadata = SimpleNamespace(id="SUSE:Maintenance:1:1", path=str(path))
+    return SimpleNamespace(
+        metadata=metadata,
+        templates=_FakeRegistry({"SUSE:Maintenance:1:1": metadata}),
+        _lock=asyncio.Lock(),
+    )
+
+
+def _multi_session(tmp_path: Path, paths: dict[str, Path]) -> SimpleNamespace:
+    """Fake session with several loaded templates keyed by RRID.
+
+    ``metadata`` points at the first entry (the "active" fallback the REPL
+    would use); ``_resolve_report`` must refuse an unscoped call here and only
+    act when ``template=<rrid>`` selects one.
+    """
+    reports = {rrid: SimpleNamespace(id=rrid, path=str(p)) for rrid, p in paths.items()}
+    first = next(iter(reports.values()))
+    return SimpleNamespace(
+        metadata=first,
+        templates=_FakeRegistry(reports),
+        _lock=asyncio.Lock(),
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -548,7 +589,6 @@ def test_two_ctx_keys_read_their_own_template(tmp_path: Path) -> None:
             targets={},
         )
         session.templates.add(report)  # ty: ignore[invalid-argument-type]
-        session.templates.set_active(report.id)
         return session
 
     registry = SessionRegistry(
@@ -680,3 +720,112 @@ def test_fill_refuses_without_loaded_report(tmp_path: Path) -> None:
     sess = _null_session(tmp_path)
     with pytest.raises(McpCommandError):
         asyncio.run(tt.testreport_fill(sess, reproducer="NO"))
+
+
+# --------------------------------------------------------------------------- #
+# template= scoping (multi-template MCP sessions)                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_read_refuses_when_multiple_loaded_without_template(tmp_path: Path) -> None:
+    """Unscoped read with >1 template loaded must refuse and name the RRIDs."""
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("alpha\n", encoding="utf-8")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("beta\n", encoding="utf-8")
+    sess = _multi_session(
+        tmp_path,
+        {"SUSE:Maintenance:1:1": file_a, "SUSE:Maintenance:2:2": file_b},
+    )
+
+    with pytest.raises(McpCommandError) as ei:
+        asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert "multiple templates" in ei.value.stderr
+    assert "SUSE:Maintenance:1:1" in ei.value.stderr
+    assert "SUSE:Maintenance:2:2" in ei.value.stderr
+
+
+def test_read_with_template_selects_that_report(tmp_path: Path) -> None:
+    """``template=<rrid>`` reads exactly that loaded template's file."""
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("alpha\n", encoding="utf-8")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("beta\nbeta2\n", encoding="utf-8")
+    sess = _multi_session(
+        tmp_path,
+        {"SUSE:Maintenance:1:1": file_a, "SUSE:Maintenance:2:2": file_b},
+    )
+
+    result: dict[str, Any] = asyncio.run(
+        tt.testreport_read(sess, template="SUSE:Maintenance:2:2")  # ty: ignore[invalid-argument-type]
+    )
+    assert result["content"] == "beta\nbeta2\n"
+    assert result["path"] == str(file_b)
+
+
+def test_patch_with_template_targets_the_right_file(tmp_path: Path) -> None:
+    """``testreport_patch`` honours ``template=`` and leaves siblings untouched."""
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("a1\na2\n", encoding="utf-8")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("b1\nb2\n", encoding="utf-8")
+    sess = _multi_session(
+        tmp_path,
+        {"SUSE:Maintenance:1:1": file_a, "SUSE:Maintenance:2:2": file_b},
+    )
+
+    asyncio.run(
+        tt.testreport_patch(sess, 1, 1, "B1!\n", template="SUSE:Maintenance:2:2")  # ty: ignore[invalid-argument-type]
+    )
+    assert file_b.read_text(encoding="utf-8") == "B1!\nb2\n"
+    assert file_a.read_text(encoding="utf-8") == "a1\na2\n"  # untouched
+
+
+def test_read_with_unknown_template_raises(tmp_path: Path) -> None:
+    """An RRID that is not loaded is refused with a clear message."""
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("alpha\n", encoding="utf-8")
+    sess = _multi_session(tmp_path, {"SUSE:Maintenance:1:1": file_a})
+
+    with pytest.raises(McpCommandError) as ei:
+        asyncio.run(
+            tt.testreport_read(sess, template="SUSE:Maintenance:9:9")  # ty: ignore[invalid-argument-type]
+        )
+    assert "template not loaded" in ei.value.stderr
+    assert "SUSE:Maintenance:9:9" in ei.value.stderr
+
+
+def test_single_template_unscoped_still_works(tmp_path: Path) -> None:
+    """Zero/one loaded keeps the historical no-template behaviour."""
+    file = tmp_path / "report.txt"
+    file.write_text("solo\n", encoding="utf-8")
+    sess = _loaded_session(tmp_path, file)
+
+    result: dict[str, Any] = asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert result["content"] == "solo\n"
+
+
+def test_template_param_in_json_schema(tmp_path: Path) -> None:
+    """``template`` is an exposed optional parameter on every testreport tool."""
+    pytest.importorskip("mcp")
+    from mcp.server.fastmcp import FastMCP
+
+    sess = _null_session(tmp_path)
+    mcp: FastMCP = FastMCP(name="test-mtui-mcp-template-schema")
+    tt.register_testreport_tools(mcp, sess)
+
+    for name in (
+        "testreport_read",
+        "testreport_logs",
+        "testreport_read_file",
+        "testreport_patch",
+        "testreport_write",
+        "testreport_fill",
+    ):
+        tool = mcp._tool_manager.get_tool(name)  # noqa: SLF001
+        assert tool is not None
+        props = tool.parameters.get("properties", {})
+        assert "template" in props, (
+            f"tool {name!r} is missing the template parameter: {list(props)!r}"
+        )
+        assert "template" not in tool.parameters.get("required", [])

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -126,6 +126,7 @@ def test_build_tools_includes_expected_commands(
         "assign",
         "update",
         "load_template",
+        "unload",
         "list_hosts",
         "openqa_overview",
         "reject",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -414,6 +414,31 @@ def test_optional_multivalue_flag_round_trip() -> None:
     assert parsed.message == ["why", "not"]
 
 
+def test_remainder_optional_emitted_after_other_flags() -> None:
+    """A REMAINDER optional must land after every other flag, not swallow it.
+
+    Regression: when a ``nargs=REMAINDER`` *optional* is declared before
+    another flag, emitting it among the flags lets REMAINDER consume the
+    later flag as a value (``--message a b --xflag`` -> ``message=['a','b',
+    '--xflag']``, ``xflag`` lost). The encoder defers the REMAINDER optional
+    to the positional tail so it is always emitted last regardless of
+    ``parser._actions`` declaration order.
+    """
+    import argparse
+    from argparse import REMAINDER
+
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("-m", "--message", nargs=REMAINDER)
+    parser.add_argument("-x", "--xflag", action="store_true")
+
+    argv = kwargs_to_argv(parser, {"message": ["a", "b"], "xflag": True})
+    # The store_true flag must precede the REMAINDER tokens.
+    assert argv == ["--xflag", "--message", "a", "b"]
+    parsed = parser.parse_args(argv)
+    assert parsed.message == ["a", "b"]
+    assert parsed.xflag is True
+
+
 def test_nargs_one_positional_accepts_scalar_round_trip() -> None:
     """``put filename`` (``nargs=1``) round-trips a scalar string.
 


### PR DESCRIPTION
## Summary

Four low-risk correctness fixes to the `mtui-mcp` surface, each in its own
commit. They close wrong-target / argv hazards that surfaced once a session can
hold more than one loaded template. No host-arbitration or parallelism changes
here — these are the correctness prerequisites.

Built on top of `fix(mcp): drop active-template semantics that MCP clients
cannot address` (already on `main`), which handled the `_resolve_templates`
fan-out default and the `list_templates` marker but not the items below.

## Changes

**1. `feat(mcp): add template= scoping to testreport file tools`**
The six hand-written testreport tools (`testreport_read`, `_logs`,
`_read_file`, `_patch`, `_write`, `_fill`) resolved their target file only via
`session.metadata` — the active-template pointer. That pointer is REPL-only
navigation state with no client-addressable equivalent over MCP, so with
several templates loaded a tool silently edited whichever was loaded last. Add
an optional `template=<rrid>` parameter (shared `_resolve_report` helper mirroring
the auto-generated tools' `-T/--template` contract): an explicit RRID selects
that template; omitted with >1 loaded refuses and names the loaded RRIDs;
omitted with 0/1 loaded falls back to the single report (unchanged).

**2. `fix(mcp): emit REMAINDER optionals after every other flag in argv encoder`**
`kwargs_to_argv` emitted a `nargs=REMAINDER` *optional* (e.g. `reject
--message`) among the other flags. That is only safe when the REMAINDER flag
happens to be declared last; when declared before another flag, REMAINDER
swallowed the later flag as a value (`--message a b --xflag` →
`message=['a','b','--xflag']`, `xflag` lost). REMAINDER optionals are now
deferred to the positional tail so they always land after every other flag,
regardless of declaration order. The existing `reject --message` case is
unchanged; the fix makes it order-independent.

**3. `feat(mcp): expose unload as an MCP tool`**
`unload` was on the REPL-only deny-list, but it takes an explicit RRID, mutates
only the loaded set (closing that template's host connections), needs no TTY and
does not call `sys.exit`. Drop it from `REPL_ONLY` (it selects its target via the
required `rrid` positional, e.g. `unload(rrid="SUSE:Maintenance:1:1")`).
`switch` stays denied. Exposing it surfaced a fan-out hazard — `unload` has
`scope="active"`, which fans out under MCP with >1 loaded and removed the same
RRID once per template, failing the second pass. Added a stricter
`scope="single"` policy for commands that name their own target and must run
exactly once; `_resolve_templates` never auto-fans-out those.

**4. `fix(mcp): stop moving the active-template pointer on load`**
`McpSession.load_update` set the active pointer to the just-loaded RRID on every
load (both `load_template` and `regenerate` route through it), making it hidden,
unaddressable state. Drop the `set_active`; the registry's `active` property
still falls back to the first-loaded report, so single-template sessions are
unchanged. The headless `interactive=False` flag is now applied to the freshly
loaded report's own host group (`tr.targets`) instead of `self.targets` (which
follows the active pointer).

## Test coverage

- testreport tools: multi-template refuse/select/unknown-RRID paths + JSON-schema exposure of `template`; single-template behaviour byte-for-byte unchanged.
- argv: synthetic parser declaring a REMAINDER optional before a `store_true` flag.
- `unload`: removes only the named template (no `FanOutError`); unknown RRID raises cleanly leaving all loaded; non-active and active-template removal both verified.
- `load_update`: a second load leaves active on the first; headless flag lands on the just-loaded (non-active) report.

Docs (`Documentation/mcp.rst`) and `CHANGELOG.md [Unreleased]` updated.

## Gate set (whole repo, observed green)

- \`uv run ruff format --check .\` → 314 files already formatted
- \`uv run ruff check .\` → All checks passed
- \`uv run ty check\` → All checks passed
- \`uv run pytest\` → 1695 passed