### PR TITLE
feat(mcp): concurrent per-template execution + atomic pool lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   unscoped action fans out across all loaded templates. A single-template
   session is unchanged (the registry's active fallback is the only loaded
   report).
+- Over `mtui-mcp`, tool calls now run **concurrently across different
+  templates** within one session: a command (or testreport tool) scoped to one
+  loaded template holds only that template's lock, so work on other templates
+  (and backgrounded per-template jobs) proceeds in parallel instead of queuing
+  behind a single session-wide lock. Two calls on the *same* template still
+  serialise, and registry-mutating commands (`load_template`, `unload`) take an
+  exclusive gate that briefly drains in-flight per-template work. Per-call
+  stdout/display capture is now isolated per call so concurrent commands never
+  cross-contaminate each other's output.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   later flag swallowed into the message when re-encoding a tool call to argv.
   The REMAINDER optional is now always emitted after every other flag, so the
   trailing flag is parsed correctly regardless of argument declaration order.
+- The remote refhost pool lock is now claimed with an atomic exclusive create
+  (`O_EXCL`) instead of a separate "read the lock state, then write it" pair.
+  This closes a TOCTOU window where two separate mtui processes/users running
+  pool selection at the same time could both believe a host was free and clobber
+  each other's claim; exactly one now wins the create and the other backs off to
+  the next candidate.
 - Transactional (read-only-root, SL Micro) hosts now install and downgrade every
   package in a SINGLE `transactional-update` snapshot. The previous per-package
   loop ran one `transactional-update pkg in` per package, each opening its own

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -432,11 +432,18 @@ Concurrency and safety
   (``id(ctx.session)``), which the SDK keeps 1:1 with the MCP session
   for the connection's lifetime. The ``Mcp-Session-Id`` header is used
   for log lines only, never to route state.
-* **Per-session ``asyncio.Lock``.** Within a single session every tool
-  invocation (auto-generated and testreport-editing alike) acquires
-  *that session's* lock, so one client's calls cannot interleave
-  mutations of its own ``metadata`` / ``targets``. Calls from different
-  clients hold different locks and run concurrently.
+* **Per-template locking within a session.** Within a single session a
+  tool invocation scoped to one loaded template (auto-generated commands
+  with ``-T``/``template=`` and the testreport-editing tools alike)
+  acquires only *that template's* lock, so calls on **different**
+  templates run concurrently while calls on the **same** template
+  serialise (they cannot interleave that template's host phase).
+  Registry-mutating commands (``load_template``, ``unload``) and unscoped
+  fan-out take a session-wide *exclusive* gate that briefly drains
+  in-flight per-template work, so the loaded set is never observed
+  mid-mutation. Per-call stdout/display capture is isolated per call, so
+  concurrent commands never cross-contaminate output. Calls from
+  different clients use different sessions and run concurrently.
 * **Bounded session count.** The HTTP registry refuses to create more
   than ``[mcp] session_cap`` concurrent sessions (default ``32``),
   failing the offending tool call with a clear error rather than
@@ -579,10 +586,10 @@ the call returns **immediately** with a job id::
         while you work elsewhere. Poll job_status(job_id='run-1') and
         fetch output with job_result(job_id='run-1')."
 
-The command still runs under the session lock for its whole duration
-(so it serialises against the session's other mutating calls exactly
-like a foreground call), but you are free to issue other (read-only)
-tool calls meanwhile and poll the job:
+The command still holds its template's lock for its whole duration (so
+it serialises against same-template calls exactly like a foreground
+call), but you are free to issue other tool calls meanwhile — including
+work on other templates, which runs concurrently — and poll the job:
 
 * ``job_list``: every job in the session and its state;
 * ``job_status(job_id=…)``: one job's state
@@ -602,10 +609,10 @@ be polled, fetched, and cancelled independently; cancelling one
 template's job leaves the others running. Scoping the call with
 ``template="<RRID>"`` (or having only one template loaded) keeps it to a
 single job with the familiar ``<command>-<n>`` id; the fanned-out ids
-additionally encode the (sanitised) RRID. Because each per-template job
-still acquires the session lock for its whole duration, the jobs run
-serially within one session; the benefit is independent tracking and
-cancellation, not intra-session parallelism.
+additionally encode the (sanitised) RRID. Because each fanned-out job is
+scoped to one template and takes only that template's lock, the jobs run
+**concurrently across templates** within one session (same-template work
+still serialises), on top of being independently tracked and cancellable.
 
 Jobs are scoped to the session: under stdio that is the single process;
 under http it is the caller's isolated session, so one client never

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 from logging import getLogger
 from pathlib import Path
+from traceback import format_exc
 from typing import Self
 
 from ...support.config import Config
