### PR TITLE
fix(commands): make load_template scope=single so it never fans out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   session's connection pool is now sized to match mtui's default worker-thread
   count (`min(32, cpu + 4)`), so the concurrent per-setting requests reuse
   connections instead of repeatedly opening and tearing them down.
+- `load_template` no longer fans out across already-loaded templates. Over
+  `mtui-mcp`, where an unscoped command fans out by default, loading a new RRID
+  while several templates were already loaded re-ran the load — and its host
+  autoconnect — once per loaded template, needlessly grabbing reference hosts
+  from the pool. `load_template` now runs exactly once (`scope = "single"`, like
+  `unload`), connecting only the newly loaded template's own hosts.
 - Over `mtui-mcp`, a command with a `nargs=REMAINDER` *optional* flag declared
   before another flag (the shape used by `reject --message`) could have the
   later flag swallowed into the message when re-encoding a tool call to argv.

--- a/Documentation/mcp.rst
+++ b/Documentation/mcp.rst
@@ -603,10 +603,13 @@ others and reports an aggregate failure at the end.
 
    ``switch`` is **not** exposed as a tool; moving the active-template
    pointer is REPL-only navigation. Over MCP you target a specific template
-   per call with the ``template`` parameter instead. ``unload <rrid>`` **is**
-   exposed — it names its own RRID and drops exactly that template (closing
-   only its host connections), leaving the others loaded. ``list_templates``
-   remains available as a read-only listing.
+   per call with the ``template`` parameter instead. ``load_template`` and
+   ``unload <rrid>`` **are** exposed — each names its own RRID and acts on
+   exactly that one template: ``load_template`` loads the given RRID and
+   connects only *its* hosts (it never fans out across the already-loaded
+   set), and ``unload`` drops exactly that template, closing only its host
+   connections and leaving the others loaded. ``list_templates`` remains
+   available as a read-only listing.
 
 Background jobs (don't block on a slow host op)
 -----------------------------------------------

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -41,14 +41,15 @@ class Command(ABC):
     #: template. A per-invocation ``-T/--template`` always wins over this, and
     #: ``--all-templates`` forces fan-out regardless of the class default. Only
     #: action commands that are safe to repeat per template opt into
-    #: ``"fanout"``; inherently single-target commands (``load_template``,
-    #: ``edit``, ``switch``, ``quit``, …) keep ``"active"``.
+    #: ``"fanout"``; REPL-only single-target commands (``edit``, ``switch``,
+    #: ``quit``, …) keep ``"active"`` since they never run under MCP fan-out.
     #:
     #: ``"single"`` is a stricter variant of ``"active"`` for commands that
     #: name their own target template and must run **exactly once** regardless
-    #: of how many templates are loaded — e.g. ``unload <rrid>``, which would
-    #: otherwise fan out under MCP (where ``"active"`` defaults to fan-out with
-    #: several loaded) and try to remove the same RRID once per template.
+    #: of how many templates are loaded — e.g. ``load_template``/``unload
+    #: <rrid>``, which would otherwise fan out under MCP (where ``"active"``
+    #: defaults to fan-out with several loaded) and re-run against the same RRID
+    #: once per loaded template.
     scope: ClassVar[str] = "active"
 
     #: Auto-populated registry of every concrete ``Command`` subclass that

--- a/mtui/commands/loadtemplate.py
+++ b/mtui/commands/loadtemplate.py
@@ -1,5 +1,7 @@
 """The `load_template` command."""
 
+from typing import ClassVar
+
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
 from ..support.messages import TestReportNotLoadedError
@@ -20,6 +22,11 @@ class LoadTemplate(Command):
     """
 
     command = "load_template"
+    # Names its own target via -a/-k, so it must run exactly once. Without this
+    # an unscoped call under MCP (where "active" fans out with several templates
+    # loaded) would re-run the load — and its host autoconnect — once per already
+    # loaded template, needlessly grabbing pool hosts. Mirrors ``unload``.
+    scope: ClassVar[str] = "single"
 
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:

--- a/tests/test_cmd_loadtemplate.py
+++ b/tests/test_cmd_loadtemplate.py
@@ -20,6 +20,65 @@ def _prompt(metadata_truthy: bool = False) -> MagicMock:
     return p
 
 
+class _FakeReport:
+    """Minimal loaded-template stand-in carrying an id and targets."""
+
+    def __init__(self, rrid: str) -> None:
+        self.id = rrid
+        self.targets: dict = {}
+
+
+class _FakeRegistry:
+    """Minimal TemplateRegistry stand-in for fan-out resolution."""
+
+    def __init__(self, reports: list[_FakeReport]) -> None:
+        self._reports = {str(r.id): r for r in reports}
+        self._active = reports[0]
+
+    def all(self) -> list[_FakeReport]:
+        return list(self._reports.values())
+
+    def get(self, rrid: str) -> _FakeReport:
+        return self._reports[rrid]
+
+    def __len__(self) -> int:
+        return len(self._reports)
+
+    @property
+    def active(self) -> _FakeReport:
+        return self._active
+
+
+def test_load_template_scope_is_single():
+    """load_template must never fan out — it names its own RRID via -a/-k."""
+    assert LoadTemplate.scope == "single"
+
+
+def test_load_template_no_fanout_under_mcp_many_loaded(mock_config):
+    """Under MCP with several templates loaded, an unscoped load runs once.
+
+    ``scope = "single"`` keeps ``_resolve_templates`` from fanning out: a
+    regression to ``"active"`` would, under MCP (non-interactive) with >1
+    template loaded, re-run the load — and its host autoconnect — once per
+    loaded template. Driving through ``run()`` (not ``__call__``) exercises
+    that resolution path.
+    """
+    reg = _FakeRegistry([_FakeReport("A"), _FakeReport("B"), _FakeReport("C")])
+    prompt = MagicMock()
+    prompt.templates = reg
+    prompt.metadata = reg.active
+    prompt.targets = reg.active.targets
+    prompt.display = MagicMock()
+    prompt.interactive = False  # MCP: "active" would otherwise fan out
+    update = MagicMock()
+    update.kind = "auto"
+    args = Namespace(update=update, template=None, all_templates=False)
+
+    LoadTemplate(args, mock_config, MagicMock(), prompt).run()
+
+    prompt.load_update.assert_called_once_with(update, autoconnect=True)
+
+
 def test_load_template_auto_kind_loads(mock_config):
     """kind=auto -> prompt.load_update is called (template is added).
 


### PR DESCRIPTION
## What

`load_template` names its own target via `-a/-k`, but inherited the default
`scope = "active"`. Under `mtui-mcp` an unscoped command fans out across **all**
loaded templates when several are loaded (there is no client-addressable active
pointer — `switch` is REPL-only). So loading a new RRID while other templates were
already loaded re-ran the load — and its host `autoconnect()` — **once per already
loaded template**, needlessly claiming reference hosts from the pool. The command's
own docstring even promised it "never reconnects hosts that belong to another loaded
template"; under MCP it did.

## Change

Set `scope = "single"` on `LoadTemplate` (exactly as `unload` already does), so
`Command._resolve_templates()` resolves to a single target and `run()` invokes the
load **once**, connecting only the newly loaded template's own hosts — regardless of
how many templates are loaded or whether the caller is interactive. The `scope`
docstring in `_command.py` is corrected to list `load_template` under `"single"`
instead of `"active"`.

## Tests

`tests/test_cmd_loadtemplate.py`:
- asserts the `scope == "single"` invariant;
- a `run()`-level regression test: under MCP (non-interactive) with three templates
  loaded, an unscoped load calls `prompt.load_update` exactly once. A revert to
  `"active"` would fan out and call it three times, failing the test.

Full suite green (1738 passed); ruff format/check + ty clean.

## Relationship to #258

Independent sibling of #258 (fan-out skips host-less templates). Same theme —
unscoped multi-template fan-out safety under MCP — but a distinct root cause and
files. They touch adjacent regions of `_command.py`/`CHANGELOG.md`; whichever merges
second may need a trivial changelog rebase.
