### PR TITLE
feat(mcp): cut tool-list token cost with schema slimming, profiles, output cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `mtui-mcp` is now much more token-efficient. Tool schemas are automatically
+  slimmed of redundant pydantic boilerplate (the per-field `title` keys and the
+  `anyOf: [T, null]` optional-field unions), shrinking the tool-list payload
+  sent on every request by roughly a quarter with no change to what the model
+  can call. A new `[mcp] tool_profile` setting selects the exposed tool surface:
+  `full` (default, every tool — unchanged behaviour) or `core` (a curated
+  everyday subset that roughly halves the payload), fine-tunable with the
+  `[mcp] tools_allow` / `tools_deny` lists. A new `[mcp] max_output_bytes`
+  setting (default `100000`, `0` to disable) caps a single tool result, with
+  oversized output truncated and a notice pointing at the testreport read
+  paging.
 - `unload` is now exposed as an `mtui-mcp` tool. It takes an RRID and drops
   exactly that loaded template (closing only its host connections), leaving the
   others loaded — the addressable counterpart to `load_template` for MCP

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -477,6 +477,43 @@ These knobs live in the ``[mcp]`` section of the mtui config file:
     [mcp]
     session_cap = 32
     session_idle_timeout = 1800
+    tool_profile = full
+    tools_allow =
+    tools_deny =
+    max_output_bytes = 100000
+
+
+Token budget: tool surface and output size
+==========================================
+
+Every tool the server registers is described to the model on **each**
+request — names, descriptions and JSON input schemas. With the full
+command set that fixed cost is several thousand tokens before any work
+happens, and a single large tool result (a ``run`` across many hosts, a
+multi-thousand-line install log) can dwarf the rest of the context. Three
+measures keep that budget in check; all are applied automatically and are
+configurable in the ``[mcp]`` section.
+
+* **Schema slimming (always on).** Each synthesised tool schema is
+  rewritten to drop redundant pydantic ``title`` keys and to flatten the
+  ``anyOf: [{type: X}, {type: null}]`` unions pydantic emits for optional
+  fields down to a flat ``{type: X}`` (the field's ``default`` already
+  marks it optional). The set of tools and what the model can call is
+  unchanged; only dead schema weight is removed. This alone trims the
+  tool-list payload by roughly a quarter.
+* **Tool profiles.** ``[mcp] tool_profile`` selects which tools are
+  exposed. ``full`` (the default) keeps every command tool, so existing
+  deployments are unchanged. ``core`` exposes only the curated everyday
+  subset (load/inspect/run/install, report editing, approve/reject, the
+  ``testreport_*`` and ``job_*`` tools), removing the long tail of
+  host-bookkeeping and server-tuning verbs and roughly halving the
+  tool-list payload. Fine-tune either profile with the comma-separated
+  ``tools_allow`` (added back on top of the profile) and ``tools_deny``
+  (removed last, always wins) lists.
+* **Output cap.** ``[mcp] max_output_bytes`` (default ``100000``) caps a
+  single tool result; output beyond the cap is truncated with a one-line
+  notice pointing at the ``offset``/``limit`` paging on the testreport
+  read tools. Set it to ``0`` to disable the cap.
 
 
 Long-running tool calls

