### PR TITLE
fix(export): surface log-download failures instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   previously required at least two digits after `python` (`python38-`,
   `python313-`), so single-digit flavors like `python3-tornado` were missed
   and their build-check log was silently skipped.
+- The kernel-export log downloader no longer swallows download failures. It
+  fanned the per-log downloads out to a thread pool without ever collecting
+  the futures, so any error raised in a worker (an unexpected one such as a
+  bad TLS CA path — or even the downloader's own `ResultsMissingError` under
+  `errormode="full"`) was stored on a discarded future and vanished: the
+  kernel export finished "successfully" with zero downloaded logs and no
+  error output. Failures are now collected from every future: unexpected
+  errors are logged with the affected test and host, a summary warning
+  reports how many downloads failed, and under `errormode="full"` the failure
+  propagates to the caller once the whole batch has finished.
 
 ## 18.2.0 - 2026-06-23
 

--- a/mtui/update_workflow/export/downloader.py
+++ b/mtui/update_workflow/export/downloader.py
@@ -2,6 +2,7 @@
 
 import os.path
 from collections.abc import Callable
+from concurrent.futures import Future, as_completed
 from logging import getLogger
 from pathlib import Path
 
@@ -32,8 +33,8 @@ def _subdl(
         logger.info("Downloading log %s", oqa_path)
         data = get_bytes(oqa_path, verify=verify)
         atomic_write_file(data, Path(l_path))
-    except requests.exceptions.RequestException:
-        logger.error("Download from %s failed", oqa_path)
+    except requests.exceptions.RequestException as error:
+        logger.error("Download from %s failed: %s", oqa_path, error)
         if errormode == "full":
             raise ResultsMissingError(test["name"], test["arch"]) from None
 
@@ -120,6 +121,10 @@ def download_logs(
         errormode: The error mode to use if a download fails.
         verify: The TLS verification policy (see ``mtui.support.http``).
 
+    Raises:
+        ResultsMissingError: If a download fails and ``errormode`` is
+            ``"full"`` (raised after the whole batch has finished).
+
     """
     results_matrix: list[tuple[str, str, str, str]] = []
     for host in oqa:
@@ -128,8 +133,37 @@ def download_logs(
                 (host.host, x.name, x.test_id, x.arch) for x in host.results
             ]
 
+    failures: list[BaseException] = []
     with ContextExecutor() as e:
+        futures: dict[Future[None], tuple[str, str, str]] = {}
         for host, name, test_id, arch in results_matrix:
             test = {"name": name, "test_id": test_id, "arch": arch}
             dl = downloader.get(name.split("_")[0], _emptylog)
-            e.submit(dl, host, test, resultsdir, installogsdir, errormode, verify)
+            futures[
+                e.submit(dl, host, test, resultsdir, installogsdir, errormode, verify)
+            ] = (host, name, arch)
+
+        for future in as_completed(futures):
+            error = future.exception()
+            if error is None:
+                continue
+            failures.append(error)
+            if not isinstance(error, ResultsMissingError):
+                # _subdl already logs the download failures it anticipates
+                # (and raises ResultsMissingError under errormode="full");
+                # anything else would otherwise vanish with the future.
+                host, name, arch = futures[future]
+                logger.error(
+                    "Downloading log of test %s (%s) from %s failed: %s",
+                    name,
+                    arch,
+                    host,
+                    error,
+                )
+
+    if failures:
+        logger.warning(
+            "%s of %s openQA log downloads failed", len(failures), len(futures)
+        )
+        if errormode == "full":
+            raise failures[0]

--- a/tests/test_export_downloader.py
+++ b/tests/test_export_downloader.py
@@ -134,25 +134,114 @@ def test_downloader_dispatch_dict_keys() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _oqa_host(*results: tuple[str, str, str]) -> MagicMock:
+    """Builds a fake openQA connector with (name, test_id, arch) results."""
+    host = MagicMock()
+    host.host = "http://h"
+    host.results = []
+    for name, test_id, arch in results:
+        result = MagicMock()
+        result.name = name
+        result.test_id = test_id
+        result.arch = arch
+        host.results.append(result)
+    return host
+
+
 def test_download_logs_no_results_is_noop() -> None:
     download_logs([], "/r", "/i", "tolerant")  # must not raise
 
 
 def test_download_logs_dispatches_via_thread_pool() -> None:
-    host = MagicMock()
-    host.host = "http://h"
-    result = MagicMock()
-    result.name = "install_x"
-    result.test_id = "1"
-    result.arch = "x"
-    host.results = [result]
+    host = _oqa_host(("install_x", "1", "x"))
+    install = MagicMock()
+    with patch.dict(downloader, {"install": install}):
+        download_logs([host], "/r", "/i", "tolerant")
+    install.assert_called_once_with(
+        "http://h",
+        {"name": "install_x", "test_id": "1", "arch": "x"},
+        "/r",
+        "/i",
+        "tolerant",
+        True,
+    )
 
-    fake_executor = MagicMock()
-    fake_executor.__enter__.return_value = fake_executor
-    fake_executor.__exit__.return_value = False
-    with patch(
-        "mtui.update_workflow.export.downloader.ContextExecutor",
-        return_value=fake_executor,
+
+def test_download_logs_unexpected_error_is_logged_not_dropped(caplog) -> None:
+    # A non-RequestException (e.g. a bad TLS CA bundle path raising OSError)
+    # bypasses _subdl's error handling and used to vanish with the discarded
+    # future. It must be surfaced in the log, without aborting tolerant mode.
+    host = _oqa_host(("install_x", "1", "x86_64"))
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes",
+            side_effect=OSError("bad CA bundle"),
+        ),
+        caplog.at_level("WARNING", logger="mtui.export.downloader"),
+    ):
+        download_logs([host], "/r", "/i", "tolerant")  # must not raise
+    errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+    assert any(
+        "install_x" in m and "http://h" in m and "bad CA bundle" in m for m in errors
+    )
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert "1 of 1 openQA log downloads failed" in warnings
+
+
+def test_download_logs_full_raises_results_missing() -> None:
+    host = _oqa_host(("install_x", "1", "x86_64"))
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes",
+            side_effect=requests.exceptions.HTTPError("404"),
+        ),
+        pytest.raises(ResultsMissingError),
+    ):
+        download_logs([host], "/r", "/i", "full")
+
+
+def test_download_logs_mixed_batch_downloads_successes(caplog) -> None:
+    host = _oqa_host(("install_x", "1", "a1"), ("install_x", "2", "a2"))
+
+    def get_bytes(url, verify=True):
+        if "/tests/1/" in url:
+            raise OSError("bad CA bundle")
+        return b"log-bytes"
+
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes", side_effect=get_bytes
+        ),
+        patch("mtui.update_workflow.export.downloader.atomic_write_file") as write_file,
+        caplog.at_level("WARNING", logger="mtui.export.downloader"),
     ):
         download_logs([host], "/r", "/i", "tolerant")
-    fake_executor.submit.assert_called_once()
+
+    # The successful download is still written...
+    write_file.assert_called_once()
+    assert write_file.call_args[0][0] == b"log-bytes"
+    # ...and the summary reports the failure instead of pretending success.
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert "1 of 2 openQA log downloads failed" in warnings
+
+
+def test_download_logs_full_mixed_batch_finishes_before_raising() -> None:
+    host = _oqa_host(("install_x", "1", "a1"), ("install_x", "2", "a2"))
+
+    def get_bytes(url, verify=True):
+        if "/tests/1/" in url:
+            raise requests.exceptions.HTTPError("404")
+        return b"log-bytes"
+
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes", side_effect=get_bytes
+        ),
+        patch("mtui.update_workflow.export.downloader.atomic_write_file") as write_file,
+        pytest.raises(ResultsMissingError),
+    ):
+        download_logs([host], "/r", "/i", "full")
+
+    # The whole batch runs to completion before the failure propagates.
+    write_file.assert_called_once()
+    assert write_file.call_args[0][0] == b"log-bytes"


### PR DESCRIPTION
## What

The kernel-export log downloader (`mtui/update_workflow/export/downloader.py`)
submitted its per-log download jobs to a `ContextExecutor` and never collected
the futures — any exception was stored on a discarded `Future` and vanished.
With a broken TLS/verify config the whole kernel export produced **zero**
downloaded logs with **no error output at all**; even the module's own
`ResultsMissingError` (errormode `full`) was silently dropped the same way.

## Change

`download_logs` now drains its futures with `concurrent.futures.as_completed`
(parallelism preserved):

- every failed download is logged at ERROR with test/arch/host and the reason;
- a summary WARNING (`N of M openQA log downloads failed`) prevents the run
  from pretending success;
- under `errormode='full'`, the first collected failure is re-raised **after**
  the whole batch finishes, so successful downloads in a mixed batch still
  land.

The other export/ modules were checked for the same shape: `auto.py`/
`manual.py` download sequentially and the remaining executors already collect
their futures, so only `downloader.py` needed the fix.

Found while investigating #260 (an invalid `ssl_verify` produced an `OSError`
that this code path swallowed without a trace).

Full gates green: ruff format/check, ty, 1745 tests.
