### PR TITLE
refactor(mcp): unify testreport read tools into testreport_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,12 +136,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   template. `list_templates` no longer shows the `*` active marker over MCP
   (the marker remains in the interactive REPL).
 - Over `mtui-mcp`, the testreport file tools (`testreport_read`,
-  `testreport_logs`, `testreport_read_file`, `testreport_patch`,
-  `testreport_write`, `testreport_fill`) gained an optional `template=RRID`
-  parameter selecting which loaded template's checkout to act on. With more than
-  one template loaded they now refuse an unscoped call (naming the loaded RRIDs)
-  instead of silently editing the last-loaded one; single-template sessions are
-  unchanged.
+  `testreport_logs`, `testreport_patch`, `testreport_write`, `testreport_fill`)
+  gained an optional `template=RRID` parameter selecting which loaded template's
+  checkout to act on. With more than one template loaded they now refuse an
+  unscoped call (naming the loaded RRIDs) instead of silently editing the
+  last-loaded one; single-template sessions are unchanged.
+- Over `mtui-mcp`, `testreport_read` now accepts an optional `relpath` to read
+  any file under the loaded template's checkout (traversal-guarded), defaulting
+  to the report's `log` file when omitted. This absorbs the former
+  `testreport_read_file` tool (see Removed); `testreport_logs` still lists the
+  auxiliary `build_checks/` and `install_logs/` files, now fetched via
+  `testreport_read`.
 - Over `mtui-mcp`, loading a template (`load_template`, `regenerate`) no longer
   moves the session's active-template pointer. The active template is REPL-only
   navigation state; setting it on every load made it hidden, unaddressable
@@ -162,6 +167,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Removed
 