@@ -293,15 +294,6 @@ class TargetLock:
             TargetLockedError: If the target is already locked.
 
         """
-        # NOTE: there is a slight race between getting the state of the
-        # lock on target host and setting the lock.
-        # TODO: test if using sftpclient.mkdir can be used to make
-        # the locking really atomic.
-        # NOTE: let the code pass through if is_mine() as
-        # setting a different comment may be desired.
-        if self.is_locked() and not self.is_mine() and not self._wait_for_lock():
-            raise TargetLockedError(self.locked_by_msg())
-
         logger.debug("%s: setting lock", self.connection.hostname)
 
         rl = RemoteLock()
@@ -310,15 +302,48 @@ class TargetLock:
         rl.pid = self.i_am_pid
         rl.comment = comment
 
-        try:
-            lockfile = self.connection.sftp_open(self.filename, "w+")
-            lockfile.write(rl.to_lockfile())
-            lockfile.close()
-        except Exception:
+        # First try an *atomic exclusive create* (paramiko maps mode ``"x"`` to
+        # ``O_CREAT | O_EXCL``): on a free host exactly one of two racing
+        # processes wins the create and the loser falls through to the
+        # reconciliation below. This closes the read-then-write TOCTOU the
+        # previous "stat, then ``w+``" sequence had.
+        if self._write_lockfile(rl, exclusive=True):
+            self._lock = rl
+            return
+
+        # The file already exists. Decide whether we may overwrite it: our own
+        # lock (re-stamp with a possibly-new comment), a stale lock we may reap,
+        # or one that frees within the optional wait budget. Otherwise refuse.
+        if self.is_locked() and not self.is_mine() and not self._wait_for_lock():
+            raise TargetLockedError(self.locked_by_msg())
+
+        if not self._write_lockfile(rl, exclusive=False):
             logger.error("failed to open lockfile")
-            raise
+            raise OSError(f"failed to write lockfile on {self.connection.hostname}")
 
         self._lock = rl
+
+    def _write_lockfile(self, rl: RemoteLock, *, exclusive: bool) -> bool:
+        """Write ``rl`` to the remote lockfile; return whether it succeeded.
+
+        With ``exclusive=True`` the file is opened ``"x"`` (atomic create that
+        fails if it already exists) and a "file exists" failure returns
+        ``False`` so the caller can reconcile. With ``exclusive=False`` the file
+        is opened ``"w+"`` (truncate/overwrite) and any failure returns
+        ``False``. Both modes log unexpected errors at DEBUG for diagnosis.
+        """
+        mode = "x" if exclusive else "w+"
+        try:
+            lockfile = self.connection.sftp_open(self.filename, mode)
+            lockfile.write(rl.to_lockfile())
+            lockfile.close()
+        except Exception:  # noqa: BLE001 - all failures are non-fatal here
+            # An exclusive create racing a winner (file already exists) is
+            # expected; any other failure is logged for diagnosis. Either way
+            # the caller decides what to do next.
+            logger.debug(format_exc())
+            return False
+        return True
 
     def locked_by_msg(self) -> str:
         """Returns a "locked by" message suitable for display to the user.

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -17,18 +17,23 @@ configurable TTL (``[mcp] session_idle_timeout``) and their hosts
 disconnected via :meth:`McpSession.close`; the number of concurrent
 sessions is bounded by ``[mcp] session_cap``.
 
