### PR TITLE
fix(config): validate ssl_verify at parse time, default to system CA bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,11 +243,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   checkout — previously internal hosts failed certificate verification there
   even with `ca-certificates-suse` correctly installed, because PyPI
   `certifi` never consults the system trust store.
-- The REPL `config set` command now routes values through the same
-  validation as the config file (`config set ssl_verify false` correctly
-  disables verification instead of storing the literal string; boolean
-  options accept the INI spellings — previously only the exact string `True`
-  worked — and invalid values are rejected with the option left unchanged).
 - Fetching openQA data from the QEM Dashboard no longer floods the log with
   "Connection pool is full, discarding connection" warnings. The shared HTTP
   session's connection pool is now sized to match mtui's default worker-thread
@@ -410,6 +405,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   errors are logged with the affected test and host, a summary warning
   reports how many downloads failed, and under `errormode="full"` the failure
   propagates to the caller once the whole batch has finished.
+- `config set` now parses values through the option's declared getter and
+  fixup — the same pipeline used for the config file — instead of coercing via
+  the current attribute's type. Boolean options accept the INI spellings
+  (`config set use_keyring true` previously set **False**, because only the
+  literal `True` compared as true), integer options reject non-numbers
+  (`config set connection_timeout abc` used to store the string `abc`), and
+  `ssl_verify` only accepts booleans or an existing CA bundle path (a typo like
+  `false1` used to be stored verbatim and made every later HTTP call fail with
+  an `OSError` about an invalid CA path — such a value is now also rejected at
+  config-file parse time, falling back to the verifying default). An invalid
+  value is rejected with a single actionable error and the option is left
+  unchanged.
 
 ## 18.2.0 - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,30 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `Ctrl-C` during a multi-template fan-out now aborts the remaining templates
   instead of being recorded as a per-template failure while the loop keeps
   going.
+- An invalid `[mtui] ssl_verify` value (e.g. the typo `false1`, a CA-bundle
+  path that does not exist, or a certificate directory without `c_rehash`-ed
+  entries) is now rejected when the config is read — one clear error naming
+  the accepted forms, falling back to the verifying default — instead of
+  flowing verbatim into `requests` and crashing the first HTTPS call (e.g.
+  loading an SLFO template) with an opaque `OSError: Could not find a
+  suitable TLS CA certificate bundle`. A `~` in a bundle path is expanded, a
+  relative path is pinned absolute at startup (so `chdir_to_template_dir`
+  cannot invalidate it), and a blank value keeps meaning "verification off"
+  but warns. Validation rejections across all config options now log a single
+  actionable line; unexpected parser errors keep their full traceback.
+- When `ssl_verify` is unset — or set to `true`, which now behaves
+  identically — TLS verification prefers the system's CA bundle (the
+  interpreter's OpenSSL default cafile, honouring `SSL_CERT_FILE`; e.g.
+  `/etc/ssl/ca-bundle.pem`) over `requests`' bundled `certifi` CAs, so
+  system-installed CAs like the SUSE root work when running mtui from a git
+  checkout — previously internal hosts failed certificate verification there
+  even with `ca-certificates-suse` correctly installed, because PyPI
+  `certifi` never consults the system trust store.
+- The REPL `config set` command now routes values through the same
+  validation as the config file (`config set ssl_verify false` correctly
+  disables verification instead of storing the literal string; boolean
+  options accept the INI spellings — previously only the exact string `True`
+  worked — and invalid values are rejected with the option left unchanged).
 - Fetching openQA data from the QEM Dashboard no longer floods the log with
   "Connection pool is full, discarding connection" warnings. The shared HTTP
   session's connection pool is now sized to match mtui's default worker-thread

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -172,20 +172,36 @@ Unknown values are reported with a warning and fall back to the default
 ``mtui.ssl_verify``
 ~~~~~~~~~~~~~~~~~~~
   | **type**
-  |     bool or string (path)
+  |     bool, or path to an existing CA bundle (PEM file or a
+        ``c_rehash``-ed certificate directory)
   | **default**
-  |     ``True``
+  |     the system's CA bundle when one exists (the interpreter's
+        OpenSSL default cafile, honouring ``SSL_CERT_FILE``, e.g.
+        ``/etc/ssl/ca-bundle.pem``), otherwise ``True``
 
 Global TLS certificate-verification policy for every outbound HTTP
 call (Gitea PR client, QEM Dashboard client, openQA job client, the
 openQA / QAM Dashboard search, the log downloads, and the
-``refhosts.yml`` fetch). Defaults to ``True``, so MTUI verifies
-certificates everywhere out of the box; reaching internal hosts that
-present an internal-CA certificate therefore requires the SUSE CA in
-the system trust store. Set ``ssl_verify = false`` to disable
-verification everywhere, or set it to a filesystem path
-(``ssl_verify = /path/to/ca-bundle.pem``) to verify against a custom CA
-bundle.
+``refhosts.yml`` fetch). MTUI verifies certificates everywhere out of
+the box. When the option is unset — or set to ``true``, which is
+deliberately identical — verification prefers the system CA bundle
+when one is found: the :mod:`requests` library otherwise validates
+only against its bundled ``certifi`` CAs, which do not include
+system-installed CAs such as the SUSE root, so internal hosts would
+fail verification when MTUI runs from a git checkout even with the CA
+properly installed system-wide.
+
+Set ``ssl_verify = false`` to disable verification everywhere, or set
+it to a filesystem path (``ssl_verify = /path/to/ca-bundle.pem``) to
+verify against a custom CA bundle — a PEM file or a ``c_rehash``-ed
+certificate directory (one containing OpenSSL hash-named entries; a
+directory of plain ``.pem`` files cannot be used for verification and
+is rejected). A leading ``~`` is expanded, a relative path is pinned to
+an absolute one at startup (so a later ``chdir_to_template_dir`` cannot
+invalidate it), and the path must exist when MTUI starts. A blank value
+keeps its historical meaning (verification off) but logs a warning; any
+other value is rejected at startup with an error naming the accepted
+forms, and MTUI falls back to the (verifying) default.
 
 
 ``mtui.tempdir``

