### PR TITLE
fix(config): validate endpoint URLs, positive ints and install_logs at parse time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   config-file parse time, falling back to the verifying default). An invalid
   value is rejected with a single actionable error and the option is left
   unchanged.
+- More config options are validated when the configuration is read, each
+  invalid value producing one actionable error and falling back to its default
+  instead of a delayed crash: the endpoint URLs (`[openqa] openqa`/`baremetal`,
+  `[qem_dashboard] api`, `[teregen] api`, `[refhosts] https_uri`) must be
+  http(s) URLs with a host and a numeric port (a typo like
+  `https://openqa.suse.de:44e3` used to surface as a raw `InvalidURL`
+  traceback at the first query), the duration/count options
+  (`connection_timeout`, `[lock] wait_poll`, `[mcp] session_cap` /
+  `session_idle_timeout`, `[refhosts] https_expiration`) must be positive
+  integers (a negative `connection_timeout` reached paramiko and failed every
+  host with a bogus "Error reading SSH protocol banner"), and
+  `[mtui] install_logs` must be a single relative directory name (a nested
+  value crashed after a successful template checkout; an absolute one silently
+  replaced the whole log path). A `[mtui] template_dir` that cannot be created
+  (e.g. a plain file in the way) is now reported as one clear error naming the
+  option instead of an `OSError` traceback, and openQA queries catch any
+  remaining URL/transport error shape instead of crashing the command.
 
 ## 18.2.0 - 2026-06-23
 

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -96,7 +96,9 @@ politely on an exhausted shared host pool.
   |     15
 
 Polling interval used while waiting for a busy lock (see ``lock.wait``).
-Ignored when ``lock.wait`` is ``0``.
+Ignored when ``lock.wait`` is ``0``. Must be a positive integer; zero or
+negative values are rejected when the configuration is read and the
+default is used instead.
 
 ``mtui.chdir_to_template_dir``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -126,18 +128,26 @@ Sets the execution timeout to the specified value.
 When the timeout limit was hit, the user is asked to wait for the current
 command to return or to proceed with the next one.
 
-To disable the timeout set it to ``0``.
+Must be a positive integer. Zero or negative values are rejected when
+the configuration is read — a non-positive timeout would reach the SSH
+layer and fail every host connection with a misleading protocol-banner
+error — and the default is used instead.
 
 
 ``mtui.install_logs``
 ~~~~~~~~~~~~~~~~~~~~~
   | **type**
-  |     string
+  |     directory name (a single relative path component)
   | **default**
   |     install_logs
 
 Name of directory for storing install logs
 Please don't change it
+
+The value is joined per update as ``template_dir/<rrid>/install_logs``,
+so it must be a bare directory name: absolute paths and values
+containing a path separator are rejected when the configuration is read
+and the default is used instead.
 
 
 ``mtui.ssh_strict_host_key_checking``
@@ -267,6 +277,10 @@ Used e.g. in lock files.
 
 URL of baremetal openqa instance
 
+Must be an ``http://`` or ``https://`` URL with a host (an explicit
+port must be numeric); an invalid value is rejected when the
+configuration is read and the default is used instead.
+
 
 ``openqa.distri``
 ~~~~~~~~~~~~~~~~~
@@ -307,6 +321,10 @@ Name of kernel installation test logfile
 
 URL of openqa instance
 
+Must be an ``http://`` or ``https://`` URL with a host (an explicit
+port must be numeric); an invalid value is rejected when the
+configuration is read and the default is used instead.
+
 
 ``qem_dashboard.api``
 ~~~~~~~~~~~~~~~~~~~~~
@@ -318,6 +336,10 @@ URL of openqa instance
 URL of the QEM Dashboard API used for incident, aggregate, and auto openQA job discovery.
 Kernel workflow still uses openQA directly.
 
+Must be an ``http://`` or ``https://`` URL with a host (an explicit
+port must be numeric); an invalid value is rejected when the
+configuration is read and the default is used instead.
+
 
 ``refhosts.https_expiration``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -328,6 +350,8 @@ Kernel workflow still uses openQA directly.
 
 Maximum age of the refhost database cache before MTUI will
 update it from ``refhosts.https_uri`` if the ``https`` resolver is used.
