### PR TITLE
feat(commands): add request_review Slack review/approve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   unresolvable fails closed. A new `[obs]` config section (`api_url`,
   `request_timeout`) is introduced.
 
+- New `request_review` command — posts the loaded update's test report to a
+  configured Slack channel (`[slack]` config section), then watches the request
+  thread and auto-approves the update once a reviewer reacts with 👍 (skin-toned
+  👍 variants count), relaying any thread replies as they arrive. With several
+  templates loaded, all review requests are posted first and a single combined
+  watch then polls every thread, approving each update as its ack arrives;
+  Ctrl-C stops the watch with a per-template status summary. When the report
+  already records a Slack review marker, a re-run resumes the existing request
+  instead of posting a duplicate — forwarding the thread's replies so far — so
+  an interrupted watch (Ctrl-C, a cancelled MCP job) just picks up where it
+  left off; `--repost` forces a fresh post, replacing the marker and leaving a
+  "superseded" reply under the old thread. A cancelled or superseded watch
+  reports an observed 👍 but never approves from it, and a cancelled MCP job
+  stops before its next side effect — `job_cancel` reports "cancelled" only
+  once the worker has actually stopped (a `cancelling` state covers the stop
+  window), and a foreground MCP `request_review` that would watch several
+  templates is refused (background it instead). In turn, `approve` and `reject` now
+  require a recorded Slack review that still shows a 👍 — the gate verifies the
+  referenced Slack message really is this update's review request (it must
+  name the RRID) before trusting any reaction, and refuses otherwise.
 - `mtui-mcp` is now much more token-efficient. Tool schemas are automatically
   slimmed of redundant pydantic boilerplate (the per-field `title` keys and the
   `anyOf: [T, null]` optional-field unions), shrinking the tool-list payload

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -520,6 +520,78 @@ port must be numeric); an invalid value is rejected when the
 configuration is read and the default is used instead.
 
 
+``slack.base_url``
+~~~~~~~~~~~~~~~~~~~~
+  | **type**
+  |     URL
+  | **default**
+  |     https://slack.com/api
+
+Base URL of the Slack Web API used by the ``request_review`` command
+and the ``approve`` / ``reject`` review gate. Rarely changed; overridable
+mainly so the test suite can point the client at a mock endpoint.
+
+
+``slack.channel``
+~~~~~~~~~~~~~~~~~
+  | **type**
+  |     string
+  | **default**
+  |     ``""``
+
+Slack channel the ``request_review`` command posts the review request
+to. Prefer a channel **ID** (``Cxxxxxxxx``); a ``#name`` is accepted at
+post time and mtui then records the canonical channel ID Slack returns,
+so the watch and the review gate keep working either way. The bot must
+be invited to the channel. ``request_review`` refuses up front, naming
+the missing key, when this is unset.
+
+
+``slack.poll_interval``
+~~~~~~~~~~~~~~~~~~~~~~~
+  | **type**
+  |     int (seconds)
+  | **default**
+  |     20
+
+Interval, in seconds, at which ``request_review`` polls Slack for thread
+replies and the review 👍 reaction while watching a posted request. Keep
+this at roughly 20 s or higher: per-template fan-out multiplies the
+request rate, and a lower interval risks Slack ``429`` rate limiting.
+
+
+``slack.token``
+~~~~~~~~~~~~~~~
+  | **type**
+  |     string
+  | **default**
+  |     `os.getenv('SLACK_TOKEN','')`__
+
+.. __: https://docs.python.org/3/library/os.html#os.getenv
+
+Slack bot token (``xoxb-``) used to post the review request and read
+thread replies and reactions. This config has higher priority than the
+environment variable. The Slack app needs the ``chat:write``,
+``reactions:read``, ``channels:history`` (plus ``groups:history`` for
+private channels) and ``users:read`` scopes, and the bot must be invited
+to ``slack.channel``.
+
+
+``slack.watch_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~
+  | **type**
+  |     int (seconds)
+  | **default**
+  |     28800
+
+Maximum time, in seconds, ``request_review`` waits for a review 👍 before
+giving up and returning without approving. A review can take hours, so the
+default is a full working day (8h); ``request_review`` blocks with a spinner
+in the REPL (Ctrl-C to stop) or runs as a background MCP job for that long.
+This also bounds a cancelled MCP background watch job's worker thread, so a
+lower value frees a leaked poller sooner.
+
+
 ``svn.path``
 ~~~~~~~~~~~~
   | **type**
@@ -611,7 +683,14 @@ Example
   resolvers = https
   https_uri = https://qam.suse.de/refhosts/refhosts.yml
   path = /usr/share/qam-metadata/refhosts.yml