--- a/mtui/commands/config.py
+++ b/mtui/commands/config.py
@@ -1,9 +1,59 @@
 """The `config` command."""
 
+import configparser
 from contextlib import suppress
+from logging import getLogger
+from typing import Any
 
 from ..cli.argparse import ArgumentParser
+from ..support.config import ConfigOption
 from . import Command
+
+logger = getLogger("mtui.commands.config")
+
+#: Accepted spellings for boolean values -- the exact table
+#: :meth:`configparser.ConfigParser.getboolean` uses to parse INI values
+#: (``1``/``yes``/``true``/``on`` and ``0``/``no``/``false``/``off``).
+_BOOLEAN_STATES = configparser.ConfigParser.BOOLEAN_STATES
+
+
+def _parse_option_value(opt: ConfigOption, raw: str) -> Any:
+    """Coerce ``raw`` the way config-file parsing would.
+
+    Emulates the option's declared ``getter`` (``getint`` parses an
+    integer, ``getboolean`` parses configparser's boolean spellings,
+    anything else keeps the string as-is), then applies the option's
+    ``fixup`` -- the same pipeline :meth:`Config._parse_config` runs on
+    INI values, so runtime `config set` cannot store a value the config
+    file would have rejected.
+
+    Raises:
+        ValueError: ``raw`` cannot be parsed by the getter semantics or
+            is rejected by the option's ``fixup``.
+
+    """
+    getter_name = getattr(opt.getter, "__name__", "")
+    value: Any = raw
+    if getter_name == "getint":
+        try:
+            value = int(raw)
+        except ValueError:
+            raise ValueError("expected an integer") from None
+    elif getter_name == "getboolean":
+        try:
+            value = _BOOLEAN_STATES[raw.lower()]
+        except KeyError:
+            raise ValueError(
+                "expected a boolean (one of: 1, yes, true, on, 0, no, false, off)"
+            ) from None
+    try:
+        return opt.fixup(value)
+    except ValueError:
+        raise
+    except Exception as e:
+        # Fixups are arbitrary callables; normalize any failure so the
+        # caller has a single rejection path.
+        raise ValueError(str(e)) from e
 
 
 class Config(Command):
@@ -43,21 +93,49 @@ class Config(Command):
                 self.println(fmt.format(i, getattr(self.config, i)))
 
     def set(self) -> None:
-        """Sets a configuration value."""
-        attr = self.args.attribute
-        val = self.args.value
+        """Sets a configuration value.
 
-        try:
-            typ = type(getattr(self.config, attr))
-        except AttributeError:
-            if val in ("True", "False"):
-                typ = bool
-            elif val.isdigit():
-                typ = int
-            else:
-                typ = str
+        Attributes backed by a declared :class:`ConfigOption` go through
+        the same getter/fixup pipeline as config-file parsing, so e.g.
+        ``config set use_keyring true`` and ``config set ssl_verify
+        false`` behave exactly like their INI counterparts. An invalid
+        value is rejected with an error and the attribute is left
+        unchanged. Attributes without a declared option (set externally,
+        e.g. ``distro``, or brand new) are coerced via the current
+        attribute type as before.
+        """
+        attr: str = self.args.attribute
+        raw: str = self.args.value
 
-        val = (val == "True") if typ is bool else typ(val)
+        opt = next(
+            (o for o in getattr(self.config, "data", []) if o.attr == attr), None
+        )
+        if opt is not None:
+            try:
+                val = _parse_option_value(opt, raw)
+            except ValueError as e:
+                logger.error("config: cannot set %s to %r: %s", attr, raw, e)
+                return
+        else:
+            try:
+                typ = type(getattr(self.config, attr))
+            except AttributeError:
+                if raw in ("True", "False"):
+                    typ = bool
+                elif raw.isdigit():
+                    typ = int
+                else:
+                    typ = str
+            try:
+                val = _BOOLEAN_STATES[raw.lower()] if typ is bool else typ(raw)
+            except (KeyError, ValueError):
+                logger.error(
+                    "config: cannot set %s to %r: expected a value of type %s",
+                    attr,
+                    raw,
+                    typ.__name__,
+                )
+                return
 
         setattr(self.config, attr, val)
         self.println(f"option: {attr} set to value : {val}")

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -6,6 +6,7 @@ overriding configuration options with command-line arguments.
 
 import configparser
 import getpass
+import re
 from argparse import Namespace
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -14,6 +15,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
+from .http import system_ca_bundle
 from .paths import terms_path
 
 logger = getLogger("mtui.config")
@@ -41,20 +43,76 @@ _TRUE_STRINGS = frozenset({"1", "yes", "true", "on"})
 _FALSE_STRINGS = frozenset({"0", "no", "false", "off"})
 
 