+Must be a positive integer; zero or negative values are rejected when
+the configuration is read and the default is used instead.
 
 
 ``refhosts.https_uri``
@@ -338,6 +362,10 @@ update it from ``refhosts.https_uri`` if the ``https`` resolver is used.
   |     https://qam.suse.de/refhosts/refhosts.yml
 
 The ``https`` resolver fetches the refhost database from this URL.
+
+Must be an ``http://`` or ``https://`` URL with a host (an explicit
+port must be numeric); an invalid value is rejected when the
+configuration is read and the default is used instead.
 
 
 ``refhosts.path``
@@ -373,6 +401,10 @@ formerly read from SMELT. It backs the ``checkers`` and ``updates`` commands, th
 ``regenerate`` command (and the loader's stale-template regeneration offer), and
 ``assign``'s display of an update's priority and deadline. The locally
 checked-out ``metadata.json`` is used as a fallback when the API is unreachable.
+
+Must be an ``http://`` or ``https://`` URL with a host (an explicit
+port must be numeric); an invalid value is rejected when the
+configuration is read and the default is used instead.
 
 
 ``svn.path``

--- a/mtui/data_sources/openqa/base.py
+++ b/mtui/data_sources/openqa/base.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import ClassVar, Self
 
 import openqa_client.exceptions
+import requests.exceptions
 from openqa_client.client import OpenQA_Client as oqa
 
 from ...support.http import disable_insecure_warnings, resolve_verify
@@ -73,6 +74,12 @@ class OpenQA(ABC):
         except openqa_client.exceptions.ConnectionError as e:
             logger.error("Cannont connect to openQA - %s", self.host)
             logger.debug("openqa_client returned: %s", e)
+            return None
+        except requests.exceptions.RequestException as e:
+            # Defensive: URL/transport failures that openqa_client does not
+            # wrap (e.g. an InvalidURL raised while preparing the request)
+            # must not escape as a raw traceback mid-command.
+            logger.error("openQA request to %s failed: %s", self.host, e)
             return None
 
         return jobs

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -14,6 +14,7 @@ from logging import getLogger
 from os import getenv
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from .http import system_ca_bundle
 from .paths import terms_path
@@ -113,6 +114,84 @@ def _parse_ssl_verify(raw: str) -> bool | str:
         "false/no/off/0, or the path of an existing CA bundle file or "
         "c_rehash-ed certificate directory"
     )
+
+
+def _parse_base_url(raw: str) -> str:
+    """Validate an ``http(s)`` endpoint-URL option at parse time.
+
+    A malformed endpoint (a typo like ``https://openqa.suse.de:44e3``)
+    otherwise survives startup untouched and only explodes at the first
+    query, deep inside :mod:`requests` as an unhandled ``InvalidURL``
+    traceback. Requires an ``http`` or ``https`` scheme, a non-empty
+    host, and — when a port is present — a numeric one. Returns the
+    stripped string.
+
+    Raises:
+        ValueError: If the value is not a usable http(s) URL.
+
+    """
+    token = raw.strip()
+    try:
+        parts = urlsplit(token)
+        # Accessing ``port`` raises ValueError on a non-numeric or
+        # out-of-range port; ``urlsplit`` itself raises on unparsable
+        # netlocs (e.g. an unclosed IPv6 bracket).
+        _ = parts.port
+        valid = parts.scheme in ("http", "https") and bool(parts.netloc)
+    except ValueError:
+        valid = False
+    if not valid:
+        raise ValueError(
+            f"invalid URL {raw!r}: expected an http:// or https:// URL "
+            "with a host and, if given, a numeric port "
+            "(e.g. https://openqa.suse.de)"
+        )
+    return token
+
+
+def _parse_positive_int(raw: Any) -> int:
+    """Coerce a duration/count option to a strictly positive ``int``.
+
+    Zero and negative values pass ``int()`` but break downstream in
+    opaque ways — e.g. a negative ``connection_timeout`` reaches paramiko
+    and surfaces as a bogus per-host ``Error reading SSH protocol
+    banner`` — so they are rejected at parse time and the option falls
+    back to its default.
+
+    Raises:
+        ValueError: If the value is not an integer greater than zero.
+
+    """
+    val = int(raw)
+    if val <= 0:
+        raise ValueError(
+            f"expected a positive integer (a timeout, interval or count "
+            f"greater than 0), got {raw!r}"
+        )
+    return val
+
+
+def _parse_install_logs(raw: str) -> Path:
+    """Validate ``[mtui] install_logs`` as a single relative directory name.
+
+    The value is joined as ``template_dir / <rrid> / install_logs`` and
+    created with ``mkdir(parents=False)`` only after a successful template
+    checkout: a nested value crashes at that point, and an absolute value
+    silently *replaces* the whole base path in the ``pathlib`` join. Both
+    are rejected at parse time instead.
+
+    Raises:
+        ValueError: If the value is empty, absolute, contains a path
+            separator, or is ``.``/``..``.
+
+    """
+    token = raw.strip()
+    if not token or "/" in token or Path(token).is_absolute() or token in (".", ".."):
+        raise ValueError(
+            f"invalid install_logs value {raw!r}: expected a single relative "
+            "directory name without a path separator (e.g. install_logs)"
+        )
+    return Path(token)
 
 
 @dataclass(frozen=True, slots=True)