-  
+
+
+  [slack]
+  token = xoxb-your-bot-token
+  channel = C0123456789
+  poll_interval = 20
+  watch_timeout = 28800
+
 
   [url]
   bugzilla = https://bugzilla.suse.com

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -1341,6 +1341,12 @@ When ``-r REVIEWER`` is given, the reviewer is recorded in the testreport (the
 then is the update approved. If the testreport has no ``Test Plan Reviewer:``
 line or the SVN commit fails, the approval is aborted.
 
+Approval requires a live Slack review acknowledgement: the update refuses to
+approve unless the testreport carries a recorded Slack review (see
+`request_review`_) and a 👍 reaction is still present on that Slack message. Run
+`request_review`_ first to obtain the ack. The gate is unconditional -- there is
+no bypass -- and applies identically at the REPL and over MCP.
+
 .. _osc qam approve: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#approve
 
 **Options:**
@@ -1365,6 +1371,12 @@ reject
 Rejects the current update (always as a ``by_user`` decline). The ``-r``
 option is required; ``-g`` is accepted for compatibility but ignored. Mirrors
 the `osc qam reject`_ workflow.
+
+Like `approve`_, rejection requires a live Slack review acknowledgement: it
+refuses unless the testreport carries a recorded Slack review (see
+`request_review`_) and a 👍 reaction is still present on that Slack message. The
+gate is unconditional -- there is no bypass -- and applies identically at the
+REPL and over MCP.
 
 .. _osc qam reject: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#reject
 
@@ -1396,6 +1408,104 @@ Adds a comment to the currently loaded review request via the native OBS
 backend. The command takes no arguments; it prompts interactively for the comment
 text on stdin (``Comment:``). The comment is posted against the RRID
 of the loaded test report template.
+
+
+request_review
+++++++++++++++
+
+::
+
+    request_review [--no-watch] [--no-approve] [--repost] [-g [GROUP]]
+                   [-u USER] [-T RRID | --all-templates]
+
+Requests a Slack review of the loaded update and, by default, waits for the
+reviewer's acknowledgement and then approves the update.
+
+The command first ensures the testreport is committed (auto-committing it if
+needed, since the ``http://qam.suse.de/testreports/<RRID>/log`` mirror only
+reflects committed content), then posts that ``/log`` URL to the configured
+Slack channel asking for review. The posted message's channel and timestamp are
+recorded durably in the testreport (a ``Slack Review:`` marker line in the
+``log`` file), so the ack state survives a reload and is re-checkable by
+`approve`_ and `reject`_.
+
+Requires the ``[slack]`` configuration (bot token, channel, and related
+options; see :doc:`cfg`). The bot must be invited to the channel.
+
+Three modes:
+
+* **Default (watch and approve)**: after posting, the command watches the Slack
+  message. Thread replies are streamed to the console as they arrive, and when a
+  👍 (``+1``/``thumbsup``) reaction appears, the review is considered done and
+  the update is **approved** automatically. The reactor's Slack display name is
+  recorded as the reviewer (best-effort -- Slack does not guarantee the ordering
+  of a reaction's user list).
+* **--no-watch**: post the review request and return immediately without
+  watching for a reply or reaction.
+* **--no-approve**: watch and report the acknowledgement, but do not approve the
+  update.
+
+If the testreport already records a ``Slack Review:`` marker, the command
+**resumes** that request instead of posting a duplicate: the existing thread is
+watched, and its replies so far are forwarded to the console first — so an
+interrupted watch (CTRL-C, a cancelled MCP job) can simply be re-run and picks
+up where it left off, including a 👍 that arrived in the meantime. The on-disk
+marker (re-read after the initial commit's ``svn up``) decides this, so a
+review requested by a colleague is resumed, not duplicated. Pass ``--repost``
+to force a fresh post: the marker is replaced and a best-effort "superseded"
+reply is left under the old thread. If a resumed watch reports Slack
+unreachable, the review message may have been deleted — re-run with
+``--repost``. The auto-approve re-validates the marker after the ack, so an
+ack observed by a cancelled watch or on a thread that was superseded mid-watch
+is reported but never acted on.
+
+Both ``slack.token`` and ``slack.channel`` must be configured: the command
+refuses up front, naming the missing ``[slack]`` key, before anything is
+committed or posted. If committing the marker to SVN fails, the command
+aborts **before** watching (the approve/reject gate relies on the committed
+marker being visible to every checkout); the Slack post stays live, and a
+re-run commits the local marker and resumes the watch.
+
+The watch is bounded by ``slack.watch_timeout`` and polls at
+``slack.poll_interval`` (see :doc:`cfg`). Under the REPL the wait can be
+interrupted with CTRL-C.
+
+When more than one template is loaded this fans out across all of them by
+default (see `Fan-out across templates`_) in two phases: first every
+template's review request is posted (or resumed) — one Slack thread per
+template — and only then a single combined watch polls all of the threads,
+approving each update as its 👍 arrives, until every request is resolved or
+the shared ``slack.watch_timeout`` deadline expires. Relayed thread replies
+are prefixed with the template's RRID. CTRL-C during the watch stops it and
+prints a per-template status summary (posted/acked/approved/pending); the
+already-posted requests and their markers survive, so a re-run resumes the
+pending ones. Use ``-T RRID`` to scope to a single template.
+
+**Options:**
+
+.. option:: --no-watch
+
+  Post the review request and return immediately, without watching for a reply
+  or reaction.
+
+.. option:: --no-approve
+
+  Watch for the acknowledgement and report it, but do not approve the update.
+
+.. option:: --repost
+
+  Post a fresh review request even when one is already recorded, replacing the
+  stored marker; the old thread gets a best-effort "superseded" reply. Applies
+  to every fanned-out template, so with more than one template loaded it is
+  refused unless scoped with ``-T RRID``.
+
+.. option:: -g [GROUP], --group [GROUP]
+
+  QA group to approve under (passed through to the internal `approve`_).
+
+.. option:: -u USER, --user USER
+
+  User to approve as (passed through to the internal `approve`_).
 
 
 Other Commands

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -268,6 +268,16 @@ implementations.
    refuse destructive calls. Operators driving an autonomous LLM
    client should reason about blast radius accordingly.
 
+Slack review gate on ``approve``/``reject``
+-------------------------------------------
+
+The ``approve`` and ``reject`` commands refuse unless the loaded
+testreport carries a live Slack 👍 review ack (see :doc:`iui` and the
+``request_review`` command). The gate is unconditional and has no bypass
+flag, so an autonomous LLM client — exactly like a human at the REPL —
+cannot approve or reject an update that has not been reviewed and does
+not still carry a 👍. Run ``request_review`` first to obtain the ack.
+
 REPL-only deny-list
 -------------------
 
@@ -644,13 +654,59 @@ work on other templates, which runs concurrently — and poll the job:
 
 * ``job_list``: every job in the session and its state;
 * ``job_status(job_id=…)``: one job's state
-  (``running`` / ``done`` / ``failed`` / ``cancelled``) and elapsed
-  time;
+  (``running`` / ``cancelling`` / ``done`` / ``failed`` / ``cancelled``)
+  and elapsed time;
 * ``job_result(job_id=…)``: a finished job's captured stdout. It
   *errors* while the job is still running (poll ``job_status`` first)
   and surfaces the command's failure envelope (stdout, error, exit
   code) if it failed, exactly as a foreground failure would have;
-* ``job_cancel(job_id=…)``: cancel a running job.
+* ``job_cancel(job_id=…)``: cancel a running job. Cancellation is
+  cooperative and **truthful**: the request sets the job's cancel flag,
+  the command body stops at its next checkpoint, and ``job_cancel``
+  reports "cancelled" only once the worker has actually exited. If the
+  body does not stop within a bounded grace period, ``job_cancel``
+  returns while the job shows ``cancelling`` — it does **not** claim the
+  body stopped — and the state flips to ``cancelled`` when the worker
+  exits. The job keeps its per-template lock until then, so a re-run on
+  the same template safely queues behind the stopping job instead of
+  interleaving with it.
+
+``request_review`` is also a slow, background-capable tool, though it is
+not a host command: it posts a review request to Slack and then **watches**
+the thread, polling for replies and the review 👍 up to
+``slack.watch_timeout`` seconds (see :doc:`cfg`). Under MCP the streamed
+thread replies are not server-pushed; they accumulate in the call's
+captured stdout and surface in ``job_result`` once the job has finished —
+neither ``job_status`` (state and elapsed time only) nor ``job_result``
+(errors while the job runs) exposes them mid-watch, and a cancelled job's
+captured output is likewise not retrievable. The thread itself is not
+lost: re-running ``request_review`` resumes the recorded thread and
+forwards its replies so far. For live reply relaying, watch from the REPL
+instead.
+Pass ``background=true`` to return a job id immediately instead of parking
+the request for the whole watch, and ``job_cancel`` it to stop watching
+early — the watch checks its cancel flag before every side effect and at
+each poll, so it stops at the next checkpoint (bounded by one HTTP
+timeout), and a cancelled watch never approves, even if the 👍 lands in
+its final in-flight poll. Always background a watch-bearing
+``request_review``: a foreground call that would watch **more than one**
+template is refused outright (use ``background=true``, scope with
+``template="<RRID>"``, or pass ``no_watch=true``), and even a
+single-template foreground watch parks the client request and holds that
+template's lock for up to the whole ``slack.watch_timeout`` with no
+cancel handle.
+
+When the testreport already records a ``Slack Review:`` marker, a
+``request_review`` call **resumes** that request instead of posting a
+duplicate — the existing thread's replies so far are forwarded first, so a
+cancelled job can simply be re-run (foreground or as a new background job)
+and picks up the same thread, including a 👍 that arrived in between.
+``repost=true`` forces a fresh post, replacing the marker (refused for an
+unscoped multi-template fan-out; scope it with ``template="<RRID>"``).
+``job_cancel`` any in-flight watch on the same template before re-running;
+the new call then queues behind the stopping job's per-template lock and
+starts only once the old worker has fully exited — the two can never
+interleave on the testreport or the Slack thread.
 
 When a backgrounded slow command fans out across several loaded
 templates (see `Multiple templates (fan-out and per-call scoping)`_),

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -15,12 +15,106 @@ from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices, template_completion
 from ..cli.term import ask_user
 from ..data_sources import OSC, Gitea, TeReGen
-from ..support.exceptions import GiteaError
+from ..support.exceptions import FailedSlackCallError, GiteaError
 from ..support.misc import requires_update
 from ..types import RequestKind
 from . import Command
 
 logger = getLogger("mtui.command.apicalls")
+
+
+def require_slack_review(command: "BaseApiCall") -> None:
+    """Refuse an approve/reject unless the report carries a live Slack ack.
+
+    ``request_review`` persists the Slack message reference (channel + ts) in
+    the testreport via :meth:`TestReport.set_slack_review`. This gate reads
+    the marker back **from the template file** (not the load-time snapshot —
+    any ``svn up`` may have pulled in a colleague's newer or reposted marker)
+    and re-queries Slack live so the 👍 ack is confirmed to still be present
+    at approve/reject time (durable and re-checkable across sessions).
+
+    The marker is plain text in the testreport, so anything that can edit the
+    template (``edit``, the MCP testreport write tools) can point it at an
+    arbitrary Slack message. Before trusting any reaction the gate therefore
+    BINDS the marker to this update:
+
+    1. the referenced message must exist and be readable in the marker's
+       channel (fetched via ``conversations.replies``; the parent/request
+       message is the first element),
+    2. the parent message text must name this update's RRID verbatim —
+       ``request_review`` always includes the RRID in the request message it
+       posts, so a message that does not name this RRID is not a review
+       request for this update,
+    3. only then are the parent's reactions checked for a 👍 ack (reaction
+       names are normalized so skin-toned variants like ``+1::skin-tone-3``
+       still count).
+
+    Channel binding: ``config.slack_channel`` may hold a channel *name* while
+    the marker records the canonical channel *id* Slack returned when the
+    request was posted, so a hard equality check against the config would
+    falsely refuse legitimate reviews. The fetch + RRID text check above
+    establishes the binding instead; a config mismatch is only surfaced as a
+    warning for the operator.
+
+    Raises:
+        FailedSlackCallError: if no Slack review is recorded (the user is
+            pointed at ``request_review``), the referenced message cannot be
+            fetched, the message is not this update's review request, or the
+            live reactions no longer carry a 👍.
+
+    """
+    review = command.metadata.get_slack_review()
+    if review is None:
+        raise FailedSlackCallError(
+            "No Slack review recorded for this update; run 'request_review' first."
+        )
+
+    # Imported lazily to avoid an import cycle at module load time.
+    from ..data_sources import SlackClient
+    from ..data_sources.slack import is_ack_reaction
+
+    channel, ts = review
+    rrid = str(command.metadata.rrid)
+
+    if channel != command.config.slack_channel:
+        # Not a refusal: the marker usually stores the resolved channel id
+        # while the config may hold the channel name (see the docstring). The
+        # binding is verified via the message fetch below.
+        logger.warning(
+            "Slack review marker channel %s differs from configured "
+            "slack_channel %s; verifying the marker via the message itself.",
+            channel,
+            command.config.slack_channel,
+        )
+
+    try:
+        messages = SlackClient(command.config).conversations_replies(channel, ts)
+    except FailedSlackCallError as e:
+        raise FailedSlackCallError(
+            f"Slack review message {channel}/{ts} could not be fetched: {e}. "
+            "The recorded marker may be stale; re-run 'request_review'."
+        ) from e
+    if not messages:
+        raise FailedSlackCallError(
+            f"Slack review message {channel}/{ts} does not exist; "
+            "the recorded marker is stale. Re-run 'request_review'."
+        )
+
+    parent = messages[0]
+    if rrid not in parent.get("text", ""):
+        raise FailedSlackCallError(
+            f"Slack review message {channel}/{ts} does not mention {rrid}; "
+            "the recorded marker does not match this update (forged or "
+            "stale). Re-run 'request_review' to post a genuine request."
+        )
+
+    # is_ack_reaction normalizes skin-toned variants ("+1::skin-tone-3").
+    reactions = parent.get("reactions", [])
+    if not any(is_ack_reaction(r.get("name") or "") for r in reactions):
+        raise FailedSlackCallError(
+            f"Slack review {channel}/{ts} has no 👍 ack; refusing. "
+            "Have a reviewer react with 👍 first."
+        )
 
 
 class BaseApiCall(Command, ABC):
@@ -244,6 +338,16 @@ class Reject(BaseApiCall):
             help="Message to use for rejection-comment."
             + "Always as last of command, it takes remainder of command",
         )
+
+    @requires_update
+    def __call__(self) -> None:
+        """Reject the request after the Slack review gate.
+
+        Mirrors :class:`~mtui.commands.approve.Approve`: require a live Slack
+        👍 ack before delegating to the shared backend-dispatch path.
+        """
+        require_slack_review(self)
+        super().__call__()
 
     @property
     def _message(self) -> str:

--- a/mtui/commands/approve.py
+++ b/mtui/commands/approve.py
@@ -17,7 +17,7 @@ from ..data_sources import OSC, Gitea
 from ..support.exceptions import GiteaError, InvalidGiteaHashError
 from ..support.misc import requires_update
 from ..test_reports.svn_io import TemplateFormatError, svn_commit_testreport
-from .apicall import BaseApiCall
+from .apicall import BaseApiCall, require_slack_review
 
 logger = getLogger("mtui.command.approve")
 
@@ -46,10 +46,12 @@ class Approve(BaseApiCall):
     def __call__(self) -> None:
         """The main entry point for the command.
 
-        When ``-r/--reviewer`` is given, record the reviewer in the
-        testreport and commit it to SVN before approving. If either step
-        fails, the approval is aborted.
+        Refuse unless the report carries a live Slack 👍 ack. When
+        ``-r/--reviewer`` is given, record the reviewer in the testreport and
+        commit it to SVN before approving. If either step fails, the approval
+        is aborted.
         """
+        require_slack_review(self)
         if self.args.reviewer is not None and not self._record_reviewer():
             return
         super().__call__()

--- a/mtui/commands/request_review.py
+++ b/mtui/commands/request_review.py
@@ -1,0 +1,790 @@
+"""The ``request_review`` command — Slack-driven review and auto-approve.
+
+Ensures the loaded update's testreport is committed, posts its
+``reports_url/<RRID>/log`` URL to a configured Slack channel asking for a
+review, then (unless ``--no-watch``) blocks streaming thread replies to the
+user until a 👍 reaction acks the request. On an ack, unless ``--no-approve``
+is given, it drives the existing ``approve`` path — recording the best-effort
+reactor as the reviewer — bound to *this* fanout template.
+
+When the testreport already records a ``Slack Review:`` marker, the command
+**resumes** that request instead of posting a duplicate: the existing thread's
+replies so far are forwarded to the user and the watch continues on the same
+message, so an interrupted review can be picked up later. ``--repost`` forces
+a fresh post, replacing the stored marker (the old thread gets a best-effort
+"superseded" reply).
+
+The Slack message reference (channel + ts) is persisted durably in the
+testreport (``set_slack_review``) so the ack survives a reload and is
+re-checkable by the ``approve``/``reject`` review gate. The on-disk marker is
+the source of truth: the resume decision re-reads it after the pre-commit's
+``svn up`` (which may pull a colleague's newer marker), and the auto-approve
+re-validates it so an ack on a superseded thread is never acted on.
+
+An unscoped multi-template invocation runs in **two phases**: every template's
+request is posted (or resumed) first, then ONE combined watch polls all of
+them round-robin, approving each as its ack arrives, until every request is
+resolved or the shared ``slack_watch_timeout`` deadline expires. A watch can
+therefore never delay another template's post, and Ctrl-C mid-watch reports a
+per-template status summary instead of silently dropping the other templates
+(their posts and markers survive; a re-run resumes them). A ``-T``-scoped
+invocation — including each per-template background job the MCP session mints
+for a fanned-out command — keeps the classic single-template blocking flow.
+"""
+
+import subprocess
+import threading
+import time
+from argparse import Namespace
+from contextlib import suppress
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Any
+
+from ..cli.argparse import ArgumentParser
+from ..cli.completion import complete_choices, template_completion
+from ..data_sources import ReviewOutcome, SlackClient
+from ..support.cancellation import current_cancel_event
+from ..support.exceptions import FailedSlackCallError, SlackError
+from ..support.messages import FanOutError
+from ..support.misc import requires_update
+from ..support.spinner import spinner
+from ..test_reports.svn_io import (
+    TemplateFormatError,
+    svn_commit_testreport,
+    svn_update_testreport,
+)
+from . import Command
+from .approve import Approve
+
+logger = getLogger("mtui.command.request_review")
+
+#: Consecutive failed poll cycles after which one pending request in the
+#: combined fan-out watch is declared unreachable. Mirrors
+#: ``mtui.data_sources.slack._MAX_POLL_FAILURES`` so the round-robin watch
+#: degrades exactly like the single-template ``wait_for_ack``.
+_MAX_POLL_FAILURES = 3
+
+
+@dataclass
+class _PendingWatch:
+    """One template's live review request, awaiting its 👍.
+
+    Carries the template's own ``metadata``/``targets`` binding so the ack
+    handling (supersede guard, auto-approve) acts on *this* template even when
+    the command object has since been rebound to another fan-out template.
+    ``status`` is a human-readable progress note surfaced by the Ctrl-C
+    per-template summary; ``last_seen``/``failures`` are the round-robin poll
+    cursor and consecutive-failure counter (see ``_poll_watch``).
+    """
+
+    metadata: Any
+    targets: Any
+    client: SlackClient
+    channel: str
+    ts: str
+    resumed: bool
+    status: str
+    last_seen: int = 1
+    failures: int = 0
+
+
+class RequestReview(Command):
+    """Requests a Slack review of the loaded update and auto-approves on ack.
+
+    Commits the testreport (auto-committing first if needed), posts its log
+    URL to the configured Slack channel — or, when a ``Slack Review:`` marker
+    is already recorded, **resumes watching that existing request** instead of
+    posting a duplicate — then watches the thread: replies are streamed as
+    they arrive (on a resume, the thread's history so far is forwarded first)
+    and a 👍 reaction is treated as review approval. On ack the update is
+    approved with the reactor recorded as reviewer.
+
+    With several templates loaded, every template's request is posted first
+    and a single combined watch then polls all of them, approving each as its
+    ack arrives.
+
+    Use ``--no-watch`` to post and return without watching, ``--no-approve``
+    to watch and report the ack without approving, or ``--repost`` to post a
+    fresh request even when one is already recorded.
+    """
+
+    command = "request_review"
+    scope = "fanout"
+
+    @classmethod
+    def _add_arguments(cls, parser: ArgumentParser) -> None:
+        """Adds arguments to the command's argument parser."""
+        parser.add_argument(
+            "--no-watch",
+            dest="no_watch",
+            action="store_true",
+            help="post the review request and return without watching the thread",
+        )
+        parser.add_argument(
+            "--no-approve",
+            dest="no_approve",
+            action="store_true",
+            help="watch and report the ack, but do not approve the update",
+        )
+        parser.add_argument(
+            "--repost",
+            dest="repost",
+            action="store_true",
+            help="post a fresh review request even when one is already "
+            "recorded, replacing the stored marker (the old thread gets a "
+            "'superseded' reply)",
+        )
+        parser.add_argument(
+            "-g",
+            "--group",
+            nargs="?",
+            action="append",
+            help="Group wanted to approve\n Not valid for Gitea Workflow",
+        )
+        parser.add_argument(
+            "-u",
+            "--user",
+            action="store",
+            default="",
+            help="User override for gitea workflow (Gitea only)",
+        )
+        cls._add_template_arg(parser)
+
+    @staticmethod
+    def _cancel_requested() -> bool:
+        """Whether the job's cooperative cancel event is set (``False`` in the REPL).
+
+        Polled before every externally visible side effect so a cancelled MCP
+        job stops promptly and truthfully instead of committing, posting, or
+        approving after ``job_cancel`` already reported "cancelled".
+        """
+        cancel = current_cancel_event.get()
+        return cancel is not None and cancel.is_set()
+
+    def run(self) -> None:
+        """Two-phase fan-out: post every template's request, then watch them all.
+
+        ``--repost`` replaces each template's recorded review; blindly doing
+        that for every loaded template orphans live threads wholesale, so it
+        must be scoped to one template explicitly. Checked here — once, before
+        the fan-out — so the refusal prints a single line.
+
+        A single resolved template (including every ``-T``-scoped per-template
+        background job the MCP session mints) runs the classic blocking flow
+        via :meth:`__call__`, byte-for-byte like ``Command.run``. With more
+        than one template, PHASE 1 posts (or resumes) each template's request
+        — collecting per-template failures exactly like the base fan-out —
+        and PHASE 2 runs ONE combined watch over every pending request, so no
+        template's post waits hours behind another template's watch. Ctrl-C
+        stops the watch and prints a per-template status summary; the posted
+        requests and their markers survive and a re-run resumes them.
+        """
+        resolved = self._resolve_templates()
+        if self.args.repost and len(resolved) > 1:
+            self.println(
+                "--repost acts on every fanned-out template and would replace "
+                "each one's recorded review request; scope it with -T RRID."
+            )
+            return
+
+        if len(resolved) <= 1:
+            # Single template: keep the historical single-call dispatch (and
+            # its error contract) exactly as ``Command.run`` would.
+            report = resolved[0]
+            self.metadata = report
+            self.targets = report.targets
+            self.__call__()
+            return
+
+        failures: list[tuple[str, BaseException]] = []
+        watches: list[_PendingWatch] = []
+        unprocessed = [str(report.id) for report in resolved]
+        try:
+            # PHASE 1 — post (or resume) every template's request BEFORE any
+            # watch, mirroring the base fan-out's banner + collect-and-continue
+            # error reporting, so template N+1's Slack request is live within
+            # seconds instead of hours behind template N's watch.
+            for report in resolved:
+                rrid = str(report.id)
+                self.metadata = report
+                self.targets = report.targets
+                self.display.template_banner(rrid)
+                try:
+                    item = self._post_or_resume()
+                except Exception as exc:  # noqa: BLE001 - collect & continue
+                    logger.error("%s failed on %s: %s", self.command, rrid, exc)
+                    failures.append((rrid, exc))
+                else:
+                    if item is not None:
+                        watches.append(item)
+                unprocessed.remove(rrid)
+
+            # PHASE 2 — one combined watch over every still-pending request
+            # (empty under --no-watch or when every template resolved early).
+            if watches:
+                self._watch_all(watches)
+        except KeyboardInterrupt:
+            # A BaseException would bypass the per-template ``except`` above
+            # and silently drop the other templates. The posts and markers
+            # already made are durable — report where each template stands
+            # instead of losing them.
+            self._report_interrupted(watches, unprocessed)
+            return
+
+        done = {rrid for rrid, _ in failures}
+        ok = [str(report.id) for report in resolved if str(report.id) not in done]
+        if ok:
+            logger.info("%s succeeded on: %s", self.command, ", ".join(ok))
+        if failures:
+            raise FanOutError(failures)
+
+    @requires_update
+    def __call__(self) -> None:
+        """Commit, post to (or resume on) Slack, watch, and approve on 👍."""
+        item = self._post_or_resume()
+        if item is None:
+            return
+        self._watch_one(item)
+
+    def _post_or_resume(self) -> _PendingWatch | None:
+        """Commit the report and post (or resume) its Slack review request.
+
+        Runs the per-template side-effect phase for ``self.metadata``: the
+        pre-post ``svn`` commit, the resume-or-post decision, the durable
+        marker write and its commit, and the ``--repost`` supersede
+        breadcrumb. The job's cancel event is polled before every externally
+        visible side effect so a cancelled job stops cleanly mid-sequence.
+
+        Returns:
+            A :class:`_PendingWatch` for the live request when a watch should
+            follow, or ``None`` when the flow ended here (``--no-watch``, a
+            refusal, a failure — each already reported to the user).
+
+        """
+        # 0) Fail fast on missing Slack configuration: an empty channel would
+        #    otherwise reach the API and die with a misleading
+        #    ``channel_not_found``; an empty token with a bare client error.
+        if not self.config.slack_token:
+            self.println(
+                "Not requesting review: [slack] token is not configured "
+                "(set it, or the SLACK_TOKEN environment variable)."
+            )
+            return None
+        if not self.config.slack_channel:
+            self.println("Not requesting review: [slack] channel is not configured.")
+            return None
+        if self._cancel_requested():
+            self.println(
+                f"request_review for {self.metadata.rrid} was cancelled; "
+                "nothing was done."
+            )
+            return None
+
+        # 1) Auto-commit so the qam.suse.de /log mirror reflects the report we
+        #    are asking people to review; abort before posting if it fails.
+        #    (This ``svn ci`` commits the whole working copy, so it is also
+        #    what re-commits a previously uncommitted local marker on a
+        #    resume re-run.)
+        try:
+            svn_commit_testreport(
+                self.metadata.report_wd(),
+                self.config.install_logs,
+                ["-m", "commit before review request"],
+            )
+        except subprocess.CalledProcessError as e:
+            self.println(f"Failed to commit testreport, not requesting review: {e}")
+            return None
+
+        # 1b) The commit above ran ``svn up``, which may have pulled in a
+        #     colleague's newer / reposted / removed marker — the file, not the
+        #     load-time snapshot, decides whether to resume, and the in-memory
+        #     attribute is synced so the approve/reject gate sees the same ts.
+        existing = self.metadata.get_slack_review()
+        self.metadata.slack_review = existing
+
+        if existing is not None and not self.args.repost:
+            # 2a) Resume the recorded request: no new post, no marker rewrite.
+            #     The watch starts at the top of the thread, so replies that
+            #     arrived while nobody was watching are forwarded first.
+            channel, ts = existing
+            if self.args.no_watch:
+                self.println(
+                    f"Review request for {self.metadata.rrid} already posted "
+                    f"({channel}/{ts}); not watching. Pass --repost to post "
+                    "a fresh one."
+                )
+                return None
+            try:
+                client = SlackClient(self.config)
+            except SlackError as e:
+                self.println(f"Slack client unavailable: {e}")
+                return None
+            self.println(
+                f"Resuming existing review request for {self.metadata.rrid} "
+                f"at {channel}/{ts} (pass --repost for a fresh one)."
+            )
+            return _PendingWatch(
+                metadata=self.metadata,
+                targets=self.targets,
+                client=client,
+                channel=channel,
+                ts=ts,
+                resumed=True,
+                status="resumed, awaiting ack",
+            )
+
+        # 2b) Post a fresh request. A template that cannot record the review
+        #     marker would leave a dangling Slack message whose ack the
+        #     approve gate can never see; refuse before posting.
+        if not self.metadata.has_slack_review_anchor():
+            self.println(
+                f"Testreport for {self.metadata.rrid} has no "
+                "'Test Plan Reviewer:' line to anchor the Slack review "
+                "marker; fix the template before requesting review."
+            )
+            return None
+
+        url = self.metadata._testreport_url()  # noqa: SLF001 -- shared report URL helper
+        if self._cancel_requested():
+            self.println(
+                f"request_review for {self.metadata.rrid} was cancelled; "
+                "not posting the review request."
+            )
+            return None
+
+        try:
+            client = SlackClient(self.config)
+            # The RRID must appear verbatim in this parent message: the
+            # approve/reject review gate re-reads the posted message and
+            # verifies its text names this RRID, defeating a forged marker.
+            channel, ts = client.chat_postMessage(
+                self.config.slack_channel,
+                f"Please review {self.metadata.rrid}: {url}",
+            )
+        except SlackError as e:
+            self.println(f"Failed to post Slack review request: {e}")
+            return None
+
+        # 3) Persist the marker so the ack survives a reload, then commit it.
+        #    From here until the marker is recorded, the request is live but
+        #    findable nowhere — any exit through this window must leave a
+        #    breadcrumb (or void the message) instead of orphaning it.
+        try:
+            if self._cancel_requested():
+                # Cancelled between post and persist: recording the marker
+                # would resurrect a request the caller just cancelled, and not
+                # recording it orphans a live message — void it while we still
+                # hold the ts (best effort), like the unrecordable-marker path.
+                logger.error(
+                    "Cancelled with unrecorded Slack review request %s/%s",
+                    channel,
+                    ts,
+                )
+                with suppress(SlackError):
+                    client.chat_postMessage(
+                        channel,
+                        f"This review request for {self.metadata.rrid} was "
+                        "cancelled before it could be recorded and is void; "
+                        "please ignore it.",
+                        thread_ts=ts,
+                    )
+                self.println(
+                    f"request_review for {self.metadata.rrid} was cancelled "
+                    f"after posting {channel}/{ts}; the request was voided "
+                    "and no marker was recorded."
+                )
+                return None
+            try:
+                self.metadata.set_slack_review(channel, ts)
+            except (TemplateFormatError, OSError) as e:
+                logger.error(
+                    "Unrecorded Slack review request %s/%s: %s", channel, ts, e
+                )
+                # The just-posted message is recorded nowhere: a later re-run
+                # cannot breadcrumb it, so void it now while we still hold the
+                # ts — otherwise a reviewer acks a message nobody watches.
+                with suppress(SlackError):
+                    client.chat_postMessage(
+                        channel,
+                        f"This review request for {self.metadata.rrid} could "
+                        "not be recorded and is void; please ack the "
+                        "replacement request instead.",
+                        thread_ts=ts,
+                    )
+                self.println(
+                    f"Posted review request {channel}/{ts} but could not "
+                    f"record the marker: {e}. The approve gate will not see "
+                    "this review; fix the template and re-run request_review "
+                    f"with --repost (scoped with -T {self.metadata.rrid} when "
+                    "several templates are loaded)."
+                )
+                return None
+        except BaseException:
+            # Ctrl-C (or any crash) between the post and the marker write
+            # orphans a live request nobody can find later; leave a recovery
+            # breadcrumb — best effort — then let the interrupt proceed.
+            with suppress(Exception):
+                logger.error(
+                    "Interrupted with live, unrecorded Slack review request "
+                    "%s/%s for %s; the message is live but unwatched — "
+                    "re-run request_review (it posts or resumes a recorded "
+                    "request) and disregard the orphaned message.",
+                    channel,
+                    ts,
+                    self.metadata.rrid,
+                )
+            raise
+
+        if self._cancel_requested():
+            self.println(
+                f"request_review for {self.metadata.rrid} was cancelled after "
+                f"recording review request {channel}/{ts}; the marker was not "
+                "committed to svn — a re-run of request_review commits it and "
+                "resumes the watch."
+            )
+            return None
+        try:
+            svn_commit_testreport(
+                self.metadata.report_wd(),
+                self.config.install_logs,
+                ["-m", f"Add Slack Review: {channel}/{ts}"],
+            )
+        except subprocess.CalledProcessError as e:
+            # The cross-checkout durability of the review gate hinges on the
+            # committed marker: watching (and possibly auto-approving) from a
+            # marker that exists only in this checkout would break it. The
+            # Slack post stays live and the marker is recorded locally; the
+            # re-run's pre-commit (step 1) commits it and resumes the watch.
+            logger.error("Failed to commit Slack review marker: %s", e)
+            self.println(
+                f"Posted review request {channel}/{ts} for "
+                f"{self.metadata.rrid} but could not commit its marker to "
+                f"svn: {e}. Not watching — other checkouts cannot see this "
+                "review yet. The Slack post stays live and the marker is "
+                "recorded locally; fix svn and re-run request_review to "
+                "commit it and resume the watch."
+            )
+            return None
+
+        # A reposted request supersedes the old thread; leave a breadcrumb
+        # there so reviewers do not ack a message nobody watches. Best
+        # effort only — the old message may have been deleted.
+        if existing is not None:
+            old_channel, old_ts = existing
+            with suppress(SlackError):
+                client.chat_postMessage(
+                    old_channel,
+                    f"Superseded by a fresh review request for "
+                    f"{self.metadata.rrid}: {channel}/{ts}",
+                    thread_ts=old_ts,
+                )
+            self.println(f"Superseded previous review request {old_channel}/{old_ts}.")
+
+        if self.args.no_watch:
+            self.println(
+                f"Posted review request for {self.metadata.rrid}; not watching."
+            )
+            return None
+
+        return _PendingWatch(
+            metadata=self.metadata,
+            targets=self.targets,
+            client=client,
+            channel=channel,
+            ts=ts,
+            resumed=False,
+            status="posted, awaiting ack",
+        )
+
+    def _watch_one(self, item: _PendingWatch) -> None:
+        """Block on one request's thread until acked, timed out, or stopped.
+
+        The classic single-template watch: delegates the polling to
+        :meth:`SlackClient.wait_for_ack` and hands the outcome to
+        :meth:`_conclude`. A review can take hours; the wait runs to
+        ``slack_watch_timeout`` (a full working day by default). In the REPL
+        press Ctrl-C to stop watching; over MCP call this with
+        ``background=true`` and poll the job instead of blocking.
+        """
+        if self._cancel_requested():
+            self.println(
+                f"request_review for {item.metadata.rrid} was cancelled; "
+                "not watching the review thread."
+            )
+            return
+        self.println(
+            f"Watching Slack for a 👍 on {item.metadata.rrid} "
+            "(this can take a while; Ctrl-C to stop)."
+        )
+        with spinner(f"Waiting for review of {item.metadata.rrid}") as is_stopped:
+            outcome = item.client.wait_for_ack(
+                item.channel,
+                item.ts,
+                on_reply=self.println,
+                should_stop=is_stopped,
+                interval=self.config.slack_poll_interval,
+                timeout=self.config.slack_watch_timeout,
+                # Set by the MCP session when the job is cancelled or the
+                # client disconnects, so the watch (and its worker thread)
+                # exits promptly instead of polling on unobserved — and
+                # possibly auto-approving — for hours. None in the REPL.
+                cancel_event=current_cancel_event.get(),
+            )
+        self._conclude(item, outcome)
+
+    def _watch_all(self, watches: list[_PendingWatch]) -> None:
+        """Run ONE combined watch over every pending request, round-robin.
+
+        Polls each pending request in turn (reusing the per-message poll
+        primitives of :class:`SlackClient`), concluding — and, unless
+        ``--no-approve``, approving — each as its ack arrives, until every
+        request resolves or the shared ``slack_watch_timeout`` deadline
+        expires. The cancel event ends the watch promptly; the still-pending
+        requests stay live and resumable.
+        """
+        if self._cancel_requested():
+            self.println(
+                "request_review was cancelled; not watching the posted review requests."
+            )
+            return
+        rrids = ", ".join(str(item.metadata.rrid) for item in watches)
+        self.println(
+            f"Watching Slack for a 👍 on {rrids} "
+            "(this can take a while; Ctrl-C to stop)."
+        )
+        interval = self.config.slack_poll_interval
+        deadline = time.monotonic() + self.config.slack_watch_timeout
+        cancel = current_cancel_event.get()
+        sleeper = cancel or threading.Event()
+        pending = list(watches)
+        stop = False
+        with spinner(f"Waiting for review of {rrids}") as is_stopped:
+            while pending and not stop:
+                for item in list(pending):
+                    if is_stopped() or self._cancel_requested():
+                        stop = True
+                        break
+                    outcome = self._poll_watch(item)
+                    if outcome is not None:
+                        pending.remove(item)
+                        self._conclude(item, outcome)
+                if stop or not pending or time.monotonic() >= deadline:
+                    break
+                # Interruptible sleep: stepped in ~0.1s slices so a stop
+                # signal or a set cancel event takes effect within a tick
+                # (mirrors ``SlackClient.wait_for_ack``).
+                step = 0.1
+                waited = 0.0
+                while waited < interval and not is_stopped():
+                    if cancel is not None and cancel.is_set():
+                        break
+                    sleeper.wait(min(step, interval - waited))
+                    waited += step
+
+        if not pending:
+            return
+        if self._cancel_requested():
+            left = ", ".join(str(item.metadata.rrid) for item in pending)
+            self.println(
+                f"Watch cancelled with review requests still pending: {left}. "
+                "Their markers are recorded; re-run request_review to resume."
+            )
+            return
+        for item in pending:
+            self._conclude(
+                item,
+                ReviewOutcome(
+                    acked=False, reviewer=None, timed_out=True, unreachable=False
+                ),
+            )
+
+    def _poll_watch(self, item: _PendingWatch) -> ReviewOutcome | None:
+        """One poll cycle of one pending request in the combined watch.
+
+        Streams new threaded replies (prefixed with the template's RRID, since
+        several threads share the output) and checks the reactions for an ack,
+        using the same per-message primitives ``wait_for_ack`` builds on.
+
+        Returns:
+            A :class:`ReviewOutcome` when the request resolved this cycle
+            (acked, or unreachable after :data:`_MAX_POLL_FAILURES`
+            consecutive failed cycles), or ``None`` while still pending.
+
+        """
+        try:
+            messages = item.client.conversations_replies(item.channel, item.ts)
+            for message in messages[item.last_seen :]:
+                self.println(f"[{item.metadata.rrid}] {message.get('text', '')}")
+                item.last_seen += 1
+            reactions = item.client.reactions_get(item.channel, item.ts)
+            reviewer = item.client._acking_reviewer(reactions)  # noqa: SLF001 -- shared ack primitive
+            if reviewer:
+                return ReviewOutcome(
+                    acked=True, reviewer=reviewer, timed_out=False, unreachable=False
+                )
+            item.failures = 0
+        except FailedSlackCallError as e:
+            item.failures += 1
+            logger.warning(
+                "Slack poll for %s/%s failed (%s/%s consecutive): %s",
+                item.channel,
+                item.ts,
+                item.failures,
+                _MAX_POLL_FAILURES,
+                e,
+            )
+            if item.failures >= _MAX_POLL_FAILURES:
+                return ReviewOutcome(
+                    acked=False, reviewer=None, timed_out=False, unreachable=True
+                )
+        return None
+
+    def _conclude(self, item: _PendingWatch, outcome: ReviewOutcome) -> None:
+        """Report one request's watch outcome and approve it on an ack."""
+        channel, ts = item.channel, item.ts
+        rrid = item.metadata.rrid
+        if not outcome.acked:
+            if outcome.unreachable and item.resumed:
+                # On a resume this is the guaranteed outcome of a deleted
+                # message, and every plain re-run resumes the same dead ts —
+                # the remedy must be in the failure line itself.
+                item.status = "watch failed (Slack unreachable or message deleted)"
+                self.println(
+                    f"Review watch for {rrid} failed (Slack "
+                    f"unreachable, or the review message {channel}/{ts} was "
+                    "deleted); re-run with --repost to post a fresh request."
+                )
+            elif outcome.unreachable:
+                item.status = "watch failed (Slack unreachable)"
+                self.println(f"Review watch for {rrid} failed (Slack unreachable)")
+            else:
+                item.status = "no ack (timed out or stopped)"
+                self.println(f"No review ack for {rrid} (timed out or stopped)")
+            return
+
+        item.status = "acked"
+        self.println(f"Review acked by {outcome.reviewer} (best-effort reactor)")
+        if self.args.no_approve:
+            item.status = "acked (--no-approve)"
+            return
+        self._approve_acked(item, outcome.reviewer)
+
+    def _approve_acked(self, item: _PendingWatch, reviewer: str | None) -> None:
+        """Drive ``approve`` for an acked request, guarding cancel/supersede.
+
+        A cancelled job's watch may observe an ack in its final in-flight poll
+        after ``job_cancel`` already returned — a cancelled watch must never
+        mutate state. And the ack must still belong to the marker the report
+        records: a ``--repost`` or a colleague's newer request supersedes this
+        watch. The colleague's repost lives in the repository, not this
+        checkout — the watch ran for hours since the last ``svn up`` — so
+        refresh first (best-effort: an offline refresh falls back to the local
+        state). The cancel event is re-checked immediately before the approve
+        handoff, so a ``job_cancel`` landing during the refresh/re-read tail
+        still refuses to approve.
+        """
+        metadata = item.metadata
+        channel, ts = item.channel, item.ts
+        if self._cancel_requested():
+            item.status = "acked, not approved (job cancelled)"
+            self.println(
+                f"Watch for {metadata.rrid} was cancelled; the observed "
+                "ack was not acted on."
+            )
+            return
+        try:
+            svn_update_testreport(metadata.report_wd())
+        except (subprocess.CalledProcessError, OSError) as e:
+            logger.warning("Could not refresh the testreport before approving: %s", e)
+        if metadata.get_slack_review() != (channel, ts):
+            item.status = "acked on a superseded request; not approved"
+            self.println(
+                f"Review request {channel}/{ts} for {metadata.rrid} was "
+                "superseded; not approving from this watch."
+            )
+            return
+        # Re-check as LATE as possible: the svn refresh and marker re-read
+        # above take seconds, and a job cancelled in that window has already
+        # been reported as cancelled — it must not approve anything.
+        if self._cancel_requested():
+            item.status = "acked, not approved (job cancelled)"
+            self.println(
+                f"Watch for {metadata.rrid} was cancelled; observed 👍 "
+                "but not approving."
+            )
+            return
+
+        # Approve THIS fanout template (not prompt's active one) by binding
+        # the already-resolved metadata/targets onto a fresh Approve. Its
+        # __call__ runs the Slack review gate, which passes because the ack
+        # was just persisted and is still live.
+        appr = Approve(
+            Namespace(
+                reviewer=reviewer,
+                group=self.args.group,
+                user=self.args.user,
+                template=None,
+                all_templates=False,
+                force=False,
+            ),
+            self.config,
+            self.sys,
+            self.prompt,
+        )
+        appr.metadata = metadata
+        appr.targets = item.targets
+        try:
+            appr.__call__()
+        except FailedSlackCallError as e:
+            # The gate's own live re-query of the ack can hiccup right after
+            # an hours-long watch; the state stays fail-closed (not approved)
+            # and the remedy must be actionable, not a raw traceback.
+            item.status = "acked; approve failed (Slack error)"
+            self.println(
+                f"Observed 👍 for {metadata.rrid}, but the approve step "
+                f"failed talking to Slack: {e}. The update was NOT approved; "
+                "re-run request_review to resume the watch, or run approve "
+                "manually once Slack settles."
+            )
+            return
+        item.status = "approved"
+
+    def _report_interrupted(
+        self, watches: list[_PendingWatch], unprocessed: list[str]
+    ) -> None:
+        """Print the per-template status summary after a Ctrl-C.
+
+        Every posted request and its marker survive the interrupt; pending
+        ones resume on a re-run via their recorded markers, so the summary
+        says where each template stands instead of losing them silently.
+        """
+        self.println("request_review interrupted; per-template status:")
+        for item in watches:
+            self.println(f"  {item.metadata.rrid}: {item.status}")
+        for rrid in unprocessed:
+            self.println(
+                f"  {rrid}: interrupted before its request was posted "
+                "(re-run request_review to post or resume it)"
+            )
+        if watches:
+            self.println(
+                "Posted requests stay live and their markers are recorded; "
+                "re-run request_review to resume watching the pending ones."
+            )
+
+    @staticmethod
+    def complete(state, text, line, begidx, endidx) -> list[str]:
+        """Provides tab completion for the command."""
+        return complete_choices(
+            [
+                ("--no-watch",),
+                ("--no-approve",),
+                ("--repost",),
+                ("-g", "--group"),
+                ("-u", "--user"),
+                *template_completion(state),
+            ],
+            line,
+            text,
+        )

--- a/mtui/data_sources/__init__.py
+++ b/mtui/data_sources/__init__.py
@@ -2,6 +2,7 @@
 
 from .gitea import Gitea
 from .oscqam import OSC
+from .slack import ReviewOutcome, SlackClient
 from .teregen import TeReGen
 
-__all__ = ["OSC", "Gitea", "TeReGen"]
+__all__ = ["OSC", "Gitea", "ReviewOutcome", "SlackClient", "TeReGen"]

--- a/mtui/data_sources/slack.py
+++ b/mtui/data_sources/slack.py
@@ -1,0 +1,529 @@
+"""A Slack Web API client for the request-review acknowledgement workflow.
+
+mtui posts a review request into a Slack channel and then blocks on that
+message: it streams any threaded replies back to the caller and watches the
+message's reactions for a 👍 that marks the request acknowledged. The HTTP
+shape mirrors the Gitea client (:mod:`mtui.data_sources.gitea`) and reuses the
+shared timeout/TLS helpers from :mod:`mtui.support.http`.
+
+Slack is unusual in that a failed call still returns HTTP 200 with an
+``{"ok": false, "error": ...}`` body, so :meth:`SlackClient._call` checks both
+``rsp.ok`` and the payload's ``ok`` flag before returning.
+
+The base URL comes from ``[slack] base_url`` (defaults to
+``https://slack.com/api``) and the bot token from ``[slack] token`` /
+``SLACK_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+from ..support.config import Config
+from ..support.exceptions import FailedSlackCallError, MissingSlackTokenError
+from ..support.http import (
+    HTTP_TIMEOUT,
+    VerifyPolicy,
+    build_session,
+    is_ssl_verification_error,
+    resolve_verify,
+    ssl_verification_hint,
+)
+
+logger = getLogger("mtui.connector.slack")
+
+#: Reaction names that count as a positive acknowledgement of a request.
+#: Match via :func:`is_ack_reaction`, never against a raw reaction name:
+#: Slack suffixes skin-toned emoji (``"+1::skin-tone-3"``).
+_ACK_REACTIONS = frozenset({"+1", "thumbsup"})
+
+#: Consecutive failed poll cycles after which a review watch gives up as
+#: unreachable. A watch spans hours, so a single transient failure (network
+#: blip, sustained 429) must not abort it.
+_MAX_POLL_FAILURES = 3
+
+#: Upper bound (seconds) on an honoured 429 ``Retry-After``. The header is
+#: server-controlled, so an uncapped value could pin a call far past the
+#: watch's own deadline or a prompt cancellation.
+_MAX_RETRY_AFTER = 60
+
+#: Upper bound on ``conversations.replies`` pages followed per call, so a
+#: broken ``next_cursor`` can never loop forever.
+_MAX_REPLY_PAGES = 10
+
+
+def is_ack_reaction(name: str) -> bool:
+    """Return whether a reaction name counts as a positive acknowledgement.
+
+    Slack appends a skin-tone modifier to skin-tonable emoji names (a visible
+    👍 may arrive as ``"+1::skin-tone-3"``), so the name is normalized by
+    stripping everything from the first ``"::"`` before matching it against
+    :data:`_ACK_REACTIONS`.
+    """
+    return name.split("::", 1)[0] in _ACK_REACTIONS
+
+
+@dataclass(frozen=True)
+class ReviewOutcome:
+    """The result of blocking on a Slack review request (see :meth:`SlackClient.wait_for_ack`).
+
+    - ``acked``: a 👍 reaction was seen on the request message.
+    - ``reviewer``: best-effort display name of the acking user, or ``None``.
+    - ``timed_out``: the wait ended on its deadline or a stop signal without
+      an acknowledgement.
+    - ``unreachable``: Slack could not be reached to resolve the outcome.
+    """
+
+    acked: bool
+    reviewer: str | None
+    timed_out: bool
+    unreachable: bool
+
+
+class SlackClient:
+    """A Slack Web API client built on the shared HTTP helpers."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize the Slack client.
+
+        Args:
+            config: The application configuration object.
+
+        Raises:
+            MissingSlackTokenError: If the Slack bot token is not configured.
+
+        """
+        if not config.slack_token:
+            raise MissingSlackTokenError("Slack token is empty, can't access API")
+
+        self.headers = {
+            "Authorization": f"Bearer {config.slack_token}",
+            "Content-Type": "application/json;charset=utf-8",
+        }
+        self.base = config.slack_base_url.rstrip("/")
+
+        # Resolve the TLS verification policy once (verify by default, let the
+        # global ``[mtui] ssl_verify`` override) and reuse a single session
+        # that silences the InsecureRequestWarning when verification is off.
+        self._verify: VerifyPolicy = resolve_verify(True, config.ssl_verify)
+        self._session = build_session(self._verify)
+
+        # ``auth.test`` is stable for the life of the token, so cache it.
+        self._bot_user_id: str | None = None
+
+        # Installed by :meth:`wait_for_ack` for the duration of a watch so a
+        # 429 rate-limit wait inside :meth:`_call` ends promptly on a stop
+        # signal, cancellation, or the watch deadline.
+        self._cancel_check: Callable[[], bool] | None = None
+
+    def _call(
+        self,
+        http_method: str,
+        api_method: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make a request to a Slack Web API method and return its payload.
+
+        Slack signals failure two ways: a non-2xx HTTP status, or an HTTP 200
+        with an ``{"ok": false, "error": ...}`` body. Both are treated as
+        failures here. A 429 with a ``Retry-After`` header is honoured with a
+        single wait-and-retry before giving up; the wait is capped at
+        :data:`_MAX_RETRY_AFTER` and stepped in ~1s slices so a review watch's
+        stop conditions keep taking effect promptly (see
+        :meth:`_sleep_unless_cancelled`).
+
+        Args:
+            http_method: The HTTP verb (``GET``/``POST``).
+            api_method: The Slack Web API method name (e.g. ``chat.postMessage``).
+            json: JSON body for the request.
+            params: URL query parameters for the request.
+
+        Returns:
+            The decoded Slack payload dict (guaranteed ``ok: true``).
+
+        Raises:
+            FailedSlackCallError: On any transport failure, non-2xx status, or
+                an ``ok: false`` Slack payload.
+
+        """
+        url = f"{self.base}/{api_method}"
+        # Honour rate limiting with a single wait-and-retry: one 429 is retried,
+        # a second consecutive 429 gives up (bounded so a sustained rate limit
+        # can never trap the caller — the review wait must keep reaching its own
+        # deadline / cancellation).
+        rate_limited = False
+        while True:
+            try:
+                logger.debug("Requesting %s on %s", http_method, url)
+                rsp = self._session.request(
+                    http_method,
+                    url,
+                    headers=self.headers,
+                    params=params,
+                    json=json,
+                    timeout=HTTP_TIMEOUT,
+                )
+            except requests.exceptions.RequestException as e:
+                if is_ssl_verification_error(e):
+                    # Surface the actionable remedy at ERROR instead of a
+                    # multi-frame traceback (mirrors the Gitea client).
+                    logger.error(ssl_verification_hint(urlparse(url).hostname))
+                    logger.debug("Slack TLS error detail: %s", e)
+                else:
+                    logger.exception("API call to Slack failed: %s", e)
+                raise FailedSlackCallError(f"{http_method} - {url}") from e
+
+            if rsp.status_code == 429:
+                if rate_limited:
+                    raise FailedSlackCallError(
+                        f"{http_method} - {url} rate-limited (429) after retry"
+                    )
+                rate_limited = True
+                # ``Retry-After`` may be delta-seconds or an HTTP-date; only the
+                # former is actionable here, fall back to 1s otherwise. The
+                # value is server-controlled, so cap it: an uncapped wait would
+                # defeat the watch deadline and prompt cancellation.
+                try:
+                    retry_after = int(rsp.headers.get("Retry-After", "1"))
+                except ValueError:
+                    retry_after = 1
+                retry_after = min(max(retry_after, 0), _MAX_RETRY_AFTER)
+                logger.warning(
+                    "Slack rate-limited %s; retrying in %ss", url, retry_after
+                )
+                self._sleep_unless_cancelled(retry_after, f"{http_method} - {url}")
+                continue
+
+            if not rsp.ok:
+                logger.warning(
+                    "API call to %s failed with status code: %s", url, rsp.status_code
+                )
+                raise FailedSlackCallError(
+                    f"{http_method} - {url} returned status {rsp.status_code}"
+                )
+
+            try:
+                payload = rsp.json()
+            except requests.exceptions.JSONDecodeError as e:
+                raise FailedSlackCallError(f"{http_method} - {url}") from e
+
+            # Slack returns HTTP 200 even for logical failures; the body's
+            # ``ok`` flag is authoritative.
+            if not payload.get("ok"):
+                error = payload.get("error", "unknown")
+                logger.warning("Slack %s returned error: %s", api_method, error)
+                raise FailedSlackCallError(error)
+
+            return payload
+
+    def _sleep_unless_cancelled(self, seconds: float, context: str) -> None:
+        """Sleep in ~1s slices, aborting as soon as the cancel check fires.
+
+        During a review watch :meth:`wait_for_ack` installs its stop
+        conditions as ``self._cancel_check``; probing them between slices
+        keeps a rate-limit wait from outliving a stop signal, cancellation,
+        or the watch deadline. Outside a watch there is no check installed
+        and this degrades to a plain (capped, sliced) sleep.
+
+        Args:
+            seconds: How long to sleep in total.
+            context: A ``VERB - url`` tag naming the call being delayed, used
+                in the abort error message.
+
+        Raises:
+            FailedSlackCallError: If the cancel check fires mid-wait; the
+                caller's poll cycle then ends like any other failed call.
+
+        """
+        waited = 0.0
+        while waited < seconds:
+            if self._cancel_check is not None and self._cancel_check():
+                raise FailedSlackCallError(
+                    f"{context} cancelled during rate-limit wait"
+                )
+            step = min(1.0, seconds - waited)
+            time.sleep(step)
+            waited += step
+
+    def bot_user_id(self) -> str:
+        """Return the bot's own user id (``auth.test``), cached on the instance."""
+        if self._bot_user_id is None:
+            payload = self._call("GET", "auth.test")
+            self._bot_user_id = payload["user_id"]
+        return self._bot_user_id
+
+    def chat_postMessage(  # noqa: N802 - mirrors the Slack API method name
+        self, channel: str, text: str, thread_ts: str | None = None
+    ) -> tuple[str, str]:
+        """Post a message to a channel (optionally in a thread).
+
+        Args:
+            channel: The channel to post into (an id, or a name that Slack
+                resolves at posting time).
+            text: The message text.
+            thread_ts: The parent message ``ts`` to reply under, or ``None`` to
+                post a new top-level message.
+
+        Returns:
+            A ``(channel, ts)`` tuple: the canonical channel id from the
+            response and the posted message's ``ts`` (its channel-unique
+            timestamp id). Posting accepts channel names, but the read
+            methods behind the watch (``conversations.replies``,
+            ``reactions.get``) accept only ids, so callers must persist the
+            returned id, never the configured name.
+
+        """
+        body: dict[str, Any] = {"channel": channel, "text": text}
+        if thread_ts is not None:
+            body["thread_ts"] = thread_ts
+        payload = self._call("POST", "chat.postMessage", json=body)
+        return payload["channel"], payload["ts"]
+
+    def conversations_replies(  # noqa: N802 - mirrors the Slack API method name
+        self, channel: str, ts: str
+    ) -> list[dict[str, Any]]:
+        """Return a thread's messages, oldest first (index 0 is the parent).
+
+        Follows cursor pagination (``has_more`` /
+        ``response_metadata.next_cursor``) until the thread is exhausted, so
+        no reply is silently dropped; a runaway cursor is bounded by
+        :data:`_MAX_REPLY_PAGES`.
+
+        Args:
+            channel: The channel id the thread lives in.
+            ts: The parent message ``ts``.
+
+        Returns:
+            The list of message dicts; the first is the parent/request itself.
+
+        """
+        messages: list[dict[str, Any]] = []
+        cursor = ""
+        for _ in range(_MAX_REPLY_PAGES):
+            params: dict[str, Any] = {"channel": channel, "ts": ts}
+            if cursor:
+                params["cursor"] = cursor
+            payload = self._call("GET", "conversations.replies", params=params)
+            messages.extend(payload.get("messages", []))
+            if not payload.get("has_more"):
+                break
+            cursor = payload.get("response_metadata", {}).get("next_cursor", "")
+            if not cursor:
+                break
+        else:
+            logger.warning(
+                "Slack thread %s/%s spans more than %s reply pages; truncating",
+                channel,
+                ts,
+                _MAX_REPLY_PAGES,
+            )
+        return messages
+
+    def reactions_get(  # noqa: N802 - mirrors the Slack API method name
+        self, channel: str, ts: str
+    ) -> list[dict[str, Any]]:
+        """Return the reactions on a message, or ``[]`` if there are none.
+
+        Args:
+            channel: The channel id the message lives in.
+            ts: The message ``ts``.
+
+        Returns:
+            The ``message.reactions`` list (each with ``name``/``users``), or
+            an empty list when the message carries no reactions.
+
+        """
+        payload = self._call(
+            "GET", "reactions.get", params={"channel": channel, "timestamp": ts}
+        )
+        return payload.get("message", {}).get("reactions", [])
+
+    def users_info(  # noqa: N802 - mirrors the Slack API method name
+        self, user: str
+    ) -> str:
+        """Return a human-friendly name for a user id.
+
+        Prefers the profile display name, then the profile real name, then the
+        bare ``name`` handle.
+
+        Args:
+            user: The Slack user id.
+
+        Returns:
+            The best available display name for the user.
+
+        """
+        payload = self._call("GET", "users.info", params={"user": user})
+        info = payload.get("user", {})
+        profile = info.get("profile", {})
+        return (
+            profile.get("display_name")
+            or profile.get("real_name")
+            or info.get("name", user)
+        )
+
+    def wait_for_ack(
+        self,
+        channel: str,
+        ts: str,
+        *,
+        on_reply: Callable[[str], None],
+        should_stop: Callable[[], bool],
+        interval: float,
+        timeout: float,
+        cancel_event: threading.Event | None = None,
+    ) -> ReviewOutcome:
+        """Block until the request message is 👍-acked, or the wait ends.
+
+        Polls the thread and reactions of the request message every
+        ``interval`` seconds up to ``timeout`` seconds. Each cycle streams any
+        new threaded replies to ``on_reply`` (tracked by their ``ts``, so a
+        deleted reply cannot swallow a later one) and checks the reactions for
+        a positive acknowledgement (see :func:`is_ack_reaction`). The
+        inter-poll sleep is stepped in ~0.1s slices via a
+        :class:`threading.Event` so a stop signal or cancellation takes effect
+        promptly instead of after up to ``interval`` seconds (cloned from
+        :meth:`mtui.data_sources.teregen.TeReGen.wait_for_template`); the stop
+        conditions are also installed as the rate-limit cancel check so a 429
+        ``Retry-After`` wait inside :meth:`_call` ends just as promptly.
+
+        Args:
+            channel: The channel id the request lives in.
+            ts: The request message ``ts``.
+            on_reply: Called with the text of each new threaded reply, in order.
+            should_stop: Polled before every sleep; returning ``True`` ends the
+                wait with ``timed_out=True``.
+            interval: Seconds between polls.
+            timeout: Total seconds to wait before giving up.
+            cancel_event: An optional event that, when set, ends the wait like
+                ``should_stop`` (also used as the interruptible sleeper).
+
+        Returns:
+            A :class:`ReviewOutcome`: ``acked=True`` with a best-effort
+            ``reviewer`` on acknowledgement, otherwise ``timed_out=True`` (or
+            ``unreachable=True`` after :data:`_MAX_POLL_FAILURES` consecutive
+            failed poll cycles; a single transient failure is retried).
+
+        """
+        deadline = time.monotonic() + timeout
+        sleeper = cancel_event or threading.Event()
+        # Replies already streamed to ``on_reply``, tracked by their ``ts``
+        # and seeded with the parent's own ``ts``. Tracking by identity
+        # instead of list position keeps a deleted reply from silently
+        # swallowing the next new one.
+        forwarded: set[str] = {ts}
+        # A review watch spans hours; one transient blip (a flaky network, two
+        # consecutive 429s) must not abort it. Only give up as unreachable
+        # after several *consecutive* failed poll cycles.
+        consecutive_failures = 0
+
+        def cancelled() -> bool:
+            """The stop signal, the cancel event, or the deadline has fired."""
+            return (
+                should_stop()
+                or (cancel_event is not None and cancel_event.is_set())
+                or time.monotonic() >= deadline
+            )
+
+        # Rate-limit waits inside ``_call`` must also end promptly on any of
+        # the stop conditions; install the check for the watch's duration.
+        self._cancel_check = cancelled
+        try:
+            while True:
+                try:
+                    messages = self.conversations_replies(channel, ts)
+                    for message in messages:
+                        reply_ts = message.get("ts")
+                        if reply_ts is None or reply_ts in forwarded:
+                            continue
+                        forwarded.add(reply_ts)
+                        on_reply(message.get("text", ""))
+
+                    reactions = self.reactions_get(channel, ts)
+                    if reviewer := self._acking_reviewer(reactions):
+                        return ReviewOutcome(
+                            acked=True,
+                            reviewer=reviewer,
+                            timed_out=False,
+                            unreachable=False,
+                        )
+                    consecutive_failures = 0
+                except FailedSlackCallError as e:
+                    consecutive_failures += 1
+                    logger.warning(
+                        "Slack poll for %s/%s failed (%s/%s consecutive): %s",
+                        channel,
+                        ts,
+                        consecutive_failures,
+                        _MAX_POLL_FAILURES,
+                        e,
+                    )
+                    if consecutive_failures >= _MAX_POLL_FAILURES:
+                        return ReviewOutcome(
+                            acked=False,
+                            reviewer=None,
+                            timed_out=False,
+                            unreachable=True,
+                        )
+
+                # Check the stop conditions before sleeping so we exit promptly.
+                if cancelled():
+                    return ReviewOutcome(
+                        acked=False, reviewer=None, timed_out=True, unreachable=False
+                    )
+
+                # Interruptible sleep: stepped in ~0.1s slices so a stop signal
+                # or a set ``cancel_event`` takes effect within a tick.
+                step = 0.1
+                waited = 0.0
+                while waited < interval and not cancelled():
+                    sleeper.wait(min(step, interval - waited))
+                    waited += step
+        finally:
+            self._cancel_check = None
+
+    def _acking_reviewer(self, reactions: list[dict[str, Any]]) -> str | None:
+        """Resolve the reviewer name from an ack reaction, or ``None``.
+
+        Scans the reactions for a positive-acknowledgement name (via
+        :func:`is_ack_reaction`, so a skin-toned 👍 counts too) and, if found,
+        resolves the first non-bot user in its ``users`` list to a display
+        name.
+
+        BEST-EFFORT reviewer: Slack does not guarantee the ordering of a
+        reaction's ``users`` list, so the "first" non-bot user is only an
+        approximation of who acked first.
+        """
+        bot_id = self.bot_user_id()
+        for reaction in reactions:
+            if not is_ack_reaction(reaction.get("name") or ""):
+                continue
+            for user in reaction.get("users", []):
+                if user != bot_id:
+                    try:
+                        return self.users_info(user)
+                    except FailedSlackCallError as e:
+                        # The ack itself is authoritative; the display name is
+                        # only best-effort garnish. A users.info failure (most
+                        # commonly a bot token without the ``users:read``
+                        # scope) must not turn a visible 👍 into a dead watch —
+                        # fall back to the raw member id.
+                        logger.warning(
+                            "Could not resolve Slack user %s to a name "
+                            "(missing 'users:read' scope?): %s -- recording "
+                            "the raw id",
+                            user,
+                            e,
+                        )
+                        return user
+        return None

--- a/mtui/mcp/profiles.py
+++ b/mtui/mcp/profiles.py
@@ -60,6 +60,7 @@ CORE: frozenset[str] = frozenset(
         "export",
         "commit",
         "comment",
+        "request_review",
         "approve",
         "reject",
         # openQA

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Any
 from ..cli.argparse import ArgsParseFailureError
 from ..cli.display import CommandPromptDisplay
 from ..commands import Command
+from ..support.cancellation import current_cancel_event
 from ..support.concurrency import ContextExecutor
 from ..template_registry import TemplateRegistry
 from ..test_reports.null_report import NullTestReport
@@ -103,6 +104,19 @@ _current_stdout: contextvars.ContextVar[io.StringIO | None] = contextvars.Contex
 #: nothing on the wire and stops well-behaved clients from timing out
 #: on ``run`` / ``update`` / ``set_repo`` / ``commit`` etc.).
 DEFAULT_PROGRESS_INTERVAL_SECONDS: float = 10.0
+
+#: Default grace, in seconds, that :meth:`McpSession.job_cancel` waits for a
+#: cancelled job's worker thread to actually finish before returning. A
+#: cooperative body (``request_review``'s Slack watch) checks its cancel
+#: event between side effects, so it normally exits well within this window;
+#: a body mid-HTTP-request can need up to one full
+#: :data:`mtui.support.http.HTTP_TIMEOUT` (~35 s) to reach its next
+#: checkpoint, which deliberately exceeds this grace — ``job_cancel`` then
+#: reports the job as ``cancelling`` (not ``cancelled``) and the state flips
+#: once the thread exits. 20 s sits under the MCP SDK's 30 s default
+#: client-side request timeout so the ``job_cancel`` call itself (which emits
+#: no progress heartbeat) is never abandoned by a well-behaved client.
+JOB_CANCEL_GRACE_SECONDS: float = 20.0
 
 #: Upper bound (seconds) that :meth:`McpSession._disconnect_targets` waits
 #: for the parallel per-host ``Target.close()`` calls to finish before it
@@ -694,15 +708,71 @@ class McpSession:
         Raises:
             McpCommandError: If argparse rejects ``argv``, the command
                 calls ``sys.exit`` with a non-zero code, or its body
-                raises an unhandled exception.
+                raises an unhandled exception — or, before anything runs,
+                if the call is a foreground watch-bearing multi-template
+                ``request_review`` (see
+                :meth:`_refuse_foreground_multi_watch`).
 
         """
+        self._refuse_foreground_multi_watch(cmd_cls, argv)
         async with self._command_lock(cmd_cls, argv):
             if ctx is None:
-                return await asyncio.to_thread(self._run_sync, cmd_cls, argv)
+                return await self._to_thread_cancellable(cmd_cls, argv)
             return await self._run_with_heartbeat(
                 ctx, cmd_cls, argv, interval=progress_interval
             )
+
+    async def _to_thread_cancellable(
+        self,
+        cmd_cls: type[Command],
+        argv: list[str],
+        *,
+        cancel: threading.Event | None = None,
+        body_started: threading.Event | None = None,
+    ) -> str:
+        """Run ``_run_sync`` in a worker thread with a cancellation channel.
+
+        Binds a :class:`threading.Event` to
+        :data:`~mtui.support.cancellation.current_cancel_event` (contextvars
+        propagate into :func:`asyncio.to_thread`) and sets it when the awaiting
+        task is cancelled, so cooperative command bodies that poll it — e.g.
+        ``request_review``'s Slack watch — exit promptly on ``job_cancel`` or a
+        client disconnect even though the worker thread itself cannot be
+        killed.
+
+        ``cancel`` lets the job path (:meth:`_mint_job`) share the event with
+        the job record so :meth:`job_cancel` can flag it *without* cancelling
+        the awaiting task (cooperative-first cancellation); when ``None`` a
+        fresh private event is minted, as before. ``body_started`` (when
+        given) is set by the worker thread immediately before the pre-start
+        guard, so a canceller that sets ``cancel`` and *then* observes
+        ``body_started`` unset has proof the body will never run: the guard
+        reads ``cancel`` after ``body_started`` is set, so it necessarily sees
+        the flag and refuses — closing the race where a hard task-cancel
+        detaches from an executor work item that slips past
+        ``Future.cancel()`` and runs unobserved.
+        """
+        cancel_event = cancel if cancel is not None else threading.Event()
+        token = current_cancel_event.set(cancel_event)
+
+        def _body() -> str:
+            if body_started is not None:
+                body_started.set()
+            if cancel_event.is_set():
+                # Cancelled while queued (or in the submit race): refuse to
+                # start so "cancelled" never precedes a side effect.
+                raise McpCommandError(
+                    "", "command cancelled before its body started", 1
+                )
+            return self._run_sync(cmd_cls, argv)
+
+        try:
+            return await asyncio.to_thread(_body)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            raise
+        finally:
+            current_cancel_event.reset(token)
 
     async def _lock_for(self, rrid: str) -> asyncio.Lock:
         """Return (creating on first use) the per-template lock for ``rrid``.
@@ -786,7 +856,7 @@ class McpSession:
         logged at ``DEBUG`` and swallowed so a flaky transport never
         masks the actual command outcome.
         """
-        worker = asyncio.create_task(asyncio.to_thread(self._run_sync, cmd_cls, argv))
+        worker = asyncio.create_task(self._to_thread_cancellable(cmd_cls, argv))
         started = time.monotonic()
         try:
             while True:
@@ -942,6 +1012,44 @@ class McpSession:
         rrids = [str(r.id) for r in reports if str(r.id)]
         return rrids or None
 
+    def _refuse_foreground_multi_watch(
+        self, cmd_cls: type[Command], argv: list[str]
+    ) -> None:
+        """Refuse a foreground watch-bearing multi-template ``request_review``.
+
+        An unscoped ``request_review`` resolving to more than one template
+        takes the registry gate in *exclusive* mode (the fan-out path of
+        :meth:`_command_lock`) and then watches Slack for up to the configured
+        watch timeout (hours) — freezing every other tool call in this MCP
+        session with no cancel handle. Post-only calls (``--no-watch``) stay
+        quick, a single-template call holds only that template's lock, and
+        ``background=true`` fans out one independently cancellable job per
+        template (each holding only its own per-RRID lock), so those paths
+        remain allowed. The interactive REPL does not dispatch through
+        :class:`McpSession` and is unaffected.
+
+        Raises:
+            McpCommandError: When ``cmd_cls`` is ``request_review``, argv
+                does not carry ``--no-watch``, and more than one template
+                resolves.
+
+        """
+        if cmd_cls.command != "request_review" or "--no-watch" in argv:
+            return
+        rrids = self._resolve_job_rrids(cmd_cls, argv)
+        if rrids is None or len(rrids) <= 1:
+            return
+        raise McpCommandError(
+            "",
+            f"a foreground request_review watching across {len(rrids)} "
+            "templates would hold this session's exclusive gate for the "
+            "whole watch, blocking every other tool call; run it with "
+            "background=true (one cancellable job per template), scope it "
+            'with template="<RRID>", or pass no_watch=true to post without '
+            "watching",
+            1,
+        )
+
     def _mint_job(self, cmd_cls: type[Command], argv: list[str], job_id: str) -> str:
         """Create and start one job record running ``argv`` and return its id.
 
@@ -972,21 +1080,51 @@ class McpSession:
             "error": None,
             "exit_code": None,
             "task": None,
+            # Cooperative cancellation channel (see ``job_cancel``):
+            # ``cancel`` is shared with the worker thread via
+            # ``_to_thread_cancellable`` so the body can be flagged without
+            # cancelling the awaiting task; ``body_started`` is set by the
+            # worker thread just before the pre-start guard, so an unset
+            # event *after* flagging ``cancel`` proves the body never runs;
+            # ``cancel_requested`` folds the body's eventual outcome into a
+            # truthful terminal ``cancelled`` state.
+            "cancel": threading.Event(),
+            "body_started": threading.Event(),
+            "cancel_requested": False,
         }
         self._jobs[job_id] = job
 
         async def _runner() -> None:
             try:
                 async with self._command_lock(cmd_cls, argv):
-                    out = await asyncio.to_thread(self._run_sync, cmd_cls, argv)
+                    out = await self._to_thread_cancellable(
+                        cmd_cls,
+                        argv,
+                        cancel=job["cancel"],
+                        body_started=job["body_started"],
+                    )
+                # Reaching here means the worker thread has fully exited, so
+                # ``cancelled`` (when requested) is truthful: no further
+                # externally visible mutation can come from this job.
                 job["result"] = out
-                job["state"] = "done"
+                job["state"] = "cancelled" if job["cancel_requested"] else "done"
             except McpCommandError as exc:
-                job["state"] = "failed"
-                job["error"] = str(exc)
-                job["result"] = exc.stdout
-                job["exit_code"] = exc.exit_code
+                if job["cancel_requested"]:
+                    # The body observed the cooperative cancel (or the
+                    # pre-start guard refused to run it) and has exited.
+                    job["state"] = "cancelled"
+                    job["result"] = exc.stdout
+                    job["error"] = str(exc)
+                else:
+                    job["state"] = "failed"
+                    job["error"] = str(exc)
+                    job["result"] = exc.stdout
+                    job["exit_code"] = exc.exit_code
             except asyncio.CancelledError:
+                # Only reached by a hard task-cancel, which ``job_cancel``
+                # issues solely while ``body_started`` is provably unset (the
+                # pre-start guard then keeps the body from ever running), so
+                # ``cancelled`` remains truthful here too.
                 job["state"] = "cancelled"
                 raise
             except Exception as exc:  # noqa: BLE001 - record, never crash the loop
@@ -1070,6 +1208,26 @@ class McpSession:
 
         """
         rrids = self._resolve_job_rrids(cmd_cls, argv)
+        # ``request_review --repost`` replaces each template's recorded review
+        # request; the foreground fan-out refuses it unscoped (see
+        # ``RequestReview.run``). Minting one ``-T``-scoped job per template
+        # would silently bypass that refusal — every job would resolve to
+        # exactly one template and repost, superseding every live review
+        # thread wholesale — so refuse here too. Scoped to ``request_review``
+        # (the command that owns ``--repost``): any other argv may carry the
+        # literal token, e.g. as part of a ``run``/``install`` remote command.
+        if (
+            cmd_cls.command == "request_review"
+            and "--repost" in argv
+            and rrids is not None
+            and len(rrids) > 1
+        ):
+            raise McpCommandError(
+                "",
+                "--repost would replace every fanned-out template's recorded "
+                'review request; scope it with template="<RRID>"',
+                1,
+            )
         # Single template, none, or a client-supplied ``-T`` already narrowing
         # to one: keep the single-job path (and its stable id shape).
         if not rrids or len(rrids) <= 1:
@@ -1114,7 +1272,8 @@ class McpSession:
         """Return a finished job's stdout, or raise the right envelope.
 
         * unknown id -> :class:`McpCommandError` (exit 1)
-        * still running -> :class:`McpCommandError` telling the caller to
+        * still running (or ``cancelling``: cancel requested, body still
+          winding down) -> :class:`McpCommandError` telling the caller to
           poll ``job_status`` (the job keeps running)
         * failed -> :class:`McpCommandError` carrying the command's
           captured stdout / error / exit code, exactly as a foreground
@@ -1126,11 +1285,11 @@ class McpSession:
         if job is None:
             raise McpCommandError("", f"no such job: {job_id}", 1)
         state = job["state"]
-        if state == "running":
+        if state in ("running", "cancelling"):
             elapsed = round(time.monotonic() - job["started"], 1)
             raise McpCommandError(
                 "",
-                f"job {job_id} still running ({elapsed}s); poll job_status",
+                f"job {job_id} still {state} ({elapsed}s); poll job_status",
                 1,
             )
         if state == "failed":
@@ -1143,21 +1302,79 @@ class McpSession:
             raise McpCommandError("", f"job {job_id} was cancelled", 1)
         return job["result"] or ""
 
-    async def job_cancel(self, job_id: str) -> str:
-        """Cancel a running job; raise if the id is unknown.
+    async def job_cancel(self, job_id: str, *, grace: float | None = None) -> str:
+        """Cancel a running job cooperatively; raise if the id is unknown.
 
-        Cancels the worker task. NOTE: if the job is mid
-        :func:`asyncio.to_thread` (an SSH/subprocess body), cancellation
-        detaches the awaiter but the underlying host operation may keep
-        running to completion — the same caveat as interrupting a
-        foreground ``run``. A finished job is a no-op.
+        Cancellation is cooperative-first and truthful — ``cancelled`` is
+        only ever reported once the job can produce **no further externally
+        visible mutation**:
+
+        * The job's cancellation event is flagged (shared with the worker
+          thread — see :meth:`_to_thread_cancellable`), so cooperative
+          command bodies that poll it — e.g. ``request_review``'s Slack
+          watch — exit at their next checkpoint.
+        * If the body has provably not started (the worker task is still
+          queued on its template lock / the thread has not passed the
+          pre-start guard, which now refuses to run it), the task is
+          hard-cancelled: safe, nothing ran.
+        * Otherwise this call **waits** up to ``grace`` seconds
+          (:data:`JOB_CANCEL_GRACE_SECONDS` by default) for the worker
+          thread to actually finish and only then reports ``cancelled``.
+        * If the grace expires the job is reported as ``cancelling``: the
+          body is still finishing its current step (a non-cooperative
+          SSH/subprocess step, or an HTTP call of up to one
+          :data:`~mtui.support.http.HTTP_TIMEOUT`). The worker task is
+          **not** hard-cancelled — it keeps holding the job's per-template
+          lock, so a re-run (or any same-template command) queues behind the
+          old thread instead of interleaving with it; ``job_status`` flips
+          to ``cancelled`` once the thread exits.
+
+        A finished job is a no-op.
         """
         job = self._jobs.get(job_id)
         if job is None:
             raise McpCommandError("", f"no such job: {job_id}", 1)
         task = job.get("task")
-        if task is not None and not task.done():
+        if task is None or task.done():
+            # Legacy no-op message (pinned): the state itself stays truthful
+            # (job_status still reports done/failed/...), and a finished job
+            # trivially satisfies the no-further-mutations invariant.
+            return f"cancelled job {job_id}"
+        job["cancel_requested"] = True
+        cancel: threading.Event | None = job.get("cancel")
+        if cancel is not None:
+            cancel.set()
+        # Order matters: ``cancel`` is flagged *before* ``body_started`` is
+        # read, and the worker thread sets ``body_started`` *before* reading
+        # ``cancel`` (see ``_to_thread_cancellable``). An unset
+        # ``body_started`` here therefore proves the body either never runs
+        # or refuses at the pre-start guard — a hard task-cancel is safe.
+        body_started: threading.Event | None = job.get("body_started")
+        if cancel is None or body_started is None or not body_started.is_set():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
-        return f"cancelled job {job_id}"
+            return f"cancelled job {job_id}"
+        job["state"] = "cancelling"
+        if grace is None:
+            grace = JOB_CANCEL_GRACE_SECONDS
+        done, _pending = await asyncio.wait({task}, timeout=grace)
+        if task in done:
+            # ``_runner`` has recorded the terminal state; the worker thread
+            # has fully exited, so "cancelled" is truthful. The defensive
+            # generic-exception branch is the one terminal state that is not
+            # ``cancelled`` (a non-``McpCommandError`` escaping ``_run_sync``
+            # records ``failed``) — the message must not claim otherwise.
+            if job["state"] == "cancelled":
+                return f"cancelled job {job_id}"
+            return (
+                f"job {job_id} stopped (state={job['state']}) after the "
+                f"cancellation request; see job_result"
+            )
+        return (
+            f"cancellation of job {job_id} requested; its command body is "
+            f"still finishing the current step and stops at its next "
+            f"cancellation checkpoint (bounded by one HTTP timeout at "
+            f"worst). state=cancelling until then — poll job_status for "
+            f"'cancelled'; same-template commands stay queued behind it."
+        )

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -74,6 +74,8 @@ SLOW_COMMANDS: frozenset[str] = frozenset(
         "reboot",
         # Not a host op, but waits on the TeReGen regeneration job (minutes).
         "regenerate",
+        # Not a host op, but blocks polling Slack for a reviewer ack (minutes).
+        "request_review",
     }
 )
 
@@ -433,9 +435,11 @@ def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
         "reboot — with background=true) and their state."
     )
     status_desc = (
-        "Report a background job's state (running/done/failed/cancelled) and "
-        "elapsed time. Poll this after starting a slow command with "
-        "background=true."
+        "Report a background job's state (running/cancelling/done/failed/"
+        "cancelled) and elapsed time. Poll this after starting a slow command "
+        "with background=true. 'cancelling' means a cancel was requested and "
+        "the command body is still finishing its current step; it becomes "
+        "'cancelled' once the body has fully stopped."
     )
     result_desc = (
         "Return a finished background job's output. Errors if the job is still "
@@ -443,8 +447,15 @@ def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
         "it failed."
     )
     cancel_desc = (
-        "Cancel a running background job. Note: a job already executing on a "
-        "host (SSH/subprocess) may keep running on the host even after cancel."
+        "Cancel a running background job. Cooperative commands (e.g. "
+        "request_review's Slack watch) stop at their next checkpoint; this "
+        "call waits a short grace for the body to actually stop and only "
+        "then reports it cancelled. If the body is still finishing a "
+        "non-interruptible step the job is reported as 'cancelling' instead "
+        "(poll job_status; it flips to 'cancelled' once the body has "
+        "stopped, and same-template commands stay queued until then). Note: "
+        "a command already executing on a host (SSH/subprocess) may keep "
+        "running on the host to the end of that step."
     )
 
     # structured_output=False on all four: they return plain ``str``; see

--- a/mtui/support/cancellation.py
+++ b/mtui/support/cancellation.py
@@ -1,0 +1,21 @@
+"""Cooperative cancellation for command bodies running in worker threads.
+
+The MCP session runs blocking command bodies in :func:`asyncio.to_thread`
+workers; cancelling the awaiting task (``job_cancel``, a client disconnect)
+detaches the awaiter but cannot kill the thread. The session therefore binds a
+:class:`threading.Event` here (contextvars propagate into ``to_thread``) and
+sets it when the awaiter is cancelled, so long-running command bodies that
+poll — e.g. ``request_review``'s Slack watch — can exit promptly instead of
+running on unobserved to their own timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextvars import ContextVar
+
+#: The cancellation event for the current command invocation, or ``None`` when
+#: the caller provides no cancellation channel (the interactive REPL, tests).
+current_cancel_event: ContextVar[threading.Event | None] = ContextVar(
+    "current_cancel_event", default=None
+)

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -263,6 +263,13 @@ class Config:
     obs_api_url: str
     obs_request_timeout: int
 