--- a/mtui/mcp/_slim.py
+++ b/mtui/mcp/_slim.py
@@ -1,0 +1,162 @@
+"""Token-slimming pass over the synthesised MCP tool JSON schemas.
+
+The tools built by :mod:`mtui.mcp.tools` (one per :class:`mtui.commands.Command`)
+get their input schema from :mod:`pydantic` via the SDK. Pydantic's generator is
+faithful but verbose: every field carries a redundant ``"title"`` key, every
+optional field is rendered as a two-member ``anyOf: [{type: X}, {type: null}]``
+union, and the shared ``template`` / ``all_templates`` / ``hosts`` help strings
+are repeated across dozens of tools. None of that changes what the model can
+call, but all of it is sent on **every** request as part of the tool list.
+
+This module rewrites the already-registered schemas in place to drop the dead
+weight while preserving meaning (type, default, description, enum). It is a pure
+transform on plain ``dict`` data plus a thin walker over the SDK's tool table;
+both are isolated here so an SDK rename only breaks one well-tested seam (see
+:func:`slim_registered_tools`, which degrades gracefully).
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+logger = getLogger("mtui.mcp.slim")
+
+
+def cap_output(text: str, limit: int) -> str:
+    """Truncate ``text`` to at most ``limit`` bytes (utf-8), with a notice.
+
+    A single tool result — a ``run`` over many hosts, a multi-thousand-line
+    install log — can dwarf the rest of the context. When the utf-8 encoding of
+    ``text`` exceeds ``limit`` the **tail** is dropped (the head usually carries
+    the command echo and the first, most diagnostic output) and a one-line
+    ``…[truncated N bytes; …]`` notice is appended pointing at the paged readers.
+
+    ``limit <= 0`` (or a non-integer ``limit``) disables the cap and returns
+    ``text`` unchanged. Under-cap text is returned byte-identical. The cut is
+    made on a decoded boundary so the result is always valid utf-8 even if the
+    byte cut would split a codepoint.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        return text
+    encoded = text.encode("utf-8")
+    if len(encoded) <= limit:
+        return text
+    dropped = len(encoded) - limit
+    head = encoded[:limit].decode("utf-8", errors="ignore")
+    notice = (
+        f"\n…[truncated {dropped} bytes; output exceeded the "
+        f"[mcp] max_output_bytes={limit} budget — use a narrower command, or "
+        f"the offset/limit paging on testreport reads]"
+    )
+    return head + notice
+
+
+#: Long argparse ``help`` strings shared across many synthesised tools, mapped to
+#: a terse equivalent. Rewriting only the MCP wire copy keeps the REPL ``--help``
+#: output (sourced from the same argparse actions in
+#: :mod:`mtui.commands._command`) verbose and unchanged. Keys are matched exactly
+#: against a field's ``description``.
+_TERSE_DESCRIPTIONS: dict[str, str] = {
+    "RRID of a single loaded template to act on (default: all loaded templates)": (
+        "RRID of one loaded template (default: all)"
+    ),
+    "Act on every loaded template (the default for this command)": (
+        "Act on all loaded templates (default)"
+    ),
+    "Host to act on. Can be used multiple times. If is ommited all hosts are used": (
+        "Host to act on (repeatable; default: all hosts)"
+    ),
+}
+
+
+def _flatten_nullable(node: dict[str, Any]) -> None:
+    """Collapse a two-member ``anyOf: [{type: X}, {type: null}]`` union in place.
+
+    Pydantic renders ``X | None`` as such a union. The ``"null"`` arm is
+    redundant for the model — the presence of a ``default`` already signals the
+    field is optional — so we hoist the non-null arm's ``"type"`` (and any
+    sibling keys it carries, e.g. ``items`` for arrays) to the node level and
+    drop the ``anyOf``. Only the exact two-member ``[T, null]`` shape is touched;
+    anything else (genuine multi-type unions) is left alone.
+    """
+    any_of = node.get("anyOf")
+    if not isinstance(any_of, list) or len(any_of) != 2:
+        return
+    non_null = [m for m in any_of if isinstance(m, dict) and m.get("type") != "null"]
+    nulls = [m for m in any_of if isinstance(m, dict) and m.get("type") == "null"]
+    if len(non_null) != 1 or len(nulls) != 1:
+        return
+    arm = non_null[0]
+    if "type" not in arm:
+        return
+    del node["anyOf"]
+    # Hoist the surviving arm's keys without clobbering node-level metadata
+    # (description/default/title live on the node, not the arm).
+    for key, value in arm.items():
+        node.setdefault(key, value)
+
+
+def slim_tool_schema(schema: Any) -> Any:
+    """Return ``schema`` recursively slimmed of redundant JSON-Schema weight.
+
+    Three transforms, applied depth-first so nested ``properties`` and ``items``
+    are covered:
+
+    * drop every ``"title"`` key (pydantic emits one per field; the model never
+      needs it);
+    * collapse ``anyOf: [{type: X}, {type: null}]`` to a flat ``{type: X}`` via
+      :func:`_flatten_nullable`;
+    * replace a known-verbose ``description`` with its terse form from
+      :data:`_TERSE_DESCRIPTIONS`.
+
+    The input is not mutated; a new structure is returned.
+    """
+    if isinstance(schema, dict):
+        out: dict[str, Any] = {}
+        for key, value in schema.items():
+            if key == "title":
+                continue
+            if key == "description" and isinstance(value, str):
+                out[key] = _TERSE_DESCRIPTIONS.get(value, value)
+                continue
+            out[key] = slim_tool_schema(value)
+        _flatten_nullable(out)
+        return out
+    if isinstance(schema, list):
+        return [slim_tool_schema(item) for item in schema]
+    return schema
+
+
+def slim_registered_tools(mcp: FastMCP) -> int:
+    """Rewrite every registered tool's input schema in place, slimmed.
+
+    Walks the SDK's tool table (``FastMCP._tool_manager._tools``) and replaces
+    each tool's ``parameters`` (the JSON input schema) with
+    :func:`slim_tool_schema` of itself. Returns the number of tools rewritten.
+
+    The private-attribute access is the one place this implementation reaches
+    into SDK internals; if a future SDK renames the table the walk is skipped
+    with a loud warning and the (un-slimmed but fully functional) tools are left
+    intact — slimming is a token optimisation, never a correctness requirement.
+    """
+    try:
+        tools = mcp._tool_manager._tools  # noqa: SLF001
+    except AttributeError:  # pragma: no cover - SDK shape drift guard
+        logger.warning(
+            "MCP SDK tool table not found (FastMCP._tool_manager._tools); "
+            "skipping schema slimming — tools remain functional but verbose"
+        )
+        return 0
+
+    count = 0
+    for tool in tools.values():
+        params = getattr(tool, "parameters", None)
+        if isinstance(params, dict):
+            tool.parameters = slim_tool_schema(params)
+            count += 1
+    logger.info("slimmed %d MCP tool schemas", count)
+    return count

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -34,7 +34,9 @@ from ..cli.colors import set_mode as set_color_mode
 from ..support.config import Config
 from ..support.http import disable_insecure_warnings, resolve_verify
 from ..support.systemcheck import detect_system