+#: A c_rehash-ed capath directory entry: OpenSSL only consults hash-named
+#: symlinks/files (``<8 hex>.<n>`` / ``<8 hex>.r<n>``) in a certificate
+#: directory, so a directory without any is a verify source that can never
+#: verify anything.
+_CAPATH_HASH_ENTRY = re.compile(r"[0-9a-f]{8}\.r?\d+")
+
+
+def _default_verify() -> bool | str:
+    """The verify policy when the user expressed no path preference.
+
+    Prefers the system CA bundle over :mod:`requests`' bundled certifi
+    CAs (see :func:`mtui.support.http.system_ca_bundle`); ``True``
+    (certifi) when the system provides no bundle. Used both for an unset
+    ``[mtui] ssl_verify`` and for an explicit ``true`` spelling, so
+    writing out the documented default never changes behaviour.
+    """
+    return system_ca_bundle() or True
+
+
 def _parse_ssl_verify(raw: str) -> bool | str:
     """Coerce the ``[mtui] ssl_verify`` value into a ``requests`` ``verify``.
 
-    Accepts the usual boolean spellings (``true``/``false``/``yes``/...)
-    and otherwise treats the value as a path to a CA bundle file, which
-    :mod:`requests` accepts directly as ``verify``.
+    The boolean spellings (``true``/``false``/``yes``/...) select the
+    default verifying policy (:func:`_default_verify` — identical to an
+    unset option) or disable verification. Any other value is the path of
+    a CA bundle — a PEM file or a **c_rehash-ed** certificate directory,
+    with a leading ``~`` expanded and the result absolutised so a later
+    ``chdir`` (``chdir_to_template_dir``) cannot invalidate it. The path
+    must exist: a typo like ``false1`` or a missing file would otherwise
+    surface only at the first HTTPS call as an opaque ``OSError`` deep
+    inside :mod:`requests`, so it is rejected here at parse time and the
+    option falls back to its (verifying) default. A blank value keeps its
+    historical requests semantics (verification off) but warns, since it
+    is almost always an unfinished edit.
+
+    Raises:
+        ValueError: If the value is neither a boolean spelling nor the
+            path of an existing CA bundle file or hashed directory.
+
     """
     token = raw.strip()
+    if not token:
+        logger.warning(
+            "blank ssl_verify disables TLS verification; write "
+            "'ssl_verify = false' to make that explicit"
+        )
+        return False
     lowered = token.lower()
     if lowered in _TRUE_STRINGS:
-        return True
+        return _default_verify()
     if lowered in _FALSE_STRINGS:
         return False
-    return token
+    expanded = Path(token).expanduser().resolve()
+    if expanded.is_file():
+        return str(expanded)
+    if expanded.is_dir():
+        if any(
+            _CAPATH_HASH_ENTRY.fullmatch(entry.name) for entry in expanded.iterdir()
+        ):
+            return str(expanded)
+        raise ValueError(
+            f"ssl_verify directory {raw!r} contains no c_rehash-ed "
+            "(hash-named) entries, so OpenSSL could never verify anything "
+            "against it; run c_rehash on it or point at a PEM bundle file"
+        )
+    raise ValueError(
+        f"invalid ssl_verify value {raw!r}: expected one of true/yes/on/1, "
+        "false/no/off/0, or the path of an existing CA bundle file or "
+        "c_rehash-ed certificate directory"
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -181,8 +239,29 @@ class Config:
             except (configparser.NoSectionError, configparser.NoOptionError):
                 # Option absent from the INI: not an error, just use the default.
                 val = opt.default() if callable(opt.default) else opt.default
+            except ValueError as e:
+                default_val = opt.default() if callable(opt.default) else opt.default
+                # A validation rejection (int(...), getboolean, the fixups'
+                # own ValueErrors) is an expected user error: one clean,
+                # actionable line — the console formatter appends
+                # ``exc_text`` to every record, so ``logger.exception``
+                # would bury the message under a traceback.
+                logger.error(
+                    "Config option %s (%s.%s) failed to parse value %r: %s; "
+                    "falling back to default %r",
+                    opt.attr,
+                    opt.ini_path[0],
+                    opt.ini_path[1],
+                    raw,
+                    e,
+                    default_val,
+                )
+                val = default_val
             except Exception:
                 default_val = opt.default() if callable(opt.default) else opt.default
+                # Anything else is a parser bug, not a bad value — keep the
+                # full traceback so a bug report from a normal run contains
+                # the stack.
                 logger.exception(
                     "Config option %s (%s.%s) failed to parse value %r; "
                     "falling back to default %r",
@@ -373,16 +452,20 @@ class Config:
                 getter=get,
             ),
             # Global policy for TLS certificate verification on every
-            # outbound HTTP call (see mtui.support.http). Defaults to
-            # ``True`` so mtui verifies certificates everywhere out of the
-            # box; this requires the SUSE CA in the system trust store to
-            # reach internal hosts that present an internal-CA certificate.
-            # Set ``ssl_verify = false`` to skip verification everywhere, or
-            # point at a CA bundle file with ``ssl_verify = /path/to/ca.pem``.
+            # outbound HTTP call (see mtui.support.http). Unset — or an
+            # explicit ``true``, which is deliberately identical — mtui
+            # verifies against the system's CA bundle when one exists, so
+            # system-installed CAs (e.g. the SUSE root) work from a git
+            # checkout, where requests' bundled certifi CAs would not
+            # contain them; requests' certifi default (``True``) otherwise.
+            # Set ``ssl_verify = false`` to skip verification everywhere,
+            # or point it at a CA bundle (an existing PEM file or
+            # c_rehash-ed certificate directory; ``~`` expanded, the path
+            # absolutised) with ``ssl_verify = /path/to/ca.pem``.
             ConfigOption(
                 "ssl_verify",
                 ("mtui", "ssl_verify"),
-                True,
+                _default_verify,
                 _parse_ssl_verify,
                 get,
             ),

--- a/mtui/support/http.py
+++ b/mtui/support/http.py
@@ -11,8 +11,9 @@ verification. This module centralises both:
   shared by all callers. It bounds a stuck socket so a broken network
   cannot hang mtui indefinitely.
 - :func:`resolve_verify` turns the user's ``[mtui] ssl_verify`` config
-  value into the effective ``verify`` passed to :mod:`requests`,
-  defaulting to ``True`` (verify) when the value is unset.
+  value into the effective ``verify`` passed to :mod:`requests`; the
+  config default prefers the distribution CA bundle
+  (:func:`system_ca_bundle`) and falls back to ``True`` (certifi).
 - :func:`build_session` / :func:`disable_insecure_warnings` make the
   ``urllib3`` ``InsecureRequestWarning`` suppression happen in exactly
   one place, and only when verification is actually disabled.
@@ -22,9 +23,11 @@ verification. This module centralises both:
 
 Verification is **on by default for every call site**. Several internal
 SUSE hosts (openqa.suse.de, dashboard.qam.suse.de, qam.suse.de,
-internal mirrors) present internal-CA certificates, so reaching them
-out of the box requires the SUSE CA in the system trust store. A user
-who cannot install that CA can disable verification globally with
+internal mirrors) present internal-CA certificates; with the SUSE CA
+installed system-wide they verify out of the box, because the default
+policy prefers the distribution CA bundle (:func:`system_ca_bundle`)
+over :mod:`requests`' bundled certifi CAs. A user who cannot install
+that CA can disable verification globally with
 ``[mtui] ssl_verify = false`` (or point at a CA bundle with
 ``ssl_verify = /path/to/ca.pem``).
 """
@@ -33,6 +36,7 @@ from __future__ import annotations
 
 import os
 import ssl
+from pathlib import Path
 
 import requests
 import requests.adapters
@@ -181,20 +185,59 @@ def is_ssl_verification_error(exc: BaseException) -> bool:
     return "CERTIFICATE_VERIFY_FAILED" in str(exc)
 
 
+#: Fallback locations of the distribution-managed CA bundle, probed only
+#: when :func:`ssl.get_default_verify_paths` names no existing cafile.
+#: :mod:`requests` validates against the *certifi* package's bundled
+#: Mozilla CAs by default — NOT the system trust store — so a CA installed
+#: system-wide (e.g. the SUSE internal root from ca-certificates-suse) is
+#: invisible to it when mtui runs from a checkout/venv with PyPI certifi.
+#: Distribution python-certifi packages patch certifi to return the system
+#: bundle, which is why the gap only shows outside RPM installs.
+_SYSTEM_CA_BUNDLES = (
+    "/etc/ssl/ca-bundle.pem",  # openSUSE / SLE
+    "/etc/ssl/certs/ca-certificates.crt",  # Debian / Ubuntu
+    "/etc/pki/tls/certs/ca-bundle.crt",  # Fedora / RHEL
+    "/etc/ssl/cert.pem",  # Alpine, BSDs
+)
+
+
+def system_ca_bundle() -> str | None:
+    """The system's CA bundle path, or ``None`` when none is found.
+
+    Used as the default TLS verification source when the user set no
+    ``[mtui] ssl_verify`` policy, so system-installed CAs work from a git
+    checkout exactly as they do from an RPM install (see
+    :data:`_SYSTEM_CA_BUNDLES` for why certifi alone is not enough).
+    Prefers the interpreter's own OpenSSL default cafile
+    (:func:`ssl.get_default_verify_paths`, which also honours the
+    ``SSL_CERT_FILE`` environment override), falling back to the
+    well-known distribution paths.
+    """
+    for candidate in (ssl.get_default_verify_paths().cafile, *_SYSTEM_CA_BUNDLES):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return None
+
+
 def ssl_verification_hint(host: str | None = None) -> str:
     """A short, actionable message for a TLS certificate-verification failure.
 