@@ -315,11 +394,13 @@ class Config:
                 getpass.getuser,
                 getter=get,
             ),
+            # A single directory name, joined per update as
+            # ``template_dir / <rrid> / install_logs``; see _parse_install_logs.
             ConfigOption(
                 "install_logs",
                 ("mtui", "install_logs"),
                 Path("install_logs"),
-                expanduser,
+                _parse_install_logs,
                 get,
             ),
             # Seconds. Bounds both establishing the SSH connection (TCP
@@ -329,7 +410,7 @@ class Config:
                 "connection_timeout",
                 ("connection", "connection_timeout"),
                 300,
-                int,
+                _parse_positive_int,
                 get_connection_timeout,
             ),
             ConfigOption(
@@ -360,13 +441,15 @@ class Config:
                 "qem_dashboard_api",
                 ("qem_dashboard", "api"),
                 "http://dashboard.qam.suse.de/api",
-                getter=get,
+                _parse_base_url,
+                get,
             ),
             ConfigOption(
                 "teregen_api",
                 ("teregen", "api"),
                 "https://qam.suse.de/api/v1",
-                getter=get,
+                _parse_base_url,
+                get,
             ),
             ConfigOption(
                 "target_tempdir",
@@ -391,13 +474,14 @@ class Config:
                 "refhosts_https_uri",
                 ("refhosts", "https_uri"),
                 "https://qam.suse.de/refhosts/refhosts.yml",
-                getter=get,
+                _parse_base_url,
+                get,
             ),
             ConfigOption(
                 "refhosts_https_expiration",
                 ("refhosts", "https_expiration"),
                 3600 * 12,
-                int,
+                _parse_positive_int,
                 getint,
             ),
             ConfigOption(
@@ -419,13 +503,15 @@ class Config:
                 "openqa_instance",
                 ("openqa", "openqa"),
                 "https://openqa.suse.de",
-                getter=get,
+                _parse_base_url,
+                get,
             ),
             ConfigOption(
                 "openqa_instance_baremetal",
                 ("openqa", "baremetal"),
                 "http://openqa.qam.suse.cz",
-                getter=get,
+                _parse_base_url,
+                get,
             ),
             ConfigOption(
                 "openqa_install_distri",
@@ -519,7 +605,7 @@ class Config:
                 "lock_wait_poll",
                 ("lock", "wait_poll"),
                 15,
-                int,
+                _parse_positive_int,
                 getint,
             ),
             # ``mtui-mcp`` http transport isolates state per client in a
@@ -533,14 +619,14 @@ class Config:
                 "mcp_session_cap",
                 ("mcp", "session_cap"),
                 32,