-Within a single session, every :meth:`McpSession.run_command` call is
-serialised through that session's :class:`asyncio.Lock`, so two
-concurrent tool calls from the *same* client cannot interleave
-mutations of its ``metadata`` / ``targets``; calls from *different*
+Within a single session, locking is **per template**: a
+:meth:`McpSession.run_command` call scoped to one loaded template holds
+only that template's lock, so two tool calls on *different* templates run
+concurrently while two on the *same* template serialise (they cannot
+interleave that template's host phase). Registry-mutating commands
+(``load_template`` / ``unload`` / ``close``) and unscoped fan-out take a
+registry-wide *exclusive* gate that drains in-flight per-template work, so
+the loaded set is never observed mid-mutation. Calls from *different*
 clients run concurrently against their own sessions. Blocking command
 bodies (SSH, subprocess) run inside :func:`asyncio.to_thread` so they
 do not stall the event loop.
 
-Stdout / stderr produced by a command are captured per-call via a
-fresh :class:`io.StringIO`; stdout is returned to the caller, stderr
-either surfaces in :class:`McpCommandError` on failure or is logged at
-WARNING on a clean return.
+Stdout / stderr produced by a command are captured per-call via a fresh
+:class:`io.StringIO` bound to per-call :mod:`contextvars` (so concurrent
+commands never clobber each other's sinks); stdout is returned to the
+caller, stderr either surfaces in :class:`McpCommandError` on failure or
+is logged at WARNING on a clean return.
 """
 
 from __future__ import annotations
@@ -67,6 +72,22 @@ logger = getLogger("mtui.mcp.session")
 #: captured.
 _capture_token: contextvars.ContextVar[object | None] = contextvars.ContextVar(
     "mtui_mcp_capture_token", default=None
+)
+
+#: Per-call output sinks. ``_run_sync`` sets these to the running command's
+#: :class:`CommandPromptDisplay` and stdout :class:`io.StringIO` for the
+#: duration of one command, and (via
+#: :class:`mtui.support.concurrency.ContextExecutor`) the values propagate
+#: into any worker threads the command fans out to. Holding them in
+#: :mod:`contextvars` rather than on the session instance is what lets two
+#: commands run concurrently (per-RRID locking) without clobbering each
+#: other's captured output. ``None`` outside a call -> ``println`` falls
+#: back to the log.
+_current_display: contextvars.ContextVar[CommandPromptDisplay | None] = (
+    contextvars.ContextVar("mtui_mcp_current_display", default=None)
+)
+_current_stdout: contextvars.ContextVar[io.StringIO | None] = contextvars.ContextVar(
+    "mtui_mcp_current_stdout", default=None
 )
 
 
@@ -207,6 +228,64 @@ class _FakeSys(SimpleNamespace):
         raise SystemExit(code)
 
 
+class _RWLock:
+    """A minimal async readers-writer lock used as the registry gate.
+
+    Many *shared* holders (per-RRID commands, which mutate only their own
+    template) may run at once, but a *shared* holder excludes every
+    *exclusive* holder and vice-versa. Exclusive holders (registry mutators:
+    ``load_template`` / ``unload`` / ``close`` / unscoped fan-out) run one at a
+    time with no shared holder present.
+
+    Writer-preference is intentional: while an exclusive waiter is pending, new
+    shared acquisitions block, so a steady stream of per-RRID commands cannot
+    starve a ``load_template``. There is no fairness queue beyond that; the
+    single-session workload (a handful of concurrent subagents) does not need
+    one.
+    """
+
+    def __init__(self) -> None:
+        self._readers = 0
+        self._writer_waiting = 0
+        # ``_cond`` guards ``_readers`` / ``_writer_waiting`` and is the
+        # rendezvous both modes wait on.
+        self._cond = asyncio.Condition()
+
+    @contextlib.asynccontextmanager
+    async def shared(self):
+        """Acquire in shared (reader) mode for the duration of the body."""
+        async with self._cond:
+            # Wait out any active or pending exclusive holder (writer pref).
+            await self._cond.wait_for(lambda: self._writer_waiting == 0)
+            self._readers += 1
+        try:
+            yield
+        finally:
+            async with self._cond:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._cond.notify_all()
+
+    @contextlib.asynccontextmanager
+    async def exclusive(self):
+        """Acquire in exclusive (writer) mode for the duration of the body."""
+        async with self._cond:
+            self._writer_waiting += 1
+            try:
+                await self._cond.wait_for(lambda: self._readers == 0)
+            finally:
+                self._writer_waiting -= 1
+            # Hold ``_cond`` across the body so no reader/writer can enter:
+            # both modes must take ``_cond`` to mutate their counters, and a
+            # would-be reader also blocks on ``_writer_waiting``/the readers
+            # check. Keeping the condition's underlying lock held is the
+            # exclusion.
+            try:
+                yield
+            finally:
+                self._cond.notify_all()
+
+
 class McpSession:
     """Headless mtui session backing one ``mtui-mcp`` client.
 
@@ -263,22 +342,23 @@ class McpSession:
         # silently misbehaving.
         self._history = None
 
-        # Per-session serialiser. Concurrent tool calls from the *same*
-        # client queue here so they cannot interleave mutations of this
-        # session's ``metadata`` / ``targets``; calls from *other* http
-        # clients hold their own session's lock and run concurrently.
-        # The lock is held across the ``to_thread`` worker so re-entrant
-        # calls (a Command's body touching ``self.prompt.load_update``)
-        # execute on the same thread without re-acquiring.
-        self._lock = asyncio.Lock()
-
-        # Per-call stdout pointer. ``println`` falls back to ``log``
-        # when no command is currently running.
-        self._current_stdout: io.StringIO | None = None
-        # Per-call display, swapped in by ``_run_sync`` so
-        # ``Command.__init__`` picks up the right StringIO-bound
-        # writer. ``None`` outside a call.
-        self.display: CommandPromptDisplay | None = None
+        # Per-RRID serialiser layered over a registry shared/exclusive gate.
+        #
+        # A command scoped to one template takes that template's per-RRID lock
+        # (``_rrid_locks``) so same-RRID calls serialise while different-RRID
+        # calls run concurrently — but it *also* enters the registry gate in
+        # *shared* mode (``_registry`` as a readers-writer lock) so it cannot
+        # overlap a registry mutation. Registry mutators (``load_template`` /
+        # ``unload`` / ``close``) and unscoped fan-out take the gate in
+        # *exclusive* mode, which waits for every in-flight per-RRID command to
+        # drain and blocks new ones, giving them a consistent view of the loaded
+        # set. ``_locks_guard`` protects lazy creation of the per-RRID lock map.
+        # Locks are held across the ``to_thread`` worker so a command's
+        # re-entrant body (touching ``self.prompt.load_update``) executes on the
+        # same thread without re-acquiring.
+        self._registry = _RWLock()
+        self._rrid_locks: dict[str, asyncio.Lock] = {}
+        self._locks_guard = asyncio.Lock()
 
         # Background-job table for the async ("don't block on a slow host
         # op") path. A backgrounded command still acquires this session's
@@ -303,6 +383,26 @@ class McpSession:
     def targets(self):
         """The active template's :class:`HostsGroup`."""
         return self.templates.active.targets
+
+    @property
+    def display(self) -> CommandPromptDisplay | None:
+        """The running command's per-call display, or ``None`` outside a call.
+
+        Backed by the :data:`_current_display` :class:`~contextvars.ContextVar`
+        (set by :meth:`_run_sync`) so concurrent commands each see their own
+        :class:`CommandPromptDisplay` rather than a shared session attribute.
+        """
+        return _current_display.get()
+
+    @property
+    def _current_stdout(self) -> io.StringIO | None:
+        """The running command's per-call stdout buffer, or ``None``.
+
+        Backed by the :data:`_current_stdout` :class:`~contextvars.ContextVar`
+        so :meth:`println` lands in the originating call's buffer even when
+        several commands run concurrently.
+        """
+        return _current_stdout.get()
 
     # ------------------------------------------------------------------
     # CommandPrompt-compatible surface
@@ -527,12 +627,76 @@ class McpSession:
                 raises an unhandled exception.
 
         """
-        async with self._lock:
+        async with self._command_lock(cmd_cls, argv):
             if ctx is None:
                 return await asyncio.to_thread(self._run_sync, cmd_cls, argv)
             return await self._run_with_heartbeat(
                 ctx, cmd_cls, argv, interval=progress_interval
             )
+
+    async def _lock_for(self, rrid: str) -> asyncio.Lock:
+        """Return (creating on first use) the per-template lock for ``rrid``.
+
+        Lazily populates :attr:`_rrid_locks` under :attr:`_locks_guard` so two
+        coroutines racing to lock the same fresh RRID share one lock object.
+        """
+        async with self._locks_guard:
+            lock = self._rrid_locks.get(rrid)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._rrid_locks[rrid] = lock
+            return lock
+
+    @contextlib.asynccontextmanager
+    async def _command_lock(self, cmd_cls: type[Command], argv: list[str]):
+        """Hold the right lock(s) for ``cmd_cls`` for the duration of the body.
+
+        Resolution mirrors the foreground dispatch:
+
+        * a command resolving to **exactly one** template → the registry gate
+          in *shared* mode **plus** that template's per-RRID lock, so
+          different-RRID commands run concurrently while same-RRID commands
+          serialise and no command overlaps a registry mutation;
+        * fan-out / unscoped-multi commands, registry mutators
+          (``load_template`` / ``unload``), or anything that resolves to no
+          real template → the registry gate in *exclusive* mode, which drains
+          in-flight per-RRID commands and blocks new ones for the duration.
+
+        A single command never holds two per-RRID locks and the exclusive path
+        holds only the gate, so the lock order (gate-shared → one rrid lock) is
+        total and cannot deadlock.
+        """
+        rrids = self._resolve_job_rrids(cmd_cls, argv)
+        if rrids is not None and len(rrids) == 1:
+            async with self._registry.shared():
+                lock = await self._lock_for(rrids[0])
+                async with lock:
+                    yield
+        else:
+            async with self._registry.exclusive():
+                yield
+
+    @contextlib.asynccontextmanager
+    async def scoped_lock(self, rrid: str | None):
+        """Hold the registry-shared gate plus one template's per-RRID lock.
+
+        For the hand-written testreport tools (which act on a single template's
+        files): entering the registry gate in *shared* mode keeps the loaded set
+        stable for the body (no concurrent ``load_template`` / ``unload``) while
+        still letting tools on *other* templates run in parallel, and the
+        per-RRID lock serialises against the foreground dispatch for the *same*
+        template (e.g. a concurrent ``commit``).
+
+        ``rrid`` is the resolved target template id, or ``None`` to fall back to
+        the active template (single-/zero-loaded case). Callers should resolve
+        and validate the target report *inside* the body, where the shared gate
+        guarantees the registry cannot change underfoot.
+        """
+        async with self._registry.shared():
+            key = rrid if rrid is not None else str(self.templates.active.id)
+            lock = await self._lock_for(key)
+            async with lock:
+                yield
 
     async def _run_with_heartbeat(
         self,
@@ -585,10 +749,13 @@ class McpSession:
         fake_sys = _FakeSys()
         display = CommandPromptDisplay(fake_sys.stdout)
 
-        prev_display = self.display
-        prev_stdout = self._current_stdout
-        self.display = display
-        self._current_stdout = fake_sys.stdout
+        # Bind the per-call output sinks via context vars (not session
+        # attributes) so concurrent commands — now that different-RRID calls
+        # hold different locks — each see their own display / stdout and never
+        # clobber one another. ``ContextExecutor`` propagates these into the
+        # worker threads a command fans out to, exactly like ``_capture_token``.
+        display_reset = _current_display.set(display)
+        stdout_reset = _current_stdout.set(fake_sys.stdout)
 
         # Tee the command's own ``mtui.*`` log records (INFO+) into the
         # captured stdout so MCP clients see warnings/errors the command
@@ -666,8 +833,8 @@ class McpSession:
             _capture_token.reset(token_reset)
             if lowered_cap_level:
                 cap_logger.setLevel(prev_cap_level)
-            self.display = prev_display
-            self._current_stdout = prev_stdout
+            _current_display.reset(display_reset)
+            _current_stdout.reset(stdout_reset)
 
     # ------------------------------------------------------------------
     # Background jobs (async path for slow host operations)
@@ -708,9 +875,11 @@ class McpSession:
         """Create and start one job record running ``argv`` and return its id.
 
         Shared core of :meth:`start_job` and :meth:`start_jobs`. The worker task
-        acquires this session's ``_lock`` for its whole duration (so it
-        serialises against the session's other mutating calls exactly like
-        :meth:`run_command`) and executes the body in :func:`asyncio.to_thread`.
+        acquires the same per-RRID / registry gate as :meth:`run_command` (via
+        :meth:`_command_lock`) for its whole duration, so a job scoped to one
+        template serialises only against same-RRID work and runs concurrently
+        with jobs on other templates, and executes the body in
+        :func:`asyncio.to_thread`.
 
         Args:
             cmd_cls: The :class:`Command` subclass to run.
@@ -737,7 +906,7 @@ class McpSession:
 
         async def _runner() -> None:
             try:
-                async with self._lock:
+                async with self._command_lock(cmd_cls, argv):
                     out = await asyncio.to_thread(self._run_sync, cmd_cls, argv)
                 job["result"] = out
                 job["state"] = "done"
@@ -768,10 +937,9 @@ class McpSession:
         """Start ``cmd_cls`` in the background and return its job id.
 
         The command runs in an :func:`asyncio.create_task` worker that
-        acquires this session's ``_lock`` for its whole duration (so it
-        serialises against the session's other mutating calls exactly
-        like :meth:`run_command`) and executes the body in
-        :func:`asyncio.to_thread`. Unlike :meth:`run_command` this
+        acquires the same per-RRID / registry gate as :meth:`run_command`
+        (via :meth:`_command_lock`) for its whole duration, and executes the
+        body in :func:`asyncio.to_thread`. Unlike :meth:`run_command` this
         returns **immediately** with a handle, so the client is not held
         on one request for the minutes a ``run`` / ``update`` /
         ``downgrade`` can take and can meanwhile issue other calls.
@@ -816,10 +984,10 @@ class McpSession:
         leaves the others running). When a single template (or none) resolves,
         this is exactly one job with the unchanged ``<command>-<n>`` id.
 
-        The per-template jobs each acquire the session ``_lock`` for their whole
-        duration, so they run **serially** within one session (matching the
-        single-session serialisation contract); the win is independent tracking
-        and cancellation, not intra-session parallelism.
+        Each fanned-out job is scoped to one template (``-T <rrid>``) and so
+        takes only that template's per-RRID lock, so the jobs run **concurrently
+        across templates** within one session (same-RRID work still serialises);
+        on top of that they remain independently observable and cancellable.
 
         Args:
             cmd_cls: The :class:`Command` subclass to run.

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -25,10 +25,12 @@ Two further read-only tools expose the rest of the checkout that the
 All three are ``async def``. The registered tool closures resolve the
 caller's own :class:`McpSession` from the
 :class:`mtui.mcp.registry.SessionProvider` (keyed on the request
-session under http, a single session under stdio) and then acquire
-*that session's* ``_lock``, so each client serialises only against its
-own concurrent :meth:`McpSession.run_command` calls and patches **only
-its own** loaded testreport file — no cross-client interference.
+session under http, a single session under stdio) and then acquire the
+target template's per-RRID lock via :meth:`McpSession.scoped_lock` (under
+the registry-shared gate), so a tool serialises only against same-template
+:meth:`McpSession.run_command` calls, runs concurrently with work on other
+templates, and patches **only** the addressed testreport file — no
+cross-client and no cross-template interference.
 
 Refusal is uniform: when ``session.metadata`` is a
 :class:`NullTestReport` or ``metadata.path`` is ``None``, every tool
@@ -286,16 +288,18 @@ async def testreport_read(
     the file's *total* line count so the caller can page; when a window was
     requested the reply also carries ``offset`` and ``returned_lines``.
 
-    Acquires ``session._lock`` so the snapshot is coherent with any
-    in-flight command dispatch (e.g. a concurrent ``commit``).
+    Acquires the target template's per-RRID lock (under the registry-shared
+    gate) so the snapshot is coherent with any in-flight command dispatch on
+    the *same* template (e.g. a concurrent ``commit``), while tools on other
+    templates run in parallel.
     """
     if offset < 1:
         raise McpCommandError("", f"offset must be >= 1 (got {offset})", 1)
     if limit is not None and limit < 0:
         raise McpCommandError("", f"limit must be >= 0 (got {limit})", 1)
 
-    await _heartbeat(ctx, "testreport_read: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_read: waiting for template lock")
+    async with session.scoped_lock(template):
         path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
 
@@ -333,8 +337,8 @@ async def testreport_logs(
     names (and byte sizes) so a caller can then fetch one with
     :func:`testreport_read_file`.
     """
-    await _heartbeat(ctx, "testreport_logs: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_logs: waiting for template lock")
+    async with session.scoped_lock(template):
         base = _resolve_template_dir(session, template)
 
         def listing(sub: str) -> list[dict[str, Any]]:
@@ -367,8 +371,8 @@ async def testreport_read_file(
     ``source.diff``, ``patchinfo.xml`` and the like. ``relpath`` is resolved
     under the checkout directory and may not escape it.
     """
-    await _heartbeat(ctx, "testreport_read_file: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_read_file: waiting for template lock")
+    async with session.scoped_lock(template):
         base = _resolve_template_dir(session, template)
         target = _safe_template_file(base, relpath)
         if not target.is_file():
@@ -402,8 +406,8 @@ async def testreport_patch(
     of the surrounding lines (which come from
     :meth:`str.splitlines` with ``keepends=True``).
     """
-    await _heartbeat(ctx, "testreport_patch: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_patch: waiting for template lock")
+    async with session.scoped_lock(template):
         path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
         lines = content.splitlines(keepends=True)
@@ -453,8 +457,8 @@ async def testreport_write(
     :func:`testreport_patch` unreliable; the LLM resends the whole
     file in one shot.
     """
-    await _heartbeat(ctx, "testreport_write: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_write: waiting for template lock")
+    async with session.scoped_lock(template):
         path = _resolve_testreport_path(session, template)
         bytes_written = _atomic_write_text(path, content)
     return {
@@ -551,8 +555,8 @@ async def testreport_fill(
             "", "nothing to fill: pass at least one of reproducer/status/summary", 1
         )
 
-    await _heartbeat(ctx, "testreport_fill: waiting for session lock")
-    async with session._lock:
+    await _heartbeat(ctx, "testreport_fill: waiting for template lock")
+    async with session.scoped_lock(template):
         path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
         lines = content.splitlines(keepends=True)

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -11,8 +11,9 @@ whose:
   :func:`mtui.mcp._schema.build_parameters`.
 * **handler** re-serialises kwargs to argv via
   :func:`mtui.mcp._argv.kwargs_to_argv` and dispatches through
-  :meth:`McpSession.run_command`, which serialises calls behind the
-  session-wide lock and captures stdout/stderr.
+  :meth:`McpSession.run_command`, which serialises calls per template
+  (different-template calls run concurrently; registry mutations take an
+  exclusive gate) and captures stdout/stderr.
 
 Subparser commands (only ``config`` today) are fanned out: one tool per
 subcommand (``config_show``, ``config_set``). The bare ``config`` tool

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -141,25 +141,24 @@ class TestTargetLock:
         assert lock.is_locked() is True
 
     def test_lock_creates_lockfile(self, lock):
-        """Test lock() creates a lockfile on the remote host."""
-        # First call to is_locked (in lock()) should return False
-        lock.connection.sftp_open.side_effect = [
-            OSError(errno.ENOENT, "not found"),  # is_locked -> load
-            MagicMock(),  # the actual lockfile write
-        ]
+        """Test lock() creates the lockfile via an atomic exclusive create."""
+        # On a free host the exclusive ``"x"`` create succeeds outright; there
+        # is no preceding stat, so a single sftp_open call (mode "x") is made.
+        lock.connection.sftp_open.return_value = MagicMock()
 
         lock.lock("test comment")
 
-        # Verify sftp_open was called with write mode
         calls = lock.connection.sftp_open.call_args_list
-        assert len(calls) == 2
-        assert calls[1][0][1] == "w+"
+        assert len(calls) == 1
+        assert calls[0][0][1] == "x"
 
     def test_lock_raises_when_locked_by_other(self, lock):
         """Test lock() raises TargetLockedError when locked by another user."""
         mock_file = MagicMock()
         mock_file.readline.return_value = "1700000000:otheruser:99999"
-        lock.connection.sftp_open.return_value = mock_file
+        # Exclusive create loses the race (file exists); subsequent reads see
+        # the foreign lock and lock() must refuse.
+        lock.connection.sftp_open.side_effect = _busy_sftp_open(mock_file)
 
         with pytest.raises(TargetLockedError):
             lock.lock()
@@ -168,9 +167,42 @@ class TestTargetLock:
         """Test lock() allows re-locking when lock is owned by current user."""
         mock_file = MagicMock()
         mock_file.readline.return_value = f"1700000000:testuser:{os.getpid()}"
-        lock.connection.sftp_open.return_value = mock_file
+        # Exclusive create loses (file exists) but it is our own lock, so the
+        # reconciliation overwrites it with the new comment instead of raising.
+        lock.connection.sftp_open.side_effect = _busy_sftp_open(mock_file)
 
         lock.lock("new comment")  # should not raise
+
+    def test_lock_uses_atomic_exclusive_create_on_free_host(self, lock):
+        """On a free host the very first open is the atomic exclusive create.
+
+        No preceding stat/read happens, so the read-then-write TOCTOU window is
+        gone: a single ``sftp_open(.., "x")`` either wins the create or the
+        process loses the race and reconciles.
+        """
+        lock.connection.sftp_open.return_value = MagicMock()
+
+        lock.lock("mtui pool RRID [owner]")
+
+        first_call = lock.connection.sftp_open.call_args_list[0]
+        assert first_call[0][1] == "x"
+
+    def test_try_claim_loses_atomic_race_to_concurrent_winner(self, lock):
+        """A second concurrent exclusive claim sees the file exist and backs off.
+
+        Models two processes racing: the winner created the lockfile, so this
+        caller's ``"x"`` create raises ``FileExistsError`` and the foreign lock
+        is fresh (not reapable), so ``try_claim`` returns ``False`` instead of
+        clobbering the winner.
+        """
+        lock.config.lock_wait = 0
+        lock.config.lock_reap_stale = False
+        fresh = int(time.time()) - 60
+        lock.connection.sftp_open.side_effect = _busy_sftp_open(
+            _file(f"{fresh}:otheruser:99999")
+        )
+
+        assert lock.try_claim("mtui pool RRID [me]") is False
 
     def test_unlock_when_not_locked(self, lock):
         """Test unlock() does nothing when not locked."""
@@ -384,7 +416,9 @@ class TestTargetLockWait:
     def test_wait_disabled_fails_fast(self, lock):
         """wait <= 0 raises immediately on a foreign lock (legacy behaviour)."""
         fresh = int(time.time()) - 60
-        lock.connection.sftp_open.return_value = _locked_by_fresh(lock, fresh)
+        lock.connection.sftp_open.side_effect = _busy_sftp_open(
+            _locked_by_fresh(lock, fresh)
+        )
         with pytest.raises(TargetLockedError):
             lock.lock()
 
@@ -395,10 +429,11 @@ class TestTargetLockWait:
         monkeypatch.setattr(time, "sleep", lambda _s: None)
 
         fresh = int(time.time()) - 60
-        # 1) lock() is_locked -> foreign; 2) _wait reap age -> foreign(fresh,
-        # not stale); 3) after sleep, is_locked -> ENOENT (freed);
-        # 4) lock() write.
+        # 1) exclusive "x" create loses the race (file exists); 2) lock()
+        # is_locked -> foreign; 3) _wait reap age -> foreign(fresh, not stale);
+        # 4) after sleep, is_locked -> ENOENT (freed); 5) lock() "w+" write.
         lock.connection.sftp_open.side_effect = [
+            FileExistsError("lockfile exists"),
             _file(f"{fresh}:otheruser:99999"),
             _file(f"{fresh}:otheruser:99999"),
             OSError(errno.ENOENT, "gone"),
@@ -415,7 +450,9 @@ class TestTargetLockWait:
         lock.config.lock_wait = 1
         lock.config.lock_wait_poll = 1
         fresh = int(time.time()) - 60
-        lock.connection.sftp_open.return_value = _file(f"{fresh}:otheruser:99999")
+        lock.connection.sftp_open.side_effect = _busy_sftp_open(
+            _file(f"{fresh}:otheruser:99999")
+        )
         with pytest.raises(TargetLockedError):
             lock.lock()
 
@@ -424,6 +461,23 @@ def _file(contents: str) -> MagicMock:
     f = MagicMock()
     f.readline.return_value = contents
     return f
+
+
+def _busy_sftp_open(read_file: MagicMock):
+    """side_effect making the exclusive ``"x"`` create lose the race.
+
+    Models a host that is already locked: the atomic ``sftp_open(.., "x")`` in
+    :meth:`TargetLock.lock` raises ``FileExistsError`` (someone else holds the
+    file), and every other open (the reconciliation reads, then the ``"w+"``
+    overwrite) returns ``read_file``.
+    """
+
+    def _open(_filename, mode="r", *_a, **_k):
+        if mode == "x":
+            raise FileExistsError("lockfile exists")
+        return read_file
+
+    return _open
 
 
 def _locked_by_fresh(lock, ts: int) -> MagicMock:

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -103,7 +103,7 @@ def test_job_result_running_tells_caller_to_poll(tmp_path: Path) -> None:
         # A job whose body blocks until we release the gate.
         async def _blocker() -> None:
             try:
-                async with sess._lock:
+                async with sess._registry.exclusive():
                     await gate.wait()
             except asyncio.CancelledError:
                 raise

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -199,7 +199,10 @@ def test_get_or_create_distinct_keys_are_isolated(tmp_path: Path) -> None:
     assert a is not b
     assert a.metadata is not b.metadata
     assert a.targets is not b.targets
-    assert a._lock is not b._lock  # noqa: SLF001
+    # Each session owns its own registry gate and per-RRID lock map, so work on
+    # one client never blocks another.
+    assert a._registry is not b._registry  # noqa: SLF001
+    assert a._rrid_locks is not b._rrid_locks  # noqa: SLF001
 
 
 def test_get_or_create_concurrent_first_calls_mint_one(tmp_path: Path) -> None:

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -116,8 +116,13 @@ class _RecordingCommand(Command):
         self.println(f"{start:.6f}-{end:.6f}")
 
 
-def test_run_command_serialises_via_lock(tmp_path: Path) -> None:
-    """Two concurrent ``run_command`` calls must not overlap in time."""
+def test_run_command_unscoped_serialises_via_exclusive_gate(tmp_path: Path) -> None:
+    """Unscoped commands (no real template) take the exclusive registry gate.
+
+    With nothing loaded, ``_resolve_job_rrids`` yields only the Null report, so
+    the command falls onto the registry-exclusive path and concurrent calls
+    must still run strictly one-at-a-time (no overlap).
+    """
     sess = _make_session(tmp_path)
     _RecordingCommand._intervals.clear()
 
@@ -137,6 +142,131 @@ def test_run_command_serialises_via_lock(tmp_path: Path) -> None:
         intervals, intervals[1:], strict=False
     ):
         assert a_end <= b_start, f"intervals overlapped: {intervals!r}"
+
+
+def _rrid_recorder_command():
+    """Build a throwaway fan-out :class:`Command` that records its interval.
+
+    Each ``__call__`` sleeps briefly and appends ``(rrid, start, end)`` to the
+    returned ``seen`` list, so a test can check whether two invocations on
+    different RRIDs overlapped in time. ``scope="fanout"`` + ``_add_template_arg``
+    lets ``-T <rrid>`` scope it to exactly one loaded template (one per-RRID
+    lock). The caller must unregister ``cls`` afterwards.
+    """
+    seen: list[tuple[str, float, float]] = []
+
+    class _RridProbe(Command):
+        command = "rrid_probe_tmp"
+        scope: ClassVar[str] = "fanout"
+        _hold_seconds: ClassVar[float] = 0.1
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            cls._add_template_arg(parser)
+
+        def __call__(self) -> None:
+            start = time.monotonic()
+            time.sleep(self._hold_seconds)
+            end = time.monotonic()
+            seen.append((str(self.metadata.id), start, end))
+
+    return _RridProbe, seen
+
+
+def test_run_command_different_rrids_run_concurrently(tmp_path: Path) -> None:
+    """Two ``run_command`` calls scoped to *different* templates overlap in time."""
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+    cls, seen = _rrid_recorder_command()
+
+    async def driver() -> None:
+        await asyncio.gather(
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:1:1"]),
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:2:1"]),
+        )
+
+    try:
+        asyncio.run(driver())
+    finally:
+        Command.registry.pop(cls.command, None)
+
+    assert len(seen) == 2
+    (_r1, s1, e1), (_r2, s2, e2) = seen
+    # Different RRID locks → the intervals must overlap (each holds for 0.1s,
+    # so a serial run would take ~0.2s and not overlap).
+    assert s2 < e1, f"expected overlap, got {seen!r}"
+    assert s1 < e2, f"expected overlap, got {seen!r}"
+
+
+def test_run_command_same_rrid_serialises(tmp_path: Path) -> None:
+    """Two ``run_command`` calls scoped to the *same* template do not overlap."""
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+    cls, seen = _rrid_recorder_command()
+
+    async def driver() -> None:
+        await asyncio.gather(
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:1:1"]),
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:1:1"]),
+        )
+
+    try:
+        asyncio.run(driver())
+    finally:
+        Command.registry.pop(cls.command, None)
+
+    assert len(seen) == 2
+    intervals = sorted((s, e) for _r, s, e in seen)
+    (_s1, e1), (s2, _e2) = intervals
+    assert e1 <= s2, f"same-RRID calls overlapped: {seen!r}"
+
+
+def _stdout_probe_command():
+    """Throwaway command that prints its RRID twice around a sleep.
+
+    Two concurrent different-RRID runs overlap (per-RRID locks); each call must
+    capture *only* its own two prints — proving ``self._current_stdout`` /
+    ``self.display`` are per-call context vars, not a clobberable session attr.
+    """
+
+    class _StdoutProbe(Command):
+        command = "stdout_probe_tmp"
+        scope: ClassVar[str] = "fanout"
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            cls._add_template_arg(parser)
+
+        def __call__(self) -> None:
+            rrid = str(self.metadata.id)
+            self.println(f"{rrid}:first")
+            time.sleep(0.1)
+            self.println(f"{rrid}:second")
+
+    return _StdoutProbe
+
+
+def test_concurrent_runs_do_not_clobber_each_others_stdout(tmp_path: Path) -> None:
+    """Overlapping different-RRID runs each capture only their own output."""
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+    cls = _stdout_probe_command()
+
+    async def driver() -> tuple[str, str]:
+        return await asyncio.gather(
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:1:1"]),
+            sess.run_command(cls, ["-T", "SUSE:Maintenance:2:1"]),
+        )
+
+    try:
+        out_a, out_b = asyncio.run(driver())
+    finally:
+        Command.registry.pop(cls.command, None)
+
+    # Each reply contains exactly its own RRID's two lines and nothing of the
+    # other call's — no cross-contamination despite the overlapping execution.
+    assert out_a == "SUSE:Maintenance:1:1:first\nSUSE:Maintenance:1:1:second\n"
+    assert out_b == "SUSE:Maintenance:2:1:first\nSUSE:Maintenance:2:1:second\n"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -27,6 +27,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Mapping
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -75,21 +76,42 @@ class _FakeRegistry:
     def all(self) -> list[object]:
         return list(self._entries.values())
 
+    @property
+    def active(self) -> object:
+        return next(iter(self._entries.values()))
+
+
+def _fake_scoped_lock(lock: asyncio.Lock):
+    """Build a ``scoped_lock(rrid)`` stand-in over a single real lock.
+
+    The tools call ``session.scoped_lock(template)``; the fakes only need the
+    ``async with`` to acquire *a* lock, so we ignore the rrid and serialise on
+    one :class:`asyncio.Lock` (matching the old ``_lock`` behaviour).
+    """
+
+    @asynccontextmanager
+    async def _scoped_lock(_rrid: str | None):
+        async with lock:
+            yield
+
+    return _scoped_lock
+
 
 def _loaded_session(tmp_path: Path, path: Path) -> SimpleNamespace:
     """Fake session that only needs the attributes the tools touch.
 
     Avoids constructing a full TestReport — we just need ``metadata.path``
     to be a non-None string and ``metadata`` to *not* be a NullTestReport.
-    ``_lock`` is a real :class:`asyncio.Lock` so the ``async with`` works.
-    A single-entry ``templates`` registry is provided so ``_resolve_report``
-    resolves to ``metadata`` (zero/one loaded -> active fallback).
+    ``scoped_lock`` wraps a real :class:`asyncio.Lock` so the ``async with``
+    works. A single-entry ``templates`` registry is provided so
+    ``_resolve_report`` resolves to ``metadata`` (zero/one loaded -> active
+    fallback).
     """
     metadata = SimpleNamespace(id="SUSE:Maintenance:1:1", path=str(path))
     return SimpleNamespace(
         metadata=metadata,
         templates=_FakeRegistry({"SUSE:Maintenance:1:1": metadata}),
-        _lock=asyncio.Lock(),
+        scoped_lock=_fake_scoped_lock(asyncio.Lock()),
     )
 
 
@@ -105,7 +127,7 @@ def _multi_session(tmp_path: Path, paths: dict[str, Path]) -> SimpleNamespace:
     return SimpleNamespace(
         metadata=first,
         templates=_FakeRegistry(reports),
-        _lock=asyncio.Lock(),
+        scoped_lock=_fake_scoped_lock(asyncio.Lock()),
     )
 
 

--- a/tests/test_target_try_claim.py
+++ b/tests/test_target_try_claim.py
@@ -29,15 +29,16 @@ def _locked_by(contents: str) -> MagicMock:
 
 
 def test_try_claim_free_host(lock):
-    """A free host is claimed (True) and the lockfile is written."""
-    # is_locked()->load (ENOENT), then lock()'s is_locked()->load (ENOENT),
-    # then the actual write.
+    """A free host is claimed (True) via the atomic exclusive create."""
+    # try_claim's is_locked()->load (ENOENT), then lock()'s exclusive ``"x"``
+    # create wins outright (no stat-before-write).
     lock.connection.sftp_open.side_effect = [
-        OSError(errno.ENOENT, "not found"),
-        OSError(errno.ENOENT, "not found"),
-        MagicMock(),
+        OSError(errno.ENOENT, "not found"),  # try_claim is_locked
+        MagicMock(),  # lock() exclusive "x" create succeeds
     ]
     assert lock.try_claim("mtui pool RRID [owner]") is True
+    # The write that won was the exclusive create.
+    assert lock.connection.sftp_open.call_args_list[-1][0][1] == "x"
 
 
 def test_try_claim_foreign_host_returns_false(lock):
@@ -61,13 +62,12 @@ def test_try_claim_stale_reaps_then_claims(lock):
     stale = int(time.time()) - 200000  # > 1 day
     # try_claim: is_locked->load(stale); is_mine->False (cached);
     # reap_if_stale: age_seconds->load(stale), unlock(force): is_locked->load,
-    # sftp_remove; then lock(): is_locked->load(ENOENT), write.
+    # sftp_remove; then lock()'s exclusive "x" create wins on the now-free host.
     lock.connection.sftp_open.side_effect = [
         _locked_by(f"{stale}:otheruser:99999"),  # try_claim is_locked
         _locked_by(f"{stale}:otheruser:99999"),  # reap age_seconds load
         _locked_by(f"{stale}:otheruser:99999"),  # unlock(force) is_locked load
-        OSError(errno.ENOENT, "not found"),  # lock() is_locked after reap
-        MagicMock(),  # write
+        MagicMock(),  # lock() exclusive "x" create succeeds
     ]
     assert lock.try_claim() is True
     lock.connection.sftp_remove.assert_called_once()


### PR DESCRIPTION
## Summary

Three remaining `mtui-mcp` concurrency/safety items, building on the
per-template fixes already merged to `main` (template scoping, REMAINDER
argv encoding, `unload` tool, no active-pointer move on load).

### 1. Per-template locking — true intra-session parallelism
Replaces the single per-session `asyncio.Lock` (held across the whole
`to_thread` worker, serialising *every* tool call) with per-template
locking layered over a registry shared/exclusive gate:

- a call scoped to one loaded template takes the gate **shared** + that
  template's per-RRID lock → calls on **different** templates run
  concurrently; calls on the **same** template still serialise; none
  overlaps a registry mutation.
- registry mutators (`load_template`, `unload`, `close`) and unscoped
  fan-out take the gate **exclusive**, draining in-flight per-template
  work so the loaded set is never observed mid-mutation.

`run_command`, the background-job runner (`_mint_job`/`start_jobs`), and
the six testreport file tools all route through the new `_command_lock`
/ `scoped_lock`. Backgrounded fan-out now runs **one job per template
concurrently** instead of serially.

### 2. Per-call output isolation (prerequisite for #1)
Moves the per-call output sinks (`display`, `_current_stdout`) off the
session instance into `contextvars` set by `_run_sync` (propagated into
fan-out worker threads via `ContextExecutor`, mirroring the existing
`_capture_token`), so two overlapping commands never clobber each
other's captured stdout.

### 3. Atomic refhost pool lock (independent)
`TargetLock.lock` claimed the remote lockfile with a stat-then-`w+`
write — a TOCTOU window where two separate mtui processes/users could
both see a host as free and clobber each other's claim. Now opens with
mode `"x"` (`O_CREAT|O_EXCL`): exactly one racer wins the atomic create,
the loser falls through to the existing busy/stale/`is_mine`
reconciliation. `PoolLock` ownership semantics (RRID+user, PID-ignored)
unchanged.

## Tests
- different-RRID `run_command` calls overlap in time; same-RRID
  serialise; concurrent runs don't cross-contaminate stdout.
- atomic exclusive-create on a free host; a lost `try_claim` race
  returns `False`; updated existing lock/try_claim mocks to the new
  call sequence.
- updated the old single-lock serialisation test, registry, and jobs
  tests off the removed `_lock`.

## Gate (whole repo, observed green)
`ruff format --check .` · `ruff check .` · `ty check` · `pytest`
(1700 passed) · `sphinx-build -W` (docs). Patch coverage: `session.py`
87%, `locks.py` 92%.

Docs (`Documentation/mcp.rst`) and `CHANGELOG.md` updated to the
per-template contract.