-    Aimed at non-technical users who hit an internal-CA host without the
-    SUSE CA installed: it names the two concrete remedies instead of
-    dumping a multi-frame traceback.
+    Aimed at non-technical users who hit an internal-CA host: it names the
+    concrete remedies instead of dumping a multi-frame traceback. The
+    default verify policy already prefers the system CA bundle
+    (:func:`system_ca_bundle`), so installing the missing CA into the
+    system trust store — which regenerates that bundle — is the primary
+    remedy. The custom-bundle example stays generic on purpose: naming the
+    system bundle here would suggest a no-op, since it is usually already
+    the verify source that just failed.
     """
     where = f" to {host}" if host else ""
     return (
         f"TLS certificate verification failed{where}. The server's "
-        "certificate could not be verified against your system's trust "
-        "store. To fix this, either install the SUSE root CA in your "
-        "system trust store, or disable verification by setting "
-        "'ssl_verify = false' under the [mtui] section of your mtui config "
-        "(e.g. ~/.mtuirc). You can also point 'ssl_verify' at a CA bundle "
-        "file: 'ssl_verify = /path/to/ca.pem'."
+        "certificate could not be verified against the trusted CA bundle. "
+        "To fix this, install the missing CA (e.g. the SUSE root CA) into "
+        "your system trust store, point 'ssl_verify' at a CA bundle file "
+        "that contains the server's CA ('ssl_verify = /path/to/ca.pem' "
+        "under the [mtui] section of your mtui config, e.g. ~/.mtuirc), "
+        "or disable verification there with 'ssl_verify = false'."
     )

--- a/tests/test_cmd_config.py
+++ b/tests/test_cmd_config.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from mtui.commands.config import Config
+from mtui.support.config import Config as RealConfig
 from mtui.support.config import ConfigOption
 
 
@@ -15,6 +19,21 @@ def _prompt() -> MagicMock:
     p.display = MagicMock()
     p.targets = MagicMock()
     return p
+
+
+@pytest.fixture
+def real_config(tmp_path) -> RealConfig:
+    """A real Config (empty INI) so `set` sees the declared ConfigOptions."""
+    cfg_file = tmp_path / "mtui.cfg"
+    cfg_file.write_text("")
+    return RealConfig(cfg_file)
+
+
+def _run_set(config, attribute: str, value: str) -> MagicMock:
+    sys_mock = MagicMock()
+    args = Namespace(func="set", attribute=attribute, value=value)
+    Config(args, config, sys_mock, _prompt())()
+    return sys_mock
 
 
 def test_config_show_named_attribute(mock_config):
@@ -63,3 +82,167 @@ def test_config_set_new_attribute_assigns_string(mock_config):
     Config(args, cfg, sys_mock, _prompt())()
 
     assert getattr(cfg, "unknown_key") == "hello"  # noqa: B009
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Regression: the old coercion was ``val == "True"``, so every
+        # spelling but the literal "True" -- including "true" -- set False.
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("0", False),
+    ],
+)
+def test_config_set_bool_parses_ini_spellings(real_config, value, expected):
+    _run_set(real_config, "use_keyring", value)
+
+    assert real_config.use_keyring is expected
+
+
+def test_config_set_bool_rejects_garbage(real_config, caplog):
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "use_keyring", "maybe")
+
+    assert real_config.use_keyring is False  # default, unchanged
+    assert any(
+        "use_keyring" in r.message and "maybe" in r.message for r in caplog.records
+    )
+
+
+def test_config_set_int_accepts_integer(real_config):
+    _run_set(real_config, "connection_timeout", "600")
+
+    assert real_config.connection_timeout == 600
+
+
+def test_config_set_int_rejects_non_integer(real_config, caplog):
+    """`config set connection_timeout abc` must not store the string 'abc'."""
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "connection_timeout", "abc")
+
+    assert real_config.connection_timeout == 300  # default, unchanged
+    assert any(
+        "connection_timeout" in r.message and "abc" in r.message for r in caplog.records
+    )
+
+
+def test_config_set_getint_option_rejects_non_integer(real_config, caplog):
+    """Options declared with the ``getint`` getter reject non-integers too."""
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "refhosts_https_expiration", "xyz")
+
+    assert real_config.refhosts_https_expiration == 3600 * 12
+    assert any(
+        "refhosts_https_expiration" in r.message and "expected an integer" in r.message
+        for r in caplog.records
+    )
+
+
+def test_config_set_ssl_verify_false_disables_verification(real_config):
+    _run_set(real_config, "ssl_verify", "false")
+
+    assert real_config.ssl_verify is False
+
+
+def test_config_set_ssl_verify_bogus_value_rejected(real_config, caplog):
+    """'false1' is neither a boolean nor a CA bundle: reject, keep the default.
+
+    Previously the string was stored verbatim once ssl_verify held a str,
+    making every later HTTP call die with a requests-level OSError about
+    an invalid CA path.
+    """
+    before = real_config.ssl_verify
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "ssl_verify", "false1")
+
+    assert real_config.ssl_verify == before  # unchanged (verifying default)
+    assert any(
+        "ssl_verify" in r.message and "false1" in r.message for r in caplog.records
+    )
+
+
+def test_config_set_ssl_verify_ca_bundle_path(real_config, tmp_path):
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy")
+
+    _run_set(real_config, "ssl_verify", str(bundle))
+
+    assert real_config.ssl_verify == str(bundle)
+
+
+def test_config_set_str_option_stays_verbatim(real_config):
+    sys_mock = _run_set(real_config, "session_user", "bob")
+
+    assert real_config.session_user == "bob"
+    written = "".join(c.args[0] for c in sys_mock.stdout.write.call_args_list)
+    assert "session_user" in written
+
+
+def test_config_set_path_option_applies_fixup(real_config):
+    """Declared path options run their ``expanduser`` fixup, like the INI."""
+    _run_set(real_config, "template_dir", "~/templates")
+
+    assert real_config.template_dir == Path.home() / "templates"
+
+
+def test_config_set_undeclared_attribute_keeps_current_type(real_config):
+    """Attributes set externally (no ConfigOption) keep the legacy coercion."""
+    real_config.distro = "sle"
+
+    _run_set(real_config, "distro", "opensuse")
+
+    assert real_config.distro == "opensuse"
+
+
+def test_config_set_fixup_nonvalueerror_is_normalized(real_config, caplog):
+    """A fixup raising something other than ValueError is one rejection path.
+
+    Fixups are arbitrary callables; the command must not crash on e.g. a
+    RuntimeError but reject the value with the same single error shape and
+    leave the attribute unchanged.
+    """
+
+    def _boom(_raw):
+        raise RuntimeError("parser bug")
+
+    real_config.data = [ConfigOption("session_user", ("mtui", "user"), "alice", _boom)]
+    before = real_config.session_user
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "session_user", "bob")
+
+    assert real_config.session_user == before
+    assert any(
+        "session_user" in r.message and "parser bug" in r.message
+        for r in caplog.records
+    )
+
+
+def test_config_set_brand_new_attribute_infers_type(real_config):
+    """A never-declared, never-set attribute infers bool/int/str from the raw."""
+    _run_set(real_config, "brand_new_flag", "True")
+    assert real_config.brand_new_flag is True
+
+    _run_set(real_config, "brand_new_count", "42")
+    assert real_config.brand_new_count == 42
+
+    _run_set(real_config, "brand_new_name", "hello")
+    assert real_config.brand_new_name == "hello"
+
+
+def test_config_set_undeclared_bool_rejects_garbage(real_config, caplog):
+    """An undeclared attribute keeps its current type; bad values are rejected."""
+    real_config.custom_flag = True  # not in the declared option table
+    with caplog.at_level("ERROR", logger="mtui.commands.config"):
+        _run_set(real_config, "custom_flag", "maybe")
+
+    assert real_config.custom_flag is True  # unchanged
+    assert any(
+        "custom_flag" in r.message and "bool" in r.message for r in caplog.records
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,6 +187,123 @@ def test_typed_getter_failure_logs_and_falls_back_to_default(
     )
 
 
+# --- [mtui] ssl_verify: parse-time validation + system-bundle default ---
+
+
+def test_ssl_verify_typo_logs_one_clean_error_and_falls_back(
+    tmpdir, caplog, monkeypatch
+):
+    """The reproduced field bug: ``ssl_verify = false1``.
+
+    Previously the string flowed verbatim into ``requests`` and died at the
+    first HTTPS call with ``OSError: ... invalid path: false1``. Now it is
+    rejected at parse time with ONE clean ERROR line (no traceback) naming
+    the accepted forms, and verification falls back to the secure default.
+    """
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: None)
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("[mtui]\nssl_verify = false1\n")
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file)
+    assert cfg.ssl_verify is True
+    errors = [r for r in caplog.records if "ssl_verify" in r.message]
+    assert len(errors) == 1
+    assert "false1" in errors[0].message
+    assert "true/yes/on/1" in errors[0].message  # accepted forms are named
+    assert errors[0].exc_info is None  # one line, no traceback
+
+
+def test_ssl_verify_unset_prefers_system_bundle(tmpdir, monkeypatch):
+    """Unset, the policy is the distribution CA bundle when one exists.
+
+    requests validates against its bundled certifi CAs, not the system
+    trust store, so without this a system-installed internal CA (e.g. the
+    SUSE root) is invisible when mtui runs from a git checkout.
+    """
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: "/etc/ssl/ca-bundle.pem")
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("")
+    assert config.Config(cfg_file).ssl_verify == "/etc/ssl/ca-bundle.pem"
+
+
+def test_ssl_verify_unset_defaults_true_without_system_bundle(tmpdir, monkeypatch):
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: None)
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("")
+    assert config.Config(cfg_file).ssl_verify is True
+
+
+def test_ssl_verify_explicit_existing_bundle_is_kept(tmpdir):
+    ca = Path(tmpdir.join("ca.pem"))
+    ca.write_text("dummy")
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text(f"[mtui]\nssl_verify = {ca}\n")
+    assert config.Config(cfg_file).ssl_verify == str(ca)
+
+
+def test_ssl_verify_false_still_disables(tmpdir):
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("[mtui]\nssl_verify = false\n")
+    assert config.Config(cfg_file).ssl_verify is False
+
+
+def test_ssl_verify_explicit_true_equals_unset_default(tmpdir, monkeypatch):
+    """Writing out the documented default must not change behaviour.
+
+    With a system bundle present, both an unset option and an explicit
+    ``true`` prefer it — otherwise users who wrote ``ssl_verify = true``
+    would keep the internal-CA verification failure the default avoids.
+    """
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: "/etc/ssl/ca-bundle.pem")
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("[mtui]\nssl_verify = true\n")
+    assert config.Config(cfg_file).ssl_verify == "/etc/ssl/ca-bundle.pem"
+
+
+def test_ssl_verify_blank_keeps_verification_off_with_warning(
+    tmpdir, caplog, monkeypatch
+):
+    """A blank value historically disabled verification; that must survive."""
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: None)
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("[mtui]\nssl_verify =\n")
+    with caplog.at_level("WARNING", logger="mtui.config"):
+        cfg = config.Config(cfg_file)
+    assert cfg.ssl_verify is False
+    assert any("blank ssl_verify" in r.message for r in caplog.records)
+
+
+def test_unexpected_fixup_error_keeps_traceback(tmpdir, caplog):
+    """Non-ValueError fixup failures are parser bugs: the stack is kept.
+
+    Only validation rejections (ValueError) get the clean one-line
+    treatment; anything else logs with the full traceback so a bug report
+    from a normal run contains the stack.
+    """
+    cfg_file = Path(tmpdir.join("boom.cfg"))
+    cfg_file.write_text("[mtui]\nconnection_timeout = 5\n")
+    cfg = config.Config(cfg_file)
+
+    def _boom(_raw):
+        raise RuntimeError("parser bug")
+
+    cfg.data = [
+        config.ConfigOption(
+            "connection_timeout",
+            ("mtui", "connection_timeout"),
+            300,
+            _boom,
+            cfg.config.get,
+        )
+    ]
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg._parse_config()
+    assert cfg.connection_timeout == 300
+    errors = [r for r in caplog.records if "connection_timeout" in r.message]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None  # traceback preserved
+
+
 # --- Realistic fixture round-trip (Phase 6 / D5) ---
 
 

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -117,24 +117,126 @@ def test_disable_insecure_warnings_is_idempotent(monkeypatch):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize(
-    ("raw", "expected"),
-    [
-        ("true", True),
-        ("TRUE", True),
-        ("yes", True),
-        ("on", True),
-        ("1", True),
-        ("false", False),
-        ("no", False),
-        ("off", False),
-        ("0", False),
-        ("  true  ", True),
-        ("/etc/ssl/ca-bundle.pem", "/etc/ssl/ca-bundle.pem"),
-    ],
-)
-def test_parse_ssl_verify(raw, expected):
-    assert _parse_ssl_verify(raw) == expected
+@pytest.mark.parametrize("raw", ["true", "TRUE", "yes", "on", "1", "  true  "])
+def test_parse_ssl_verify_true_spellings_equal_the_default(raw, monkeypatch):
+    """An explicit true is deliberately identical to an unset option.
+
+    Writing out the documented default must never change behaviour: with a
+    system bundle present both prefer it, without one both are certifi
+    ``True``.
+    """
+    import mtui.support.config as _config
+
+    monkeypatch.setattr(_config, "system_ca_bundle", lambda: None)
+    assert _parse_ssl_verify(raw) is True
+    monkeypatch.setattr(_config, "system_ca_bundle", lambda: "/sys/ca.pem")
+    assert _parse_ssl_verify(raw) == "/sys/ca.pem"
+
+
+@pytest.mark.parametrize("raw", ["false", "no", "off", "0"])
+def test_parse_ssl_verify_false_spellings(raw):
+    assert _parse_ssl_verify(raw) is False
+
+
+def test_parse_ssl_verify_blank_disables_with_warning(caplog):
+    """A blank value keeps its historical requests semantics (verify off)."""
+    with caplog.at_level("WARNING", logger="mtui.config"):
+        assert _parse_ssl_verify("  ") is False
+    assert any("blank ssl_verify" in r.message for r in caplog.records)
+
+
+def test_parse_ssl_verify_existing_file(tmp_path):
+    ca = tmp_path / "ca.pem"
+    ca.write_text("dummy")
+    assert _parse_ssl_verify(str(ca)) == str(ca)
+
+
+def test_parse_ssl_verify_relative_path_is_absolutised(tmp_path, monkeypatch):
+    """A relative CA path must survive a later chdir_to_template_dir."""
+    (tmp_path / "ca.pem").write_text("dummy")
+    monkeypatch.chdir(tmp_path)
+    assert _parse_ssl_verify("ca.pem") == str(tmp_path / "ca.pem")
+
+
+def test_parse_ssl_verify_hashed_directory_accepted(tmp_path):
+    # OpenSSL only consults hash-named entries in a capath directory.
+    (tmp_path / "0a1b2c3d.0").write_text("dummy")
+    assert _parse_ssl_verify(str(tmp_path)) == str(tmp_path)
+
+
+def test_parse_ssl_verify_unhashed_directory_rejected(tmp_path):
+    """A directory without c_rehash-ed entries could never verify anything."""
+    (tmp_path / "some-ca.pem").write_text("dummy")
+    with pytest.raises(ValueError, match="c_rehash"):
+        _parse_ssl_verify(str(tmp_path))
+
+
+def test_parse_ssl_verify_expands_tilde(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "ca.pem").write_text("dummy")
+    assert _parse_ssl_verify("~/ca.pem") == str(tmp_path / "ca.pem")
+
+
+@pytest.mark.parametrize("bad", ["false1", "ture", "/nonexistent/ca.pem"])
+def test_parse_ssl_verify_invalid_value_raises(bad):
+    """Neither a boolean spelling nor an existing path: reject at parse time.
+
+    ``false1`` is the reproduced field bug — previously it flowed verbatim
+    into ``requests`` and died at the first HTTPS call with an opaque
+    ``OSError`` instead of a config error.
+    """
+    with pytest.raises(ValueError, match="true/yes/on/1"):
+        _parse_ssl_verify(bad)
+
+
+# ---------------------------------------------------------------------------
+# system_ca_bundle
+# ---------------------------------------------------------------------------
+
+
+def _no_default_verify_paths(monkeypatch, tmp_path):
+    """Point the interpreter's OpenSSL cafile at a nonexistent path."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        _http.ssl,
+        "get_default_verify_paths",
+        lambda: SimpleNamespace(cafile=str(tmp_path / "openssl-absent.pem")),
+    )
+
+
+def test_system_ca_bundle_prefers_interpreter_cafile(tmp_path, monkeypatch):
+    """ssl.get_default_verify_paths().cafile wins over the fallback list.
+
+    It reflects the interpreter's real OpenSSL configuration and honours
+    the SSL_CERT_FILE override.
+    """
+    from types import SimpleNamespace
+
+    openssl = tmp_path / "openssl.pem"
+    openssl.write_text("dummy")
+    fallback = tmp_path / "fallback.pem"
+    fallback.write_text("dummy")
+    monkeypatch.setattr(
+        _http.ssl, "get_default_verify_paths", lambda: SimpleNamespace(cafile=str(openssl))
+    )
+    monkeypatch.setattr(_http, "_SYSTEM_CA_BUNDLES", (str(fallback),))
+    assert _http.system_ca_bundle() == str(openssl)
+
+
+def test_system_ca_bundle_falls_back_to_wellknown_paths(tmp_path, monkeypatch):
+    _no_default_verify_paths(monkeypatch, tmp_path)
+    missing = tmp_path / "missing.pem"
+    present = tmp_path / "present.pem"
+    present.write_text("dummy")
+    monkeypatch.setattr(_http, "_SYSTEM_CA_BUNDLES", (str(missing), str(present)))
+    assert _http.system_ca_bundle() == str(present)
+
+
+def test_system_ca_bundle_none_when_no_candidate_exists(tmp_path, monkeypatch):
+    _no_default_verify_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(_http, "_SYSTEM_CA_BUNDLES", (str(tmp_path / "no.pem"),))
+    assert _http.system_ca_bundle() is None
 
 
 # ---------------------------------------------------------------------------