-                int,
+                _parse_positive_int,
                 getint,
             ),
             ConfigOption(
                 "mcp_session_idle_timeout",
                 ("mcp", "session_idle_timeout"),
                 1800,
-                int,
+                _parse_positive_int,
                 getint,
             ),
             # Tool-surface budget. ``tool_profile`` selects which synthesised

--- a/mtui/support/messages.py
+++ b/mtui/support/messages.py
@@ -95,6 +95,20 @@ class SvnCheckoutFailed(ErrorMessage):
         self.message = self._msg.format(rrid, report_url)
 
 
+class TemplateDirNotUsableError(ErrorMessage):
+    """Raised when the configured template_dir cannot be created."""
+
+    _msg = (
+        "Cannot create template directory {0}: {1}\n"
+        "Please check the [mtui] template_dir option in your configuration."
+    )
+
+    def __init__(self, path, reason) -> None:
+        self.path = path
+        self.reason = reason
+        self.message = self._msg.format(path, reason)
+
+
 class ConnectingTargetFailedMessage(UserMessage):
     """A message for when connecting to a target fails."""
 

--- a/mtui/test_reports/svn_io.py
+++ b/mtui/test_reports/svn_io.py
@@ -6,7 +6,11 @@ from os.path import join
 from pathlib import Path
 
 from ..support.fileops import ensure_dir_exists
-from ..support.messages import SvnCheckoutFailed, SvnCheckoutInterruptedError
+from ..support.messages import (
+    SvnCheckoutFailed,
+    SvnCheckoutInterruptedError,
+    TemplateDirNotUsableError,
+)
 from ..types import RequestReviewID
 
 # Logger name kept at the original "mtui.template" string for log-config
@@ -74,12 +78,18 @@ def testreport_svn_checkout(config, path: str, rrid: RequestReviewID) -> None:
         rrid: The RequestReviewID of the test report.
 
     """
-    ensure_dir_exists(
-        config.template_dir,
-        on_create=lambda path: logger.debug(
-            "created config.template_dir directory %s", path
-        ),
-    )
+    try:
+        ensure_dir_exists(
+            config.template_dir,
+            on_create=lambda path: logger.debug(
+                "created config.template_dir directory %s", path
+            ),
+        )
+    except OSError as e:
+        # A template_dir that cannot be created (permission denied, a
+        # plain file in the way, ...) otherwise escapes as a raw OSError
+        # traceback; surface it as one clear error naming the option.
+        raise TemplateDirNotUsableError(config.template_dir, e) from None
     uri = join(path, str(rrid))
 
     try:

--- a/mtui/types/updateid.py
+++ b/mtui/types/updateid.py
@@ -25,6 +25,7 @@ from ..support.http import resolve_verify
 from ..support.messages import (
     SvnCheckoutFailed,
     SvnCheckoutInterruptedError,
+    TemplateDirNotUsableError,
     TestReportNotLoadedError,
 )
 from ..test_reports.null_report import NullTestReport
@@ -94,7 +95,11 @@ class UpdateID(ABC):
                     raise
                 try:
                     self._vcs_checkout(config, config.svn_path, self.id)
-                except (SvnCheckoutInterruptedError, SvnCheckoutFailed) as e:
+                except (
+                    SvnCheckoutInterruptedError,
+                    SvnCheckoutFailed,
+                    TemplateDirNotUsableError,
+                ) as e:
                     logger.error(e)
                     raise TestReportNotLoadedError from e
                 # Retry the read now that the template is on disk. Any
@@ -194,6 +199,7 @@ class UpdateID(ABC):
         except (
             SvnCheckoutInterruptedError,
             SvnCheckoutFailed,
+            TemplateDirNotUsableError,
             TemplateIOError,
             InvalidGiteaHashError,
             FailedGiteaCallError,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,13 +44,10 @@ def test_path_options_expand_tilde(tmpdir):
     """``~``-prefixed path options expand to the user's home directory."""
     config_file = Path(tmpdir.join("test.cfg"))
     config_file.write_text(
-        "[refhosts]\npath = ~/qam/refhosts.yml\n"
-        "[mtui]\ninstall_logs = ~/logs\n"
-        "[target]\ntempdir = ~/scratch\n"
+        "[refhosts]\npath = ~/qam/refhosts.yml\n[target]\ntempdir = ~/scratch\n"
     )
     cfg = config.Config(config_file)
     assert cfg.refhosts_path == Path.home() / "qam/refhosts.yml"
