### PR TITLE
fix(http): size HTTP connection pool to the worker-thread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Fetching openQA data from the QEM Dashboard no longer floods the log with
+  "Connection pool is full, discarding connection" warnings. The shared HTTP
+  session's connection pool is now sized to match mtui's default worker-thread
+  count (`min(32, cpu + 4)`), so the concurrent per-setting requests reuse
+  connections instead of repeatedly opening and tearing them down.
 - Over `mtui-mcp`, a command with a `nargs=REMAINDER` *optional* flag declared
   before another flag (the shape used by `reject --message`) could have the
   later flag swallowed into the message when re-encoding a tool call to argv.

--- a/mtui/support/concurrency.py
+++ b/mtui/support/concurrency.py
@@ -19,6 +19,13 @@ Routing MTUI's thread pools through this class instead of the bare
 and every transport (stdio / http / REPL); code that does not set any
 context var is unaffected (copying an unmodified context is cheap and
 side-effect free).
+
+When constructed without ``max_workers`` (the common case for MTUI's
+HTTP fan-out), this inherits ``ThreadPoolExecutor``'s default of
+``min(32, cpu + 4)`` workers. :func:`mtui.support.http.default_pool_size`
+mirrors that same formula to size the shared ``requests`` connection
+pool, so a fan-out of workers hitting one host has one cached connection
+per worker and never triggers ``urllib3``'s pool-full connection churn.
 """
 
 from collections.abc import Callable

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -31,15 +31,32 @@ who cannot install that CA can disable verification globally with
 
 from __future__ import annotations
 
+import os
 import ssl
 
 import requests
+import requests.adapters
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 
 #: Shared ``(connect, read)`` timeout in seconds for every outbound HTTP
 #: call. Bounds a stuck socket so a broken network can't hang mtui.
 HTTP_TIMEOUT: tuple[float, float] = (5.0, 30.0)
+
+
+def default_pool_size() -> int:
+    """The default thread-pool / connection-pool width shared across mtui.
+
+    Matches :class:`concurrent.futures.ThreadPoolExecutor`'s own default
+    (``min(32, cpu + 4)``) so a pool of worker threads fanning HTTP
+    requests at one host has exactly one cached connection per worker.
+    Sizing the :class:`requests.Session` connection pool to the same
+    value stops ``urllib3`` from logging "Connection pool is full,
+    discarding connection" and tearing down (then re-handshaking)
+    connections under concurrent fan-out.
+    """
+    return min(32, (os.process_cpu_count() or 1) + 4)
+
 
 #: A ``requests``-compatible ``verify`` value: ``True`` (use the system
 #: trust store), ``False`` (skip verification), or a path to a CA
@@ -87,11 +104,23 @@ def resolve_verify(
 def build_session(verify: VerifyPolicy) -> requests.Session:
     """Create a :class:`requests.Session` with a fixed ``verify`` policy.
 
+    The session's HTTP(S) connection pool is sized to
+    :func:`default_pool_size` (the same width as mtui's default thread
+    pool) so concurrent fan-out at a single host reuses connections
+    instead of triggering ``urllib3``'s "Connection pool is full,
+    discarding connection" churn.
+
     When ``verify`` is falsy, the module-wide insecure-request warning
     is suppressed so callers do not have to repeat that boilerplate.
     """
     session = requests.Session()
     session.verify = verify
+    pool_size = default_pool_size()
+    adapter = requests.adapters.HTTPAdapter(
+        pool_connections=pool_size, pool_maxsize=pool_size
+    )
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
     if not verify:
         disable_insecure_warnings()
     return session

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -37,6 +37,33 @@ def test_resolve_verify_precedence(default, override, expected):
     assert _http.resolve_verify(default, override) == expected
 
 
+def test_default_pool_size_matches_threadpool_default(monkeypatch):
+    # Mirrors ThreadPoolExecutor's own default of min(32, cpu + 4).
+    monkeypatch.setattr(_http.os, "process_cpu_count", lambda: 4)
+    assert _http.default_pool_size() == 8
+
+    monkeypatch.setattr(_http.os, "process_cpu_count", lambda: 100)
+    assert _http.default_pool_size() == 32  # capped at 32
+
+    # os.process_cpu_count() can return None; fall back to 1 + 4.
+    monkeypatch.setattr(_http.os, "process_cpu_count", lambda: None)
+    assert _http.default_pool_size() == 5
+
+
+def test_build_session_sizes_connection_pool(monkeypatch):
+    monkeypatch.setattr(_http, "default_pool_size", lambda: 17)
+
+    session = _http.build_session(verify=True)
+
+    for scheme in ("https://", "http://"):
+        adapter = session.get_adapter(f"{scheme}example.test")
+        assert isinstance(adapter, _http.requests.adapters.HTTPAdapter)
+        # pool_maxsize is forwarded to the underlying urllib3 pool manager
+        # connection_pool_kw; assert on that public surface rather than the
+        # adapter's private _pool_maxsize attribute.
+        assert adapter.poolmanager.connection_pool_kw["maxsize"] == 17
+
+
 def test_build_session_sets_verify_true_and_keeps_warnings(monkeypatch):
     calls = []
     monkeypatch.setattr(


### PR DESCRIPTION
## What

Sizes the shared `requests.Session` connection pool to match mtui's default worker-thread count, eliminating the noisy `urllib3` warnings emitted while fetching openQA data from the QEM Dashboard.

## Why

`DashboardAutoOpenQA._load_jobs()` fans out one HTTP request per setting through `ContextExecutor` (a `ThreadPoolExecutor` defaulting to `min(32, cpu + 4)` workers), all hitting a single host (`dashboard.qam.suse.de`). The session used the `requests` library default pool of 10 connections per host, so once more than 10 workers finished concurrently, urllib3 logged:

```
WARNING  Connection pool is full, discarding connection: dashboard.qam.suse.de. Connection pool size: 10
```

and discarded each overflow connection — forcing a fresh TLS handshake on the next call. Requests still succeeded, but the log was flooded and connection reuse was lost.

## How

- Add `mtui.support.http.default_pool_size()` → `min(32, (os.process_cpu_count() or 1) + 4)`, mirroring `ThreadPoolExecutor`'s own default formula (single source of truth for the fan-out width).
- `build_session()` now mounts an `HTTPAdapter(pool_connections=N, pool_maxsize=N)` on both `http://` and `https://`.
- Document the alignment in `concurrency.py`: `ContextExecutor` inherits the same `min(32, cpu+4)` default, so there is now exactly one cached connection per worker.

## Tests

- `test_default_pool_size_matches_threadpool_default` — covers the `cpu+4`, cap-at-32, and `None`→5 branches.
- `test_build_session_sizes_connection_pool` — asserts the configured `maxsize` reaches the urllib3 pool manager for both schemes.

## Gate set (whole repo)

- `ruff format --check .` ✅
- `ruff check .` ✅
- `ty check` ✅
- `pytest` ✅ — 1737 passed

Changelog entry added under `[Unreleased] / Fixed`.