### PR TITLE
fix: normalize python3- prefix in openqa_overview build-checks matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   reported as dangling (also mis-classifying the real base product as an
   unexpected addon). The symlink target is now reduced to its basename, so
   both relative and absolute forms resolve.
+- `openqa_overview` build-checks now match `python3-<pkg>` binary packages
+  against their `python-<pkg>`-named source log. The normalization regex
+  previously required at least two digits after `python` (`python38-`,
+  `python313-`), so single-digit flavors like `python3-tornado` were missed
+  and their build-check log was silently skipped.
 
 ## 18.2.0 - 2026-06-23
 

--- a/mtui/data_sources/oqa_search/heuristics.py
+++ b/mtui/data_sources/oqa_search/heuristics.py
@@ -93,4 +93,4 @@ TESTSUITE_SUMMARY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^(ok|fail|expected fail|unexpected pass|skipped):\s*\d+"),
 ]
 
-PYTHON_FLAVOR_RE = re.compile(r"^python\d{2,3}-")
+PYTHON_FLAVOR_RE = re.compile(r"^python\d+-")

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -391,7 +391,7 @@ def log_matches_package(log: str, packages: list[str]) -> bool:
     """Return ``True`` if ``log`` belongs to any package in ``packages``.
 
     Besides the plain substring check this also tries a normalized form of
-    each package name (``pythonNNN-foo`` -> ``python-foo``) so the flavored
+    each package name (``pythonN[N...]-foo`` -> ``python-foo``) so the flavored
     Python binary packages still match their source-named build_checks log.
     """
     for pkg in packages:

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -412,8 +412,10 @@ def test_build_checks_matches_flavored_python_package_to_source_log():
         ("python-ecdsa.log", ["bash", "python311-ecdsa"], True),
         # Unrelated package does not match.
         ("python-ecdsa.log", ["python-rsa"], False),
-        # `python3-foo` (single digit) is not a flavor and is not normalized.
-        ("python-foo.log", ["python3-foo"], False),
+        # `python3-foo` (single digit) is also normalized.
+        ("python-foo.log", ["python3-foo"], True),
+        # Regression: python3-tornado -> python-tornado (SUSE:Maintenance:44982:414912).
+        ("python-tornado.x86_64.log", ["python3-tornado"], True),
         # Empty package list never matches.
         ("python-ecdsa.log", [], False),
     ],


### PR DESCRIPTION
## Summary

openqa_overview build-checks were silently skipping `python3-<pkg>` packages because the normalization regex required at least two digits after python. In SUSE, python3-tornado is a binary built from the python-tornado source, so the build-checks index names the log `python-tornado.arch.log`, and the match was missed.

## Changes

- Widen PYTHON_FLAVOR_RE from `^python\d{2,3}-` to `^python\d+-` so single-digit flavors (`python3-`) are normalized to `python-` alongside `python38-` / `python313-`
- Update log_matches_package docstring to reflect the broader match
- Fix the existing test case that incorrectly expected `python3-foo` not to normalize, and add a regression case for `python3-tornado`

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `uv run ruff format --check .` is clean.
- [x] `uv run ruff check .` is clean.
- [x] `uv run ty check` is clean.
- [x] `uv run pytest` passes.
- [x] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
- [ ] Documentation under `Documentation/` updated where relevant.
