### PR TITLE
fix(testreport): run svn checkout with cwd= instead of global chdir

### DIFF
--- a/mtui/test_reports/svn_io.py
+++ b/mtui/test_reports/svn_io.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from os.path import join
 from pathlib import Path
 
-from ..support.fileops import chdir, ensure_dir_exists
+from ..support.fileops import ensure_dir_exists
 from ..support.messages import SvnCheckoutFailed, SvnCheckoutInterruptedError
 from ..types import RequestReviewID
 
@@ -82,22 +82,24 @@ def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:
     )
     uri = join(path, str(rrid))
 
-    with chdir(config.template_dir):
-        try:
-            # Capture stderr so svn's cryptic "E170000: URL ... doesn't
-            # exist" line does not reach the user; it is surfaced at debug
-            # while the caller logs a clear, actionable message instead.
-            result = subprocess.run(
-                ["svn", "co", uri],
-                stderr=subprocess.PIPE,
-                text=True,
-                check=False,
-            )
-        except KeyboardInterrupt:
-            raise SvnCheckoutInterruptedError(uri) from None
+    try:
+        # Capture stderr so svn's cryptic "E170000: URL ... doesn't
+        # exist" line does not reach the user; it is surfaced at debug
+        # while the caller logs a clear, actionable message instead.
+        # The svn uri is absolute, so run svn co with cwd=template_dir
+        # rather than mutating the process-global working directory.
+        result = subprocess.run(
+            ["svn", "co", uri],
+            cwd=config.template_dir,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except KeyboardInterrupt:
+        raise SvnCheckoutInterruptedError(uri) from None
 
-        if result.returncode != 0:
-            if result.stderr:
-                logger.debug("svn co %s failed: %s", uri, result.stderr.strip())
-            report_url = f"{config.fancy_reports_url.rstrip('/')}/{rrid}/log"
-            raise SvnCheckoutFailed(str(rrid), report_url) from None
+    if result.returncode != 0:
+        if result.stderr:
+            logger.debug("svn co %s failed: %s", uri, result.stderr.strip())
+        report_url = f"{config.fancy_reports_url.rstrip('/')}/{rrid}/log"
+        raise SvnCheckoutFailed(str(rrid), report_url) from None

--- a/tests/test_svn_io.py
+++ b/tests/test_svn_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -54,3 +55,26 @@ def test_svn_checkout_success_does_not_raise(tmp_path: Path) -> None:
 
     with patch("mtui.test_reports.svn_io.subprocess.run", return_value=completed):
         svn_io.testreport_svn_checkout(cfg, "svn+ssh://svn@example/testreports", rrid)
+
+
+def test_svn_checkout_runs_with_cwd_not_global_chdir(tmp_path: Path) -> None:
+    """``svn co`` runs with ``cwd=template_dir`` and never chdir's the process."""
+    cfg = _cfg(tmp_path)
+    rrid = RequestReviewID("SUSE:Maintenance:1:1")
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
+    before = os.getcwd()
+
+    with patch(
+        "mtui.test_reports.svn_io.subprocess.run", return_value=completed
+    ) as run:
+        svn_io.testreport_svn_checkout(cfg, "svn+ssh://svn@example/testreports", rrid)
+
+    # The checkout targets the absolute uri via cwd= instead of os.chdir.
+    assert run.call_args.kwargs.get("cwd") == tmp_path
+    assert run.call_args.args[0] == [
+        "svn",
+        "co",
+        "svn+ssh://svn@example/testreports/SUSE:Maintenance:1:1",
+    ]
+    # The process working directory is untouched.
+    assert os.getcwd() == before


### PR DESCRIPTION
## `fix(testreport): run svn checkout with cwd= instead of global chdir`

`testreport_svn_checkout` mutated the process-global CWD via `with chdir(config.template_dir):` around the `svn co`. This replaces it with `cwd=config.template_dir` on the `subprocess.run` call (the svn URI is absolute), matching the existing style in `svn_commit_testreport`. The now-unused `chdir` import is dropped (`ensure_dir_exists` kept). `TestReport.read`'s `os.chdir` stays gated behind `config.chdir_to_template_dir` (default `False`) and is unchanged.

Removing the process-global `chdir` is hygiene: it eliminates the only `chdir` on the MCP checkout path, so cwd-safety no longer relies on the registry exclusive-gate invariant draining all in-flight work during a load.

### Testing
- Full `AGENTS.md` gate green on the whole repo: `ruff format --check .`, `ruff check .`, `ty check`, `pytest` — **1701 passed**.
- New test asserts `svn co` is invoked with `cwd=template_dir`, the full absolute argv, and that `os.getcwd()` is unchanged across the call.

---
*History note: this branch originally bundled four commits (ContextVar output sinks, svn `cwd=`, registry mutex, per-RRID lock sharding). The other three were independently implemented upstream while this was in draft — `fcafc91`/`ca42ad6`/`46da7d7` and then `ac6282b` (per-template concurrent execution via a shared/exclusive registry RW-lock) + `188ff30` (atomic pool lock). Under that RW-lock the registry mutex is redundant and the lock-sharding is superseded, so the branch was rebased down to just this independent cleanup.*