+from ._slim import slim_registered_tools
 from .args import get_parser
+from .profiles import apply_profile
 from .registry import SessionRegistry
 from .session import McpSession
 from .testreport_tools import register_testreport_tools
@@ -187,6 +189,18 @@ def main() -> int:
     build_tools(mcp, provider)
     register_testreport_tools(mcp, provider)
     register_job_tools(mcp, provider)
+
+    # Token-budget passes (see mtui.mcp._slim / mtui.mcp.profiles): slim every
+    # tool's JSON schema of redundant pydantic boilerplate, then narrow the tool
+    # surface to the configured profile. ``full`` with no allow/deny override is
+    # a no-op, so the default deployment is unchanged.
+    slim_registered_tools(mcp)
+    apply_profile(
+        mcp,
+        cfg.mcp_tool_profile,
+        allow=cfg.mcp_tools_allow,
+        deny=cfg.mcp_tools_deny,
+    )
 
     try:
         if args.transport == "http":

--- a/mtui/mcp/profiles.py
+++ b/mtui/mcp/profiles.py
@@ -1,0 +1,173 @@
+"""Selectable tool *profiles* for the ``mtui-mcp`` server.
+
+The server synthesises ~66 command tools plus the testreport and job tools. The
+full set is sent to the model on every request, which is the dominant fixed token
+cost of an MCP session. Many of those tools (``set_log_level``, ``lrun``,
+``reload_*``, ``config_*``, host-bookkeeping verbs) are rarely needed in a normal
+maintenance-test workflow.
+
+A *profile* is a named allow-set of tool names. The ``full`` profile is a no-op
+(every registered tool stays). The ``core`` profile keeps only the curated
+everyday subset below, removing the rest from the live SDK tool table so they
+never reach the wire. An operator selects a profile with ``[mcp] tool_profile``
+and can fine-tune with ``[mcp] tools_allow`` / ``[mcp] tools_deny`` (see
+:func:`apply_profile`).
+
+The default is ``full`` so existing deployments are unchanged; slimming the tool
+surface is strictly opt-in.
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+logger = getLogger("mtui.mcp.profiles")
+
+#: The curated everyday tool set exposed under ``tool_profile = core``. Chosen to
+#: cover load → inspect → run/install → fill report → approve/reject without the
+#: long tail of host-bookkeeping and server-tuning verbs. The hand-written
+#: ``testreport_*`` and ``job_*`` tools are always part of core because the slow
+#: background-command flow and report editing depend on them.
+CORE: frozenset[str] = frozenset(
+    {
+        # load / inspect
+        "load_template",
+        "unload",
+        "list_templates",
+        "list_metadata",
+        "list_bugs",
+        "list_packages",
+        "list_products",
+        "list_versions",
+        "list_hosts",
+        "updates",
+        "show_diff",
+        "show_log",
+        "analyze_diff",
+        # act
+        "assign",
+        "run",
+        "update",
+        "install",
+        "uninstall",
+        "prepare",
+        "set_repo",
+        # report lifecycle
+        "export",
+        "commit",
+        "comment",
+        "approve",
+        "reject",
+        # openQA
+        "openqa_overview",
+        "openqa_jobs",
+        # hand-written tools (always kept)
+        "testreport_read",
+        "testreport_read_file",
+        "testreport_logs",
+        "testreport_patch",
+        "testreport_write",
+        "testreport_fill",
+        "job_list",
+        "job_status",
+        "job_result",
+        "job_cancel",
+    }
+)
+
+#: Registered profiles. ``full`` maps to ``None`` (sentinel: keep everything).
+_PROFILES: dict[str, frozenset[str] | None] = {
+    "full": None,
+    "core": CORE,
+}
+
+
+def resolve_keep_set(
+    registered: set[str],
+    profile: str,
+    allow: tuple[str, ...] = (),
+    deny: tuple[str, ...] = (),
+) -> set[str]:
+    """Compute the set of tool names to keep, given a profile and overrides.
+
+    Resolution order: start from the profile's allow-set (``full`` → everything),
+    add back any ``allow`` names that are actually registered, then subtract
+    ``deny`` last (deny always wins). Unknown profile names fall back to ``full``
+    with a warning, so a typo never silently hides the whole tool surface.
+
+    Args:
+        registered: All currently-registered tool names.
+        profile: Profile name (``full`` / ``core``).
+        allow: Extra tool names to keep on top of the profile.
+        deny: Tool names to remove regardless of profile/allow.
+
+    Returns:
+        The subset of ``registered`` to keep.
+
+    """
+    base = _PROFILES.get(profile, "MISSING")
+    if base == "MISSING":
+        logger.warning("unknown [mcp] tool_profile %r; falling back to 'full'", profile)
+        keep = set(registered)
+    elif base is None:  # full
+        keep = set(registered)
+    else:
+        keep = set(registered) & set(base)
+
+    keep |= set(allow) & registered
+    keep -= set(deny)
+    return keep
+
+
+def apply_profile(
+    mcp: FastMCP,
+    profile: str = "full",
+    allow: tuple[str, ...] = (),
+    deny: tuple[str, ...] = (),
+) -> list[str]:
+    """Remove every registered tool not in the resolved keep-set.
+
+    Walks the SDK tool table, computes the keep-set via :func:`resolve_keep_set`,
+    and calls ``ToolManager.remove_tool`` for each tool outside it. ``full`` with
+    no overrides is a fast no-op. Returns the sorted list of tools that remain.
+
+    Like :mod:`mtui.mcp._slim`, the private-attribute access is isolated here; if
+    the SDK shape drifts the filtering is skipped with a warning and the full set
+    is left intact (a larger-than-asked tool surface is safe; a broken server is
+    not).
+    """
+    try:
+        tools = mcp._tool_manager._tools  # noqa: SLF001
+    except AttributeError:  # pragma: no cover - SDK shape drift guard
+        logger.warning(
+            "MCP SDK tool table not found; skipping profile filtering "
+            "(all tools remain exposed)"
+        )
+        return []
+
+    registered = set(tools)
+    if profile == "full" and not allow and not deny:
+        return sorted(registered)
+
+    keep = resolve_keep_set(registered, profile, allow, deny)
+    removed: list[str] = []
+    for name in sorted(registered - keep):
+        try:
+            mcp._tool_manager.remove_tool(name)  # noqa: SLF001
+        except Exception as exc:  # noqa: BLE001 - best-effort; never break boot
+            logger.warning("could not remove tool %r: %s", name, exc)
+            continue
+        removed.append(name)
+
+    remaining = sorted(set(tools))
+    logger.info(
+        "tool profile %r: kept %d, removed %d tool(s)",
+        profile,
+        len(remaining),
+        len(removed),
+    )
+    return remaining

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -56,6 +56,7 @@ from ..commands import Command
 from ..support.concurrency import ContextExecutor
 from ..template_registry import TemplateRegistry
 from ..test_reports.null_report import NullTestReport
+from ._slim import cap_output
 
 if TYPE_CHECKING:
     from ..support.config import Config
@@ -827,7 +828,9 @@ class McpSession:
                     stderr.rstrip(),
                 )
 
-            return fake_sys.stdout.getvalue()
+            return cap_output(
+                fake_sys.stdout.getvalue(), self.config.mcp_max_output_bytes
+            )
         finally:
             cap_logger.removeHandler(cap_handler)
             _capture_token.reset(token_reset)

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..test_reports.null_report import NullTestReport
+from ._slim import cap_output
 from .registry import resolve_session
 from .session import McpCommandError
 
@@ -247,6 +248,17 @@ def _count_lines(text: str) -> int:
     return len(text.splitlines())
 
 
+def _output_cap(session: McpSession) -> int:
+    """Return the session's ``[mcp] max_output_bytes`` budget, 0 if unset.
+
+    Read defensively via :func:`getattr` so a session object without a fully
+    populated ``config`` (direct-call tests, fakes) simply disables the cap
+    instead of raising. ``cap_output`` treats a non-int / non-positive value as
+    "no cap", so a missing setting is harmless.
+    """
+    return getattr(getattr(session, "config", None), "mcp_max_output_bytes", 0)
+
+
 async def _heartbeat(ctx: Context | None, message: str) -> None:
     """Best-effort single progress frame for the testreport tools.
 