-    assert cfg.install_logs == Path.home() / "logs"
     assert cfg.target_tempdir == Path.home() / "scratch"
     # An absolute path is passed through unchanged.
     abs_cfg = Path(tmpdir.join("abs.cfg"))
@@ -302,6 +299,173 @@ def test_unexpected_fixup_error_keeps_traceback(tmpdir, caplog):
     errors = [r for r in caplog.records if "connection_timeout" in r.message]
     assert len(errors) == 1
     assert errors[0].exc_info is not None  # traceback preserved
+
+
+# --- Endpoint URLs / positive ints / install_logs: parse-time validation ---
+
+
+@pytest.mark.parametrize(
+    ("ini_section", "ini_key", "ini_value", "attr", "expected_default"),
+    [
+        # URL-typed endpoints. The non-numeric port is the reproduced field
+        # bug: it used to survive startup and crash the first query deep in
+        # requests as an unhandled InvalidURL.
+        (
+            "openqa",
+            "openqa",
+            "https://openqa.suse.de:44e3",
+            "openqa_instance",
+            "https://openqa.suse.de",
+        ),
+        (
+            "openqa",
+            "baremetal",
+            "openqa.qam.suse.cz",  # missing scheme
+            "openqa_instance_baremetal",
+            "http://openqa.qam.suse.cz",
+        ),
+        (
+            "qem_dashboard",
+            "api",
+            "ftp://dashboard.qam.suse.de/api",  # unsupported scheme
+            "qem_dashboard_api",
+            "http://dashboard.qam.suse.de/api",
+        ),
+        (
+            "teregen",
+            "api",
+            "https://",  # empty host
+            "teregen_api",
+            "https://qam.suse.de/api/v1",
+        ),
+        (
+            "refhosts",
+            "https_uri",
+            "qam.suse.de/refhosts/refhosts.yml",  # missing scheme
+            "refhosts_https_uri",
+            "https://qam.suse.de/refhosts/refhosts.yml",
+        ),
+        # Positive-int options: zero/negative pass int() but break downstream
+        # opaquely (a negative connection_timeout reaches paramiko and shows
+        # up as a bogus 'Error reading SSH protocol banner' per host).
+        ("connection", "connection_timeout", "-5", "connection_timeout", 300),
+        ("connection", "connection_timeout", "0", "connection_timeout", 300),
+        ("lock", "wait_poll", "0", "lock_wait_poll", 15),
+        ("mcp", "session_cap", "-1", "mcp_session_cap", 32),
+        ("mcp", "session_idle_timeout", "0", "mcp_session_idle_timeout", 1800),
+        ("refhosts", "https_expiration", "-3600", "refhosts_https_expiration", 43200),
+        # install_logs is joined as template_dir / <rrid> / install_logs and
+        # created with mkdir(parents=False): a nested value crashed AFTER a
+        # successful svn checkout, an absolute one replaced the whole base.
+        ("mtui", "install_logs", "logs/zypper", "install_logs", Path("install_logs")),
+        ("mtui", "install_logs", "/srv/logs", "install_logs", Path("install_logs")),
+    ],
+)
+def test_invalid_value_logs_one_error_and_falls_back(
+    tmpdir, caplog, ini_section, ini_key, ini_value, attr, expected_default
+):
+    """Each hardened option rejects bad values with ONE clean ERROR line."""
+    cfg_file = Path(tmpdir.join("validated.cfg"))
+    cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file)
+    assert getattr(cfg, attr) == expected_default
+    errors = [r for r in caplog.records if attr in r.message]
+    assert len(errors) == 1, (
+        f"expected exactly one ERROR naming {attr!r}; "
+        f"got: {[r.message for r in caplog.records]}"
+    )
+    assert ini_value in errors[0].message  # the offending value is shown
+    assert errors[0].exc_info is None  # one line, no traceback
+
+
+@pytest.mark.parametrize(
+    ("ini_section", "ini_key", "ini_value", "attr", "expected"),
+    [
+        (
+            "openqa",
+            "openqa",
+            "https://openqa.opensuse.org",
+            "openqa_instance",
+            "https://openqa.opensuse.org",
+        ),
+        (
+            "openqa",
+            "baremetal",
+            "http://openqa.example.com:9526",  # numeric port is fine
+            "openqa_instance_baremetal",
+            "http://openqa.example.com:9526",
+        ),
+        (
+            "teregen",
+            "api",
+            "https://qam.example.com/api/v1",
+            "teregen_api",
+            "https://qam.example.com/api/v1",
+        ),
+        ("connection", "connection_timeout", "45", "connection_timeout", 45),
+        ("lock", "wait_poll", "30", "lock_wait_poll", 30),
+        ("refhosts", "https_expiration", "600", "refhosts_https_expiration", 600),
+        ("mtui", "install_logs", "zypper_logs", "install_logs", Path("zypper_logs")),
+    ],
+)
+def test_valid_value_is_kept(
+    tmpdir, caplog, ini_section, ini_key, ini_value, attr, expected
+):
+    """Good values pass the new validations unchanged (no ERROR logged)."""
+    cfg_file = Path(tmpdir.join("validated.cfg"))
+    cfg_file.write_text(f"[{ini_section}]\n{ini_key} = {ini_value}\n")
+    with caplog.at_level("ERROR", logger="mtui.config"):
+        cfg = config.Config(cfg_file)
+    assert getattr(cfg, attr) == expected
+    assert not [r for r in caplog.records if attr in r.message]
+
+
+def test_documented_zero_semantics_are_untouched(tmpdir):
+    """``lock.wait`` (fail-fast) and ``lock.stale_age`` (disable) keep 0."""
+    cfg_file = Path(tmpdir.join("locks.cfg"))
+    cfg_file.write_text("[lock]\nwait = 0\nstale_age = 0\n")
+    cfg = config.Config(cfg_file)
+    assert cfg.lock_wait == 0
+    assert cfg.lock_stale_age == 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("https://openqa.suse.de", "https://openqa.suse.de"),
+        ("http://dashboard.qam.suse.de/api", "http://dashboard.qam.suse.de/api"),
+        # Surrounding whitespace is stripped.
+        ("  https://qam.suse.de/api/v1  ", "https://qam.suse.de/api/v1"),
+        # Numeric ports and userinfo are accepted.
+        ("https://openqa.suse.de:443", "https://openqa.suse.de:443"),
+        (
+            "http://user:pw@openqa.example.com:80/x",
+            "http://user:pw@openqa.example.com:80/x",
+        ),
+    ],
+)
+def test_parse_base_url_accepts(raw, expected):
+    assert config._parse_base_url(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "https://openqa.suse.de:44e3",  # non-numeric port
+        "https://openqa.suse.de:-1",  # out-of-range port
+        "openqa.suse.de",  # no scheme
+        "ftp://openqa.suse.de",  # unsupported scheme
+        "https://",  # empty host
+        "https:///api",  # empty host, path only
+        "http://[::1",  # unparsable IPv6 netloc
+        "",
+        "   ",
+    ],
+)
+def test_parse_base_url_rejects(raw):
+    with pytest.raises(ValueError, match="http"):
+        config._parse_base_url(raw)
 
 
 # --- Realistic fixture round-trip (Phase 6 / D5) ---