@@ -263,3 +365,16 @@ def test_ssl_verification_hint_mentions_remedies():
 def test_ssl_verification_hint_without_host():
     msg = _http.ssl_verification_hint()
     assert "ssl_verify = false" in msg
+
+
+def test_ssl_verification_hint_names_the_system_bundle(monkeypatch):
+    """With a distribution bundle present, the hint gives its exact path."""
+    monkeypatch.setattr(_http, "system_ca_bundle", lambda: "/etc/ssl/ca-bundle.pem")
+    msg = _http.ssl_verification_hint()
+    assert "ssl_verify = /etc/ssl/ca-bundle.pem" in msg
+
+
+def test_ssl_verification_hint_generic_without_system_bundle(monkeypatch):
+    monkeypatch.setattr(_http, "system_ca_bundle", lambda: None)
+    msg = _http.ssl_verification_hint()
+    assert "/path/to/ca.pem" in msg

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -218,7 +218,9 @@ def test_system_ca_bundle_prefers_interpreter_cafile(tmp_path, monkeypatch):
     fallback = tmp_path / "fallback.pem"
     fallback.write_text("dummy")
     monkeypatch.setattr(
-        _http.ssl, "get_default_verify_paths", lambda: SimpleNamespace(cafile=str(openssl))
+        _http.ssl,
+        "get_default_verify_paths",
+        lambda: SimpleNamespace(cafile=str(openssl)),
     )
     monkeypatch.setattr(_http, "_SYSTEM_CA_BUNDLES", (str(fallback),))
     assert _http.system_ca_bundle() == str(openssl)
