### PR TITLE
fix(commands): skip host-less templates in fan-out instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- An unscoped multi-template fan-out of a host-phase command (e.g. `lock`,
+  `run`) no longer fails the whole fan-out — or, for `lock`, pretends to
+  succeed — when a loaded template has no connected host. A host-less template
+  is now skipped with a warning when no `-t` host was named, the command still
+  runs on every template that does have hosts, and it fails with "No refhosts
+  defined" if every template was skipped. Naming a disconnected host with `-t`
+  is still a per-template failure, and explicitly `-T`/`--template`-scoped
+  calls are unchanged and still raise.
+- `Ctrl-C` during a multi-template fan-out now aborts the remaining templates
+  instead of being recorded as a per-template failure while the loop keeps
+  going.
 - Fetching openQA data from the QEM Dashboard no longer floods the log with
   "Connection pool is full, discarding connection" warnings. The shared HTTP
   session's connection pool is now sized to match mtui's default worker-thread

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -86,7 +86,15 @@ template only.
 
 If a fanned-out command fails on one template, it continues running on the
 remaining templates and then reports an aggregate failure once the loop is done;
-a failure on one template does not abort the others.
+a failure on one template does not abort the others. When a host-phase command
+(one accepting ``-t``) fans out without explicit ``-t`` hosts, a loaded
+template that has **no connected host** is skipped with a warning rather than
+counted as a failure, so an unscoped ``lock``/``run``/… still succeeds on the
+templates that do have hosts. If *every* template gets skipped that way the
+command executed nowhere and fails with "No refhosts defined". Naming a host
+that is not connected (``-t <host>``) is still a per-template failure, and an
+explicitly ``-T``/``--template``-scoped call keeps the single-template error
+behaviour — you asked for exactly that one.
 
 .. note::
 

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -597,7 +597,16 @@ therefore exposes two optional parameters in its schema:
 
 Omitting both fans the call out across the session's loaded templates.
 When a fanned-out call fails on one template it keeps running on the
-others and reports an aggregate failure at the end.
+others and reports an aggregate failure at the end. A host-phase tool called
+without explicit ``-t`` hosts skips a loaded template with **no connected
+host** (warning, not a failure), so an unscoped ``lock`` still succeeds on
+the templates that do have hosts; if every template is host-less the call
+fails with "No refhosts defined" instead of reporting an empty success.
+Naming a disconnected host with ``-t`` is still a failure, and a call scoped
+with ``template="<RRID>"`` keeps the single-template error behaviour. With
+``background=true`` each template runs as its own independent job, so a
+host-less template fails only its own job and never blocks the jobs of the
+other templates.
 
 .. note::
 

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -11,6 +11,7 @@ from ..hosts.target.hostgroup import HostsGroup
 from ..support.messages import (
     FanOutError,
     HostIsNotConnectedError,
+    NoRefhostsDefinedError,
     TemplateNotLoadedError,
 )
 
@@ -302,7 +303,11 @@ class Command(ABC):
         more than one template is resolved, each gets an RRID banner and its own
         ``try/except``: a per-template failure is logged and collected, the loop
         continues, and a :class:`FanOutError` aggregate is raised afterwards if
-        any template failed.
+        any template failed. A template with no connected host is skipped up
+        front (warning, never collected) when the invocation named no ``-t``
+        hosts; if every template got skipped that way the command ran nowhere
+        and :class:`NoRefhostsDefinedError` is raised instead of reporting
+        success.
         """
         resolved = self._resolve_templates()
 
@@ -313,23 +318,51 @@ class Command(ABC):
             self.__call__()
             return
 
+        # A host-phase command (one taking ``-t``) invoked without explicit
+        # hosts opportunistically applies to every loaded template; a template
+        # with no connected host has nothing to act on and is skipped so it
+        # can't fail the fan-out (or, for commands like ``lock`` whose body
+        # no-ops on an empty host group, be reported as a success that never
+        # happened). Explicitly named hosts must keep failing loudly: a typo'd
+        # ``-t`` raises HostIsNotConnectedError inside the body and lands in
+        # the aggregate below.
+        skippable = hasattr(self.args, "hosts") and not self.args.hosts
+
         failures: list[tuple[str, BaseException]] = []
+        skipped: list[str] = []
         for report in resolved:
             rrid = str(report.id)
+            if skippable and not report.targets:
+                logger.warning(
+                    "%s skipped on %s: no connected hosts", self.command, rrid
+                )
+                skipped.append(rrid)
+                continue
             self.metadata = report
             self.targets = report.targets
             self.display.template_banner(rrid)
             try:
                 self.__call__()
-            except BaseException as exc:  # noqa: BLE001 - collect & continue
+            except Exception as exc:  # noqa: BLE001 - collect & continue
                 logger.error("%s failed on %s: %s", self.command, rrid, exc)
                 failures.append((rrid, exc))
 
-        ok = [str(r.id) for r in resolved if str(r.id) not in {f[0] for f in failures}]
+        done = {*(f[0] for f in failures), *skipped}
+        ok = [str(r.id) for r in resolved if str(r.id) not in done]
         if ok:
             logger.info("%s succeeded on: %s", self.command, ", ".join(ok))
+        if skipped:
+            logger.info(
+                "%s skipped (no connected host): %s",
+                self.command,
+                ", ".join(skipped),
+            )
         if failures:
             raise FanOutError(failures)
+        if skipped and not ok:
+            # Every resolved template was skipped: the command executed on
+            # nothing, which must stay an error, not a silent success.
+            raise NoRefhostsDefinedError
 
     def parse_hosts(self, enabled: bool = True) -> HostsGroup:
         """Parses the `hosts` argument and returns a `HostsGroup` object.

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -8,10 +8,13 @@ import pytest
 
 from mtui.cli.argparse import ArgsParseFailureError
 from mtui.commands._command import Command