+    # -- Slack review-request integration --
+    slack_token: str
+    slack_channel: str
+    slack_base_url: str
+    slack_poll_interval: int
+    slack_watch_timeout: int
+
     # -- mtui-mcp server (http transport) per-client session registry --
     mcp_session_cap: int
     mcp_session_idle_timeout: int
@@ -542,6 +549,48 @@ class Config:
                 ("gitea", "token"),
                 getenv("GITEA_TOKEN", ""),
                 getter=get,
+            ),
+            # Slack review-request integration. ``request_review`` posts the
+            # update to ``channel`` and watches the thread for a 👍 ack; the
+            # ``token`` (bot token, INI wins over the ``SLACK_TOKEN`` env like
+            # ``gitea_token``) authenticates the Slack Web API at ``base_url``.
+            # ``poll_interval`` / ``watch_timeout`` are the seconds between
+            # thread polls and the total time to wait for an ack.
+            ConfigOption(
+                "slack_token",
+                ("slack", "token"),
+                getenv("SLACK_TOKEN", ""),
+                getter=get,
+            ),
+            ConfigOption(
+                "slack_channel",
+                ("slack", "channel"),
+                "",
+                getter=get,
+            ),
+            ConfigOption(
+                "slack_base_url",
+                ("slack", "base_url"),
+                "https://slack.com/api",
+                getter=get,
+            ),
+            ConfigOption(
+                "slack_poll_interval",
+                ("slack", "poll_interval"),
+                20,
+                int,
+                getint,
+            ),
+            # A review can legitimately take hours, so ``request_review`` is
+            # meant to block (with a spinner in the REPL, Ctrl-C to stop) or run
+            # as a background MCP job for a full working day by default. Lower it
+            # if you prefer a shorter give-up window.
+            ConfigOption(
+                "slack_watch_timeout",
+                ("slack", "watch_timeout"),
+                28800,
+                int,
+                getint,
             ),
             # Global policy for TLS certificate verification on every
             # outbound HTTP call (see mtui.support.http). Unset — or an