--- a/tests/test_openqa_connector.py
+++ b/tests/test_openqa_connector.py
@@ -3,7 +3,9 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import openqa_client.exceptions
 import pytest
+import requests.exceptions
 
 from mtui.data_sources.openqa.standard import AutoOpenQA
 
@@ -81,6 +83,53 @@ class TestHasPassedInstallJobs:
             {"test": "qam-somethertest", "result": "failed"},
         ]
         assert auto_oqa._has_passed_install_jobs(jobs) is True
+
+
+# --- OpenQA._get_jobs error handling ---
+
+
+class TestGetJobsErrorHandling:
+    """No URL/transport failure shape may escape ``_get_jobs`` as a traceback."""
+
+    def test_openqa_request_error_returns_none(self, auto_oqa):
+        """An openqa_client RequestError (HTTP error code) yields None."""
+        auto_oqa.client = MagicMock()
+        auto_oqa.client.openqa_request.side_effect = (
+            openqa_client.exceptions.RequestError(
+                "GET", "https://openqa/jobs", 404, "not found"
+            )
+        )
+        assert auto_oqa._get_jobs() is None
+
+    def test_openqa_connection_error_logs_and_returns_none(self, auto_oqa, caplog):
+        """An openqa_client ConnectionError is logged and yields None."""
+        auto_oqa.client = MagicMock()
+        auto_oqa.client.openqa_request.side_effect = (
+            openqa_client.exceptions.ConnectionError(
+                requests.exceptions.ConnectionError("refused")
+            )
+        )
+        with caplog.at_level("ERROR", logger="mtui.connector.openqa"):
+            assert auto_oqa._get_jobs() is None
+        assert any("openQA" in r.message for r in caplog.records)
+
+    def test_requests_exception_logs_and_returns_none(self, auto_oqa, caplog):
+        """A requests failure openqa_client does not wrap is caught too.
+
+        The reproduced shape: a malformed instance URL (e.g. a non-numeric
+        port) escapes ``OpenQA_Client`` as ``InvalidURL`` from
+        ``prepare_request``, outside its retry ``try``. It must be logged
+        and turned into the usual "no jobs" result, not a raw traceback.
+        """
+        auto_oqa.client = MagicMock()
+        auto_oqa.client.openqa_request.side_effect = requests.exceptions.InvalidURL(
+            "Failed to parse: https://openqa.suse.de:44e3"
+        )
+        with caplog.at_level("ERROR", logger="mtui.connector.openqa"):
+            assert auto_oqa._get_jobs() is None
+        errors = [r for r in caplog.records if "openQA request" in r.message]
+        assert len(errors) == 1
+        assert "44e3" in errors[0].message
 
 
 # --- AutoOpenQA._pretty_print ---