+from mtui.commands.hostslock import HostLock
+from mtui.commands.run import Run
 from mtui.hosts.target.hostgroup import HostsGroup
 from mtui.support.messages import (
     FanOutError,
     HostIsNotConnectedError,
+    NoRefhostsDefinedError,
     TemplateNotLoadedError,
 )
 
@@ -300,10 +303,36 @@ class FailingFanoutCommand(Command):
             raise RuntimeError(f"boom on {rrid}")
 
 
+class InterruptingFanoutCommand(Command):
+    """Fans out but raises KeyboardInterrupt on a configured RRID."""
+
+    command = "interrupting_fanout_cmd"
+    scope = "fanout"
+
+    interrupt_on: str = ""
+    calls: ClassVar[list] = []
+
+    def __call__(self):
+        rrid = str(self.metadata.id)
+        self.calls.append(rrid)
+        if rrid == self.interrupt_on:
+            raise KeyboardInterrupt
+
+
+def _report_with_host(rrid, hostname):
+    """A _FakeReport whose targets group holds one connected, enabled host."""
+    report = _FakeReport(rrid)
+    host = MagicMock()
+    host.hostname = hostname
+    host.state = "enabled"
+    report.targets = HostsGroup([host])
+    return report
+
+
 def _make_cmd(
-    cmd_cls, registry, *, template=None, all_templates=False, interactive=True
+    cmd_cls, registry, *, template=None, all_templates=False, interactive=True, **extra
 ):
-    args = Namespace(template=template, all_templates=all_templates)
+    args = Namespace(template=template, all_templates=all_templates, **extra)
     prompt = MagicMock()
     prompt.templates = registry
     prompt.metadata = registry.active
@@ -411,3 +440,76 @@ class TestRun:
         assert FailingFanoutCommand.calls == ["A", "B", "C"]
         # The aggregate names only the failed template.
         assert [rrid for rrid, _ in exc.value.failures] == ["B"]