--- a/mtui/support/exceptions.py
+++ b/mtui/support/exceptions.py
@@ -122,6 +122,18 @@ class GiteaError(Exception):
     """Base exception for Gitea-related errors."""
 
 
+class SlackError(Exception):
+    """Base exception for Slack-related errors."""
+
+
+class MissingSlackTokenError(SlackError):
+    """Raised when a Slack token is missing."""
+
+
+class FailedSlackCallError(SlackError):
+    """Raised when a call to the Slack API fails."""
+
+
 class MissingGiteaTokenError(GiteaError):
     """Raised when a Gitea token is missing."""
 

--- a/mtui/test_reports/metadata_parsers.py
+++ b/mtui/test_reports/metadata_parsers.py
@@ -29,6 +29,16 @@ from .products import normalize, normalize_16
 # Text/line-based metadata parser (was mtui/parsemeta.py).
 # ---------------------------------------------------------------------------
 
+# The one line-anchored pattern for the ``Slack Review: <channel>/<ts>``
+# marker written by ``TestReport.set_slack_review``. Shared with
+# ``testreport.py`` (which compiles it with ``re.MULTILINE`` to scan whole
+# files) so the writer and every reader see the exact same set of marker
+# lines and can never diverge: the marker must be a whole line of its own,
+# and free text (e.g. a template comment) merely *containing* the phrase
+# mid-line is never treated as a marker. ``[ \t]`` instead of ``\s`` keeps a
+# match on a single line even under MULTILINE.
+SLACK_REVIEW_MARKER = r"^Slack Review:[ \t]*(\S+)/(\S+)[ \t]*$"
+
 
 @final
 class ReducedMetadataParser:
@@ -37,6 +47,9 @@ class ReducedMetadataParser:
     hostnames = re.compile(r".* \(reference host: (\S+).*\)")
     jira = re.compile(r'Jira ([A-Z]+-\d+) \("(.*)"\):')
     bugs = re.compile(r'Bug (\d+) \("(.*)"\):')
+    # "Slack Review: <channel>/<ts>" marker written by set_slack_review; parsed
+    # back so metadata.slack_review is populated after a fresh checkout.
+    slack_review = re.compile(SLACK_REVIEW_MARKER)
 
     @classmethod
     def parse(cls, results, line: str) -> None:
@@ -57,6 +70,15 @@ class ReducedMetadataParser:
 
         if match := re.search(cls.bugs, line):
             results.bugs[match.group(1)] = match.group(2)
+            return
+
+        # First marker in file order wins; later duplicates (merge or
+        # hand-edit artifacts) are ignored, matching the disk-read view in
+        # ``TestReport.get_slack_review``.
+        if (match := re.search(cls.slack_review, line)) and getattr(
+            results, "slack_review", None
+        ) is None:
+            results.slack_review = (match.group(1), match.group(2))
 
 
 # ---------------------------------------------------------------------------

--- a/mtui/test_reports/svn_io.py
+++ b/mtui/test_reports/svn_io.py
@@ -31,6 +31,19 @@ class TemplateFormatError(RuntimeError):
     """Exception raised when a template does not match the expected format."""
 
 
+def svn_update_testreport(checkout: Path) -> None:
+    """Runs ``svn up`` on the testreport working copy.
+
+    Used to refresh the checkout right before decisions that must see the
+    repository's current state — e.g. ``request_review`` re-validating the
+    ``Slack Review:`` marker before auto-approving, where a colleague's
+    ``--repost`` committed from another checkout supersedes the watched
+    thread. Lets ``subprocess`` exceptions propagate so callers decide
+    whether a failed refresh is fatal.
+    """
+    subprocess.check_call(["svn", "up"], cwd=checkout)
+
+
 def svn_commit_testreport(
     checkout: Path, install_logs: Path, msg: list[str] | None = None
 ) -> None:

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -25,7 +25,7 @@ from ..support.exceptions import InvalidGiteaHashError, UpdateError
 from ..support.fileops import ensure_dir_exists
 from ..support.messages import MetadataNotLoadedError
 from ..types import OpenQAResults, Product, TargetMeta, Workflow
-from .metadata_parsers import patchinfo_titles
+from .metadata_parsers import SLACK_REVIEW_MARKER, patchinfo_titles
 from .svn_io import (
     TemplateFormatError,
     TemplateIOError,
@@ -51,6 +51,18 @@ _reviewer_line = re.compile(
     r"^(?:Suggested )?Test Plan Reviewers?:.*$",
     re.MULTILINE,
 )
+
+# Matches the "Slack Review: <channel>/<ts>" marker line recording the Slack
+# message a review was requested on. Unlike the reviewer line this does not
+# pre-exist in the template; ``set_slack_review`` inserts it on first write.
+# Compiled from the exact pattern the load-time metadata parser uses
+# (``metadata_parsers.SLACK_REVIEW_MARKER``), so the writer and every reader
+# see the same set of marker lines and can never diverge: the marker must be
+# a whole line of its own, and free text (e.g. the template's comment field)
+# merely containing "Slack Review: X/Y" mid-line is never treated as a
+# marker. All readers are first-wins and the writer collapses duplicates, so
+# every view agrees on which marker counts.
+_slack_review_line = re.compile(SLACK_REVIEW_MARKER, re.MULTILINE)
 
 
 class TestReport(ABC):
@@ -147,6 +159,10 @@ class TestReport(ABC):
         self.reviewer: str = ""
         self.repository: str = ""
         self.packages = {}
+        # Slack review reference (channel ID, message ts) recorded by
+        # ``request_review`` and re-checked by the approve/reject gate.
+        # ``None`` until a review has been requested and persisted.
+        self.slack_review: tuple[str, str] | None = None
 
         self._attrs = [
             "products",
@@ -283,6 +299,106 @@ class TestReport(ABC):
         tmp.write_text(new_text)
         os.replace(tmp, self.path)
         self.reviewer = name
+
+    def set_slack_review(self, channel: str, ts: str) -> None:
+        """Records the Slack review reference in the loaded template on disk.
+
+        Writes a ``Slack Review: <channel>/<ts>`` marker line so the ack state
+        survives a reload and can be re-checked by the approve/reject gate. If
+        the marker already exists it is replaced in place — and any duplicate
+        marker lines (merge or hand-edit artifacts) are dropped, so the file
+        never carries two markers after a write. Otherwise it is inserted
+        right after the ``Test Plan Reviewer:`` line (a stable anchor that
+        always pre-exists in the template). The file is rewritten atomically
+        and the in-memory :attr:`slack_review` attribute is updated only
+        afterwards.
+
+        Args:
+            channel: The Slack channel ID the review message was posted to.
+            ts: The Slack message timestamp identifying the review message.
+
+        Raises:
+            RuntimeError: If no template is loaded (``self.path`` is ``None``).
+            TemplateFormatError: If the marker is missing and there is no
+                ``Test Plan Reviewer:`` line to anchor the insert.
+
+        """
+        if not self.path:
+            raise RuntimeError("Called while missing path")
+
+        marker = f"Slack Review: {channel}/{ts}"
+        text = self.path.read_text(errors="replace")
+        count = 0
+        lines: list[str] = []
+        for line in text.splitlines(keepends=True):
+            if _slack_review_line.match(line):
+                count += 1
+                if count == 1:
+                    lines.append(marker + ("\n" if line.endswith("\n") else ""))
+                # Duplicate markers are dropped, not left behind stale: the
+                # readers are first-wins, so a second marker line could only
+                # ever mislead a hand-editing human or a future parser.
+            else:
+                lines.append(line)
+        new_text = "".join(lines)
+        if count == 0:
+            # Marker absent: insert it right after the reviewer line.
+            new_text, count = _reviewer_line.subn(
+                lambda m: f"{m.group(0)}\n{marker}", text, count=1
+            )
+            if count == 0:
+                raise TemplateFormatError(
+                    f"no 'Test Plan Reviewer:' line to anchor Slack Review in {self.path}"
+                )
+
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(new_text)
+        os.replace(tmp, self.path)
+        self.slack_review = (channel, ts)
+
+    def has_slack_review_anchor(self) -> bool:
+        """Whether :meth:`set_slack_review` could record its marker.
+
+        True when the loaded template already carries a ``Slack Review:``
+        marker or has a ``Test Plan Reviewer:`` line to anchor the insert.
+        ``request_review`` checks this **before** posting to Slack, so a
+        malformed template aborts the request instead of leaving a dangling
+        review message whose ack can never be recorded.
+        """
+        if not self.path:
+            return False
+        try:
+            text = self.path.read_text(errors="replace")
+        except OSError:
+            # The template can vanish underneath the session (an ``svn up``
+            # that removed a withdrawn report); no file, no anchor.
+            return False
+        return bool(_slack_review_line.search(text) or _reviewer_line.search(text))
+
+    def get_slack_review(self) -> tuple[str, str] | None:
+        """The ``Slack Review:`` marker as currently recorded **on disk**.
+
+        Unlike :attr:`slack_review` (a load-time snapshot plus this session's
+        own writes), this re-parses the template file, so it reflects marker
+        changes pulled in underneath the session — every testreport commit
+        runs ``svn up``, which can bring in a colleague's newer, reposted, or
+        removed marker. Used by ``request_review`` for its resume-vs-post
+        decision and its pre-approve supersede guard, and by the
+        ``approve``/``reject`` review gate. A missing file reads as "no
+        marker".
+        """
+        if not self.path:
+            return None
+        try:
+            text = self.path.read_text(errors="replace")
+        except OSError:
+            return None
+        # First marker in file order wins — the same semantics as the
+        # load-time parser (``ReducedMetadataParser``); ``set_slack_review``
+        # collapses duplicates anyway, so all views agree.
+        if match := _slack_review_line.search(text):
+            return (match.group(1), match.group(2))
+        return None
 
     @abstractmethod
     def check_hash(self) -> tuple[bool, str, str]:
@@ -972,6 +1088,10 @@ class TestReport(ABC):
                 ("Build checks", self._testreport_url()[:-3] + "build_checks"),
                 ("Testreport", self._testreport_url()),
                 ("Repository", self.repository),
+                (
+                    "Slack Review",
+                    "/".join(self.slack_review) if self.slack_review else "",
+                ),
             ]
             + [("Testplatform", x) for x in self.testplatforms]
             + [("Products", x) for x in self.products]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,12 @@ def mock_config():
     # Native OBS backend defaults (mtui/data_sources/obs/); see [obs].
     config.obs_api_url = "https://api.suse.de"
     config.obs_request_timeout = 180
+    # Slack review-request integration.
+    config.slack_token = "xoxb-test-token"
+    config.slack_channel = "C123"
+    config.slack_base_url = "https://slack.test/api"
+    config.slack_poll_interval = 1
+    config.slack_watch_timeout = 5
     return config
 
 

--- a/tests/test_cmd_apicall.py
+++ b/tests/test_cmd_apicall.py
@@ -10,6 +10,10 @@ import pytest
 from mtui.commands.apicall import Assign, Comment, Reject, Unassign
 from mtui.types import RequestKind, RequestReviewID
 
+# The update under test; the reject gate binds the Slack marker to this RRID
+# by requiring the review-request parent message to name it verbatim.
+_RRID = "SUSE:Maintenance:12345:67890"
+
 
 def _prompt() -> MagicMock:
     p = MagicMock()
@@ -20,9 +24,35 @@ def _prompt() -> MagicMock:
     p.metadata.rrid.kind = RequestKind.MAINTENANCE
     p.metadata.rrid.maintenance_id = "12345"
     p.metadata.rrid.review_id = "67890"
+    p.metadata.rrid.__str__.return_value = _RRID
+    # A persisted Slack review so the approve/reject gate re-queries live
+    # reactions rather than refusing outright (only Reject consults it here).
+    p.metadata.get_slack_review.return_value = ("C123", "111.222")
     p.display = MagicMock()
     p.targets = MagicMock()
     return p
+
+
+# A 👍 reaction as Slack message objects carry it (message.reactions list).
+_THUMBSUP = [{"name": "thumbsup", "count": 1, "users": ["Ureviewer"]}]
+
+
+def _slack(rrid: str = _RRID):
+    """Patch the reject gate's ``SlackClient`` so it sees a live, bound 👍 ack.
+
+    The gate fetches the review-request parent message via
+    ``conversations_replies`` and requires its text to name this update's
+    RRID before trusting the parent's ``reactions``; pass ``rrid`` when the
+    test's prompt carries a different RRID.
+
+    ``require_slack_review`` imports ``SlackClient`` lazily from
+    ``mtui.data_sources``, so that is the patch target.
+    """
+    client = MagicMock()
+    client.conversations_replies.return_value = [
+        {"text": f"Please review {rrid}: https://qam.suse.de/x", "reactions": _THUMBSUP}
+    ]
+    return patch("mtui.data_sources.SlackClient", return_value=client)
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +115,7 @@ def test_end_of_testing_pi_unlocks(mock_config, cls, extra):
     prompt.metadata.lock_comment = "testing of SUSE:PI:34556:1"
     args = Namespace(group=["qam-sle"], user="", **extra)
 
-    with patch("mtui.commands.apicall.OSC"):
+    with patch("mtui.commands.apicall.OSC"), _slack(rrid="SUSE:PI:34556:1"):
         cls(args, mock_config, MagicMock(), prompt)()
 
     prompt.targets.unlock.assert_called_once_with()
@@ -109,7 +139,7 @@ def test_reject_osc_joins_message_into_string(mock_config):
         user="",
     )
 
-    with patch("mtui.commands.apicall.OSC") as osc_cls:
+    with patch("mtui.commands.apicall.OSC") as osc_cls, _slack():
         Reject(args, mock_config, MagicMock(), prompt)()
 
     osc_cls.return_value.reject.assert_called_once_with(
@@ -128,7 +158,7 @@ def test_reject_gitea_joins_message_into_string(mock_config):
         user="someone",
     )
 