@@ -367,14 +369,10 @@ def test_ssl_verification_hint_without_host():
     assert "ssl_verify = false" in msg
 
 
-def test_ssl_verification_hint_names_the_system_bundle(monkeypatch):
-    """With a distribution bundle present, the hint gives its exact path."""
-    monkeypatch.setattr(_http, "system_ca_bundle", lambda: "/etc/ssl/ca-bundle.pem")
-    msg = _http.ssl_verification_hint()
-    assert "ssl_verify = /etc/ssl/ca-bundle.pem" in msg
-
-
-def test_ssl_verification_hint_generic_without_system_bundle(monkeypatch):
-    monkeypatch.setattr(_http, "system_ca_bundle", lambda: None)
+def test_ssl_verification_hint_gives_generic_bundle_example():
+    """The custom-bundle example stays generic: naming the system bundle
+    would suggest a no-op, since it is usually already the failing verify
+    source."""
     msg = _http.ssl_verification_hint()
     assert "/path/to/ca.pem" in msg
+    assert "ca-bundle.pem" not in msg


### PR DESCRIPTION
## What

Field report: `[mtui] ssl_verify = false1` (a typo for `false`) in `~/.mtuirc`
crashed `mtui -a SUSE:SLFO:1.2:5797` with a raw traceback ending in
`OSError: Could not find a suitable TLS CA certificate bundle, invalid path:
false1` — the string flowed verbatim into `requests` as a supposed CA-bundle
path and detonated at the first HTTPS call (Gitea `get_hash` during template
load). The `OSError` is not a `RequestException`, so it bypasses every
consumer's error handling: raw traceback in gitea/openQA paths, a
never-collected future (fully silent) in the export log downloader, a silent
degrade to the possibly-stale local `refhosts.yml` in the refhosts resolver.

