### PR TITLE
feat(commands): default updates to the unassigned in-testing queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   API (`GET /api/v1/updates`, fed from SMELT) and sorted by priority. Each row
   shows priority, status, kind (SLFO / Maintenance / ...), deadline and the
   RRID; the queue merges gitea-sourced updates (SLFO/SL-Micro) with the classic
-  Maintenance updates in QAM testing. Optional `--review-group`/`--status`/
+  Maintenance updates in QAM testing. By default it shows the actionable pickup
+  queue — **unassigned** updates that are **in testing** — so bare `updates`
+  is usable without wading through released entries; pass `--status all` for the
+  full queue (every status and assignee). Optional `--review-group`/`--status`/
   `--limit` filters. This is the TeReGen-backed replacement for the removed
   `smelt_updates`/`smelt_requests` commands.
 - `updates` gained assignment exposure (restoring functionality dropped with
   SMELT): `--assignee <user>` and `--mine` (the current session user) filter the
-  queue to updates assigned to that user, `--unassigned` to updates with no
-  assignee, and `--show-assignment` annotates every row with its assignee
-  without filtering. Requires the matching TeReGen `/updates` assignment support.
+  queue to updates assigned to that user, while `--all-assignees` shows every
+  update regardless of assignee (overriding the unassigned default) and
+  annotates each row with its assignee. Requires the matching TeReGen
+  `/updates` assignment support.
 - New `checkers` command — lists the build-check (checker) result runs for the
   loaded update, fetched live from the TeReGen report API
   (`GET /reports/{id}/checkers`). This is the TeReGen-backed replacement for the

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -465,12 +465,20 @@ updates
 ::
 
     updates [--review-group GROUP] [--status STATUS] [--limit N]
+            [--assignee USER | --mine | --all-assignees]
 
-Enumerates the unreleased update queue, fetched live from the TeReGen API
+Enumerates the update queue, fetched live from the TeReGen API
 (``GET /updates``, fed from SMELT behind the scenes), one line per update with
-its priority, status and RRID. This is the TeReGen-backed replacement for the
-former ``smelt_updates`` / ``smelt_requests`` commands. Not template-scoped; does
-not fan out. Requires the TeReGen base URL in ``[teregen] api`` (see :doc:`cfg`).
+its priority, status, kind, deadline and RRID. This is the TeReGen-backed
+replacement for the former ``smelt_updates`` / ``smelt_requests`` commands. Not
+template-scoped; does not fan out. Requires the TeReGen base URL in
+``[teregen] api`` (see :doc:`cfg`).
+
+By default the command shows the actionable pickup queue: **unassigned**
+updates that are **in testing**. Choosing another assignment view
+(``--assignee``/``--mine``/``--all-assignees``) drops the unassigned default,
+and ``--status all`` widens the queue to every status and assignee (including
+released updates).
 
 **Options:**
 
@@ -480,11 +488,27 @@ not fan out. Requires the TeReGen base URL in ``[teregen] api`` (see :doc:`cfg`)
 
 .. option:: --status STATUS
 
-  Only updates with this status (e.g. ``testing``).
+  Only updates with this status. Defaults to ``testing``; pass ``all`` to show
+  every status (including released updates).
 
 .. option:: --limit N
 
   Cap the number of rows (``0`` = all).
+
+.. option:: --assignee USER
+
+  Filter to updates assigned to ``USER`` (any qam group). Drops the unassigned
+  default.
+
+.. option:: --mine
+
+  Filter to updates assigned to the current session user. Drops the unassigned
+  default.
+
+.. option:: --all-assignees
+
+  Show every update regardless of assignee (assigned and unassigned), with the
+  assignee on each row. Overrides the unassigned default.
 
 
 regenerate

--- a/mtui/commands/updates.py
+++ b/mtui/commands/updates.py
@@ -5,6 +5,12 @@ Lists the update queue, fetched live from the TeReGen API
 priority. Each row shows priority, status, kind (SLFO / Maintenance / ...),
 deadline and the RRID. The queue merges gitea-sourced updates (SLFO/SL-Micro)
 with the classic Maintenance updates in QAM testing.