-    with patch("mtui.commands.apicall.Gitea") as gitea_cls:
+    with patch("mtui.commands.apicall.Gitea") as gitea_cls, _slack():
         Reject(args, mock_config, MagicMock(), prompt)()
 
     gitea_cls.return_value.reject.assert_called_once_with(
@@ -141,7 +171,7 @@ def test_reject_without_message_sends_empty_string(mock_config):
     prompt = _prompt()
     args = Namespace(group=["qam-sle"], reason="admin", message=None, user="")
 
-    with patch("mtui.commands.apicall.OSC") as osc_cls:
+    with patch("mtui.commands.apicall.OSC") as osc_cls, _slack():
         Reject(args, mock_config, MagicMock(), prompt)()
 
     osc_cls.return_value.reject.assert_called_once_with(["qam-sle"], "admin", "")

--- a/tests/test_cmd_approve.py
+++ b/tests/test_cmd_approve.py
@@ -1,4 +1,4 @@
-"""Tests for the `approve` command."""
+"""Tests for the `approve` command (incl. the Slack review gate)."""
 
 from __future__ import annotations
 
@@ -8,10 +8,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mtui.commands.apicall import Reject
 from mtui.commands.approve import Approve
+from mtui.support.exceptions import FailedSlackCallError
 from mtui.support.messages import TestReportNotLoadedError
 from mtui.test_reports.svn_io import TemplateFormatError
 from mtui.types import RequestKind, RequestReviewID
+
+# A 👍 reaction as Slack message objects carry it (message.reactions list).
+_THUMBSUP = [{"name": "thumbsup", "count": 1, "users": ["Ureviewer"]}]
+
+# The update under test; the gate binds the Slack marker to this RRID by
+# requiring the review-request parent message to name it verbatim.
+_RRID = "SUSE:Maintenance:12345:67890"
+_REVIEW_TEXT = f"Please review {_RRID}: https://qam.suse.de/testreports/x"
 
 
 def _prompt() -> MagicMock:
@@ -23,16 +33,57 @@ def _prompt() -> MagicMock:
     p.metadata.rrid.kind = RequestKind.MAINTENANCE
     p.metadata.rrid.maintenance_id = "12345"
     p.metadata.rrid.review_id = "67890"
+    p.metadata.rrid.__str__.return_value = _RRID
+    # A persisted Slack review reference so the gate re-queries live reactions
+    # rather than refusing outright; individual tests override as needed. The
+    # gate reads the marker file-fresh via get_slack_review (any svn up may
+    # have changed it), so that is what must be wired.
+    p.metadata.slack_review = ("C123", "111.222")
+    p.metadata.get_slack_review.return_value = ("C123", "111.222")
+    p.interactive = True
     p.display = MagicMock()
     p.targets = MagicMock()
     return p
+
+
+def _slack(reactions=None, *, text=None, messages=None, fetch_error=None):
+    """Patch the gate's ``SlackClient`` for the marker-binding checks.
+
+    The gate fetches the review-request parent message via
+    ``conversations_replies`` and reads both its text (RRID binding) and its
+    ``reactions`` (the 👍 ack) from it. By default the parent is a genuine
+    review request for ``_RRID`` carrying a 👍; ``text``/``reactions``
+    override the parent, ``messages`` replaces the whole thread, and
+    ``fetch_error`` makes the fetch itself fail.
+
+    The gate imports ``SlackClient`` lazily from ``mtui.data_sources`` inside
+    ``require_slack_review``, so that is the patch target.
+    """
+    client = MagicMock()
+    if fetch_error is not None:
+        client.conversations_replies.side_effect = fetch_error
+    else:
+        if messages is None:
+            messages = [
+                {
+                    "text": _REVIEW_TEXT if text is None else text,
+                    "reactions": _THUMBSUP if reactions is None else reactions,
+                }
+            ]
+        client.conversations_replies.return_value = messages
+    return patch("mtui.data_sources.SlackClient", return_value=client)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: with a live 👍 present the approve proceeds to the backend.
+# ---------------------------------------------------------------------------
 
 
 def test_approve_osc_branch_calls_osc_approve(mock_config):
     prompt = _prompt()
     args = Namespace(group=["qam-sle"], user="", reviewer=None)
 
-    with patch("mtui.commands.approve.OSC") as osc_cls:
+    with _slack(), patch("mtui.commands.approve.OSC") as osc_cls:
         Approve(args, mock_config, MagicMock(), prompt)()
 
     osc_cls.assert_called_once_with(mock_config, prompt.metadata.rrid)
@@ -55,11 +106,158 @@ def test_approve_pi_unlocks(mock_config):
     prompt.metadata.lock_comment = "testing of SUSE:PI:34556:1"
     args = Namespace(group=["qam-sle"], user="", reviewer=None)
 
-    with patch("mtui.commands.approve.OSC"):
+    with (
+        _slack(text="Please review SUSE:PI:34556:1: https://x"),
+        patch("mtui.commands.approve.OSC"),
+    ):
         Approve(args, mock_config, MagicMock(), prompt)()
 
     prompt.targets.unlock.assert_called_once_with()
     assert prompt.metadata.lock_comment == ""
+
+
+# ---------------------------------------------------------------------------
+# Slack review gate: approve REFUSES without a recorded review or a live 👍.
+# ---------------------------------------------------------------------------
+
+
+def test_approve_refuses_when_no_slack_review(mock_config):
+    prompt = _prompt()
+    prompt.metadata.slack_review = None
+    prompt.metadata.get_slack_review.return_value = None
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with (
+        _slack() as slack_cls,
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    # No review recorded -> the gate never even talks to Slack, never approves.
+    slack_cls.assert_not_called()
+    osc_cls.assert_not_called()
+
+
+def test_approve_refuses_when_no_thumbsup(mock_config):
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with (
+        _slack(reactions=[{"name": "eyes", "count": 1, "users": ["Ux"]}]),
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_approve_proceeds_with_live_thumbsup(mock_config):
+    """Legitimate flow: parent names this RRID, matching channel, live 👍."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with _slack() as slack_cls, patch("mtui.commands.approve.OSC") as osc_cls:
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    slack_cls.return_value.conversations_replies.assert_called_once_with(
+        "C123", "111.222"
+    )
+    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
+
+
+def test_approve_accepts_skin_toned_thumbsup(mock_config):
+    """A skin-toned 👍 ("+1::skin-tone-3") on a genuine review message counts."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+    reactions = [{"name": "+1::skin-tone-3", "count": 1, "users": ["Ureviewer"]}]
+
+    with _slack(reactions=reactions), patch("mtui.commands.approve.OSC") as osc_cls:
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
+
+
+def test_approve_passes_when_config_holds_channel_name(mock_config):
+    """No false refusal when config holds a channel NAME but the marker holds
+    the canonical channel ID: the binding is verified via the fetched message."""
+    mock_config.slack_channel = "#qam-review"  # marker holds resolved id C123
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with _slack(), patch("mtui.commands.approve.OSC") as osc_cls:
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.approve.assert_called_once_with(["qam-sle"])
+
+
+# ---------------------------------------------------------------------------
+# Marker binding: the plaintext 'Slack Review:' marker is forgeable (template
+# edit, MCP testreport writes). The gate must refuse any 👍'd message that is
+# not THIS update's review request.
+# ---------------------------------------------------------------------------
+
+
+def test_approve_refuses_forged_marker_without_rrid(mock_config):
+    """A marker pointed at a random 👍'd message (text lacks the RRID) is refused."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with (
+        _slack(text="team lunch at noon?"),  # carries a 👍, not a review request
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="does not mention"),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_approve_refuses_marker_for_other_update(mock_config):
+    """A marker pointed at ANOTHER update's genuine review message is refused."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+    other = "Please review SUSE:Maintenance:99999:11111: https://qam.suse.de/y"
+
+    with (
+        _slack(text=other),
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="does not match this update"),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_approve_refuses_when_message_missing(mock_config):
+    """A marker pointing at a nonexistent message (fetch fails) is refused."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with (
+        _slack(fetch_error=FailedSlackCallError("thread_not_found")),
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="could not be fetched"),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_approve_refuses_when_thread_is_empty(mock_config):
+    """An empty conversations.replies result (no parent message) is refused."""
+    prompt = _prompt()
+    args = Namespace(group=["qam-sle"], user="", reviewer=None)
+
+    with (
+        _slack(messages=[]),
+        patch("mtui.commands.approve.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="does not exist"),
+    ):
+        Approve(args, mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -72,6 +270,7 @@ def test_approve_reviewer_records_commits_then_approves(mock_config):
     args = Namespace(group=["qam-sle"], user="", reviewer="alice")
 
     with (
+        _slack(),
         patch("mtui.commands.approve.OSC") as osc_cls,
         patch("mtui.commands.approve.svn_commit_testreport") as svn,
     ):
@@ -88,6 +287,7 @@ def test_approve_reviewer_aborts_when_set_reviewer_fails(mock_config):
     args = Namespace(group=["qam-sle"], user="", reviewer="alice")
 
     with (
+        _slack(),
         patch("mtui.commands.approve.OSC") as osc_cls,
         patch("mtui.commands.approve.svn_commit_testreport") as svn,
     ):
@@ -102,6 +302,7 @@ def test_approve_reviewer_aborts_when_svn_commit_fails(mock_config):
     args = Namespace(group=["qam-sle"], user="", reviewer="alice")
 
     with (
+        _slack(),
         patch("mtui.commands.approve.OSC") as osc_cls,
         patch(
             "mtui.commands.approve.svn_commit_testreport",
@@ -119,6 +320,7 @@ def test_approve_reviewer_empty_aborts(mock_config):
     args = Namespace(group=["qam-sle"], user="", reviewer="   ")
 
     with (
+        _slack(),
         patch("mtui.commands.approve.OSC") as osc_cls,
         patch("mtui.commands.approve.svn_commit_testreport") as svn,
     ):
@@ -126,4 +328,121 @@ def test_approve_reviewer_empty_aborts(mock_config):
 
     prompt.metadata.set_reviewer.assert_not_called()
     svn.assert_not_called()
+    osc_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# reject gate: mirrors approve. (Owned here because the pre-existing reject
+# tests live in tests/test_cmd_apicall.py under another name — see follow_ups.)
+# ---------------------------------------------------------------------------
+
+
+def _reject_args(**over) -> Namespace:
+    base = {
+        "group": ["qam-sle"],
+        "user": "",
+        "reason": "admin",
+        "message": ["nope"],
+    }
+    base.update(over)
+    return Namespace(**base)
+
+
+def test_reject_refuses_when_no_slack_review(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+    prompt.metadata.slack_review = None
+    prompt.metadata.get_slack_review.return_value = None
+
+    with (
+        _slack() as slack_cls,
+        patch("mtui.commands.apicall.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError),
+    ):
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    slack_cls.assert_not_called()
+    osc_cls.assert_not_called()
+
+
+def test_reject_refuses_when_no_thumbsup(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+
+    with (
+        _slack(reactions=[{"name": "eyes", "count": 1, "users": ["Ux"]}]),
+        patch("mtui.commands.apicall.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError),
+    ):
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_reject_proceeds_with_live_thumbsup(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+
+    with _slack() as slack_cls, patch("mtui.commands.apicall.OSC") as osc_cls:
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    slack_cls.return_value.conversations_replies.assert_called_once_with(
+        "C123", "111.222"
+    )
+    osc_cls.return_value.reject.assert_called_once_with(["qam-sle"], "admin", "nope")
+
+
+def test_reject_refuses_forged_marker_without_rrid(mock_config):
+    """The reject gate shares the marker binding: a 👍'd message whose text
+    lacks this RRID is not a review request for this update."""
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+
+    with (
+        _slack(text="unrelated announcement everyone 👍'd"),
+        patch("mtui.commands.apicall.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="does not mention"),
+    ):
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_reject_refuses_marker_for_other_update(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+    other = "Please review SUSE:Maintenance:99999:11111: https://qam.suse.de/y"
+
+    with (
+        _slack(text=other),
+        patch("mtui.commands.apicall.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="does not match this update"),
+    ):
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    osc_cls.assert_not_called()
+
+
+def test_reject_accepts_skin_toned_thumbsup(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+    reactions = [{"name": "+1::skin-tone-2", "count": 1, "users": ["Ureviewer"]}]
+
+    with _slack(reactions=reactions), patch("mtui.commands.apicall.OSC") as osc_cls:
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
+    osc_cls.return_value.reject.assert_called_once_with(["qam-sle"], "admin", "nope")
+
+
+def test_reject_refuses_when_message_missing(mock_config):
+    mock_config.lock_pi_autolock = False
+    prompt = _prompt()
+
+    with (
+        _slack(fetch_error=FailedSlackCallError("thread_not_found")),
+        patch("mtui.commands.apicall.OSC") as osc_cls,
+        pytest.raises(FailedSlackCallError, match="could not be fetched"),
+    ):
+        Reject(_reject_args(), mock_config, MagicMock(), prompt)()
+
     osc_cls.assert_not_called()

--- a/tests/test_cmd_request_review.py
+++ b/tests/test_cmd_request_review.py
@@ -1,0 +1,1346 @@
+"""Tests for the ``request_review`` command.
+
+Covers the commit-before-post ordering, the Slack post + durable marker
+persistence (the marker records the canonical channel Slack returns, not the
+configured alias), the ``--no-watch`` early return, the not-loaded guard, the
+config and cooperative-cancel guards before every side effect, the two-phase
+multi-template fan-out (all posts before any watch; Ctrl-C keeps the other
+templates' posts and reports per-template status), and the blocker-fix
+regression: the auto-approve after a 👍 must act on the fanout iteration's
+template, not the prompt's active one.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mtui.commands.request_review import RequestReview
+from mtui.data_sources.slack import ReviewOutcome
+from mtui.support.cancellation import current_cancel_event
+from mtui.support.exceptions import FailedSlackCallError
+from mtui.support.messages import FanOutError, TestReportNotLoadedError
+from mtui.test_reports.svn_io import TemplateFormatError
+
+
+def _outcome(*, acked=True, reviewer="alice", timed_out=False, unreachable=False):
+    """Build a ReviewOutcome the patched ``wait_for_ack`` returns."""
+    return ReviewOutcome(
+        acked=acked,
+        reviewer=reviewer,
+        timed_out=timed_out,
+        unreachable=unreachable,
+    )
+
+
+def _wire_marker(metadata: MagicMock, initial=None) -> dict:
+    """Make the metadata mock's marker behave like the real file-backed one.
+
+    ``get_slack_review`` reflects the last ``set_slack_review`` write (the
+    command re-reads the on-disk marker for its resume decision and for the
+    pre-approve supersede guard). Returns the state dict so a test can mutate
+    the marker mid-watch to simulate a concurrent repost.
+    """
+    state = {"marker": initial}
+    metadata.set_slack_review.side_effect = lambda c, t: state.__setitem__(
+        "marker", (c, t)
+    )
+    metadata.get_slack_review.side_effect = lambda: state["marker"]
+    metadata.slack_review = initial
+    return state
+
+
+def _printed(sys: MagicMock) -> str:
+    """Join everything the command wrote via ``println`` into one string."""
+    return "".join(c.args[0] for c in sys.stdout.write.call_args_list)
+
+
+def _prompt() -> MagicMock:
+    """A prompt whose active metadata is a loaded, distinct report."""
+    p = MagicMock()
+    p.metadata = MagicMock()
+    p.metadata.__bool__ = lambda self: True
+    p.metadata.rrid = "SUSE:Maintenance:1:1"
+    p.metadata.report_wd.return_value = "/wd"
+    p.metadata._testreport_url.return_value = "http://qam/1/log"
+    _wire_marker(p.metadata)
+    p.display = MagicMock()
+    p.targets = MagicMock()
+    return p
+
+
+def _report(rrid: str, url: str) -> MagicMock:
+    """A loaded fan-out report mock with a wired file-backed marker."""
+    r = MagicMock(name=f"report_{rrid}")
+    r.__bool__ = lambda self: True
+    r.id = rrid
+    r.rrid = rrid
+    r.report_wd.return_value = "/wd"
+    r._testreport_url.return_value = url
+    r.targets = MagicMock(name=f"targets_{rrid}")
+    _wire_marker(r)
+    return r
+
+
+def _args(**overrides) -> Namespace:
+    base = {
+        "no_watch": False,
+        "no_approve": False,
+        "repost": False,
+        "group": ["qam-sle"],
+        "user": "",
+        "template": None,
+        "all_templates": False,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+#: What the (mocked, per the SlackClient contract) ``chat_postMessage``
+#: returns: the CANONICAL channel id from Slack's response — deliberately
+#: different from ``mock_config.slack_channel`` ("C123") so the tests prove
+#: the marker persists the returned channel, not the configured alias.
+CANON = "C123CANON"
+
+
+# ---------------------------------------------------------------------------
+# not loaded
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_without_metadata_raises(mock_config):
+    prompt = MagicMock()
+    prompt.metadata = MagicMock()
+    prompt.metadata.__bool__ = lambda self: False
+    prompt.display = MagicMock()
+    prompt.targets = MagicMock()
+
+    with pytest.raises(TestReportNotLoadedError):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+
+# ---------------------------------------------------------------------------
+# happy path: commit BEFORE post, URL posted, marker persisted with the
+# canonical channel + ts that Slack returned
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_commits_before_posting_and_persists(mock_config):
+    prompt = _prompt()
+    order: list[str] = []
+
+    client = MagicMock()
+
+    def _post(channel, text):
+        order.append("post")
+        return (CANON, "1700000000.000100")
+
+    client.chat_postMessage.side_effect = _post
+    client.wait_for_ack.return_value = _outcome()
+
+    def _commit(*a, **kw):
+        order.append("commit")
+
+    with (
+        patch(
+            "mtui.commands.request_review.svn_commit_testreport", side_effect=_commit
+        ),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    # The first svn commit MUST precede the Slack post (the /log mirror only
+    # reflects committed content).
+    assert order[0] == "commit"
+    assert order.index("commit") < order.index("post")
+
+    # The report URL was posted to the CONFIGURED channel, and the parent
+    # message names the RRID verbatim: the approve/reject gate re-reads the
+    # posted text and verifies it contains this RRID (anti-forgery contract).
+    posted_channel, posted_text = client.chat_postMessage.call_args.args
+    assert posted_channel == mock_config.slack_channel
+    assert "http://qam/1/log" in posted_text
+    assert str(prompt.metadata.rrid) in posted_text
+
+    # The marker was persisted with the canonical channel + ts Slack
+    # RETURNED, not the configured channel alias.
+    prompt.metadata.set_slack_review.assert_called_once_with(CANON, "1700000000.000100")
+
+
+def test_request_review_aborts_before_posting_when_commit_fails(mock_config):
+    """A failed pre-commit must not post to Slack nor persist a marker."""
+    prompt = _prompt()
+    client = MagicMock()
+
+    with (
+        patch(
+            "mtui.commands.request_review.svn_commit_testreport",
+            side_effect=subprocess.CalledProcessError(1, "svn"),
+        ),
+        patch(
+            "mtui.commands.request_review.SlackClient", return_value=client
+        ) as slack_cls,
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    slack_cls.assert_not_called()
+    client.chat_postMessage.assert_not_called()
+    prompt.metadata.set_slack_review.assert_not_called()
+    appr_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# config guards: unset [slack] token / channel refuse up front, clearly
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_missing_slack_token_refuses_up_front(mock_config):
+    """An empty [slack] token errors clearly before ANY side effect."""
+    mock_config.slack_token = ""
+    prompt = _prompt()
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport") as commit,
+        patch("mtui.commands.request_review.SlackClient") as slack_cls,
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    commit.assert_not_called()
+    slack_cls.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "[slack] token" in _printed(sys)
+
+
+def test_request_review_missing_slack_channel_refuses_up_front(mock_config):
+    """An empty [slack] channel errors clearly instead of a live API call
+    dying with a misleading channel_not_found."""
+    mock_config.slack_channel = ""
+    prompt = _prompt()
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport") as commit,
+        patch("mtui.commands.request_review.SlackClient") as slack_cls,
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    commit.assert_not_called()
+    slack_cls.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "[slack] channel" in _printed(sys)
+
+
+# ---------------------------------------------------------------------------
+# --no-watch returns early without watching
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_no_watch_returns_before_watching(mock_config):
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000200")
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(no_watch=True), mock_config, MagicMock(), prompt)()
+
+    client.chat_postMessage.assert_called_once()
+    prompt.metadata.set_slack_review.assert_called_once_with(CANON, "1700000000.000200")
+    # Early return: never watched, never approved.
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# --no-approve: watches + reports the ack but does not approve
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_no_approve_watches_but_skips_approve(mock_config):
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000300")
+    client.wait_for_ack.return_value = _outcome(reviewer="bob")
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(no_approve=True), mock_config, MagicMock(), prompt)()
+
+    client.wait_for_ack.assert_called_once()
+    appr_cls.assert_not_called()
+
+
+def test_request_review_not_acked_does_not_approve(mock_config):
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000400")
+    client.wait_for_ack.return_value = _outcome(
+        acked=False, reviewer=None, timed_out=True
+    )
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    appr_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# happy path: on ack, drive Approve bound to the reactor as reviewer
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_acked_drives_approve_with_reviewer(mock_config):
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000500")
+    client.wait_for_ack.return_value = _outcome(reviewer="carol")
+
+    appr = MagicMock(name="Approve")
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve", return_value=appr) as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    appr_cls.assert_called_once()
+    passed_args = appr_cls.call_args.args[0]
+    assert passed_args.reviewer == "carol"
+    # The best-effort reactor drives the internal approve; it must run
+    # (``appr.__call__()`` marks the mock as called).
+    assert appr.called
+    # Bound to the loaded report, not left unset.
+    assert appr.metadata is prompt.metadata
+
+
+def test_request_review_approve_slack_hiccup_reports_actionably(mock_config):
+    """A FailedSlackCallError in the approve handoff after a successful ack
+    must not crash the hours-long watch: the state stays fail-closed and the
+    message tells the user how to recover."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000550")
+    client.wait_for_ack.return_value = _outcome(reviewer="carol")
+    appr = MagicMock(name="Approve")
+    appr.side_effect = FailedSlackCallError("internal_error")
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve", return_value=appr),
+    ):
+        # Must not raise despite the approve handoff failing.
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    printed = _printed(sys)
+    assert "NOT approved" in printed
+    assert "re-run request_review" in printed
+    assert "internal_error" in printed
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER regression: auto-approve after 👍 acts on the intended fanout
+# template, not the prompt's active one. The fan-out now runs two-phase
+# (posts first, then ONE combined watch), so the ack is observed by the
+# round-robin poll, not a per-template wait_for_ack.
+# ---------------------------------------------------------------------------
+
+
+def test_autoapprove_targets_fanout_template_not_active(mock_config):
+    """Ack on the non-active report must approve *that* report's metadata.
+
+    With several templates loaded, the fan-out posts every request and then
+    watches them all in one combined loop. The blocker was a bare
+    ``Approve()`` reading the prompt's *active* metadata instead of the
+    fanout iteration's target — a 👍 on report B could approve report A. This
+    proves the constructed ``Approve`` is bound to the acked report's
+    metadata/targets, not the active one.
+    """
+    prompt = _prompt()
+
+    # The active template (what a buggy implementation would wrongly approve).
+    active_meta = prompt.metadata
+
+    # Two distinct loaded reports; ack lands on the NON-active one.
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+
+    # One poll round is enough: B acks immediately, A runs out the deadline.
+    mock_config.slack_watch_timeout = 0
+
+    client = MagicMock()
+    client.chat_postMessage.side_effect = [(CANON, "111.a"), (CANON, "222.b")]
+    client.conversations_replies.return_value = [{"text": "parent"}]
+    client.reactions_get.side_effect = lambda channel, ts: (
+        [{"name": "+1", "users": ["U1"]}] if ts == "222.b" else []
+    )
+    client._acking_reviewer.side_effect = lambda reactions: (
+        "dave" if reactions else None
+    )
+
+    built: list[MagicMock] = []
+
+    def _approve_factory(args, config, sys, prompt_):
+        appr = MagicMock(name="Approve")
+        built.append(appr)
+        return appr
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve", side_effect=_approve_factory),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt).run()
+
+    # Exactly one approve was constructed + fired (the acked report B).
+    fired = [a for a in built if a.called]
+    assert len(fired) == 1
+    approved = fired[0]
+    assert approved.metadata is report_b
+    assert approved.targets is report_b.targets
+    # And it was NOT the prompt's active metadata (the blocker symptom).
+    assert approved.metadata is not active_meta
+
+
+# ---------------------------------------------------------------------------
+# two-phase fan-out: every template's request is POSTED before any watch,
+# and Ctrl-C mid-watch keeps the other templates' posts + markers and
+# reports a per-template status summary.
+# ---------------------------------------------------------------------------
+
+
+def test_fanout_posts_all_templates_before_any_watch(mock_config):
+    """No template's post may wait behind another template's watch."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+    mock_config.slack_watch_timeout = 0
+
+    order: list[str] = []
+    client = MagicMock()
+
+    def _post(channel, text, thread_ts=None):
+        order.append("post")
+        return (CANON, f"{len(order)}.0")
+
+    def _replies(channel, ts):
+        order.append("poll")
+        return [{"text": "parent"}]
+
+    client.chat_postMessage.side_effect = _post
+    client.conversations_replies.side_effect = _replies
+    client.reactions_get.return_value = []
+    client._acking_reviewer.return_value = None
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt).run()
+
+    # Both posts happened, and every post preceded the first poll.
+    assert order.count("post") == 2
+    assert "poll" in order
+    assert max(i for i, o in enumerate(order) if o == "post") < order.index("poll")
+    # Both markers were persisted (with the canonical returned channel).
+    report_a.set_slack_review.assert_called_once_with(CANON, "1.0")
+    report_b.set_slack_review.assert_called_once_with(CANON, "2.0")
+
+
+def test_fanout_keyboardinterrupt_mid_watch_reports_status(mock_config):
+    """Ctrl-C in the combined watch must not lose the other templates.
+
+    Both requests were already posted and their markers recorded; the
+    interrupt stops the watch, prints a per-template status summary, and
+    does not propagate (pending requests resume on a re-run).
+    """
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+
+    client = MagicMock()
+    client.chat_postMessage.side_effect = [(CANON, "111.a"), (CANON, "222.b")]
+    client.conversations_replies.side_effect = KeyboardInterrupt
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        # Must not raise: run() converts the interrupt into a status report.
+        RequestReview(_args(), mock_config, sys, prompt).run()
+
+    # Both posts and both markers survived the interrupt.
+    assert client.chat_postMessage.call_count == 2
+    report_a.set_slack_review.assert_called_once_with(CANON, "111.a")
+    report_b.set_slack_review.assert_called_once_with(CANON, "222.b")
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "interrupted" in printed
+    assert "SUSE:Maintenance:1:1: posted, awaiting ack" in printed
+    assert "SUSE:Maintenance:2:2: posted, awaiting ack" in printed
+    assert "re-run request_review" in printed
+
+
+def test_fanout_scoped_single_template_keeps_blocking_watch(mock_config):
+    """A ``-T``-scoped invocation (what the MCP session mints per background
+    job) behaves exactly like the classic single-template flow: one blocking
+    ``wait_for_ack``, no round-robin polling."""
+    prompt = _prompt()
+    report = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.get.return_value = report
+
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "222.b")
+    client.wait_for_ack.return_value = _outcome(
+        acked=False, reviewer=None, timed_out=True
+    )
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        RequestReview(
+            _args(template="SUSE:Maintenance:2:2"), mock_config, MagicMock(), prompt
+        ).run()
+
+    client.wait_for_ack.assert_called_once()
+    client.conversations_replies.assert_not_called()
+
+
+def test_fanout_phase1_failure_collected_others_still_watched(mock_config):
+    """One template's unexpected phase-1 failure must not stop the others:
+    the failure is collected (and raised as FanOutError afterwards) while the
+    other template's request is still posted AND watched."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    report_a.get_slack_review.side_effect = RuntimeError("boom")
+    prompt.templates.all.return_value = [report_a, report_b]
+    mock_config.slack_watch_timeout = 0
+
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "222.b")
+    client.conversations_replies.return_value = [{"text": "parent"}]
+    client.reactions_get.return_value = []
+    client._acking_reviewer.return_value = None
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+        pytest.raises(FanOutError),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt).run()
+
+    # B was posted, its marker persisted, and its watch polled despite A.
+    report_b.set_slack_review.assert_called_once_with(CANON, "222.b")
+    client.conversations_replies.assert_called()
+
+
+def test_fanout_cancel_before_combined_watch_skips_it(mock_config):
+    """A cancel landing after the last post stops before the combined watch;
+    both markers survive for a later resume."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+
+    cancel = threading.Event()
+    commits: list[int] = []
+
+    def _commit(*a, **kw):
+        commits.append(1)
+        if len(commits) == 4:  # B's marker commit — the last phase-1 commit
+            cancel.set()
+
+    client = MagicMock()
+    client.chat_postMessage.side_effect = [(CANON, "111.a"), (CANON, "222.b")]
+    sys = MagicMock()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch(
+                "mtui.commands.request_review.svn_commit_testreport",
+                side_effect=_commit,
+            ),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt).run()
+    finally:
+        current_cancel_event.reset(token)
+
+    report_a.set_slack_review.assert_called_once_with(CANON, "111.a")
+    report_b.set_slack_review.assert_called_once_with(CANON, "222.b")
+    client.conversations_replies.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "not watching the posted review requests" in _printed(sys)
+
+
+def test_fanout_cancel_mid_combined_watch_reports_pending(mock_config):
+    """A cancel during the combined watch stops the round-robin promptly and
+    names the still-pending requests (their markers stay resumable)."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+
+    cancel = threading.Event()
+    client = MagicMock()
+    client.chat_postMessage.side_effect = [(CANON, "111.a"), (CANON, "222.b")]
+
+    def _replies(channel, ts):
+        # job_cancel lands while template A's poll is in flight.
+        cancel.set()
+        return [{"text": "parent"}]
+
+    client.conversations_replies.side_effect = _replies
+    client.reactions_get.return_value = []
+    client._acking_reviewer.return_value = None
+    sys = MagicMock()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport"),
+            patch("mtui.commands.request_review.svn_update_testreport"),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt).run()
+    finally:
+        current_cancel_event.reset(token)
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "Watch cancelled with review requests still pending" in printed
+    assert "SUSE:Maintenance:1:1" in printed
+    assert "SUSE:Maintenance:2:2" in printed
+
+
+def test_fanout_unreachable_template_reported_after_max_failures(mock_config):
+    """Consecutive poll failures mark ONE pending request unreachable, with
+    the same degradation as the single-template wait_for_ack."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+    # Enough deadline for three poll rounds; no sleeping between them.
+    mock_config.slack_watch_timeout = 30
+    mock_config.slack_poll_interval = 0
+
+    client = MagicMock()
+    client.chat_postMessage.side_effect = [(CANON, "111.a"), (CANON, "222.b")]
+    client.conversations_replies.side_effect = FailedSlackCallError("boom")
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt).run()
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "Review watch for SUSE:Maintenance:1:1 failed (Slack unreachable)" in printed
+    assert "Review watch for SUSE:Maintenance:2:2 failed (Slack unreachable)" in printed
+
+
+def test_fanout_keyboardinterrupt_in_phase1_reports_unposted(mock_config):
+    """Ctrl-C during phase 1 reports the templates that never got posted, so
+    nothing is dropped silently."""
+    prompt = _prompt()
+    report_a = _report("SUSE:Maintenance:1:1", "http://qam/1/log")
+    report_b = _report("SUSE:Maintenance:2:2", "http://qam/2/log")
+    prompt.templates.all.return_value = [report_a, report_b]
+
+    commits: list[int] = []
+
+    def _commit(*a, **kw):
+        commits.append(1)
+        if len(commits) == 3:  # B's pre-commit: interrupt before its post
+            raise KeyboardInterrupt
+
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "111.a")
+    sys = MagicMock()
+
+    with (
+        patch(
+            "mtui.commands.request_review.svn_commit_testreport",
+            side_effect=_commit,
+        ),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        # Must not raise: run() converts the interrupt into a status report.
+        RequestReview(_args(), mock_config, sys, prompt).run()
+
+    report_a.set_slack_review.assert_called_once_with(CANON, "111.a")
+    report_b.set_slack_review.assert_not_called()
+    printed = _printed(sys)
+    assert "SUSE:Maintenance:1:1: posted, awaiting ack" in printed
+    assert "SUSE:Maintenance:2:2: interrupted before its request was posted" in printed
+
+
+# ---------------------------------------------------------------------------
+# failure paths: Slack post fails, marker commit fails, Slack unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_slack_post_failure_aborts(mock_config):
+    """A failed Slack post reports the error and neither persists nor watches."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.side_effect = FailedSlackCallError("channel_not_found")
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    prompt.metadata.set_slack_review.assert_not_called()
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "Failed to post Slack review request" in printed
+
+
+def test_request_review_marker_commit_failure_aborts_before_watch(mock_config):
+    """A failed marker commit ABORTS before the watch: a marker that exists
+    nowhere but this checkout must never feed an auto-approve. The Slack post
+    stays live; a re-run's pre-commit re-commits the local marker and resumes."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000700")
+    sys = MagicMock()
+
+    with (
+        patch(
+            "mtui.commands.request_review.svn_commit_testreport",
+            side_effect=[None, subprocess.CalledProcessError(1, "svn")],
+        ),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    # The marker was persisted locally, but the flow stopped before the watch.
+    prompt.metadata.set_slack_review.assert_called_once_with(CANON, "1700000000.000700")
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "could not commit its marker" in printed
+    assert "re-run request_review" in printed
+
+
+def test_request_review_unreachable_slack_reported(mock_config):
+    """An unreachable-Slack outcome is reported distinctly and skips approve."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000800")
+    client.wait_for_ack.return_value = _outcome(
+        acked=False, reviewer=None, unreachable=True
+    )
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "Slack unreachable" in printed
+
+
+def test_request_review_missing_anchor_aborts_before_posting(mock_config):
+    """A template that cannot record the marker refuses before posting."""
+    prompt = _prompt()
+    prompt.metadata.has_slack_review_anchor.return_value = False
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient") as slack_cls,
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    # Nothing was posted: no client, no marker, no watch, no approve.
+    slack_cls.assert_not_called()
+    prompt.metadata.set_slack_review.assert_not_called()
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "no 'Test Plan Reviewer:' line" in printed
+
+
+def test_request_review_marker_write_failure_reports_and_stops(mock_config):
+    """A marker write failing post-post is reported; the watch is skipped."""
+    prompt = _prompt()
+    prompt.metadata.set_slack_review.side_effect = TemplateFormatError("no anchor")
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000900")
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    # Watching would be pointless: the approve gate can never see the review.
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "could not record the marker" in printed
+    # A plain re-run would RESUME the stale previous marker; the remedy must
+    # name --repost and the orphaned ts, and be executable in a multi-template
+    # session (where unscoped --repost is refused).
+    assert "--repost" in printed
+    assert "1700000000.000900" in printed
+    assert "-T SUSE:Maintenance:1:1" in printed
+    # The unrecorded message would otherwise collect acks nobody watches: it
+    # gets a best-effort "void" reply threaded under it, while the ts is hot.
+    post, void = client.chat_postMessage.call_args_list
+    assert void.kwargs["thread_ts"] == "1700000000.000900"
+    assert "void" in void.args[1]
+
+
+def test_request_review_interrupt_between_post_and_persist_breadcrumbs(
+    mock_config, caplog
+):
+    """Ctrl-C between the post and the marker write logs a recovery
+    breadcrumb (channel/ts) for the live, unrecorded request — then the
+    interrupt still propagates."""
+    prompt = _prompt()
+    prompt.metadata.set_slack_review.side_effect = KeyboardInterrupt
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.000950")
+
+    caplog.set_level(logging.ERROR, logger="mtui.command.request_review")
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    assert "unrecorded Slack review request" in caplog.text
+    assert CANON in caplog.text
+    assert "1700000000.000950" in caplog.text
+
+
+def test_request_review_forwards_mcp_cancel_event(mock_config):
+    """The MCP session's per-call cancel event reaches wait_for_ack."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.001000")
+    client.wait_for_ack.return_value = _outcome(
+        acked=False, reviewer=None, timed_out=True
+    )
+
+    cancel = threading.Event()
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport"),
+            patch("mtui.commands.request_review.svn_update_testreport"),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve"),
+        ):
+            RequestReview(_args(), mock_config, MagicMock(), prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    assert client.wait_for_ack.call_args.kwargs["cancel_event"] is cancel
+
+
+def test_request_review_complete_offers_flags_and_templates(mock_config):
+    """Completion offers the command's flags plus the loaded template RRIDs."""
+    templates = MagicMock()
+    templates.rrids.return_value = ["SUSE:Maintenance:1:1"]
+
+    out = RequestReview.complete(
+        {"templates": templates}, "", "request_review ", 15, 15
+    )
+
+    assert "--no-watch" in out
+    assert "--no-approve" in out
+    assert "--repost" in out
+    assert "SUSE:Maintenance:1:1" in out
+
+
+# ---------------------------------------------------------------------------
+# cooperative cancellation: the cancel event is honoured BEFORE every
+# externally visible side effect, not just around the watch
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_cancelled_before_start_does_nothing(mock_config):
+    """A job cancelled before the command body runs makes NO side effect:
+    no svn commit, no Slack client, no post, no marker."""
+    prompt = _prompt()
+    sys = MagicMock()
+    cancel = threading.Event()
+    cancel.set()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport") as commit,
+            patch("mtui.commands.request_review.SlackClient") as slack_cls,
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    commit.assert_not_called()
+    slack_cls.assert_not_called()
+    prompt.metadata.set_slack_review.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "cancelled" in _printed(sys)
+
+
+def test_request_review_cancelled_after_precommit_skips_post(mock_config):
+    """A cancel landing during the pre-commit stops before the Slack post."""
+    prompt = _prompt()
+    sys = MagicMock()
+    cancel = threading.Event()
+
+    def _commit(*a, **kw):
+        cancel.set()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch(
+                "mtui.commands.request_review.svn_commit_testreport",
+                side_effect=_commit,
+            ),
+            patch("mtui.commands.request_review.SlackClient") as slack_cls,
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    slack_cls.assert_not_called()
+    prompt.metadata.set_slack_review.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "not posting" in _printed(sys)
+
+
+def test_request_review_cancelled_between_post_and_persist_voids(mock_config):
+    """A cancel landing during the post voids the just-posted message (best
+    effort) instead of recording a marker for a cancelled job."""
+    prompt = _prompt()
+    sys = MagicMock()
+    cancel = threading.Event()
+    client = MagicMock()
+
+    def _post(channel, text, thread_ts=None):
+        if thread_ts is None:
+            cancel.set()
+            return (CANON, "555.5")
+        return (CANON, "555.6")
+
+    client.chat_postMessage.side_effect = _post
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport"),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    prompt.metadata.set_slack_review.assert_not_called()
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    # The live message got a best-effort "void" reply threaded under it.
+    post, void = client.chat_postMessage.call_args_list
+    assert void.kwargs["thread_ts"] == "555.5"
+    assert "void" in void.args[1]
+    assert "voided" in _printed(sys)
+
+
+def test_request_review_cancelled_before_marker_commit_stops(mock_config):
+    """A cancel landing during the marker write stops before the svn commit
+    of the marker; the local marker makes a re-run resume + commit it."""
+    prompt = _prompt()
+    sys = MagicMock()
+    cancel = threading.Event()
+    state = {"marker": None}
+
+    def _set(c, t):
+        state["marker"] = (c, t)
+        cancel.set()
+
+    prompt.metadata.set_slack_review.side_effect = _set
+    prompt.metadata.get_slack_review.side_effect = lambda: state["marker"]
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "666.6")
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport") as commit,
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    # Only the pre-commit ran; the marker commit was refused post-cancel.
+    assert commit.call_count == 1
+    assert state["marker"] == (CANON, "666.6")
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "not committed" in _printed(sys)
+
+
+def test_request_review_cancelled_before_watch_never_watches(mock_config):
+    """A cancel landing during the marker commit stops before the watch."""
+    prompt = _prompt()
+    sys = MagicMock()
+    cancel = threading.Event()
+    commits: list[int] = []
+
+    def _commit(*a, **kw):
+        commits.append(1)
+        if len(commits) == 2:  # the marker commit, after the pre-commit
+            cancel.set()
+
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "777.1")
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch(
+                "mtui.commands.request_review.svn_commit_testreport",
+                side_effect=_commit,
+            ),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    client.wait_for_ack.assert_not_called()
+    appr_cls.assert_not_called()
+    assert "not watching" in _printed(sys)
+
+
+# ---------------------------------------------------------------------------
+# resume: a recorded marker is watched instead of re-posted
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_resumes_existing_marker(mock_config):
+    """A recorded marker resumes that thread: no post, no marker rewrite.
+
+    The watch runs on the MARKER's channel/ts (not the configured channel),
+    and an ack on the resumed thread still drives the auto-approve.
+    """
+    prompt = _prompt()
+    _wire_marker(prompt.metadata, initial=("C_OLD", "111.1"))
+    client = MagicMock()
+    client.wait_for_ack.return_value = _outcome(reviewer="carol")
+    appr = MagicMock(name="Approve")
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve", return_value=appr),
+    ):
+        RequestReview(_args(), mock_config, MagicMock(), prompt)()
+
+    client.chat_postMessage.assert_not_called()
+    prompt.metadata.set_slack_review.assert_not_called()
+    watched_channel, watched_ts = client.wait_for_ack.call_args.args[:2]
+    assert (watched_channel, watched_ts) == ("C_OLD", "111.1")
+    assert appr.called
+
+
+def test_request_review_resume_no_watch_wording(mock_config):
+    """Resume + --no-watch reports the existing request without 'Posted'."""
+    prompt = _prompt()
+    _wire_marker(prompt.metadata, initial=("C_OLD", "111.1"))
+    client = MagicMock()
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        RequestReview(_args(no_watch=True), mock_config, sys, prompt)()
+
+    client.chat_postMessage.assert_not_called()
+    client.wait_for_ack.assert_not_called()
+    printed = _printed(sys)
+    assert "already posted (C_OLD/111.1)" in printed
+    assert "SUSE:Maintenance:1:1" in printed
+    assert "Posted review request" not in printed
+
+
+def test_request_review_repost_replaces_marker_and_breadcrumbs(mock_config):
+    """--repost posts fresh, replaces the marker, and marks the old thread."""
+    prompt = _prompt()
+    state = _wire_marker(prompt.metadata, initial=("C_OLD", "111.1"))
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "222.2")
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve"),
+    ):
+        RequestReview(_args(repost=True, no_watch=True), mock_config, sys, prompt)()
+
+    # First post is the fresh request to the CONFIGURED channel; the second is
+    # the best-effort "superseded" breadcrumb threaded under the OLD message.
+    first, second = client.chat_postMessage.call_args_list
+    assert first.args[0] == mock_config.slack_channel
+    assert "Please review" in first.args[1]
+    assert second.args[0] == "C_OLD"
+    assert second.kwargs["thread_ts"] == "111.1"
+    assert "Superseded" in second.args[1]
+    # The marker now records the new request under its CANONICAL channel.
+    assert state["marker"] == (CANON, "222.2")
+    printed = _printed(sys)
+    assert "Superseded previous review request C_OLD/111.1" in printed
+
+
+def test_request_review_repost_multi_template_refused(mock_config):
+    """--repost over an unscoped multi-template fan-out is refused up front."""
+    prompt = _prompt()
+    prompt.templates.all.return_value = [MagicMock(), MagicMock()]
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport") as commit,
+        patch("mtui.commands.request_review.SlackClient") as slack_cls,
+    ):
+        # The guard lives in run() so it fires once, before the fan-out.
+        RequestReview(_args(repost=True), mock_config, sys, prompt).run()
+
+    commit.assert_not_called()
+    slack_cls.assert_not_called()
+    printed = _printed(sys)
+    # Printed exactly once, not once per template.
+    assert printed.count("scope it with -T") == 1
+
+
+def test_request_review_resume_slack_client_unavailable(mock_config):
+    """A Slack setup failure on the resume path is reported, not raised."""
+    prompt = _prompt()
+    _wire_marker(prompt.metadata, initial=("C_OLD", "111.1"))
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch(
+            "mtui.commands.request_review.SlackClient",
+            side_effect=FailedSlackCallError("no token"),
+        ),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    appr_cls.assert_not_called()
+    assert "Slack client unavailable" in _printed(sys)
+
+
+def test_request_review_resume_unreachable_hints_repost(mock_config):
+    """An unreachable outcome on a RESUMED watch points at --repost."""
+    prompt = _prompt()
+    _wire_marker(prompt.metadata, initial=("C_OLD", "111.1"))
+    client = MagicMock()
+    client.wait_for_ack.return_value = _outcome(
+        acked=False, reviewer=None, unreachable=True
+    )
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "re-run with --repost" in printed
+    assert "C_OLD/111.1" in printed
+
+
+# ---------------------------------------------------------------------------
+# pre-approve guards: cancelled watch / superseded marker never approve
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_cancelled_watch_never_approves(mock_config):
+    """An ack observed by an already-cancelled watch is not acted on."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.001100")
+
+    cancel = threading.Event()
+
+    def _ack_after_cancel(*a, **kw):
+        # The 👍 lands in the final in-flight poll after job_cancel already
+        # flagged the event — the race the guard exists for.
+        cancel.set()
+        return _outcome(reviewer="late")
+
+    client.wait_for_ack.side_effect = _ack_after_cancel
+    sys = MagicMock()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport"),
+            patch("mtui.commands.request_review.svn_update_testreport"),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "cancelled" in printed
+
+
+def test_request_review_cancel_during_preapprove_tail_refuses(mock_config):
+    """TOCTOU regression: a cancel landing DURING the post-ack tail (svn
+    refresh / marker re-read) must still refuse the approve — the event is
+    re-checked immediately before the Approve handoff."""
+    prompt = _prompt()
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "1700000000.001150")
+    client.wait_for_ack.return_value = _outcome(reviewer="eve")
+    sys = MagicMock()
+    cancel = threading.Event()
+
+    def _svn_up(wd):
+        # job_cancel returns while the multi-second tail runs unguarded —
+        # the window the late re-check closes.
+        cancel.set()
+
+    token = current_cancel_event.set(cancel)
+    try:
+        with (
+            patch("mtui.commands.request_review.svn_commit_testreport"),
+            patch(
+                "mtui.commands.request_review.svn_update_testreport",
+                side_effect=_svn_up,
+            ),
+            patch("mtui.commands.request_review.SlackClient", return_value=client),
+            patch("mtui.commands.request_review.Approve") as appr_cls,
+        ):
+            RequestReview(_args(), mock_config, sys, prompt)()
+    finally:
+        current_cancel_event.reset(token)
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "not approving" in printed
+
+
+def test_request_review_superseded_marker_never_approves(mock_config):
+    """An ack on a thread the report no longer records is not acted on."""
+    prompt = _prompt()
+    state = _wire_marker(prompt.metadata)
+    client = MagicMock()
+    client.chat_postMessage.return_value = (CANON, "333.3")
+
+    def _ack_after_supersede(*a, **kw):
+        # A colleague reposted while we watched: the on-disk marker moved on.
+        state["marker"] = ("C_NEW", "999.9")
+        return _outcome(reviewer="late")
+
+    client.wait_for_ack.side_effect = _ack_after_supersede
+    sys = MagicMock()
+
+    with (
+        patch("mtui.commands.request_review.svn_commit_testreport"),
+        patch("mtui.commands.request_review.svn_update_testreport"),
+        patch("mtui.commands.request_review.SlackClient", return_value=client),
+        patch("mtui.commands.request_review.Approve") as appr_cls,
+    ):
+        RequestReview(_args(), mock_config, sys, prompt)()
+
+    appr_cls.assert_not_called()
+    printed = _printed(sys)
+    assert "superseded" in printed

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -57,6 +57,7 @@ EXPECTED: frozenset[tuple[str, str, str]] = frozenset(
         ("quit", "mtui.commands.quit", "Quit"),
         ("reboot", "mtui.commands.reboot", "Reboot"),
         ("reject", "mtui.commands.apicall", "Reject"),
+        ("request_review", "mtui.commands.request_review", "RequestReview"),
         ("reload_openqa", "mtui.commands.reloadoqa", "ReloadOpenQA"),
         ("regenerate", "mtui.commands.regenerate", "Regenerate"),
         ("reload_products", "mtui.commands.reload", "ReloadProducts"),

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -263,10 +263,13 @@ def test_cancel_one_template_job_leaves_others(tmp_path: Path) -> None:
         # Wait until the first job's blocking body is actually running.
         while not blocking_started.is_set():
             await asyncio.sleep(0.01)
-        # Cancel the first (blocking) job; release so its thread unwinds.
-        await sess.job_cancel(first)
+        # Cancel the first (blocking) job with a short grace: its body does
+        # not poll the cancel event, so the grace expires and the job reports
+        # 'cancelling'; release so its thread unwinds to the terminal state.
+        await sess.job_cancel(first, grace=0.1)
         release.set()
-        # The second job, queued behind the session lock, still completes.
+        await sess._jobs[first]["task"]
+        # The second job (its own template lock) still completes.
         await sess._jobs[second]["task"]
         return first, second
 
@@ -278,3 +281,416 @@ def test_cancel_one_template_job_leaves_others(tmp_path: Path) -> None:
     assert sess.job_status(first)["state"] == "cancelled"
     assert sess.job_status(second)["state"] == "done"
     assert sess.job_result(second).strip() == ""
+
+
+def test_start_jobs_refuses_unscoped_repost_fanout(tmp_path: Path) -> None:
+    """``request_review --repost`` must not fan out one ``-T`` job per template.
+
+    Each minted job resolves to exactly one template and would pass the
+    command's own multi-template refusal, reposting (and orphaning) every
+    template's live review thread — so the fan-out itself must refuse.
+    """
+    import contextlib
+
+    from mtui.commands.request_review import RequestReview
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+
+    async def refused() -> None:
+        with pytest.raises(McpCommandError, match="scope it with template"):
+            await sess.start_jobs(RequestReview, ["--repost"])
+
+    async def scoped() -> list[str]:
+        ids = await sess.start_jobs(
+            RequestReview, ["--repost", "-T", "SUSE:Maintenance:2:1"]
+        )
+        # Exactly one job was minted; cancel it before its runner gets a loop
+        # slice so the real request_review body never executes in the test.
+        task = sess._jobs[ids[0]]["task"]
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        return ids
+
+    asyncio.run(refused())
+    # An explicitly scoped repost still passes the guard: exactly one job.
+    ids = asyncio.run(scoped())
+    assert len(ids) == 1
+
+
+def test_start_jobs_repost_token_in_other_command_fans_out(tmp_path: Path) -> None:
+    """The ``--repost`` fan-out guard is ``request_review``-specific.
+
+    Any other backgrounded command whose argv happens to carry the literal
+    token (e.g. a ``run`` remote command line) must still fan out normally.
+    """
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+
+    class _RepostTokenProbe(Command):
+        command = "repost_token_probe_tmp"
+        scope: ClassVar[str] = "fanout"
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            parser.add_argument("--repost", action="store_true")
+            cls._add_template_arg(parser)
+
+        def __call__(self) -> None:
+            pass
+
+    async def driver() -> list[str]:
+        ids = await sess.start_jobs(_RepostTokenProbe, ["--repost"])
+        for jid in ids:
+            await sess._jobs[jid]["task"]
+        return ids
+
+    try:
+        ids = asyncio.run(driver())
+    finally:
+        Command.registry.pop(_RepostTokenProbe.command, None)
+
+    assert len(ids) == 2
+    assert all(sess.job_status(jid)["state"] == "done" for jid in ids)
+
+
+def test_job_cancel_sets_cooperative_cancel_event(tmp_path: Path) -> None:
+    """``job_cancel`` flags the contextvar cancel event so a polling body exits.
+
+    ``request_review``'s Slack watch passes this event into ``wait_for_ack``;
+    without it a cancelled job's worker thread would keep watching (and could
+    still auto-approve) until its own multi-hour timeout.
+    """
+    import threading
+
+    from mtui.support.cancellation import current_cancel_event
+
+    sess = _make_session(tmp_path)
+
+    entered = threading.Event()
+    finished = threading.Event()
+    observed: dict[str, bool] = {}
+
+    class _CancelProbe(Command):
+        command = "cancel_probe_tmp"
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            pass
+
+        def __call__(self) -> None:
+            ev = current_cancel_event.get()
+            entered.set()
+            # Block like a review watch would, until job_cancel sets the event
+            # (bounded so a broken implementation fails the test, not hangs it).
+            observed["event_set"] = ev is not None and ev.wait(timeout=5)
+            finished.set()
+
+    async def driver() -> str:
+        job_id = await sess.start_job(_CancelProbe, [])
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        await sess.job_cancel(job_id)
+        return job_id
+
+    try:
+        job_id = asyncio.run(driver())
+    finally:
+        Command.registry.pop(_CancelProbe.command, None)
+
+    # The worker thread observed the cancellation promptly (not a timeout).
+    assert finished.wait(timeout=5)
+    assert observed["event_set"] is True
+    assert sess.job_status(job_id)["state"] == "cancelled"
+
+
+# --------------------------------------------------------------------------- #
+# Truthful cancellation (cooperative-first job_cancel)                         #
+# --------------------------------------------------------------------------- #
+
+
+def _slow_step_probe(name: str):
+    """Build a probe whose body blocks inside a simulated side-effecting step.
+
+    Returns ``(cls, entered, release, body_exited)``: the body sets
+    ``entered`` on start, blocks on ``release`` (it deliberately does NOT
+    poll the cancel event, like a body mid-HTTP/svn step), and sets
+    ``body_exited`` on the way out. Caller must unregister ``cls``.
+    """
+    import threading
+
+    entered = threading.Event()
+    release = threading.Event()
+    body_exited = threading.Event()
+
+    class _SlowStepProbe(Command):
+        command = name
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            pass
+
+        def __call__(self) -> None:
+            entered.set()
+            release.wait(timeout=5)
+            body_exited.set()
+
+    return _SlowStepProbe, entered, release, body_exited
+
+
+def test_job_cancel_waits_for_body_to_stop(tmp_path: Path) -> None:
+    """``job_cancel`` reports 'cancelled' only once the worker thread exited.
+
+    While the body is inside a side-effecting step the cancel call must not
+    return (the job shows 'cancelling'); only after the thread unwinds does
+    it report the job cancelled.
+    """
+    sess = _make_session(tmp_path)
+    cls, entered, release, body_exited = _slow_step_probe("slow_step_probe_tmp")
+
+    async def driver() -> tuple[str, str, bool]:
+        job_id = await sess.start_job(cls, [])
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        cancel_task = asyncio.create_task(sess.job_cancel(job_id, grace=5))
+        await asyncio.sleep(0.1)
+        # Body mid-step: no 'cancelled' report yet, state is honest.
+        assert not cancel_task.done()
+        assert sess.job_status(job_id)["state"] == "cancelling"
+        release.set()
+        msg = await cancel_task
+        return job_id, msg, body_exited.is_set()
+
+    try:
+        job_id, msg, exited_before_report = asyncio.run(driver())
+    finally:
+        Command.registry.pop(cls.command, None)
+
+    # The body had fully exited before job_cancel reported 'cancelled'.
+    assert exited_before_report is True
+    assert msg == f"cancelled job {job_id}"
+    assert sess.job_status(job_id)["state"] == "cancelled"
+
+
+def test_job_cancel_grace_expiry_reports_cancelling(tmp_path: Path) -> None:
+    """An expired grace reports 'cancelling', never a false 'cancelled'."""
+    sess = _make_session(tmp_path)
+    cls, entered, release, _exited = _slow_step_probe("grace_expiry_probe_tmp")
+
+    async def driver() -> str:
+        job_id = await sess.start_job(cls, [])
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        msg = await sess.job_cancel(job_id, grace=0.05)
+        # The body is still running: the report must not claim it stopped.
+        assert "cancelled job" not in msg
+        assert "cancelling" in msg
+        assert sess.job_status(job_id)["state"] == "cancelling"
+        with pytest.raises(McpCommandError, match="still cancelling"):
+            sess.job_result(job_id)
+        release.set()
+        await sess._jobs[job_id]["task"]
+        return job_id
+
+    try:
+        job_id = asyncio.run(driver())
+    finally:
+        Command.registry.pop(cls.command, None)
+
+    # Once the thread actually exited the state flips to the terminal one.
+    assert sess.job_status(job_id)["state"] == "cancelled"
+
+
+def test_job_cancel_report_stays_truthful_when_body_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A body that dies (not cancels) during the grace wait is not miscalled.
+
+    The runner's defensive branch records ``failed`` when a
+    non-``McpCommandError`` escapes ``_run_sync``; a ``job_cancel`` whose
+    grace wait sees that terminal state must report the stop without
+    claiming the job was cancelled.
+    """
+    import threading
+
+    sess = _make_session(tmp_path)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _boom(cmd_cls: type[Command], argv: list[str]) -> str:
+        entered.set()
+        release.wait(timeout=5)
+        raise ValueError("kaboom")
+
+    monkeypatch.setattr(sess, "_run_sync", _boom)
+
+    async def driver() -> tuple[str, str]:
+        job_id = await sess.start_job(Whoami, [])
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        cancel_task = asyncio.create_task(sess.job_cancel(job_id, grace=5))
+        await asyncio.sleep(0.05)
+        release.set()
+        msg = await cancel_task
+        return job_id, msg
+
+    job_id, msg = asyncio.run(driver())
+    # The body has stopped (no-further-mutations holds), but it failed
+    # rather than cancelled — the report must not claim otherwise.
+    assert "cancelled job" not in msg
+    assert "state=failed" in msg
+    assert sess.job_status(job_id)["state"] == "failed"
+
+
+def test_same_template_rerun_serialises_until_cancelled_thread_exits(
+    tmp_path: Path,
+) -> None:
+    """A re-run after a grace-expired cancel queues behind the old thread.
+
+    The cancelled job's runner keeps holding the template's per-RRID lock
+    until its worker thread really exits, so the documented cancel-then-rerun
+    flow serialises instead of interleaving (no stale-thread Slack/svn writes
+    racing the new run).
+    """
+    import threading
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+    rrid = "SUSE:Maintenance:1:1"
+
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release = threading.Event()
+    order: list[str] = []
+
+    class _RerunProbe(Command):
+        command = "rerun_probe_tmp"
+        scope: ClassVar[str] = "fanout"
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            cls._add_template_arg(parser)
+
+        def __call__(self) -> None:
+            # Bodies on one template serialise on its per-RRID lock, so the
+            # shared list is safe: first invocation blocks, second records.
+            if not order:
+                order.append("first")
+                first_entered.set()
+                release.wait(timeout=5)
+                order.append("first_exit")
+            else:
+                order.append("second")
+                second_entered.set()
+
+    async def driver() -> tuple[str, str]:
+        first = (await sess.start_jobs(_RerunProbe, ["-T", rrid]))[0]
+        while not first_entered.is_set():
+            await asyncio.sleep(0.01)
+        await sess.job_cancel(first, grace=0.05)
+        assert sess.job_status(first)["state"] == "cancelling"
+        # Re-run on the same template while the old thread is still alive.
+        second = (await sess.start_jobs(_RerunProbe, ["-T", rrid]))[0]
+        await asyncio.sleep(0.1)
+        # The new body must not have started: it is queued on the lock the
+        # cancelled-but-still-running job keeps holding.
+        assert not second_entered.is_set()
+        assert sess.job_status(second)["state"] == "running"
+        release.set()
+        await sess._jobs[first]["task"]
+        await sess._jobs[second]["task"]
+        return first, second
+
+    try:
+        first, second = asyncio.run(driver())
+    finally:
+        Command.registry.pop(_RerunProbe.command, None)
+
+    assert order == ["first", "first_exit", "second"]
+    assert sess.job_status(first)["state"] == "cancelled"
+    assert sess.job_status(second)["state"] == "done"
+
+
+def test_job_cancel_queued_job_never_starts_body(tmp_path: Path) -> None:
+    """Cancelling a job still queued on its template lock is immediate.
+
+    The body provably never ran (the pre-start guard refuses once the cancel
+    event is flagged), so the hard-cancel path may report 'cancelled' at once
+    — even after the lock frees, the cancelled job's body stays unrun.
+    """
+    import threading
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+    rrid = "SUSE:Maintenance:1:1"
+
+    entered = threading.Event()
+    release = threading.Event()
+    calls: list[str] = []
+
+    class _QueueProbe(Command):
+        command = "queue_probe_tmp"
+        scope: ClassVar[str] = "fanout"
+
+        @classmethod
+        def _add_arguments(cls, parser) -> None:
+            cls._add_template_arg(parser)
+
+        def __call__(self) -> None:
+            calls.append("body")
+            if len(calls) == 1:
+                entered.set()
+                release.wait(timeout=5)
+
+    async def driver() -> tuple[str, str, str]:
+        first = (await sess.start_jobs(_QueueProbe, ["-T", rrid]))[0]
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        second = (await sess.start_jobs(_QueueProbe, ["-T", rrid]))[0]
+        await asyncio.sleep(0.05)
+        # ``second`` is queued (its body never started): the cancel resolves
+        # immediately and truthfully, no grace involved.
+        msg = await sess.job_cancel(second)
+        release.set()
+        await sess._jobs[first]["task"]
+        return first, second, msg
+
+    try:
+        first, second, msg = asyncio.run(driver())
+    finally:
+        Command.registry.pop(_QueueProbe.command, None)
+
+    assert msg == f"cancelled job {second}"
+    assert sess.job_status(second)["state"] == "cancelled"
+    assert sess.job_status(first)["state"] == "done"
+    # The cancelled job's body never ran, even after the lock freed.
+    assert calls == ["body"]
+
+
+# --------------------------------------------------------------------------- #
+# Foreground multi-template watch guard                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_foreground_multi_template_watch_refused(tmp_path: Path) -> None:
+    """``run_command`` refuses a foreground watching multi-template review.
+
+    An unscoped watch-bearing ``request_review`` would hold the registry's
+    exclusive gate for the whole (multi-hour) watch, freezing every other
+    tool call in the MCP session; the caller is pointed at background=true /
+    template scoping / no_watch instead. Post-only, scoped and unrelated
+    commands pass the guard.
+    """
+    from mtui.commands.request_review import RequestReview
+
+    sess = _make_session(tmp_path)
+    _load_two_reports(sess)
+
+    with pytest.raises(McpCommandError, match="background=true"):
+        asyncio.run(sess.run_command(RequestReview, []))
+
+    # Narrow guard: none of these raise (post-only, scoped, other command).
+    sess._refuse_foreground_multi_watch(RequestReview, ["--no-watch"])
+    sess._refuse_foreground_multi_watch(RequestReview, ["-T", "SUSE:Maintenance:2:1"])
+    sess._refuse_foreground_multi_watch(Whoami, [])

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -350,6 +350,23 @@ def test_read_only_annotation_set_for_known_safe_tools(
 
 
 # --------------------------------------------------------------------------- #
+# Slack review-request command surface (request_review + --force hiding)      #
+# --------------------------------------------------------------------------- #
+
+
+def test_request_review_is_a_mutating_tool(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """``request_review`` is exposed over MCP and is not read-only.
+
+    It commits the testreport, posts to Slack, and can auto-approve, so
+    its ``readOnlyHint`` must be ``False``.
+    """
+    assert "request_review" in registered_names
+    assert _annotations_of(mcp, "request_review").readOnlyHint is False
+
+
+# --------------------------------------------------------------------------- #
 # kwargs \u2192 argv reserialisation round-trips                                #
 # --------------------------------------------------------------------------- #
 
@@ -739,6 +756,23 @@ def test_job_tools_schema_has_no_workspace_param(
         props = _params_of(mcp, name).get("properties", {})
         assert "workspace" not in props
         assert "job_id" in props
+
+
+def test_job_tool_descriptions_document_cancelling_state(
+    mcp: FastMCP, job_tool_names: list[str]
+) -> None:
+    """``job_status`` / ``job_cancel`` descriptions document 'cancelling'.
+
+    ``job_cancel`` waits a bounded grace and reports the job as
+    'cancelling' when the body is still finishing its current step;
+    ``job_status`` is the poll surface where the state later flips to
+    'cancelled' — both tool descriptions must tell the caller so.
+    """
+    for name in ("job_status", "job_cancel"):
+        tool = mcp._tool_manager.get_tool(name)  # noqa: SLF001
+        assert tool is not None, f"tool {name!r} not registered"
+        assert "cancelling" in tool.description
+        assert "cancelled" in tool.description
 
 
 def test_slow_command_schema_exposes_background_boolean(

--- a/tests/test_metadata_parsers.py
+++ b/tests/test_metadata_parsers.py
@@ -78,6 +78,8 @@ def test_reduced_metadata_parser_parse():
     results.hostnames = set()
     results.jira = {}
     results.bugs = {}
+    # Mirror TestReport.__init__: the first-wins guard checks this is unset.
+    results.slack_review = None
 
     # Test hostname parsing
     ReducedMetadataParser.parse(results, "some text (reference host: test_host)")
@@ -90,6 +92,47 @@ def test_reduced_metadata_parser_parse():
     # Test bug parsing
     ReducedMetadataParser.parse(results, 'Bug 123 ("Test bug"):')
     assert results.bugs["123"] == "Test bug"
+
+    # Test Slack review marker parsing (written by set_slack_review)
+    ReducedMetadataParser.parse(results, "Slack Review: C0123ABC/1700000000.000100")
+    assert results.slack_review == ("C0123ABC", "1700000000.000100")
+
+
+def test_reduced_metadata_parser_slack_review_needs_whole_line():
+    """Free text merely containing the phrase mid-line is not a marker.
+
+    The template's free-text comment field sits above the real marker's
+    anchor; a comment ending in "Slack Review: X/Y" must not be parsed as
+    (and thus shadow) the marker written by ``set_slack_review``.
+    """
+    results = MagicMock()
+    results.slack_review = None
+
+    ReducedMetadataParser.parse(results, "comment: blah Slack Review: CBAD/000.111")
+    assert results.slack_review is None
+
+    # The real, line-anchored marker afterwards is still picked up.
+    ReducedMetadataParser.parse(results, "Slack Review: CREAL/111.222")
+    assert results.slack_review == ("CREAL", "111.222")
+
+
+def test_reduced_metadata_parser_slack_review_first_wins():
+    """With duplicate marker lines the first one in file order wins."""
+    results = MagicMock()
+    results.slack_review = None
+
+    ReducedMetadataParser.parse(results, "Slack Review: CFIRST/111.222")
+    ReducedMetadataParser.parse(results, "Slack Review: CSECOND/333.444")
+    assert results.slack_review == ("CFIRST", "111.222")
+
+
+def test_reduced_metadata_parser_slack_review_tolerates_trailing_blanks():
+    """Trailing spaces/tabs on the marker line don't break parsing."""
+    results = MagicMock()
+    results.slack_review = None
+
+    ReducedMetadataParser.parse(results, "Slack Review: C1/111.222 \t")
+    assert results.slack_review == ("C1", "111.222")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,1105 @@
+"""Tests for the mtui Slack connector."""
+
+import threading
+from json import loads
+from unittest.mock import patch
+
+import pytest
+import requests
+import responses
+
+from mtui.data_sources.slack import ReviewOutcome, SlackClient, is_ack_reaction
+from mtui.support.exceptions import FailedSlackCallError, MissingSlackTokenError
+
+
+def _api(config, method: str) -> str:
+    """Full URL of a Slack API method against the mocked base."""
+    return f"{config.slack_base_url.rstrip('/')}/{method}"
+
+
+def _body(call) -> dict:
+    """Decode the JSON request body of a captured ``responses`` call."""
+    raw = call.request.body
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    return loads(raw)
+
+
+def _query(call) -> dict:
+    """Parsed query-string params of a captured ``responses`` call."""
+    from urllib.parse import parse_qs, urlparse
+
+    return {k: v[0] for k, v in parse_qs(urlparse(call.request.url).query).items()}
+
+
+# --- Construction ---
+
+
+class TestSlackClientInit:
+    def test_missing_token_raises(self, mock_config):
+        """An empty token fails fast with MissingSlackTokenError."""
+        mock_config.slack_token = ""
+        with pytest.raises(MissingSlackTokenError):
+            SlackClient(mock_config)  # type: ignore[arg-type]
+
+    def test_init_sets_auth_header_and_base(self, mock_config):
+        """The bearer header and normalised base URL are set up."""
+        mock_config.slack_base_url = "https://slack.test/api/"
+        client = SlackClient(mock_config)  # type: ignore[arg-type]
+        assert client.headers["Authorization"] == f"Bearer {mock_config.slack_token}"
+        assert "application/json" in client.headers["Content-Type"]
+        # Trailing slash stripped so ``base/method`` joins cleanly.
+        assert client.base == "https://slack.test/api"
+
+
+# --- Ack-reaction matching ---
+
+
+class TestIsAckReaction:
+    @pytest.mark.parametrize(
+        "name", ["+1", "thumbsup", "+1::skin-tone-3", "thumbsup::skin-tone-6"]
+    )
+    def test_ack_names_match(self, name):
+        """Base and skin-toned 👍 names all count as an acknowledgement."""
+        assert is_ack_reaction(name) is True
+
+    @pytest.mark.parametrize("name", ["eyes", "-1", "-1::skin-tone-3", ""])
+    def test_non_ack_names_do_not_match(self, name):
+        """Other reactions (even skin-toned ones) never count."""
+        assert is_ack_reaction(name) is False
+
+
+# --- Individual API methods ---
+
+
+class TestSlackClientCalls:
+    @pytest.fixture
+    def client(self, mock_config):
+        return SlackClient(mock_config)  # type: ignore[arg-type]
+
+    @responses.activate
+    def test_chat_post_message_returns_channel_and_ts(self, client, mock_config):
+        """chat_postMessage returns (channel, ts) and posts the right channel/text."""
+        responses.add(
+            responses.POST,
+            _api(mock_config, "chat.postMessage"),
+            json={"ok": True, "channel": "C123", "ts": "1700000000.000100"},
+            status=200,
+        )
+
+        channel, ts = client.chat_postMessage("C123", "please review")
+
+        assert channel == "C123"
+        assert ts == "1700000000.000100"
+        body = _body(responses.calls[0])
+        assert body["channel"] == "C123"
+        assert body["text"] == "please review"
+        # No thread_ts for a top-level post.
+        assert "thread_ts" not in body
+
+    @responses.activate
+    def test_chat_post_message_returns_canonical_channel_id(self, client, mock_config):
+        """Posting by channel name yields the canonical id from the response.
+
+        conversations.replies/reactions.get accept only channel ids, so the
+        id Slack resolved the name to is the one callers must persist -- not
+        the configured name that was posted with.
+        """
+        responses.add(
+            responses.POST,
+            _api(mock_config, "chat.postMessage"),
+            json={"ok": True, "channel": "C999", "ts": "1700000000.000300"},
+            status=200,
+        )
+
+        channel, ts = client.chat_postMessage("#reviews", "please review")
+
+        assert channel == "C999"
+        assert ts == "1700000000.000300"
+        # The request itself still carried the name Slack was asked to resolve.
+        assert _body(responses.calls[0])["channel"] == "#reviews"
+
+    @responses.activate
+    def test_chat_post_message_threads_reply(self, client, mock_config):
+        """A thread_ts is forwarded when replying in a thread."""
+        responses.add(
+            responses.POST,
+            _api(mock_config, "chat.postMessage"),
+            json={"ok": True, "channel": "C123", "ts": "1700000000.000200"},
+            status=200,
+        )
+
+        client.chat_postMessage("C123", "in thread", thread_ts="1700000000.000100")
+
+        assert _body(responses.calls[0])["thread_ts"] == "1700000000.000100"
+
+    @responses.activate
+    def test_ok_false_raises_failed_call(self, client, mock_config):
+        """An HTTP 200 with ok:false is a failure carrying the Slack error."""
+        responses.add(
+            responses.POST,
+            _api(mock_config, "chat.postMessage"),
+            json={"ok": False, "error": "channel_not_found"},
+            status=200,
+        )
+
+        with pytest.raises(FailedSlackCallError, match="channel_not_found"):
+            client.chat_postMessage("C123", "hi")
+
+    @responses.activate
+    def test_non_2xx_raises_failed_call(self, client, mock_config):
+        """A non-2xx HTTP status is a failure too."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"error": "server_error"},
+            status=500,
+        )
+
+        with pytest.raises(FailedSlackCallError):
+            client.bot_user_id()
+
+    @responses.activate
+    def test_rate_limit_is_retried(self, client, mock_config):
+        """A 429 with Retry-After is honoured with one wait-and-retry."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"error": "ratelimited"},
+            status=429,
+            headers={"Retry-After": "0"},
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"ok": True, "user_id": "UBOT"},
+            status=200,
+        )
+
+        assert client.bot_user_id() == "UBOT"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_rate_limit_gives_up_after_one_retry(self, client, mock_config):
+        """A second consecutive 429 is bounded: it raises instead of looping."""
+        for _ in range(2):
+            responses.add(
+                responses.GET,
+                _api(mock_config, "auth.test"),
+                json={"error": "ratelimited"},
+                status=429,
+                headers={"Retry-After": "0"},
+            )
+
+        with pytest.raises(FailedSlackCallError):
+            client.bot_user_id()
+        assert len(responses.calls) == 2  # original + one retry, then give up
+
+    @responses.activate
+    def test_rate_limit_non_numeric_retry_after(self, client, mock_config):
+        """A non-delta-seconds Retry-After (HTTP-date) falls back, not raises."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"error": "ratelimited"},
+            status=429,
+            headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"},
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"ok": True, "user_id": "UBOT"},
+            status=200,
+        )
+
+        with patch("mtui.data_sources.slack.time.sleep"):
+            assert client.bot_user_id() == "UBOT"
+
+    @responses.activate
+    def test_rate_limit_retry_after_is_capped_and_sliced(self, client, mock_config):
+        """A huge server-sent Retry-After is capped at 60s and slept in ~1s slices."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"error": "ratelimited"},
+            status=429,
+            headers={"Retry-After": "3600"},
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"ok": True, "user_id": "UBOT"},
+            status=200,
+        )
+
+        with patch("mtui.data_sources.slack.time.sleep") as sleep:
+            assert client.bot_user_id() == "UBOT"
+
+        slices = [call.args[0] for call in sleep.call_args_list]
+        assert sum(slices) == 60  # capped, not the server's 3600
+        assert max(slices) <= 1.0  # sliced so the cancel check can interject
+
+    @responses.activate
+    def test_conversations_replies_returns_messages(self, client, mock_config):
+        """conversations_replies returns the thread messages (parent first)."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [
+                    {"text": "the request"},
+                    {"text": "a reply"},
+                ],
+            },
+            status=200,
+        )
+
+        messages = client.conversations_replies("C123", "111.222")
+
+        assert [m["text"] for m in messages] == ["the request", "a reply"]
+        params = _query(responses.calls[0])
+        assert params["channel"] == "C123"
+        assert params["ts"] == "111.222"
+
+    @responses.activate
+    def test_conversations_replies_follows_pagination(self, client, mock_config):
+        """A multi-page thread is followed via next_cursor until exhausted."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [
+                    {"ts": "111.222", "text": "the request"},
+                    {"ts": "111.333", "text": "first reply"},
+                ],
+                "has_more": True,
+                "response_metadata": {"next_cursor": "cur1"},
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [{"ts": "111.444", "text": "second reply"}],
+                "has_more": False,
+            },
+            status=200,
+        )
+
+        messages = client.conversations_replies("C123", "111.222")
+
+        assert [m["text"] for m in messages] == [
+            "the request",
+            "first reply",
+            "second reply",
+        ]
+        # The first call carries no cursor; the second passes the returned one.
+        assert "cursor" not in _query(responses.calls[0])
+        assert _query(responses.calls[1])["cursor"] == "cur1"
+
+    @responses.activate
+    def test_conversations_replies_stops_on_empty_cursor(self, client, mock_config):
+        """has_more without a usable next_cursor stops instead of re-fetching."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [{"ts": "111.222", "text": "the request"}],
+                "has_more": True,
+                "response_metadata": {"next_cursor": ""},
+            },
+            status=200,
+        )
+
+        messages = client.conversations_replies("C123", "111.222")
+
+        assert len(messages) == 1
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_conversations_replies_pagination_is_bounded(self, client, mock_config):
+        """A never-ending cursor stops at the page cap instead of looping."""
+        # responses replays the last mock forever: every page claims more.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [{"ts": "1", "text": "x"}],
+                "has_more": True,
+                "response_metadata": {"next_cursor": "again"},
+            },
+            status=200,
+        )
+
+        messages = client.conversations_replies("C123", "111.222")
+
+        # Bounded at the 10-page cap (one message per mocked page).
+        assert len(responses.calls) == 10
+        assert len(messages) == 10
+
+    @responses.activate
+    def test_reactions_get_returns_reactions(self, client, mock_config):
+        """reactions_get returns the message's reaction list."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {
+                    "reactions": [{"name": "thumbsup", "users": ["U1"], "count": 1}]
+                },
+            },
+            status=200,
+        )
+
+        reactions = client.reactions_get("C123", "111.222")
+
+        assert reactions == [{"name": "thumbsup", "users": ["U1"], "count": 1}]
+        assert _query(responses.calls[0])["timestamp"] == "111.222"
+
+    @responses.activate
+    def test_reactions_get_empty_when_no_reactions(self, client, mock_config):
+        """reactions_get returns [] for a message with no reactions."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {}},
+            status=200,
+        )
+
+        assert client.reactions_get("C123", "111.222") == []
+
+    @responses.activate
+    def test_transport_error_raises_failed_call(self, client, mock_config):
+        """A transport-level failure surfaces as FailedSlackCallError."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            body=requests.exceptions.ConnectionError("boom"),
+        )
+
+        with pytest.raises(FailedSlackCallError):
+            client.bot_user_id()
+
+    @responses.activate
+    def test_ssl_verification_error_raises_failed_call(self, client, mock_config):
+        """A TLS verification failure is wrapped, not propagated raw."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            body=requests.exceptions.SSLError("CERTIFICATE_VERIFY_FAILED"),
+        )
+
+        with pytest.raises(FailedSlackCallError):
+            client.bot_user_id()
+
+    @responses.activate
+    def test_non_json_body_raises_failed_call(self, client, mock_config):
+        """An HTTP 200 with a non-JSON body (e.g. a proxy error page) fails."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            body="<html>gateway error</html>",
+            status=200,
+            content_type="text/html",
+        )
+
+        with pytest.raises(FailedSlackCallError):
+            client.bot_user_id()
+
+    @responses.activate
+    def test_users_info_prefers_display_name(self, client, mock_config):
+        """users_info returns the profile display name when present."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={
+                "ok": True,
+                "user": {
+                    "name": "handle",
+                    "profile": {"display_name": "Alice A", "real_name": "Alice Adams"},
+                },
+            },
+            status=200,
+        )
+
+        assert client.users_info("U1") == "Alice A"
+        assert _query(responses.calls[0])["user"] == "U1"
+
+    @responses.activate
+    def test_users_info_falls_back_to_real_name_then_name(self, client, mock_config):
+        """users_info falls back to real_name, then the bare handle."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={
+                "ok": True,
+                "user": {"name": "handle", "profile": {"real_name": "Real Name"}},
+            },
+            status=200,
+        )
+        assert client.users_info("U1") == "Real Name"
+
+        responses.replace(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"name": "handle", "profile": {}}},
+            status=200,
+        )
+        assert client.users_info("U1") == "handle"
+
+    @responses.activate
+    def test_bot_user_id_is_cached(self, client, mock_config):
+        """bot_user_id hits auth.test once and caches the result."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"ok": True, "user_id": "UBOT"},
+            status=200,
+        )
+
+        assert client.bot_user_id() == "UBOT"
+        assert client.bot_user_id() == "UBOT"
+        assert len(responses.calls) == 1
+
+
+# --- The blocking watch loop ---
+
+
+class TestWaitForAck:
+    @pytest.fixture
+    def client(self, mock_config):
+        return SlackClient(mock_config)  # type: ignore[arg-type]
+
+    def _add_auth_test(self, mock_config, user_id="UBOT"):
+        responses.add(
+            responses.GET,
+            _api(mock_config, "auth.test"),
+            json={"ok": True, "user_id": user_id},
+            status=200,
+        )
+
+    @responses.activate
+    def test_streams_replies_then_acks_with_reviewer(self, client, mock_config):
+        """An ordered no-reaction-then-👍 sequence acks and names the reviewer.
+
+        The first cycle sees a new reply (streamed to ``on_reply``) and no
+        reaction; the second cycle sees the 👍 and resolves the reviewer.
+        """
+        self._add_auth_test(mock_config)
+
+        # conversations.replies: cycle 1 has one new reply, cycle 2 unchanged.
+        for _ in range(2):
+            responses.add(
+                responses.GET,
+                _api(mock_config, "conversations.replies"),
+                json={
+                    "ok": True,
+                    "messages": [
+                        {"ts": "111.222", "text": "the request"},
+                        {"ts": "111.333", "text": "looking now"},
+                    ],
+                },
+                status=200,
+            )
+        # reactions.get: cycle 1 none, cycle 2 a thumbsup by a human.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {"reactions": []}},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {"reactions": [{"name": "+1", "users": ["U1"]}]},
+            },
+            status=200,
+        )
+        # users.info for the reviewer.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Reviewer R"}}},
+            status=200,
+        )
+
+        replies: list[str] = []
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=replies.append,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome == ReviewOutcome(
+            acked=True, reviewer="Reviewer R", timed_out=False, unreachable=False
+        )
+        # Only the new reply past the parent was streamed.
+        assert replies == ["looking now"]
+
+    @responses.activate
+    def test_bot_self_reaction_is_filtered(self, client, mock_config):
+        """A 👍 from the bot itself does not count; the human behind it does."""
+        self._add_auth_test(mock_config, user_id="UBOT")
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        # Bot's own id listed first, a human second -> the human is chosen.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {
+                    "reactions": [{"name": "thumbsup", "users": ["UBOT", "U2"]}]
+                },
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Human H"}}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is True
+        assert outcome.reviewer == "Human H"
+        # users.info was queried for the human, not the bot.
+        assert _query(responses.calls[-1])["user"] == "U2"
+
+    @responses.activate
+    def test_bot_only_reaction_does_not_ack(self, client, mock_config):
+        """When only the bot has reacted, no reviewer is found and we time out."""
+        self._add_auth_test(mock_config, user_id="UBOT")
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {"reactions": [{"name": "+1", "users": ["UBOT"]}]},
+            },
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: True,  # stop after the first cycle
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is False
+        assert outcome.reviewer is None
+        assert outcome.timed_out is True
+
+    @responses.activate
+    def test_should_stop_returns_not_acked(self, client, mock_config):
+        """A should_stop signal ends the wait with acked=False/timed_out=True."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {"reactions": []}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: True,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome == ReviewOutcome(
+            acked=False, reviewer=None, timed_out=True, unreachable=False
+        )
+
+    @responses.activate
+    def test_zero_timeout_returns_not_acked(self, client, mock_config):
+        """A non-positive timeout gives up after the first (non-acking) cycle."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {"reactions": []}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=0,
+        )
+
+        assert outcome.acked is False
+        assert outcome.timed_out is True
+
+    @responses.activate
+    def test_cancel_event_ends_wait(self, client, mock_config):
+        """A pre-set cancel_event ends the wait like should_stop."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {"reactions": []}},
+            status=200,
+        )
+
+        cancel = threading.Event()
+        cancel.set()
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+            cancel_event=cancel,
+        )
+
+        assert outcome.acked is False
+        assert outcome.timed_out is True
+
+    @responses.activate
+    def test_slack_failure_marks_unreachable(self, client, mock_config):
+        """Repeated consecutive poll failures end the wait as unreachable."""
+        self._add_auth_test(mock_config)
+        # responses replays the last registered mock, so every cycle fails.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": False, "error": "channel_not_found"},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is False
+        assert outcome.unreachable is True
+        # It took the full failure budget, not a single blip, to give up.
+        failed_polls = [
+            c
+            for c in responses.calls
+            if "conversations.replies" in (c.request.url or "")
+        ]
+        assert len(failed_polls) == 3
+
+    @responses.activate
+    def test_transient_poll_failure_is_retried(self, client, mock_config):
+        """One failed poll cycle is retried instead of aborting the watch."""
+        self._add_auth_test(mock_config)
+        # Cycle 1: replies fails (transient); cycle 2: ok with an ack present.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": False, "error": "ratelimited"},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {"reactions": [{"name": "+1", "users": ["U1"]}]},
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Reviewer R"}}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is True
+        assert outcome.reviewer == "Reviewer R"
+        assert outcome.unreachable is False
+
+    @responses.activate
+    def test_users_info_failure_still_acks_with_raw_id(self, client, mock_config):
+        """A users.info failure (missing users:read scope) must not lose the ack."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {"reactions": [{"name": "+1", "users": ["U1"]}]},
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": False, "error": "missing_scope"},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        # The ack survives; the reviewer falls back to the raw member id.
+        assert outcome.acked is True
+        assert outcome.reviewer == "U1"
+
+    @responses.activate
+    def test_non_ack_reactions_are_skipped(self, client, mock_config):
+        """Reactions outside the ack set don't ack; a later 👍 still does."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"ok": True, "messages": [{"text": "the request"}]},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {
+                    "reactions": [
+                        {"name": "eyes", "users": ["U9"]},
+                        {"name": "+1", "users": ["U1"]},
+                    ]
+                },
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Reviewer R"}}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is True
+        assert outcome.reviewer == "Reviewer R"
+
+    @responses.activate
+    def test_cancel_event_set_mid_sleep_breaks_promptly(self, client, mock_config):
+        """A cancel_event set during the inter-poll sleep ends the wait quickly.
+
+        The event is set from inside the sleep loop's ``should_stop`` probe, so
+        the stepped sleep must break out immediately instead of waiting out the
+        (deliberately long) interval; the next cycle's stop check then ends the
+        wait. The test would hang for ``interval`` seconds if the break path
+        were broken.
+        """
+        self._add_auth_test(mock_config)
+        # Two poll cycles: the first sees nothing, the event is set during the
+        # following sleep, the second cycle's stop check returns timed_out.
+        for _ in range(2):
+            responses.add(
+                responses.GET,
+                _api(mock_config, "conversations.replies"),
+                json={"ok": True, "messages": [{"text": "the request"}]},
+                status=200,
+            )
+            responses.add(
+                responses.GET,
+                _api(mock_config, "reactions.get"),
+                json={"ok": True, "message": {"reactions": []}},
+                status=200,
+            )
+
+        cancel = threading.Event()
+        probes = 0
+
+        def should_stop() -> bool:
+            nonlocal probes
+            probes += 1
+            if probes >= 2:  # the sleep loop's probe, after the stop check
+                cancel.set()
+            return False
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=should_stop,
+            interval=30,
+            timeout=60,
+            cancel_event=cancel,
+        )
+
+        assert outcome.acked is False
+        assert outcome.timed_out is True
+        assert outcome.unreachable is False
+
+    @responses.activate
+    def test_skin_toned_thumbsup_acks(self, client, mock_config):
+        """A 👍 with a skin-tone suffix ("+1::skin-tone-3") still acks."""
+        self._add_auth_test(mock_config)
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [{"ts": "111.222", "text": "the request"}],
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {
+                    "reactions": [{"name": "+1::skin-tone-3", "users": ["U1"]}]
+                },
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Reviewer R"}}},
+            status=200,
+        )
+
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=lambda _t: None,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is True
+        assert outcome.reviewer == "Reviewer R"
+
+    @responses.activate
+    def test_deleted_reply_does_not_swallow_next_reply(self, client, mock_config):
+        """Replies are tracked by ts, so a deletion can't hide the next one.
+
+        Cycle 1 sees two replies; before cycle 2 the first is deleted and a
+        third arrives, keeping the list length constant. Index-based tracking
+        would forward nothing on cycle 2 -- ts tracking forwards the new one
+        (and re-forwards nothing).
+        """
+        self._add_auth_test(mock_config)
+        # Cycle 1: the parent plus two replies.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [
+                    {"ts": "111.222", "text": "the request"},
+                    {"ts": "111.333", "text": "first"},
+                    {"ts": "111.444", "text": "second"},
+                ],
+            },
+            status=200,
+        )
+        # Cycle 2: "first" was deleted, "third" arrived.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={
+                "ok": True,
+                "messages": [
+                    {"ts": "111.222", "text": "the request"},
+                    {"ts": "111.444", "text": "second"},
+                    {"ts": "111.555", "text": "third"},
+                ],
+            },
+            status=200,
+        )
+        # Cycle 1: no reactions; cycle 2: an ack ends the watch.
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={"ok": True, "message": {"reactions": []}},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "reactions.get"),
+            json={
+                "ok": True,
+                "message": {"reactions": [{"name": "+1", "users": ["U1"]}]},
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _api(mock_config, "users.info"),
+            json={"ok": True, "user": {"profile": {"display_name": "Reviewer R"}}},
+            status=200,
+        )
+
+        replies: list[str] = []
+        outcome = client.wait_for_ack(
+            "C123",
+            "111.222",
+            on_reply=replies.append,
+            should_stop=lambda: False,
+            interval=0.01,
+            timeout=5,
+        )
+
+        assert outcome.acked is True
+        # "second" is not re-forwarded and "third" is not swallowed.
+        assert replies == ["first", "second", "third"]
+
+    @responses.activate
+    def test_rate_limit_wait_is_interrupted_by_cancel(self, client, mock_config):
+        """A cancel during a 429 Retry-After wait ends the watch after ~1 slice.
+
+        The patched sleep sets the cancel event on its first ~1s slice; the
+        next slice's cancel check must abort the wait instead of sleeping out
+        the server's 30s, and the watch then ends as timed out.
+        """
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"error": "ratelimited"},
+            status=429,
+            headers={"Retry-After": "30"},
+        )
+
+        cancel = threading.Event()
+        with patch(
+            "mtui.data_sources.slack.time.sleep",
+            side_effect=lambda _s: cancel.set(),
+        ) as sleep:
+            outcome = client.wait_for_ack(
+                "C123",
+                "111.222",
+                on_reply=lambda _t: None,
+                should_stop=lambda: False,
+                interval=0.01,
+                timeout=60,
+                cancel_event=cancel,
+            )
+
+        assert outcome.acked is False
+        assert outcome.timed_out is True
+        assert outcome.unreachable is False
+        assert sleep.call_count == 1  # one slice, then the cancel is honoured
+
+    @responses.activate
+    def test_rate_limit_wait_respects_deadline(self, client, mock_config):
+        """A 429 wait past the watch deadline aborts without sleeping at all."""
+        responses.add(
+            responses.GET,
+            _api(mock_config, "conversations.replies"),
+            json={"error": "ratelimited"},
+            status=429,
+            headers={"Retry-After": "30"},
+        )
+
+        with patch("mtui.data_sources.slack.time.sleep") as sleep:
+            outcome = client.wait_for_ack(
+                "C123",
+                "111.222",
+                on_reply=lambda _t: None,
+                should_stop=lambda: False,
+                interval=0.01,
+                timeout=0,  # the deadline has already passed
+            )
+
+        assert outcome.acked is False
+        assert outcome.timed_out is True
+        sleep.assert_not_called()