+
+    def test_fanout_interrupt_aborts_remaining_templates(self):
+        # Ctrl-C must abort the fan-out, not be collected as a per-template
+        # failure while the loop keeps going.
+        reg = _FakeRegistry([_FakeReport("A"), _FakeReport("B"), _FakeReport("C")])
+        InterruptingFanoutCommand.interrupt_on = "B"
+        InterruptingFanoutCommand.calls = []
+        cmd = _make_cmd(InterruptingFanoutCommand, reg)
+        with pytest.raises(KeyboardInterrupt):
+            cmd.run()
+        # C never ran: the interrupt propagated instead of being swallowed.
+        assert InterruptingFanoutCommand.calls == ["A", "B"]
+
+    def test_fanout_skips_hostless_template_without_error(self):
+        # A real host-phase command (lock) fanning out unscoped over a template
+        # with no connected host: the host-less template is skipped (warn), the
+        # others run, nothing raises.
+        hosted_a = _report_with_host("A", "ha.example.com")
+        hostless = _FakeReport("B")
+        hosted_c = _report_with_host("C", "hc.example.com")
+        reg = _FakeRegistry([hosted_a, hostless, hosted_c])
+        cmd = _make_cmd(HostLock, reg, hosts=None, comment=None)
+        cmd.run()
+        # lock reached the connected hosts; the host-less template was skipped.
+        assert hosted_a.targets["ha.example.com"].lock.called
+        assert hosted_c.targets["hc.example.com"].lock.called
+
+    def test_fanout_named_missing_host_is_failure(self):
+        # Naming a -t host that is not connected anywhere must stay a hard
+        # failure on every template — never a silent skip that lets the command
+        # "succeed" while executing on zero hosts.
+        reg = _FakeRegistry(
+            [_report_with_host("A", "h1"), _report_with_host("B", "h2")]
+        )
+        cmd = _make_cmd(HostLock, reg, hosts=["typo.example.com"], comment=None)
+        with pytest.raises(FanOutError) as exc:
+            cmd.run()
+        assert [rrid for rrid, _ in exc.value.failures] == ["A", "B"]
+        assert all(
+            isinstance(e, HostIsNotConnectedError) for _, e in exc.value.failures
+        )
+
+    def test_fanout_all_hostless_raises_no_refhosts(self):
+        # Every resolved template skipped == the command executed nowhere;
+        # that must surface as an error, not as a clean return.
+        reg = _FakeRegistry([_FakeReport("A"), _FakeReport("B")])
+        cmd = _make_cmd(HostLock, reg, hosts=None, comment=None)
+        with pytest.raises(NoRefhostsDefinedError):
+            cmd.run()
+
+    def test_fanout_hostless_skip_excluded_from_aggregate(self):
+        # A host-less skip and a genuine failure in the same fan-out: only the
+        # genuine failure is aggregated into the FanOutError; the skip is not.
+        hosted_a = _report_with_host("A", "ha.example.com")
+        hostless = _FakeReport("B")
+        hosted_c = _report_with_host("C", "hc.example.com")
+        hosted_c.targets["hc.example.com"].lock.side_effect = RuntimeError("boom")
+        reg = _FakeRegistry([hosted_a, hostless, hosted_c])
+        cmd = _make_cmd(HostLock, reg, hosts=None, comment=None)
+        with pytest.raises(FanOutError) as exc:
+            cmd.run()
+        # Only the genuinely-failed template is named; the host-less skip is not.
+        assert [rrid for rrid, _ in exc.value.failures] == ["C"]
+        assert hosted_a.targets["ha.example.com"].lock.called
+
+    def test_scoped_hostless_template_still_raises(self):
+        # An explicitly -T-scoped call resolves to one template and takes the
+        # single-template branch, so a real host-phase command still raises
+        # directly on a host-less target instead of skipping.
+        reg = _FakeRegistry([_report_with_host("A", "h1"), _FakeReport("B")])
+        cmd = _make_cmd(Run, reg, template="B", hosts=None, command=["uname"])
+        with pytest.raises(NoRefhostsDefinedError):
+            cmd.run()


### PR DESCRIPTION
## What

An unscoped multi-template fan-out of a host-phase command misbehaved when a
loaded template had no connected host: `run`/`update`/`prepare`/… failed the
whole fan-out with a `FanOutError` (via `NoRefhostsDefinedError`) even though
the command succeeded on every template that *did* have hosts, while `lock`
silently no-op'd on the empty host group and was reported as a success that
never happened. Under `mtui-mcp`, where an unscoped call fans out across all
loaded templates by design, one host-less template thus either masked
otherwise-successful work behind an error or faked success.

## Change

`Command.run()`'s fan-out loop now **skips a template up front, with a
warning**, when the invocation named no `-t` hosts and the template's target
group is empty. The skip is keyed on that actual condition rather than on
`HostIsNotConnectedError` — that exception is only ever raised for an
explicitly named `-t` host, so catching it (the first iteration of this PR)
never fired for a genuinely host-less template and would have silently skipped
every template on a typo'd `-t` hostname, letting the command report success
while executing on zero hosts.

Guard rails around the skip:

- a named `-t` host that is not connected stays a per-template failure and
  lands in the `FanOutError` aggregate;
- if *every* resolved template gets skipped, the command raises
  `NoRefhostsDefinedError` — executing on nothing is never a silent success;
- explicitly `-T`/`--template`-scoped calls take the single-template branch
  and keep the unchanged error contract;
- with `background=true` each template already runs as its own independent
  job, so a host-less template fails only its own job (documented in
  `mcp.rst`).

The fan-out collector also now catches `Exception` instead of
`BaseException`, so Ctrl-C aborts the remaining templates instead of being
recorded as a per-template failure while the loop keeps going.

## Tests

The fan-out tests now drive real host-phase commands (`lock`, `run`) against
reports with real (empty / populated) `HostsGroup`s instead of a synthetic
command raising the exception the loop happens to catch:

- unscoped `lock` fan-out over a host-less template: skipped, connected
  templates locked, no error;
- typo'd `-t` host: `FanOutError` naming every template
  (`HostIsNotConnectedError`), never a silent skip;
- all templates host-less: `NoRefhostsDefinedError`;
- host-less skip + genuine failure in one fan-out: aggregate names only the
  genuine failure;
- `-T`-scoped `run` on a host-less template still raises
  `NoRefhostsDefinedError` directly;
- `KeyboardInterrupt` propagates and aborts the remaining templates.

Full suite green (1747 passed); ruff format/check + ty clean.