A second, related field failure: with `ssl_verify` unset and
`ca-certificates-suse` correctly installed, internal hosts (src.suse.de)
still failed verification when running mtui from a git checkout — `requests`
validates against PyPI `certifi`'s bundled CAs, never the system trust store
(distribution `python-certifi` packages patch this away, which is why RPM
installs were unaffected).

## Change

- `_parse_ssl_verify` keeps the boolean spellings byte-for-byte, expands `~`,
  and requires any other value to be the path of an **existing** file or
  directory; otherwise it raises with the accepted forms. Riding the config
  machinery's documented fallback contract, that surfaces as **one**
  actionable ERROR at parse time and the option falls back to the verifying
  default — the codebase's established policy for bad config values.
- The generic config-failure log is now a single clean line (`logger.error`
  with the exception text inline) instead of a full traceback
  (`logger.exception`); the traceback moved to DEBUG.
- New `system_ca_bundle()`: when `ssl_verify` is unset, verification prefers
  the distribution CA bundle (`/etc/ssl/ca-bundle.pem` on SUSE, plus the
  Debian/RHEL/Alpine equivalents), falling back to `True` (certifi) when none
  exists. System-installed CAs now work from a checkout exactly as from an
  RPM install.
- `ssl_verification_hint` names the concrete `ssl_verify = <system bundle>`
  remedy and no longer implies that installing the CA system-wide alone is
  sufficient (it wasn't, pre-fix, for checkout runs).
- Docs (`cfg.rst`), option comment, and CHANGELOG updated.

Verified end-to-end on a machine with the SUSE CA installed: the `false1`
config now yields one ERROR + fallback to `/etc/ssl/ca-bundle.pem`, and an
unset config fetches `https://src.suse.de` successfully through mtui's HTTP
path.

## Follow-up candidates (found during the investigation, out of scope here)

- `openqa_instance`/`openqa_instance_baremetal`: malformed URL escapes the
  connector's handlers as `requests.InvalidURL` at first query.
- `install_logs`/`template_dir`: bad paths crash `mkdir` after a successful
  checkout / outside svn error handling.
- `connection_timeout` accepts negative values, misattributed later as an SSH
  banner error.
- REPL `config set ssl_verify ...` bypasses fixups entirely (generic to all
  options).
- The export log downloader never collects its futures, so *any* exception
  there is silently dropped.

## Rework (response to the adversarial review — 10 findings, all addressed)

The first iteration had real defects; this rework addresses every one:

1. **`config set ssl_verify false` stored the literal string** (the runtime
   set path infers coercion from the current attribute's type, which became
   `str`): fixed properly by the second commit — `config set` now routes
   every declared option through its ConfigOption getter semantics + fixup,
   which also fixes the pre-existing `config set use_keyring true` →
   **False** bug and makes bad runtime values rejected with the option
   unchanged.
2. **Relative CA paths broke after `chdir_to_template_dir`**: paths are now
   absolutised at parse time.
3. **Blank `ssl_verify =` silently flipped from verify-off to verify-on**:
   blank keeps its historical meaning (off) and logs a warning.
4. **Explicit `true` diverged from unset** (kept certifi, losing the
   system-bundle fix): `true` is now deliberately identical to unset.
5. **Un-rehashed cert directories validated but could never verify**: a
   directory is only accepted when it contains OpenSSL hash-named entries;
   otherwise rejected with a message naming `c_rehash`.
6. **The failure hint recommended the exact bundle that just failed**: the
   custom-bundle example is now generic; installing the CA into the system
   store (which regenerates the default bundle) is the primary remedy.
7. **Tracebacks lost for unexpected parser errors**: only `ValueError`
   (validation) gets the clean one-line treatment; any other exception keeps
   `logger.exception` with the full stack.
8. **Hand-rolled bundle probe**: `system_ca_bundle()` now prefers
   `ssl.get_default_verify_paths().cafile` (the interpreter's real OpenSSL
   bundle, honouring `SSL_CERT_FILE`), with the well-known distro paths as
   fallback only.
9. **Late-mounted CA path rejected at startup** (NFS/automount): accepted
   trade-off — the rejection logs exactly why and falls back to the
   verifying default; create the file before launch or use `SSL_CERT_FILE`.
10. **Stale system bundle preferred over certifi**: accepted trade-off — on
    the target audience's systems the distribution bundle includes the
    Mozilla roots and is what every other system tool trusts.