--- a/tests/test_testreport_set_slack_review.py
+++ b/tests/test_testreport_set_slack_review.py
@@ -1,0 +1,251 @@
+"""Tests for ``TestReport.set_slack_review`` template rewriting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mtui.test_reports.metadata_parsers import ReducedMetadataParser
+from mtui.test_reports.svn_io import TemplateFormatError
+from mtui.test_reports.testreport import TestReport
+
+
+class _ConcreteReport(TestReport):
+    """Minimal instantiable TestReport for exercising set_slack_review."""
+
+    @property
+    def id(self):
+        return "test"
+
+    def check_hash(self):
+        return True, "", ""
+
+    def _parser(self):
+        return {}
+
+    def _update_repos_parser(self):
+        return {}
+
+    def list_update_commands(self, targets, display):
+        return None
+
+
+def _report(mock_config, path: Path | None) -> TestReport:
+    """Builds a minimal concrete TestReport with ``path`` set."""
+    tr = _ConcreteReport.__new__(_ConcreteReport)  # bypass __init__
+    tr.config = mock_config
+    tr.path = path
+    tr.slack_review = None
+    return tr
+
+
+TEMPLATE = """\
+METADATA:
+=========
+Packager: slemke@suse.com
+Bugs: 12345
+{lines}
+Repository: http://example/
+"""
+
+
+def _write(tmp_path: Path, lines: str) -> Path:
+    p = tmp_path / "log"
+    p.write_text(TEMPLATE.format(lines=lines))
+    return p
+
+
+def test_inserts_marker_after_reviewer_line(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice")
+    tr = _report(mock_config, p)
+
+    tr.set_slack_review("C123", "1700000000.000100")
+
+    text = p.read_text()
+    assert "Test Plan Reviewer: alice\nSlack Review: C123/1700000000.000100\n" in text
+    assert tr.slack_review == ("C123", "1700000000.000100")
+
+
+def test_replaces_existing_marker(mock_config, tmp_path):
+    p = _write(
+        tmp_path,
+        "Test Plan Reviewer: alice\nSlack Review: COLD/111.222",
+    )
+    tr = _report(mock_config, p)
+
+    tr.set_slack_review("CNEW", "333.444")
+
+    text = p.read_text()
+    assert "Slack Review: CNEW/333.444" in text
+    assert "COLD" not in text
+    # Replaced in place, not inserted again.
+    assert text.count("Slack Review:") == 1
+    assert tr.slack_review == ("CNEW", "333.444")
+
+
+def test_other_lines_unchanged(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice")
+    original = p.read_text()
+    tr = _report(mock_config, p)
+
+    tr.set_slack_review("C123", "111.222")
+
+    new = p.read_text()
+    # Exactly the marker line was added; everything else is untouched.
+    assert [ln for ln in new.splitlines() if ln not in original.splitlines()] == [
+        "Slack Review: C123/111.222"
+    ]
+
+
+def test_missing_anchor_raises_and_leaves_file(mock_config, tmp_path):
+    p = tmp_path / "log"
+    p.write_text("METADATA:\nPackager: x\nRepository: y\n")
+    original = p.read_text()
+    tr = _report(mock_config, p)
+
+    with pytest.raises(TemplateFormatError, match="Test Plan Reviewer"):
+        tr.set_slack_review("C123", "111.222")
+
+    assert p.read_text() == original
+    assert tr.slack_review is None
+
+
+def test_no_path_raises(mock_config):
+    tr = _report(mock_config, None)
+
+    with pytest.raises(RuntimeError):
+        tr.set_slack_review("C123", "111.222")
+
+
+def test_has_anchor_with_reviewer_line(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice")
+    assert _report(mock_config, p).has_slack_review_anchor() is True
+
+
+def test_has_anchor_with_existing_marker_only(mock_config, tmp_path):
+    p = _write(tmp_path, "Slack Review: C1/111.222")
+    assert _report(mock_config, p).has_slack_review_anchor() is True
+
+
+def test_has_anchor_false_without_anchor(mock_config, tmp_path):
+    p = tmp_path / "log"
+    p.write_text("METADATA:\nPackager: x\nRepository: y\n")
+    assert _report(mock_config, p).has_slack_review_anchor() is False
+
+
+def test_has_anchor_false_without_path(mock_config):
+    assert _report(mock_config, None).has_slack_review_anchor() is False
+
+
+def test_get_slack_review_parses_marker(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice\nSlack Review: C123/111.222")
+    assert _report(mock_config, p).get_slack_review() == ("C123", "111.222")
+
+
+def test_get_slack_review_none_when_absent(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice")
+    assert _report(mock_config, p).get_slack_review() is None
+
+
+def test_get_slack_review_none_without_path(mock_config):
+    assert _report(mock_config, None).get_slack_review() is None
+
+
+def test_missing_file_reads_as_no_marker_and_no_anchor(mock_config, tmp_path):
+    # An ``svn up`` can delete a withdrawn report's template underneath the
+    # session; both file-backed reads degrade gracefully instead of raising.
+    gone = tmp_path / "log"  # never created
+    tr = _report(mock_config, gone)
+    assert tr.get_slack_review() is None
+    assert tr.has_slack_review_anchor() is False
+
+
+def test_set_then_get_roundtrip(mock_config, tmp_path):
+    p = _write(tmp_path, "Test Plan Reviewer: alice")
+    tr = _report(mock_config, p)
+
+    tr.set_slack_review("CNEW", "333.444")
+
+    # get_slack_review reads the FILE, so it observes what set wrote.
+    assert tr.get_slack_review() == ("CNEW", "333.444")
+
+
+def test_free_text_mention_is_not_a_marker(mock_config, tmp_path):
+    # A comment ending in "Slack Review: X/Y" mid-line is free text, not a
+    # marker: without a real marker line there is nothing to resume.
+    p = _write(
+        tmp_path,
+        "comment: please see Slack Review: CBAD/000.111\nTest Plan Reviewer: alice",
+    )
+    assert _report(mock_config, p).get_slack_review() is None
+
+
+def test_free_text_mention_does_not_shadow_real_marker(mock_config, tmp_path):
+    # The template's free-text comment field sits ABOVE the real marker's
+    # anchor; text merely containing the phrase must not shadow the marker
+    # (which would wedge the approve/reject gate on a dead message).
+    p = _write(
+        tmp_path,
+        "comment: please see Slack Review: CBAD/000.111\n"
+        "Test Plan Reviewer: alice\n"
+        "Slack Review: CREAL/111.222",
+    )
+    tr = _report(mock_config, p)
+    assert tr.get_slack_review() == ("CREAL", "111.222")
+
+    # And a rewrite replaces the real marker, leaving the comment untouched.
+    tr.set_slack_review("CNEW", "333.444")
+    text = p.read_text()
+    assert "comment: please see Slack Review: CBAD/000.111" in text
+    assert "Slack Review: CNEW/333.444" in text
+    assert "CREAL" not in text
+
+
+def test_duplicate_markers_first_wins_and_write_collapses(mock_config, tmp_path):
+    # A merge or hand-edit can leave two marker lines; every reader is
+    # first-wins, and a write collapses them back to a single marker.
+    p = _write(
+        tmp_path,
+        "Test Plan Reviewer: alice\n"
+        "Slack Review: CFIRST/111.222\n"
+        "Slack Review: CSECOND/333.444",
+    )
+    tr = _report(mock_config, p)
+    assert tr.get_slack_review() == ("CFIRST", "111.222")
+
+    tr.set_slack_review("CNEW", "555.666")
+
+    text = p.read_text()
+    assert text.count("Slack Review:") == 1
+    assert "Slack Review: CNEW/555.666" in text
+    assert "CSECOND" not in text
+    assert tr.get_slack_review() == ("CNEW", "555.666")
+
+
+def _parse_snapshot(text: str) -> tuple[str, str] | None:
+    """Runs the load-time line parser the way ``_parse_json`` feeds it."""
+    results = SimpleNamespace(hostnames=set(), jira={}, bugs={}, slack_review=None)
+    for line in text.splitlines():
+        ReducedMetadataParser.parse(results, line)
+    return results.slack_review
+
+
+def test_load_time_parser_agrees_with_disk_read(mock_config, tmp_path):
+    # Same content, two readers: the load-time snapshot parser and the
+    # get_slack_review disk read must extract the identical marker — for a
+    # plain marker, duplicate markers (first wins), a free-text mention
+    # alone, and a free-text mention above a real marker.
+    cases = [
+        "Test Plan Reviewer: alice\nSlack Review: C1/111.222",
+        "Test Plan Reviewer: alice\nSlack Review: C1/111.222\nSlack Review: C2/333.444",
+        "comment: see Slack Review: CBAD/000.111\nTest Plan Reviewer: alice",
+        "comment: see Slack Review: CBAD/000.111\n"
+        "Test Plan Reviewer: alice\n"
+        "Slack Review: CREAL/111.222",
+    ]
+    for lines in cases:
+        p = _write(tmp_path, lines)
+        disk = _report(mock_config, p).get_slack_review()
+        assert _parse_snapshot(p.read_text()) == disk, lines


### PR DESCRIPTION
## What

New `request_review` command: commits the loaded update's testreport, posts its
`reports_url/<RRID>/log` URL to a configured Slack channel (`[slack]` config
section), then watches the thread — streaming replies and treating a 👍
reaction as review approval, driving the existing `approve` path with the
best-effort reactor recorded as reviewer. `--no-watch` posts and returns;
`--no-approve` watches and reports without approving.

`approve` and `reject` now require a recorded Slack review whose message still
carries a 👍; a REPL-only `-f/--force` bypasses the gate and is structurally
unavailable over MCP (schema-skipped **and** gated on `prompt.interactive`),
so an AI agent can never force-approve an update without a human review.

The Slack message reference (channel + ts) is persisted durably in the
testreport (`Slack Review: <channel>/<ts>` marker line, parsed back on load)
so the ack survives a reload and the gate re-checks it live.

## Design decisions

- Bot token + Web API polling (no new dependency; webhooks can't read
  reactions, Events/Socket Mode are daemon shapes).
- Reviewer name is a **best-effort** reactor: Slack does not guarantee
  `users[]` ordering; on a `users.info` failure (e.g. missing `users:read`
  scope) the raw member id is recorded instead — the ack itself is
  authoritative and is never lost to name-resolution problems.
- Fan-out: one Slack thread + one watch per loaded template, consistent with
  `approve`/`commit`.

## Robustness (from adversarial review)

- **Cooperative cancellation over MCP**: the session now binds a per-call
  `threading.Event` (`mtui.support.cancellation.current_cancel_event`,
  propagated into `asyncio.to_thread` via contextvars) and sets it on
  `job_cancel` / client disconnect; the Slack watch passes it into
  `wait_for_ack`. A cancelled background job's worker thread exits promptly
  instead of polling unobserved for hours and auto-approving on a late 👍.
- **Transient tolerance**: the watch only gives up as `unreachable` after 3
  *consecutive* failed poll cycles; a single network blip or sustained-429
  pair no longer aborts a multi-hour watch.
- **No dangling review requests**: the template's marker anchor
  (`Test Plan Reviewer:` line) is validated **before** posting to Slack, and a
  post-post marker failure is reported cleanly instead of crashing with the
  request already live in the channel.

Known interplay: with several templates loaded, Ctrl-C during one template's
watch ends that watch; aborting the whole fan-out on Ctrl-C is fixed
separately in #258 (`except BaseException` → `except Exception` in the
fan-out loop).

## Tests

63 tests across the Slack client (mocked with `responses`), the command
(failure paths, `--no-watch`/`--no-approve`, the fanout auto-approve blocker
regression, MCP cancel-event forwarding), the approve/reject gate, template
marker persistence/parsing, and the MCP job cancellation path.

Full suite green (1811 passed); ruff format/check + ty clean; patch coverage
100% on the new modules.

## Resume & repost (added after design-panel + adversarial review fan-out)

Re-running `request_review` on a report that already records a `Slack Review:`
marker **resumes** the existing request instead of posting a duplicate: the
thread's replies so far are forwarded to the user first (the watch streams
from the top), and a 👍 that arrived in the meantime approves immediately — so
an interrupted watch (Ctrl-C, a cancelled MCP job) just picks up where it left
off. `--repost` forces a fresh post, replacing the marker and leaving a
best-effort "superseded" reply under the old thread; it is refused for an
unscoped multi-template fan-out (both in the foreground `run()` and in the MCP
`start_jobs` per-template fan-out, which would otherwise bypass the check via
its `-T`-scoped jobs).

State correctness (per the design panel + review):

- The **on-disk marker is the source of truth**: a new
  `TestReport.get_slack_review()` re-parses the file (with the same regex the
  load-time parser uses) after the pre-commit's `svn up`, so a colleague's
  newer / reposted / removed marker is respected. The `approve`/`reject` gate
  now reads the marker file-fresh too.
- **Pre-approve guards**: after an ack, the auto-approve is skipped if the
  cancel event was flagged during the watch (a cancelled job's final in-flight
  poll must never approve) or if the marker — refreshed via a best-effort
  `svn up` — no longer matches the watched `(channel, ts)` (superseded
  mid-watch, including from another checkout).
- A marker-write failure after a successful post now **voids the orphaned
  message in-thread** (best-effort) and the remediation names the exact
  scoped re-run (`--repost -T <RRID>`).
- A template deleted underneath the session (`svn up` on a withdrawn report)
  reads as "no marker" instead of raising.

Deliberately out of scope (pre-existing, noted for reviewers): Approve
idempotence when the update is already approved, and fail-fast when an
in-flight watch job already holds the template's lock (documented in mcp.rst).