+
+By default the command shows the actionable pickup queue: **unassigned**
+updates that are **in testing** (``--status testing``). Pick another
+assignment view (``--assignee``/``--mine``/``--all-assignees``) to drop the
+unassigned default, or pass ``--status all`` to see the whole queue (every
+status, every assignee), including released updates.
 """
 
 from __future__ import annotations
@@ -20,9 +26,13 @@ logger = getLogger("mtui.commands.updates")
 
 
 class Updates(Command):
-    """List the unreleased update queue (via the TeReGen API)."""
+    """List the unassigned, in-testing update queue (via the TeReGen API)."""
 
     command = "updates"
+
+    #: ``--status`` value that widens the queue to every status (the escape
+    #: hatch translated to ``status=None`` server-side).
+    STATUS_ALL = "all"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
@@ -34,8 +44,8 @@ class Updates(Command):
         )
         parser.add_argument(
             "--status",
-            default=None,
-            help="filter by status, e.g. testing",
+            default="testing",
+            help="filter by status (default: testing); use 'all' for every status",
         )
         parser.add_argument(
             "--limit",
@@ -43,8 +53,9 @@ class Updates(Command):
             default=0,
             help="cap the number of rows (0 = all)",
         )
-        # --assignee/--mine/--unassigned select at most one assignment view;
-        # argparse rejects any combination of the three for us.
+        # --assignee/--mine/--all-assignees select at most one assignment view;
+        # argparse rejects any combination of the three for us. The default
+        # (no flag) is the unassigned queue.
         assignment = parser.add_mutually_exclusive_group()
         assignment.add_argument(
             "--assignee",
@@ -57,14 +68,10 @@ class Updates(Command):
             help="filter to updates assigned to the current session user",
         )
         assignment.add_argument(
-            "--unassigned",
+            "--all-assignees",
             action="store_true",
-            help="filter to updates with no assignee",
-        )
-        parser.add_argument(
-            "--show-assignment",
-            action="store_true",
-            help="show the assignee on each row without filtering",
+            help="show every update regardless of assignee (assigned and "
+            "unassigned), overriding the unassigned default",
         )
 
     def __call__(self) -> None:
@@ -73,16 +80,26 @@ class Updates(Command):
         if self.args.mine:
             assignee = self.config.session_user
 
-        # Any assignment-related flag means rows should carry assignment info.
-        want_assignment = bool(
-            assignee or self.args.unassigned or self.args.show_assignment
-        )
+        # '--status all' is the escape hatch: widen to every status by sending
+        # no status filter at all (the server returns released updates too).
+        status_all = self.args.status == self.STATUS_ALL
+        status = None if status_all else self.args.status
+
+        # Default view is the unassigned pickup queue: with no assignment view
+        # chosen, filter to unassigned. --assignee/--mine pick a specific user;
+        # --all-assignees and --status all opt out of the unassigned filter (the
+        # latter because 'unassigned' implies status=testing server-side).
+        chose_other_view = bool(assignee or self.args.all_assignees)
+        unassigned = not chose_other_view and not status_all
+
+        # Show the assignee column whenever assignment is part of the view.
+        want_assignment = bool(assignee or unassigned or self.args.all_assignees)
 
         updates = TeReGen(self.config).updates(
             review_group=self.args.review_group,
-            status=self.args.status,
+            status=status,
             assignee=assignee,
-            unassigned=self.args.unassigned,
+            unassigned=unassigned,
             with_assignment=want_assignment,
         )
         if not updates:
@@ -119,8 +136,7 @@ class Updates(Command):
                 ("--limit",),
                 ("--assignee",),
                 ("--mine",),
-                ("--unassigned",),
-                ("--show-assignment",),
+                ("--all-assignees",),
             ],
             line,
             text,

--- a/tests/test_cmd_updates.py
+++ b/tests/test_cmd_updates.py
@@ -21,12 +21,11 @@ def _sysmock() -> MagicMock:
 def _args(**kw) -> Namespace:
     base = {
         "review_group": None,
-        "status": None,
+        "status": "testing",
         "limit": 0,
         "assignee": None,
         "mine": False,
-        "unassigned": False,
-        "show_assignment": False,
+        "all_assignees": False,
     }
     base.update(kw)
     return Namespace(**base)
@@ -62,10 +61,10 @@ def test_updates_lists_queue(mock_config):
 
     teregen.updates.assert_called_once_with(
         review_group="qam-sle",
-        status=None,
+        status="testing",
         assignee=None,
-        unassigned=False,
-        with_assignment=False,
+        unassigned=True,
+        with_assignment=True,
     )
     out = sysmock.stdout.getvalue()
     assert "SUSE:SLFO:1.2:5444" in out
@@ -87,7 +86,7 @@ def test_updates_limit(mock_config):
     assert "Update queue (1)" in out
 
 
-def test_updates_show_assignment_renders_assignee(mock_config):
+def test_updates_all_assignees_renders_assignee(mock_config):
     sysmock = _sysmock()
     with patch("mtui.commands.updates.TeReGen") as teregen_cls:
         teregen = teregen_cls.return_value
@@ -95,11 +94,11 @@ def test_updates_show_assignment_renders_assignee(mock_config):
             {"id": "SUSE:SLFO:1.2:1", "assignee": "alice"},
             {"id": "SUSE:SLFO:1.2:2", "assignee": None},
         ]
-        Updates(_args(show_assignment=True), mock_config, sysmock, MagicMock())()
+        Updates(_args(all_assignees=True), mock_config, sysmock, MagicMock())()
 
     teregen.updates.assert_called_once_with(
         review_group=None,
-        status=None,
+        status="testing",
         assignee=None,
         unassigned=False,
         with_assignment=True,
@@ -118,25 +117,73 @@ def test_updates_mine_maps_to_session_user(mock_config):
 
     teregen.updates.assert_called_once_with(
         review_group=None,
-        status=None,
+        status="testing",
         assignee="testuser",
         unassigned=False,
         with_assignment=True,
     )
 
 
-def test_updates_unassigned_passes_through(mock_config):
+def test_updates_all_assignees_drops_unassigned_filter(mock_config):
     sysmock = _sysmock()
     with patch("mtui.commands.updates.TeReGen") as teregen_cls:
         teregen = teregen_cls.return_value
         teregen.updates.return_value = []
-        Updates(_args(unassigned=True), mock_config, sysmock, MagicMock())()
+        Updates(_args(all_assignees=True), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status="testing",
+        assignee=None,
+        unassigned=False,
+        with_assignment=True,
+    )
+
+
+def test_updates_default_is_unassigned_testing(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = []
+        Updates(_args(), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status="testing",
+        assignee=None,
+        unassigned=True,
+        with_assignment=True,
+    )
+
+
+def test_updates_status_all_widens_to_full_queue(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = []
+        Updates(_args(status="all"), mock_config, sysmock, MagicMock())()
 
     teregen.updates.assert_called_once_with(
         review_group=None,
         status=None,
         assignee=None,
-        unassigned=True,
+        unassigned=False,
+        with_assignment=False,
+    )
+
+
+def test_updates_assignee_drops_unassigned_default(mock_config):
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen = teregen_cls.return_value
+        teregen.updates.return_value = []
+        Updates(_args(assignee="bob"), mock_config, sysmock, MagicMock())()
+
+    teregen.updates.assert_called_once_with(
+        review_group=None,
+        status="testing",
+        assignee="bob",
+        unassigned=False,
         with_assignment=True,
     )
 
@@ -146,11 +193,11 @@ def test_updates_mine_and_assignee_are_mutually_exclusive():
         _parser().parse_args(["--mine", "--assignee", "bob"])
 
 
-def test_updates_unassigned_with_assignee_errors():
+def test_updates_all_assignees_with_assignee_errors():
     with pytest.raises(ArgsParseFailureError):
-        _parser().parse_args(["--unassigned", "--assignee", "bob"])
+        _parser().parse_args(["--all-assignees", "--assignee", "bob"])
 
 
-def test_updates_mine_and_unassigned_are_mutually_exclusive():
+def test_updates_mine_and_all_assignees_are_mutually_exclusive():
     with pytest.raises(ArgsParseFailureError):
-        _parser().parse_args(["--mine", "--unassigned"])
+        _parser().parse_args(["--mine", "--all-assignees"])


### PR DESCRIPTION
## What

`updates` no longer dumps the entire TeReGen `/updates` queue (including released entries). Bare `updates` now shows the actionable pickup queue: **unassigned** updates that are **in testing**.

## Why

The command sent no `status`/assignment filter by default, so the server returned everything — released, every status, every assignee — which is noisy and unusable as a work queue.

## Changes

- `--status` now defaults to `testing` (was unset). Pass `--status all` to restore the full queue (every status and assignee, including released).
- With no assignment view chosen, the command now filters to **unassigned** updates.
- Replaced the now-redundant `--unassigned`/`--show-assignment` flags with a single **`--all-assignees`**: shows every update regardless of assignee (assigned + unassigned), with the assignee column on, overriding the unassigned default. `--assignee`/`--mine` still target a specific user.
- Updated `Documentation/iui.rst` and the `[Unreleased]` CHANGELOG entry (the `updates` command is still unreleased, so the new defaults are folded into its existing notes rather than a separate "Changed" line).

## Default behaviour matrix

| invocation | status | assignment filter |
|---|---|---|
| `updates` | `testing` | unassigned |
| `updates --assignee X` / `--mine` | `testing` | that user |
| `updates --all-assignees` | `testing` | none (shows all, with assignee column) |
| `updates --status all` | all | none |

## Testing

Full gate set on the whole repo, all green:

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 1704 passed
- `uv run --group doc sphinx-build -W -b html Documentation Documentation/.build/html` — build succeeded