--- a/tests/test_svn_io.py
+++ b/tests/test_svn_io.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mtui.support.messages import SvnCheckoutFailed
+from mtui.support.messages import SvnCheckoutFailed, TemplateDirNotUsableError
 from mtui.test_reports import svn_io
 from mtui.types import RequestReviewID
 
@@ -55,6 +55,35 @@ def test_svn_checkout_success_does_not_raise(tmp_path: Path) -> None:
 
     with patch("mtui.test_reports.svn_io.subprocess.run", return_value=completed):
         svn_io.testreport_svn_checkout(cfg, "svn+ssh://svn@example/testreports", rrid)
+
+
+def test_svn_checkout_unusable_template_dir_raises_clear_error(
+    tmp_path: Path,
+) -> None:
+    """A template_dir that cannot be created is one actionable error.
+
+    A plain file sitting where ``[mtui] template_dir`` points (or a
+    permission problem) used to escape ``ensure_dir_exists`` as a raw
+    ``OSError`` traceback before ``svn co`` even ran.
+    """
+    blocked = tmp_path / "templates"
+    blocked.write_text("a file, not a directory")
+    cfg = SimpleNamespace(
+        template_dir=blocked, fancy_reports_url="https://qam.suse.de/reports"
+    )
+    rrid = RequestReviewID("SUSE:Maintenance:1:1")
+
+    with (
+        patch("mtui.test_reports.svn_io.subprocess.run") as run,
+        pytest.raises(TemplateDirNotUsableError) as excinfo,
+    ):
+        svn_io.testreport_svn_checkout(cfg, "svn+ssh://svn@example/testreports", rrid)
+
+    # svn co is never attempted against an unusable template_dir.
+    run.assert_not_called()
+    msg = str(excinfo.value)
+    assert "[mtui] template_dir" in msg
+    assert str(blocked) in msg
 
 
 def test_svn_checkout_runs_with_cwd_not_global_chdir(tmp_path: Path) -> None:

--- a/tests/test_updateid_checkout.py
+++ b/tests/test_updateid_checkout.py
@@ -1,0 +1,51 @@
+"""Tests for ``UpdateID._checkout`` error mapping."""
+
+from __future__ import annotations
+
+from errno import ENOENT
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.support.messages import (
+    TemplateDirNotUsableError,
+    TestReportNotLoadedError,
+)
+from mtui.test_reports.svn_io import TemplateIOError
+from mtui.types import RequestReviewID
+from mtui.types.updateid import UpdateID
+
+
+class _StubUpdateID(UpdateID):
+    """Concrete UpdateID: only _checkout is under test."""
+
+    def make_testreport(self, *a, **kw):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def test_checkout_unusable_template_dir_maps_to_not_loaded(mock_config, tmp_path):
+    """An unusable template_dir surfaces as TestReportNotLoadedError.
+
+    The svn checkout raises TemplateDirNotUsableError (e.g. a plain file in
+    the way of the configured directory); _checkout must log it and map it to
+    the same clean error as any other failed checkout instead of letting it
+    escape as a raw traceback.
+    """
+    report = MagicMock()
+    report.read.side_effect = TemplateIOError(ENOENT, "no template on disk")
+    factory = MagicMock(return_value=report)
+    vcs = MagicMock(
+        side_effect=TemplateDirNotUsableError(tmp_path / "templates", "in the way")
+    )
+    mock_config.template_dir = tmp_path
+
+    uid = _StubUpdateID(
+        RequestReviewID("SUSE:Maintenance:1:1"),
+        testreport_factory=factory,
+        testreport_svn_checkout=vcs,
+    )
+
+    with pytest.raises(TestReportNotLoadedError):
+        uid._checkout(mock_config, interactive=False)
+
+    vcs.assert_called_once()


### PR DESCRIPTION
## What

Follow-up to #260, hardening the rest of the config options whose invalid
values surfaced as late tracebacks (or silent misbehavior) instead of a clear
parse-time error. All fixes ride the same tested fallback contract as #260:
an invalid value logs **one** actionable ERROR naming the option, the bad
value and the accepted forms, then falls back to the declared default.

- **Endpoint URLs** (`openqa.openqa`, `openqa.baremetal`, `url.qem_dashboard_api`,
  `url.teregen_api`, `refhosts.https_uri`): new `_parse_base_url` fixup requires
  an http(s) scheme, a non-empty host, and a parseable port. Previously e.g.
  `openqa = https://openqa.suse.de:44e3` escaped as `requests.InvalidURL` at the
  first query, outside every handler.
- **Positive integers** (`connection_timeout`, `lock.wait_poll`,
  `mcp.session_cap`, `mcp.session_idle_timeout`, `refhosts.https_expiration`):
  zero/negative rejected. A negative `connection_timeout` previously reached
  paramiko and failed every host with a misleading "Error reading SSH protocol
  banner". Documented zero-semantics (`lock.wait`, `lock.stale_age`) untouched.
- **`install_logs`**: must be a single relative path component (it is joined as
  `template_dir/<rrid>/install_logs`; a nested value crashed `mkdir` after a
  successful checkout, and an absolute value silently replaced the whole base
  in the pathlib join).
- **`template_dir`**: an unusable path (unwritable parent, path through a file)
  now raises a single actionable `TemplateDirNotUsableError` naming the option
  instead of a raw `OSError` outside the svn error handling.
- **Defensive**: `openqa` `_get_jobs` also catches `requests.exceptions.RequestException`
  so no URL/transport shape escapes as a traceback.

## Notes

Stacked on #260 (`fix(config): validate ssl_verify at parse time...`) — the
first commit here is that PR's commit; review only the second. Will be rebased
onto main once #260 merges.

Full gates green: ruff format/check, ty, 1795 tests, sphinx docs build.