@@ -303,12 +315,13 @@ async def testreport_read(
         path = _resolve_testreport_path(session, template)
         content = path.read_text(encoding="utf-8", errors="replace")
 
+    cap = _output_cap(session)
     windowed = offset != 1 or limit is not None
     if not windowed:
         return {
             "path": str(path),
             "line_count": _count_lines(content),
-            "content": content,
+            "content": cap_output(content, cap),
         }
 
     # 1-indexed line slicing matching testreport_patch's numbering.
@@ -320,7 +333,7 @@ async def testreport_read(
         "line_count": len(lines),
         "offset": offset,
         "returned_lines": len(sliced),
-        "content": "".join(sliced),
+        "content": cap_output("".join(sliced), cap),
     }
 
 
@@ -385,7 +398,7 @@ async def testreport_read_file(
     return {
         "path": str(target),
         "line_count": _count_lines(content),
-        "content": content,
+        "content": cap_output(content, _output_cap(session)),
     }
 
 

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -205,18 +205,13 @@ def _make_wrapper(
             if len(job_ids) == 1:
                 job_id = job_ids[0]
                 return (
-                    f"started background job {job_id!r} for `{cls.command}`; it "
-                    f"runs on the hosts while you work elsewhere. Poll "
-                    f"job_status(job_id={job_id!r}) and fetch output with "
-                    f"job_result(job_id={job_id!r})."
+                    f"started job {job_id!r} (`{cls.command}`); poll "
+                    f"job_status({job_id!r}), then job_result({job_id!r})."
                 )
             joined = ", ".join(repr(j) for j in job_ids)
             return (
-                f"started {len(job_ids)} background jobs for `{cls.command}`, "
-                f"one per loaded template: {joined}. They run on the hosts "
-                f"while you work elsewhere. Poll job_status(job_id=…) per job "
-                f"(or job_list) and fetch output with job_result(job_id=…); "
-                f"cancelling one job leaves the others running."
+                f"started {len(job_ids)} jobs (`{cls.command}`, one per "
+                f"template): {joined}. Poll job_status/job_result per job."
             )
         return await session.run_command(cls, argv, ctx=ctx)
 

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -24,6 +24,19 @@ def _identity(x: Any) -> Any:
     return x
 
 
+def _parse_csv_set(raw: str) -> tuple[str, ...]:
+    """Split a comma/whitespace-separated INI value into an ordered tuple.
+
+    Used for the ``[mcp] tools_allow`` / ``tools_deny`` lists. Empty entries are
+    dropped and surrounding whitespace stripped, so ``"run, update ,"`` →
+    ``("run", "update")``. An empty/blank value yields an empty tuple.
+    """
+    if not raw:
+        return ()
+    parts = (p.strip() for chunk in raw.split(",") for p in chunk.split())
+    return tuple(p for p in parts if p)
+
+
 _TRUE_STRINGS = frozenset({"1", "yes", "true", "on"})
 _FALSE_STRINGS = frozenset({"0", "no", "false", "off"})
 
@@ -110,6 +123,12 @@ class Config:
     # -- mtui-mcp server (http transport) per-client session registry --
     mcp_session_cap: int
     mcp_session_idle_timeout: int
+
+    # -- mtui-mcp tool surface / output budget (both transports) --
+    mcp_tool_profile: str
+    mcp_tools_allow: tuple[str, ...]
+    mcp_tools_deny: tuple[str, ...]
+    mcp_max_output_bytes: int
 
     # -- Attributes set externally in main.py --
     distro: str
@@ -438,6 +457,43 @@ class Config:
                 "mcp_session_idle_timeout",
                 ("mcp", "session_idle_timeout"),
                 1800,
+                int,
+                getint,
+            ),
+            # Tool-surface budget. ``tool_profile`` selects which synthesised
+            # tools the ``mtui-mcp`` server exposes: ``full`` (default) keeps
+            # every command tool, ``core`` exposes only the curated everyday
+            # subset (see mtui.mcp.profiles) to shrink the per-request tool list
+            # the model must carry. ``tools_allow`` / ``tools_deny`` are
+            # comma-separated overrides layered on top of the profile (allow is
+            # added back, deny is removed last). ``max_output_bytes`` caps a
+            # single tool result's size before it is truncated with a notice
+            # (0 disables the cap).
+            ConfigOption(
+                "mcp_tool_profile",
+                ("mcp", "tool_profile"),
+                "full",
+                str,
+                get,
+            ),
+            ConfigOption(
+                "mcp_tools_allow",
+                ("mcp", "tools_allow"),
+                (),
+                _parse_csv_set,
+                get,
+            ),
+            ConfigOption(
+                "mcp_tools_deny",
+                ("mcp", "tools_deny"),
+                (),
+                _parse_csv_set,
+                get,
+            ),
+            ConfigOption(
+                "mcp_max_output_bytes",
+                ("mcp", "max_output_bytes"),
+                100_000,
                 int,
                 getint,
             ),

--- a/tests/test_mcp_output_cap.py
+++ b/tests/test_mcp_output_cap.py
@@ -1,0 +1,91 @@
+"""Tests for the Tier-3 output-cap wired into the testreport read tools.
+
+:func:`mtui.mcp._slim.cap_output` itself is unit-tested in
+``tests/test_mcp_slim.py``; here we assert the cap is actually applied to the
+``content`` returned by ``testreport_read`` / ``testreport_read_file`` using the
+session's ``config.mcp_max_output_bytes``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mtui.mcp import testreport_tools as tt  # noqa: E402
+
+
+@contextlib.asynccontextmanager
+async def _noop_lock(_template=None):  # noqa: ANN001, ANN202
+    yield
+
+
+def _session(path: Path, cap: int) -> SimpleNamespace:
+    """Fake session exposing only what the testreport read tools touch."""
+    metadata = SimpleNamespace(id="SUSE:Maintenance:1:1", path=str(path))
+
+    class _Reg:
+        def get(self, rrid):  # noqa: ANN001, ANN202
+            return metadata
+
+        def all(self):  # noqa: ANN202
+            return [metadata]
+
+    return SimpleNamespace(
+        metadata=metadata,
+        templates=_Reg(),
+        scoped_lock=lambda _t=None: _noop_lock(),
+        config=SimpleNamespace(mcp_max_output_bytes=cap),
+    )
+
+
+def test_read_caps_oversized_content(tmp_path: Path) -> None:
+    log = tmp_path / "log"
+    log.write_text("A" * 5000, encoding="utf-8")
+    sess = _session(log, cap=100)
+
+    res = asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert res["content"].startswith("A" * 100)
+    assert "truncated" in res["content"]
+    # line_count reflects the true file, not the truncated view.
+    assert res["line_count"] == 1
+
+
+def test_read_under_cap_is_identical(tmp_path: Path) -> None:
+    log = tmp_path / "log"
+    body = "hello\nworld\n"
+    log.write_text(body, encoding="utf-8")
+    sess = _session(log, cap=100_000)
+
+    res = asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert res["content"] == body
+    assert "truncated" not in res["content"]
+
+
+def test_read_cap_zero_disables(tmp_path: Path) -> None:
+    log = tmp_path / "log"
+    body = "B" * 5000
+    log.write_text(body, encoding="utf-8")
+    sess = _session(log, cap=0)
+
+    res = asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert res["content"] == body
+
+
+def test_read_file_caps_oversized_content(tmp_path: Path) -> None:
+    log = tmp_path / "log"
+    log.write_text("x", encoding="utf-8")
+    big = tmp_path / "build_checks"
+    big.mkdir()
+    (big / "pkg.x86_64.log").write_text("C" * 5000, encoding="utf-8")
+    sess = _session(log, cap=100)
+
+    call = tt.testreport_read_file(sess, "build_checks/pkg.x86_64.log")  # ty: ignore[invalid-argument-type]
+    res = asyncio.run(call)
+    assert res["content"].startswith("C" * 100)
+    assert "truncated" in res["content"]

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -1,0 +1,102 @@
+"""Tests for :mod:`mtui.mcp.profiles` — the selectable tool-surface profiles."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from mtui.mcp.profiles import (  # noqa: E402
+    CORE,
+    apply_profile,
+    resolve_keep_set,
+)
+from mtui.mcp.testreport_tools import register_testreport_tools  # noqa: E402
+from mtui.mcp.tools import build_tools, register_job_tools  # noqa: E402
+
+
+class _Provider:
+    async def get_or_create(self, key):  # noqa: ANN001, ANN201, D102
+        raise AssertionError("not used")
+
+
+def _build() -> FastMCP:
+    mcp = FastMCP(name="mtui-test")
+    prov = _Provider()
+    build_tools(mcp, prov)
+    register_job_tools(mcp, prov)
+    register_testreport_tools(mcp, prov)
+    return mcp
+
+
+def test_full_keeps_everything() -> None:
+    reg = {"run", "update", "whoami"}
+    assert resolve_keep_set(reg, "full") == reg
+
+
+def test_core_intersects_with_registered() -> None:
+    reg = {"run", "whoami", "set_log_level"}
+    keep = resolve_keep_set(reg, "core")
+    assert "run" in keep  # in CORE
+    assert "set_log_level" not in keep  # not in CORE
+    assert "whoami" not in keep  # not in CORE
+
+
+def test_allow_adds_back_only_registered() -> None:
+    reg = {"run", "whoami"}
+    keep = resolve_keep_set(reg, "core", allow=("whoami", "ghost"))
+    assert "whoami" in keep
+    assert "ghost" not in keep  # not registered → not invented
+
+
+def test_deny_wins_last() -> None:
+    reg = {"run", "update"}
+    keep = resolve_keep_set(reg, "full", deny=("run",))
+    assert "run" not in keep
+    assert "update" in keep
+
+
+def test_allow_then_deny_same_name_denies() -> None:
+    reg = {"run"}
+    keep = resolve_keep_set(reg, "core", allow=("run",), deny=("run",))
+    assert "run" not in keep
+
+
+def test_unknown_profile_falls_back_to_full() -> None:
+    reg = {"run", "whoami"}
+    assert resolve_keep_set(reg, "does-not-exist") == reg
+
+
+def test_apply_full_is_noop() -> None:
+    mcp = _build()
+    before = set(mcp._tool_manager._tools)
+    remaining = apply_profile(mcp, "full")
+    assert set(remaining) == before
+    assert set(mcp._tool_manager._tools) == before
+
+
+def test_apply_core_removes_non_core_tools() -> None:
+    mcp = _build()
+    all_names = set(mcp._tool_manager._tools)
+    remaining = apply_profile(mcp, "core")
+    assert set(remaining) == (CORE & all_names)
+    assert set(mcp._tool_manager._tools) == (CORE & all_names)
+    # A known non-core tool is gone; a known core tool remains.
+    assert "set_log_level" not in remaining
+    assert "run" in remaining
+
+
+def test_apply_core_with_allow_and_deny() -> None:
+    mcp = _build()
+    remaining = apply_profile(mcp, "core", allow=("whoami",), deny=("run",))
+    assert "whoami" in remaining
+    assert "run" not in remaining
+
+
+def test_core_names_all_exist_in_registry() -> None:
+    mcp = _build()
+    registered = set(mcp._tool_manager._tools)
+    # Guards against typos in the curated CORE set.
+    assert registered >= CORE

--- a/tests/test_mcp_slim.py
+++ b/tests/test_mcp_slim.py
@@ -1,0 +1,167 @@
+"""Tests for :mod:`mtui.mcp._slim` — the tool-schema token-slimming pass.
+
+Covers the three slimming transforms (drop ``title``, flatten ``[T, null]``
+unions, terse shared descriptions), the in-place rewrite over a live FastMCP
+tool table, and the :func:`cap_output` budget helper.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from mtui.mcp._slim import (  # noqa: E402
+    cap_output,
+    slim_registered_tools,
+    slim_tool_schema,
+)
+from mtui.mcp.tools import build_tools, register_job_tools  # noqa: E402
+
+
+class _Provider:
+    async def get_or_create(self, key):  # noqa: ANN001, ANN201, D102
+        raise AssertionError("not used in schema tests")
+
+
+# --------------------------------------------------------------------------- #
+# slim_tool_schema                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_slim_drops_all_title_keys() -> None:
+    schema = {
+        "title": "tool_runArguments",
+        "type": "object",
+        "properties": {
+            "command": {"title": "Command", "type": "array", "items": {"type": "str"}},
+        },
+    }
+    out = slim_tool_schema(schema)
+    assert "title" not in out
+    assert "title" not in out["properties"]["command"]
+    # non-title content preserved
+    assert out["properties"]["command"]["type"] == "array"
+
+
+def test_slim_flattens_nullable_union_and_keeps_default() -> None:
+    node = {
+        "anyOf": [{"type": "string"}, {"type": "null"}],
+        "default": None,
+        "description": "some field",
+    }
+    out = slim_tool_schema(node)
+    assert "anyOf" not in out
+    assert out["type"] == "string"
+    assert out["default"] is None
+    assert out["description"] == "some field"
+
+
+def test_slim_flattens_nullable_array_union_hoists_items() -> None:
+    node = {
+        "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "null"}],
+        "default": None,
+    }
+    out = slim_tool_schema(node)
+    assert "anyOf" not in out
+    assert out["type"] == "array"
+    assert out["items"] == {"type": "string"}
+
+
+def test_slim_leaves_genuine_multitype_union_untouched() -> None:
+    node = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+    out = slim_tool_schema(node)
+    # No null arm → not the [T, null] shape → left as-is.
+    assert "anyOf" in out
+    assert len(out["anyOf"]) == 2
+
+
+def test_slim_rewrites_known_verbose_description() -> None:
+    node = {
+        "type": "string",
+        "default": None,
+        "description": (
+            "RRID of a single loaded template to act on (default: all loaded templates)"
+        ),
+    }
+    out = slim_tool_schema(node)
+    assert out["description"] == "RRID of one loaded template (default: all)"
+
+
+def test_slim_input_not_mutated() -> None:
+    schema = {"title": "X", "properties": {"a": {"title": "A", "type": "string"}}}
+    before = json.dumps(schema, sort_keys=True)
+    slim_tool_schema(schema)
+    assert json.dumps(schema, sort_keys=True) == before
+
+
+# --------------------------------------------------------------------------- #
+# slim_registered_tools                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_slim_registered_tools_reduces_bytes_keeps_count() -> None:
+    mcp = FastMCP(name="mtui-test")
+    prov = _Provider()
+    build_tools(mcp, prov)
+    register_job_tools(mcp, prov)
+
+    tools = mcp._tool_manager._tools
+    before_count = len(tools)
+    before_bytes = sum(len(json.dumps(t.parameters)) for t in tools.values())
+
+    n = slim_registered_tools(mcp)
+
+    after_bytes = sum(len(json.dumps(t.parameters)) for t in tools.values())
+    assert n == before_count
+    assert len(tools) == before_count  # no tool lost
+    # At least a 15% schema shrink (titles alone are ~16%).
+    assert after_bytes < before_bytes * 0.85
+    # No residual boilerplate anywhere.
+    blob = " ".join(json.dumps(t.parameters) for t in tools.values())
+    assert '"title"' not in blob
+    assert '{"type": "null"}' not in blob
+
+
+def test_slim_registered_tools_missing_table_is_graceful() -> None:
+    class Fake:
+        pass
+
+    # No _tool_manager attribute at all → returns 0, no raise.
+    assert slim_registered_tools(Fake()) == 0  # ty: ignore[invalid-argument-type]
+
+
+# --------------------------------------------------------------------------- #
+# cap_output                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_cap_output_under_limit_is_identical() -> None:
+    text = "small output"
+    assert cap_output(text, 1000) == text
+
+
+def test_cap_output_zero_limit_disables() -> None:
+    text = "x" * 10_000
+    assert cap_output(text, 0) == text
+    assert cap_output(text, -1) == text
+
+
+def test_cap_output_truncates_with_notice() -> None:
+    text = "A" * 500
+    out = cap_output(text, 100)
+    assert out.startswith("A" * 100)
+    assert "truncated 400 bytes" in out
+    assert "max_output_bytes=100" in out
+
+
+def test_cap_output_result_is_valid_utf8_on_codepoint_boundary() -> None:
+    # Multi-byte chars; a naive byte cut could split one. Result must decode.
+    text = "é" * 200  # each is 2 bytes in utf-8
+    out = cap_output(text, 101)  # odd cut lands mid-codepoint
+    out.encode("utf-8")  # must not raise
+    assert "truncated" in out

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -774,7 +774,7 @@ def test_slow_command_background_true_starts_job(
         return await tool.fn(command=["true"], hosts=[], background=True)
 
     out = asyncio.run(_call())
-    assert "started background job" in out
+    assert "started job" in out
     assert "run-1" in out
     assert "job_status" in out
     assert "job_result" in out


### PR DESCRIPTION
## Summary

The `mtui-mcp` server describes all 66 synthesised tools to the model on **every** request — names, descriptions and JSON input schemas — a fixed cost of **~13k tokens** before any work happens, dominated by repetitive pydantic schema boilerplate (redundant `title` keys, `anyOf:[T,null]` optional-field unions, help text repeated across dozens of tools). A single large tool result could also dwarf the rest of the context.

This PR adds three layered, mostly-automatic measures.

### Tier 1 — schema slimming (always on, zero behaviour change)
`mtui/mcp/_slim.py` rewrites each registered tool schema to drop redundant pydantic `title` keys and flatten `anyOf:[{type:X},{type:null}]` → flat `{type:X}` (the `default` already marks the field optional). The tool set and what the model can call is unchanged; only dead schema weight is removed.

### Tier 2 — opt-in tool profiles (default `full` = unchanged)
`mtui/mcp/profiles.py` + new `[mcp] tool_profile`:
- `full` (default) keeps every tool — existing deployments unchanged.
- `core` exposes a curated everyday subset (load/inspect/assign/run/install, report editing, approve/reject, the `testreport_*` and `job_*` tools).
- Fine-tune either with comma-separated `[mcp] tools_allow` (added back) / `tools_deny` (removed last, wins).

### Tier 3 — output discipline
`[mcp] max_output_bytes` (default `100000`, `0` disables) caps a single tool result; overflow is truncated with a notice pointing at the testreport read `offset`/`limit` paging. Also trims the verbose background-job success blurbs.

## Measured impact

| Configuration | Tools | Tokens | Reduction |
|---|---|---|---|
| Baseline (today) | 66 | ~13,000 | — |
| **Default** (`full` + slim) | 66 | ~10,000 | **22%** |
| **Opt-in** (`core` + slim) | 37 | ~5,900 | **54%** |

## New config knobs (`[mcp]`)
`tool_profile` (default `full`), `tools_allow`, `tools_deny`, `max_output_bytes` (default `100000`). Documented in `Documentation/mcp.rst`.

## Tests
26 new tests across `test_mcp_slim.py`, `test_mcp_profiles.py`, `test_mcp_output_cap.py` (schema transforms, profile resolution + mutation, output capping, SDK-drift graceful fallback). Full suite: **1735 passed**.

## Gate (whole repo)
- `ruff format --check .` — clean
- `ruff check .` — All checks passed
- `ty check` — All checks passed
- `pytest` — 1735 passed
- `sphinx-build -W` — build succeeded

## Notes / risks
- The slimming and profile passes touch the SDK's private tool table (`FastMCP._tool_manager._tools` / `remove_tool`); both are isolated behind a graceful fallback that skips the optimisation (leaving tools fully functional) with a warning if the SDK shape drifts.
- Null-union flattening only collapses the exact 2-member `[T, null]` shape; genuine multi-type unions are left intact (covered by a test).