+- The `mtui-mcp` `testreport_read_file` tool has been removed; its function is
+  now served by `testreport_read` with the new optional `relpath` parameter
+  (which defaults to the report's `log` file). Replace
+  `testreport_read_file(relpath=…)` calls with `testreport_read(relpath=…)`.
 - The initrd / pre-post custom-check framework has been removed. The
   `PreScript`/`PostScript`/`CompareScript` hook engine that copied probe
   scripts onto reference hosts and ran them before/after an `update` (diffing

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -15,8 +15,9 @@ headless mtui session to LLM clients. Every non-interactive mtui
 command is auto-exposed as an MCP tool, and dedicated testreport tools
 (``testreport_read``, ``testreport_patch``, ``testreport_write``)
 replace the REPL's ``$EDITOR``-based ``edit`` flow, with
-``testreport_logs`` and ``testreport_read_file`` exposing the rest of
-the checkout (build-check and install logs, ``source.diff``, …).
+``testreport_logs`` and ``testreport_read`` (passing ``relpath``)
+exposing the rest of the checkout (build-check and install logs,
+``source.diff``, …).
 
 Session state is isolated per client. Under ``stdio`` one process
 serves one client, so there is exactly one ``Config`` / loaded test
@@ -340,10 +341,18 @@ silently editing the last-loaded report. With zero or one template loaded
 the parameter may be omitted and behaves as before. An unknown RRID is
 refused with ``template not loaded: <rrid>``.
 
-``testreport_read(offset: int = None, limit: int = None) -> dict``
+``testreport_read(relpath: str = None, offset: int = None, limit: int = None) -> dict``
     Returns ``{"path": str, "line_count": int, "content": str}``.
     Reads the file as UTF-8 with ``errors="replace"``. Marked
     ``readOnlyHint=True`` and ``idempotentHint=True``.
+
+    Without ``relpath`` the report's ``log`` file is read. Pass
+    ``relpath`` to read any other file in the checkout by path relative
+    to the checkout directory, e.g. ``build_checks/<pkg>.<arch>.log``,
+    ``install_logs/<host>.log``, ``source.diff`` or ``patchinfo.xml``.
+    The path is resolved under the checkout and may **not** escape it
+    (``..`` traversal and absolute paths are refused); a missing file is
+    refused with ``no such file in testreport checkout: <relpath>``.
 
     ``offset`` (1-based first line) and ``limit`` (max lines) return a
     line window instead of the whole file, using the same 1-indexed
@@ -374,15 +383,8 @@ refused with ``template not loaded: <rrid>``.
     build-check logs (``build_checks/``) and the per-refhost install
     logs (``install_logs/``). Returns ``{"path": str, "build_checks":
     [{"name", "size"}], "install_logs": [{"name", "size"}]}``. Marked
-    ``readOnlyHint=True``.
-
-``testreport_read_file(relpath: str) -> dict``
-    Reads any file in the checkout by path relative to the checkout
-    directory, e.g. ``build_checks/<pkg>.<arch>.log``,
-    ``install_logs/<host>.log``, ``source.diff`` or ``patchinfo.xml``.
-    The path is resolved under the checkout and may **not** escape it
-    (``..`` traversal and absolute paths are refused). Returns
-    ``{"path", "line_count", "content"}``. Marked ``readOnlyHint=True``.
+    ``readOnlyHint=True``. Fetch one of the listed files with
+    ``testreport_read`` (passing ``relpath``).
 
 .. warning::
 

--- a/mtui/mcp/profiles.py
+++ b/mtui/mcp/profiles.py
@@ -67,7 +67,6 @@ CORE: frozenset[str] = frozenset(
         "openqa_jobs",
         # hand-written tools (always kept)
         "testreport_read",
-        "testreport_read_file",
         "testreport_logs",
         "testreport_patch",
         "testreport_write",

--- a/mtui/mcp/testreport_tools.py
+++ b/mtui/mcp/testreport_tools.py
@@ -6,21 +6,22 @@ command spawns ``$EDITOR`` on ``metadata.path`` — meaningless under
 MCP. This module replaces it with three explicit tools that operate
 directly on the file path tracked by ``session.metadata.path``:
 
-* :func:`testreport_read` — return the file's bytes plus a line count
-  computed with the same convention :func:`testreport_patch` consumes.
-  Optional ``offset``/``limit`` read a 1-indexed line window so a large
-  report (a Product Increment log) can be paged instead of overflowing.
+* :func:`testreport_read` — return a checkout file's bytes plus a line
+  count computed with the same convention :func:`testreport_patch`
+  consumes. Defaults to the ``log`` file; pass ``relpath`` to read any
+  other file under the checkout directory (traversal-guarded). Optional
+  ``offset``/``limit`` read a 1-indexed line window so a large report (a
+  Product Increment log) can be paged instead of overflowing.
 * :func:`testreport_patch` — splice an inclusive 1-indexed line range,
   written atomically via ``NamedTemporaryFile`` + :func:`os.replace`.
 * :func:`testreport_write` — full-file overwrite, also atomic.
 
-Two further read-only tools expose the rest of the checkout that the
+One further read-only tool exposes the rest of the checkout that the
 ``log`` file does not cover:
 
 * :func:`testreport_logs` — list the ``build_checks/`` and
-  ``install_logs/`` files (name + size).
-* :func:`testreport_read_file` — read any file under the checkout
-  directory by relative path (traversal-guarded).
+  ``install_logs/`` files (name + size); fetch one with
+  :func:`testreport_read` (pass ``relpath``).
 
 All three are ``async def``. The registered tool closures resolve the
 caller's own :class:`McpSession` from the
@@ -284,21 +285,29 @@ async def _heartbeat(ctx: Context | None, message: str) -> None:
 
 async def testreport_read(
     session: McpSession,
+    relpath: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     offset: int = 1,  # noqa: PT028 - tool entrypoint, not a pytest test
     limit: int | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
     ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
 ) -> dict[str, Any]:
-    """Return the loaded testreport file's content and line count.
+    """Return a testreport checkout file's content and line count.
 
-    By default the whole file is returned. ``offset``/``limit`` request a
-    1-indexed inclusive line window — the same numbering ``testreport_patch``
-    consumes — so a large report (a Product Increment ``log`` runs to thousands
-    of lines after ``export``) can be paged instead of overflowing the caller.
-    ``offset`` is the first line to return (1-based, default 1); ``limit`` caps
-    how many lines to return (default: to end of file). ``line_count`` is always
-    the file's *total* line count so the caller can page; when a window was
-    requested the reply also carries ``offset`` and ``returned_lines``.
+    By default (``relpath`` omitted) the report's ``log`` file is read. Pass
+    ``relpath`` to read any other file under the checkout directory instead —
+    ``build_checks/<pkg>.<arch>.log``, ``install_logs/<host>.log``,
+    ``source.diff``, ``patchinfo.xml`` and the like; the path is resolved under
+    the checkout directory and may not escape it.
+
+    The whole file is returned unless a window is requested. ``offset``/``limit``
+    request a 1-indexed inclusive line window — the same numbering
+    ``testreport_patch`` consumes — so a large report (a Product Increment
+    ``log`` runs to thousands of lines after ``export``) can be paged instead of
+    overflowing the caller. ``offset`` is the first line to return (1-based,
+    default 1); ``limit`` caps how many lines to return (default: to end of
+    file). ``line_count`` is always the file's *total* line count so the caller
+    can page; when a window was requested the reply also carries ``offset`` and
+    ``returned_lines``.
 
     Acquires the target template's per-RRID lock (under the registry-shared
     gate) so the snapshot is coherent with any in-flight command dispatch on
@@ -312,7 +321,17 @@ async def testreport_read(
 
     await _heartbeat(ctx, "testreport_read: waiting for template lock")
     async with session.scoped_lock(template):
-        path = _resolve_testreport_path(session, template)
+        if relpath is None:
+            path = _resolve_testreport_path(session, template)
+        else:
+            base = _resolve_template_dir(session, template)
+            path = _safe_template_file(base, relpath)
+            if not path.is_file():
+                raise McpCommandError(
+                    "",
+                    f"no such file in testreport checkout: {relpath}",
+                    1,
+                )
         content = path.read_text(encoding="utf-8", errors="replace")
 
     cap = _output_cap(session)
@@ -348,7 +367,7 @@ async def testreport_logs(
     install logs live in ``build_checks/`` and ``install_logs/`` next to the
     testreport, but are not part of the ``log`` file. This returns their
     names (and byte sizes) so a caller can then fetch one with
-    :func:`testreport_read_file`.
+    :func:`testreport_read` (passing ``relpath``).
     """
     await _heartbeat(ctx, "testreport_logs: waiting for template lock")
     async with session.scoped_lock(template):
@@ -369,37 +388,6 @@ async def testreport_logs(
             "build_checks": listing("build_checks"),
             "install_logs": listing("install_logs"),
         }
-
-
-async def testreport_read_file(
-    session: McpSession,
-    relpath: str,
-    template: str | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
-    ctx: Context | None = None,  # noqa: PT028 - tool entrypoint, not a pytest test
-) -> dict[str, Any]:
-    """Read a file from the loaded testreport's checkout by relative path.
-
-    Complements :func:`testreport_read` (which only returns the ``log``):
-    use this for ``build_checks/<pkg>.<arch>.log``, ``install_logs/<host>.log``,
-    ``source.diff``, ``patchinfo.xml`` and the like. ``relpath`` is resolved
-    under the checkout directory and may not escape it.
-    """
-    await _heartbeat(ctx, "testreport_read_file: waiting for template lock")
-    async with session.scoped_lock(template):
-        base = _resolve_template_dir(session, template)
-        target = _safe_template_file(base, relpath)
-        if not target.is_file():
-            raise McpCommandError(
-                "",
-                f"no such file in testreport checkout: {relpath}",
-                1,
-            )
-        content = target.read_text(encoding="utf-8", errors="replace")
-    return {
-        "path": str(target),
-        "line_count": _count_lines(content),
-        "content": cap_output(content, _output_cap(session)),
-    }
 
 
 async def testreport_patch(
@@ -646,6 +634,7 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
     globals().setdefault("Context", _Context)
 
     async def _read(
+        relpath: str | None = None,
         offset: int = 1,
         limit: int | None = None,
         template: str | None = None,
@@ -653,7 +642,12 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
     ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
         return await testreport_read(
-            session, offset=offset, limit=limit, template=template, ctx=ctx
+            session,
+            relpath=relpath,
+            offset=offset,
+            limit=limit,
+            template=template,
+            ctx=ctx,
         )
 
     async def _logs(
@@ -661,12 +655,6 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
     ) -> dict[str, Any]:
         session = await resolve_session(provider, ctx)
         return await testreport_logs(session, template=template, ctx=ctx)
-
-    async def _read_file(
-        relpath: str, template: str | None = None, ctx: Context | None = None
-    ) -> dict[str, Any]:
-        session = await resolve_session(provider, ctx)
-        return await testreport_read_file(session, relpath, template=template, ctx=ctx)
 
     async def _patch(
         start_line: int,
@@ -704,11 +692,15 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         )
 
     read_desc = (
-        "Read the currently loaded testreport file. Returns the path, total "
-        "line count, and content (utf-8, errors replaced). By default returns "
-        "the whole file; pass `offset` (1-based first line) and/or `limit` (max "
-        "lines) to read a line window instead — use this to page a large report "
-        "(a Product Increment log can be thousands of lines) without overflowing. "
+        "Read a file from the loaded testreport's checkout. Returns the path, "
+        "total line count, and content (utf-8, errors replaced). By default "
+        "(no `relpath`) reads the report's `log` file; pass `relpath` to read "
+        "another checkout file instead, e.g. 'build_checks/<pkg>.<arch>.log', "
+        "'install_logs/<host>.log', 'source.diff' or 'patchinfo.xml' — the path "
+        "may not escape the checkout directory. Pass `offset` (1-based first "
+        "line) and/or `limit` (max lines) to read a line window instead of the "
+        "whole file — use this to page a large report (a Product Increment log "
+        "can be thousands of lines) without overflowing. "
         f"{_READ_FIRST_WARNING} {_TEMPLATE_NOTE}"
     )
     patch_desc = (
@@ -727,13 +719,7 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
         "List the auxiliary log files in the loaded testreport's checkout: the "
         "per-package/arch build-check logs (build_checks/) and the per-refhost "
         "install logs (install_logs/). Returns each file's name and size; fetch "
-        f"one with testreport_read_file. {_TEMPLATE_NOTE}"
-    )
-    read_file_desc = (
-        "Read a file from the loaded testreport's checkout by relative path, "
-        "e.g. 'build_checks/<pkg>.<arch>.log', 'install_logs/<host>.log', "
-        "'source.diff' or 'patchinfo.xml'. The path may not escape the checkout "
-        f"directory. Returns path, line count and full content. {_TEMPLATE_NOTE}"
+        f"one with testreport_read (pass relpath). {_TEMPLATE_NOTE}"
     )
     fill_desc = (
         "Bulk-set the repetitive per-bug placeholder tokens an exported "
@@ -761,12 +747,6 @@ def register_testreport_tools(mcp: FastMCP, provider: SessionProvider) -> list[s
             "testreport_logs",
             _logs,
             logs_desc,
-            ToolAnnotations(readOnlyHint=True, idempotentHint=True),
-        ),
-        (
-            "testreport_read_file",
-            _read_file,
-            read_file_desc,
             ToolAnnotations(readOnlyHint=True, idempotentHint=True),
         ),
         (

--- a/tests/test_mcp_output_cap.py
+++ b/tests/test_mcp_output_cap.py
@@ -2,8 +2,9 @@
 
 :func:`mtui.mcp._slim.cap_output` itself is unit-tested in
 ``tests/test_mcp_slim.py``; here we assert the cap is actually applied to the
-``content`` returned by ``testreport_read`` / ``testreport_read_file`` using the
-session's ``config.mcp_max_output_bytes``.
+``content`` returned by ``testreport_read`` (both for the default ``log`` and
+for a ``relpath`` checkout file) using the session's
+``config.mcp_max_output_bytes``.
 """
 
 from __future__ import annotations
@@ -85,7 +86,7 @@ def test_read_file_caps_oversized_content(tmp_path: Path) -> None:
     (big / "pkg.x86_64.log").write_text("C" * 5000, encoding="utf-8")
     sess = _session(log, cap=100)
 
-    call = tt.testreport_read_file(sess, "build_checks/pkg.x86_64.log")  # ty: ignore[invalid-argument-type]
+    call = tt.testreport_read(sess, relpath="build_checks/pkg.x86_64.log")  # ty: ignore[invalid-argument-type]
     res = asyncio.run(call)
     assert res["content"].startswith("C" * 100)
     assert "truncated" in res["content"]

--- a/tests/test_mcp_testreport_tools.py
+++ b/tests/test_mcp_testreport_tools.py
@@ -410,7 +410,6 @@ def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
         "testreport_logs",
         "testreport_patch",
         "testreport_read",
-        "testreport_read_file",
         "testreport_write",
     ]
 
@@ -421,7 +420,7 @@ def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
         tools[n] = tool
 
     # The read-only tools advertise it; the mutating ones must not.
-    for n in ("testreport_read", "testreport_logs", "testreport_read_file"):
+    for n in ("testreport_read", "testreport_logs"):
         assert tools[n].annotations is not None
         assert tools[n].annotations.readOnlyHint is True
         assert tools[n].annotations.idempotentHint is True
@@ -435,7 +434,7 @@ def test_register_testreport_tools_exposes_all_tools(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Auxiliary checkout files: testreport_logs / testreport_read_file            #
+# Auxiliary checkout files: testreport_logs / testreport_read(relpath=...)    #
 # --------------------------------------------------------------------------- #
 
 
@@ -452,7 +451,7 @@ def test_logs_and_read_file_roundtrip(tmp_path: Path) -> None:
     assert [f["name"] for f in logs["install_logs"]] == ["host1.log"]
 
     out = asyncio.run(
-        tt.testreport_read_file(sess, "build_checks/libica.s390x.log")  # ty: ignore[invalid-argument-type]
+        tt.testreport_read(sess, relpath="build_checks/libica.s390x.log")  # ty: ignore[invalid-argument-type]
     )
     assert out["content"] == "ok\nfine\n"
     assert out["line_count"] == 2
@@ -468,7 +467,7 @@ def test_logs_empty_when_subdirs_absent(tmp_path: Path) -> None:
 def test_read_file_missing_raises(tmp_path: Path) -> None:
     sess = _loaded_session(tmp_path, tmp_path / "log")
     with pytest.raises(McpCommandError, match="no such file"):
-        asyncio.run(tt.testreport_read_file(sess, "build_checks/nope.log"))  # ty: ignore[invalid-argument-type]
+        asyncio.run(tt.testreport_read(sess, relpath="build_checks/nope.log"))  # ty: ignore[invalid-argument-type]
 
 
 def test_read_file_rejects_traversal(tmp_path: Path) -> None:
@@ -476,7 +475,7 @@ def test_read_file_rejects_traversal(tmp_path: Path) -> None:
     (tmp_path.parent / "secret.txt").write_text("nope\n")
     sess = _loaded_session(tmp_path, tmp_path / "log")
     with pytest.raises(McpCommandError, match="escapes"):
-        asyncio.run(tt.testreport_read_file(sess, "../secret.txt"))  # ty: ignore[invalid-argument-type]
+        asyncio.run(tt.testreport_read(sess, relpath="../secret.txt"))  # ty: ignore[invalid-argument-type]
 
 
 def test_logs_and_read_file_refuse_without_loaded_report(tmp_path: Path) -> None:
@@ -484,7 +483,7 @@ def test_logs_and_read_file_refuse_without_loaded_report(tmp_path: Path) -> None
     with pytest.raises(McpCommandError):
         asyncio.run(tt.testreport_logs(sess))
     with pytest.raises(McpCommandError):
-        asyncio.run(tt.testreport_read_file(sess, "source.diff"))
+        asyncio.run(tt.testreport_read(sess, relpath="source.diff"))
 
 
 # --------------------------------------------------------------------------- #
@@ -839,7 +838,6 @@ def test_template_param_in_json_schema(tmp_path: Path) -> None:
     for name in (
         "testreport_read",
         "testreport_logs",
-        "testreport_read_file",
         "testreport_patch",
         "testreport_write",
         "testreport_fill",
@@ -851,3 +849,27 @@ def test_template_param_in_json_schema(tmp_path: Path) -> None:
             f"tool {name!r} is missing the template parameter: {list(props)!r}"
         )
         assert "template" not in tool.parameters.get("required", [])
+
+
+def test_read_relpath_optional_in_schema_and_reads_log_by_default(
+    tmp_path: Path,
+) -> None:
+    """``relpath`` is exposed and optional; omitting it reads the log file."""
+    pytest.importorskip("mcp")
+    from mcp.server.fastmcp import FastMCP
+
+    mcp: FastMCP = FastMCP(name="test-mtui-mcp-relpath-schema")
+    tt.register_testreport_tools(mcp, _null_session(tmp_path))
+    tool = mcp._tool_manager.get_tool("testreport_read")  # noqa: SLF001
+    assert tool is not None
+    props = tool.parameters.get("properties", {})
+    assert "relpath" in props
+    assert "relpath" not in tool.parameters.get("required", [])
+
+    # No relpath -> the report's log file.
+    log = tmp_path / "log"
+    log.write_text("the log\n")
+    sess = _loaded_session(tmp_path, log)
+    out = asyncio.run(tt.testreport_read(sess))  # ty: ignore[invalid-argument-type]
+    assert out["path"] == str(log)
+    assert out["content"] == "the log\n"


### PR DESCRIPTION
## What

Unifies the two redundant MCP *read* tools on the testreport surface. The
write tools are intentionally left split.

- `testreport_read` gains an optional `relpath` parameter: omit it to read the
  report's `log` file (unchanged behaviour); pass it to read any other file
  under the loaded template's checkout (`build_checks/<pkg>.<arch>.log`,
  `install_logs/<host>.log`, `source.diff`, `patchinfo.xml`, …). The path is
  traversal-guarded. `offset`/`limit` paging still works in both cases.
- `testreport_read_file` is **removed** — its function is now served by
  `testreport_read(relpath=…)`.
- `testreport_logs` is unchanged; it still lists the auxiliary `build_checks/`
  and `install_logs/` files, now fetched via `testreport_read`.

Net surface: **6 → 5** testreport tools.

## Why

`testreport_read` was effectively `testreport_read_file` hardwired to the `log`
file plus `offset`/`limit`, with near-identical return shapes — a genuine
overlap. Merging them removes a redundant tool and shrinks the tool list the
LLM has to reason over.

The three write tools (`testreport_patch` / `testreport_write` /
`testreport_fill`) were deliberately **not** merged: each has distinct,
single-purpose editing semantics (range splice / full overwrite / idempotent
placeholder fill), and collapsing them behind a `mode` arg would overload the
argument schema and hurt LLM tool-selection accuracy.

## Breaking change

`testreport_read_file` shipped in 18.0.1, so its removal is a breaking change
for any MCP client/prompt calling it by name. Migration:

```
testreport_read_file(relpath=…)  ->  testreport_read(relpath=…)
```

Documented in `CHANGELOG.md` under `[Unreleased]` (Changed + Removed).

## Tests / docs

- Updated `tests/test_mcp_testreport_tools.py` and `tests/test_mcp_output_cap.py`
  to drive `testreport_read(relpath=…)`; registration/schema tests now expect 5
  tools; added a test asserting `relpath` is optional and defaults to the `log`.
- Updated `Documentation/mcp.rst` (synopsis, `testreport_read` signature,
  `testreport_logs` cross-reference; removed the `testreport_read_file` section).

## Gate (whole repo, observed green)

- `uv run ruff format --check .` → all formatted
- `uv run ruff check .` → passed
- `uv run ty check` → passed
- `uv run pytest` → 1736 passed
- `uv run --group doc sphinx-build -W …` → build succeeded