### PR TITLE
fix(cli): render mid-spin log lines flush-left, coordinating spinner and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (e.g. a plain file in the way) is now reported as one clear error naming the
   option instead of an `OSError` traceback, and openQA queries catch any
   remaining URL/transport error shape instead of crashing the command.
+- Log lines emitted while the TTY spinner is painting (e.g. the per-host
+  `Removing repo … on <host>` lines under the `set_repo remove` spinner during
+  `update`/`prepare`) no longer render with phantom leading padding — or, with
+  colours off, glued to the leftover frame text. The spinner and the logging
+  handler now coordinate through a shared paint lock: each record first erases
+  the live frame and homes the cursor to column 0, then prints, and the spinner
+  repaints on its next tick. Interactive prompts raised under a live spinner
+  (e.g. the SSH command-timeout question) also pause the spinner for the whole
+  read instead of repainting over the prompt. Off a TTY nothing changes.
 
 ## 18.2.0 - 2026-06-23
 

--- a/mtui/cli/colors/formatter.py
+++ b/mtui/cli/colors/formatter.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 
+from ...support.spinner import spinner_suspended
 from .mode import colors_enabled
 
 # ANSI color offsets (added to 30 to form the foreground color escape code).
@@ -60,8 +61,7 @@ class ColorFormatter(logging.Formatter):
             if not colors_enabled():
                 return levelname.lower() + suffix
             return (
-                "\033[2K"
-                + COLOR_SEQ.format(30 + COLORS[levelname])
+                COLOR_SEQ.format(30 + COLORS[levelname])
                 + levelname.lower()
                 + RESET_SEQ
                 + suffix
@@ -69,12 +69,7 @@ class ColorFormatter(logging.Formatter):
             )
         if not colors_enabled():
             return levelname.lower()
-        return (
-            "\033[2K"
-            + COLOR_SEQ.format(30 + COLORS[levelname])
-            + levelname.lower()
-            + RESET_SEQ
-        )
+        return COLOR_SEQ.format(30 + COLORS[levelname]) + levelname.lower() + RESET_SEQ
 
     @staticmethod
     def _find_caller_frame() -> tuple[object, str] | None:
@@ -113,8 +108,31 @@ class ColorFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
+class SpinnerAwareStreamHandler(logging.StreamHandler):
+    """A stream handler that coordinates with a live TTY spinner.
+
+    Every record is emitted inside :func:`spinner_suspended`: while a
+    :class:`mtui.support.spinner.TtySpinner` is painting, the handler
+    erases the current frame (``\\r`` + erase-to-end, homing the cursor
+    to column 0), writes the record from a clean line, and lets the
+    spinner repaint on its next tick. Without this, a record emitted
+    mid-spin starts at the column where the frame write left the
+    cursor, rendering with phantom leading padding (or, with colours
+    off, appended straight after the frame text).
+
+    When no spinner is active — notably off a TTY, where spinners never
+    start — the wrapper adds nothing and the handler behaves exactly
+    like a plain :class:`logging.StreamHandler`.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit the record with any live spinner frame erased first."""
+        with spinner_suspended():
+            super().emit(record)
+
+
 def create_logger(name: str, level: str = "INFO") -> logging.Logger:
-    """Creates a logger with a colorized output.
+    """Creates a logger with a colorized, spinner-aware output.
 
     Args:
         name: The name of the logger.
@@ -126,7 +144,7 @@ def create_logger(name: str, level: str = "INFO") -> logging.Logger:
     """
     out = logging.getLogger(name) if name else logging.getLogger()
     out.setLevel(level)
-    handler = logging.StreamHandler()
+    handler = SpinnerAwareStreamHandler()
     formatter = ColorFormatter("%(levelname)s: %(message)s")
     handler.setFormatter(formatter)
     out.addHandler(handler)

--- a/mtui/cli/prompter.py
+++ b/mtui/cli/prompter.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 
+from ..support.spinner import spinner_suspended
+
 
 class Prompter:
     """Serialise interactive prompts across worker threads.
@@ -53,7 +55,11 @@ class Prompter:
         """Prompt the user with ``text`` and return the typed response.
 
         Acquires the prompter's lock for the duration of the read so
-        sibling workers cannot race for ``stdin``.
+        sibling workers cannot race for ``stdin``, and holds
+        :func:`mtui.support.spinner.spinner_suspended` for the whole
+        read so a live TTY spinner (e.g. ``run_parallel``'s) erases its
+        frame and stops repainting over the prompt until the user has
+        answered. A no-op when no spinner is active.
 
         Args:
             text: The prompt text shown to the user.
@@ -63,5 +69,5 @@ class Prompter:
             identical to :func:`input`).
 
         """
-        with self._lock:
+        with self._lock, spinner_suspended():
             return self._reader(text)

--- a/mtui/support/spinner.py
+++ b/mtui/support/spinner.py
@@ -4,6 +4,14 @@ Repaints a ``|/-\\`` frame on stderr while work is in flight, but only when
 stderr is a TTY. Off a TTY (pytest, redirected output, log files, the
 ``mtui-mcp`` transport) it is a no-op, so test output and log files stay clean
 and the MCP layer can surface progress through its own channel instead.
+
+Frame painting is serialised through a module-level paint lock so other
+writers on the same terminal can coordinate with a live spinner: wrap the
+write in :func:`spinner_suspended` to erase the current frame, keep the
+spinner from repainting while the block runs, and write from column 0. The
+logging handler installed by :func:`mtui.cli.colors.create_logger` does this
+for every record, so worker-thread log lines emitted mid-spin render
+flush-left instead of starting at the cursor column the frame left behind.
 """
 
 from __future__ import annotations
@@ -12,6 +20,38 @@ import sys
 import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
+
+#: Serialises every write that repaints or erases a spinner frame. An
+#: ``RLock`` so a thread already holding it (e.g. a prompt inside
+#: :func:`spinner_suspended`) can log without deadlocking itself.
+_paint_lock = threading.RLock()
+
+#: Spinners currently painting frames (TTY-enabled and started, not yet
+#: stopped). Guarded by :data:`_paint_lock`. Empty off a TTY, so
+#: :func:`spinner_suspended` is a strict no-op there.
+_active: set[TtySpinner] = set()
+
+
+@contextmanager
+def spinner_suspended() -> Iterator[None]:
+    """Pause spinner painting for the block and erase any visible frame.
+
+    Acquires the paint lock for the whole block, so a live spinner cannot
+    repaint while the caller writes to the terminal. If a spinner is
+    active, the current frame is erased first (``\\r`` + erase-to-end) and
+    the cursor is homed to column 0, so the caller's output starts on a
+    clean line. The spinner repaints on its next tick after the block
+    exits.
+
+    A no-op (beyond taking the lock) when no spinner is active — in
+    particular off a TTY, where spinners never register.
+    """
+    with _paint_lock:
+        if _active:
+            with suppress(Exception):
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
+        yield
 
 
 class TtySpinner:
@@ -33,6 +73,8 @@ class TtySpinner:
         """Start the spinner thread (no-op when stderr is not a TTY)."""
         if not self._enabled:
             return
+        with _paint_lock:
+            _active.add(self)
         self._thread = threading.Thread(target=self._spin, daemon=True)
         self._thread.start()
 
@@ -47,9 +89,12 @@ class TtySpinner:
             self._thread.join(timeout=1.0)
             self._thread = None
         # Erase the spinner line so the next caller writes from column 0.
-        with suppress(Exception):
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
+        # Under the paint lock so the erase cannot race a frame repaint.
+        with _paint_lock:
+            _active.discard(self)
+            with suppress(Exception):
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
 
     def is_stopped(self) -> bool:
         """True once :meth:`stop` has been called (set even off a TTY).
@@ -62,9 +107,15 @@ class TtySpinner:
     def _spin(self) -> None:
         i = 0
         while not self._stop.is_set():
-            with suppress(Exception):
-                sys.stderr.write(f"\r[{self._FRAMES[i % 4]}] {self._desc}")
-                sys.stderr.flush()
+            with _paint_lock:
+                # Re-check under the lock: a long ``spinner_suspended`` hold
+                # (e.g. an interactive prompt) can outlive ``stop()``; never
+                # repaint a frame that ``stop`` has already erased.
+                if self._stop.is_set():
+                    return
+                with suppress(Exception):
+                    sys.stderr.write(f"\r[{self._FRAMES[i % 4]}] {self._desc}")
+                    sys.stderr.flush()
             i += 1
             self._stop.wait(self._INTERVAL)
 

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -43,7 +43,10 @@ def test_spin_paints_a_frame(monkeypatch):
     fake = _fake_tty(monkeypatch)
     s = TtySpinner("regen")
 
-    calls = iter([False, True])  # one loop body, then exit
+    # ``_spin`` checks the stop event twice per iteration: once in the loop
+    # condition and once under the paint lock (so a frame is never repainted
+    # after ``stop`` erased it). One painted frame, then exit.
+    calls = iter([False, False, True])
     s._stop = MagicMock()  # noqa: SLF001
     s._stop.is_set.side_effect = lambda: next(calls)  # noqa: SLF001
     s._stop.wait.return_value = None  # noqa: SLF001
@@ -81,3 +84,21 @@ def test_is_stopped_set_even_off_a_tty(monkeypatch):
     assert s.is_stopped() is False
     s.stop()
     assert s.is_stopped() is True
+
+
+def test_spin_never_repaints_after_stop_wins_the_lock(monkeypatch):
+    """stop() landing between the while-check and the paint lock wins.
+
+    A long ``spinner_suspended`` hold can outlive ``stop()``; the frame
+    painter must re-check the stop flag under the lock and bail without
+    painting, or it would repaint a frame stop() already erased.
+    """
+    fake = _fake_tty(monkeypatch)
+    s = TtySpinner("desc")
+    # First is_set(): the outer while condition (not stopped yet). Second:
+    # the re-check under the paint lock (stop() got there first).
+    s._stop.is_set = MagicMock(side_effect=[False, True])
+
+    s._spin()
+
+    fake.write.assert_not_called()

--- a/tests/test_spinner_logging.py
+++ b/tests/test_spinner_logging.py
@@ -1,0 +1,244 @@
+"""Spinner/logging coordination: records emitted mid-spin render flush-left.
+
+Regression tests for the interleaving artifact where a log record emitted
+while :class:`mtui.support.spinner.TtySpinner` was painting started at the
+cursor column the frame write left behind (e.g. 19 phantom leading columns
+after a ``[|] set_repo remove`` frame), because the old ``ColorFormatter``
+erased the line with ``\\x1b[2K`` without homing the cursor first.
+
+The fix routes every record through
+:class:`mtui.cli.colors.formatter.SpinnerAwareStreamHandler`, which holds
+:func:`mtui.support.spinner.spinner_suspended` around the emit: the frame is
+erased with ``\\r\\x1b[K`` (cursor homed to column 0), the record is written
+from a clean line, and the spinner repaints on its next tick.
+
+The main test here drives the REAL spinner and the REAL ``create_logger``
+handler against a genuine pseudo-terminal and asserts on the raw bytes the
+terminal receives, plus on a minimal rendering of those bytes (``\\r``,
+``\\n``, ``\\x1b[K``, ``\\x1b[2K``; SGR colour sequences stripped).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import os
+import pty
+import re
+import select
+import sys
+import time
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from mtui.cli import colors
+from mtui.cli.colors.formatter import ColorFormatter, create_logger
+from mtui.support import spinner as _spinner
+from mtui.support.spinner import TtySpinner, spinner_suspended
+
+# --------------------------------------------------------------------- pty
+
+
+def _read_until(
+    master_fd: int,
+    buf: bytes,
+    predicate: Callable[[bytes], bool],
+    timeout: float = 5.0,
+) -> bytes:
+    """Accumulate bytes from the pty master until ``predicate`` or timeout."""
+    deadline = time.monotonic() + timeout
+    while not predicate(buf) and time.monotonic() < deadline:
+        readable, _, _ = select.select([master_fd], [], [], 0.05)
+        if readable:
+            try:
+                data = os.read(master_fd, 4096)
+            except OSError:
+                break
+            if not data:
+                break
+            buf += data
+    return buf
+
+
+_SGR = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _render(stream: bytes) -> list[str]:
+    """Minimal terminal emulation of the captured byte stream.
+
+    Handles ``\\r`` (cursor to column 0), ``\\n`` (new line; the pty's ONLCR
+    already inserts the ``\\r``), ``\\x1b[K`` (erase to end of line, cursor
+    unmoved) and ``\\x1b[2K`` (erase entire line, cursor unmoved). SGR colour
+    sequences are stripped. Returns the visible lines.
+    """
+    text = _SGR.sub("", stream.decode("utf-8", "replace"))
+    lines: list[list[str]] = [[]]
+    col = 0
+    i = 0
+    while i < len(text):
+        if text.startswith("\x1b[2K", i):
+            lines[-1] = [" "] * len(lines[-1])
+            i += 4
+            continue
+        if text.startswith("\x1b[K", i):
+            del lines[-1][col:]
+            i += 3
+            continue
+        ch = text[i]
+        if ch == "\r":
+            col = 0
+        elif ch == "\n":
+            lines.append([])
+            col = 0
+        else:
+            row = lines[-1]
+            while len(row) < col:
+                row.append(" ")
+            if col < len(row):
+                row[col] = ch
+            else:
+                row.append(ch)
+            col += 1
+        i += 1
+    return ["".join(row) for row in lines]
+
+
+@pytest.mark.parametrize("mode", ["always", "never"])
+def test_log_emitted_mid_spin_is_erased_and_flush_left(monkeypatch, mode):
+    """A record landing while a frame is on screen renders from column 0.
+
+    ``mode="always"`` covers the coloured path (the field symptom: 19 phantom
+    leading columns); ``mode="never"`` covers the NO_COLOR-on-a-TTY path where
+    the old code appended the record straight after the frame text.
+    """
+    master_fd, slave_fd = pty.openpty()
+    slave = io.TextIOWrapper(
+        os.fdopen(slave_fd, "wb", buffering=0),
+        encoding="utf-8",
+        write_through=True,
+    )
+    # Both the spinner and StreamHandler() (constructed inside create_logger)
+    # must see the pty slave as stderr, exactly like mtui.main on a real tty.
+    monkeypatch.setattr(sys, "stderr", slave)
+    assert sys.stderr.isatty()
+
+    saved_mode = colors.get_mode()
+    colors.set_mode(mode)
+    logger = create_logger(f"test-spinlog-{mode}")
+    spin = TtySpinner("set_repo remove")  # '[|] set_repo remove' = 19 cols
+    buf = b""
+    try:
+        spin.start()
+        # Wait until at least one frame is painted, so the record provably
+        # lands mid-spin with the cursor parked at the end of the frame.
+        buf = _read_until(master_fd, buf, lambda b: b"] set_repo remove" in b)
+        assert b"] set_repo remove" in buf, f"no frame painted: {buf!r}"
+
+        logger.info("Removing repo repo-oscrc on shrikebill")
+        buf = _read_until(master_fd, buf, lambda b: b"Removing repo" in b)
+    finally:
+        spin.stop()
+        colors.set_mode(saved_mode)
+        for h in list(logger.handlers):
+            logger.removeHandler(h)
+        with contextlib.suppress(OSError):
+            slave.close()
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+
+    msg_at = buf.index(b"Removing repo")
+    frame_at = buf.rindex(b"set_repo remove", 0, msg_at)
+    # The record must be preceded by a clean line-erase that homes the cursor
+    # (CR + erase-to-end), not by the old cursor-in-place \x1b[2K.
+    assert b"\r\x1b[K" in buf[frame_at:msg_at], buf[frame_at:msg_at]
+    assert b"\x1b[2K" not in buf
+
+    rendered = _render(buf)
+    line = next(ln for ln in rendered if "Removing repo" in ln)
+    # Flush-left: no phantom leading columns, no frame residue on the line.
+    assert line.startswith("info: Removing repo"), rendered
+    assert not any(
+        "set_repo remove" in ln and "Removing repo" in ln for ln in rendered
+    ), rendered
+
+
+# ------------------------------------------------------- spinner_suspended
+
+
+def _fake_stderr(monkeypatch, isatty: bool) -> MagicMock:
+    fake = MagicMock()
+    fake.isatty.return_value = isatty
+    monkeypatch.setattr(_spinner.sys, "stderr", fake)
+    return fake
+
+
+def test_suspended_erases_frame_while_spinner_active(monkeypatch):
+    fake = _fake_stderr(monkeypatch, isatty=True)
+    s = TtySpinner("working")
+    s.start()
+    try:
+        fake.write.reset_mock()
+        with spinner_suspended():
+            fake.write.assert_any_call("\r\033[K")
+    finally:
+        s.stop()
+
+
+def test_suspended_noop_without_active_spinner(monkeypatch):
+    fake = _fake_stderr(monkeypatch, isatty=True)
+    with spinner_suspended():
+        pass
+    fake.write.assert_not_called()
+
+
+def test_suspended_noop_off_tty_even_with_started_spinner(monkeypatch):
+    """Off a TTY the spinner never registers, so nothing is ever written."""
+    fake = _fake_stderr(monkeypatch, isatty=False)
+    s = TtySpinner("working")
+    s.start()
+    with spinner_suspended():
+        pass
+    s.stop()
+    fake.write.assert_not_called()
+
+
+# ----------------------------------------------------- non-TTY logger path
+
+
+def test_handler_off_tty_emits_plain_record_byte_exact(monkeypatch):
+    """Off a TTY (pytest, redirects, mtui-mcp) the handler adds nothing."""
+    stream = io.StringIO()  # isatty() is False
+    monkeypatch.setattr(sys, "stderr", stream)
+    saved_mode = colors.get_mode()
+    colors.set_mode("never")
+    logger = create_logger("test-spinlog-notty")
+    try:
+        s = TtySpinner("set_repo remove")
+        s.start()  # no-op off a TTY
+        logger.info("hello")
+        s.stop()
+    finally:
+        colors.set_mode(saved_mode)
+        for h in list(logger.handlers):
+            logger.removeHandler(h)
+
+    assert stream.getvalue() == "info: hello\n"
+
+
+def test_colorformatter_no_longer_injects_line_erase():
+    """Screen management moved to the handler; the formatter emits only SGR."""
+    saved_mode = colors.get_mode()
+    colors.set_mode("always")
+    try:
+        formatter = ColorFormatter("%(levelname)s: %(message)s")
+        record = logging.LogRecord(
+            "test-spinlog", logging.INFO, __file__, 1, "msg", None, None
+        )
+        out = formatter.format(record)
+    finally:
+        colors.set_mode(saved_mode)
+    assert "\x1b[2K" not in out
+    assert out.startswith("\x1b[1;32minfo\x1b[0m: msg")


### PR DESCRIPTION
## What

Field report: during `update`, the first worker-thread log line rendered with
~19 spaces of leading padding:

    info: Updating
                       info: Removing repo .../SLES-16.0-aarch64 on lorikeet...
    info: Removing repo .../SLES-16.0-ppc64le on bianca...

## Root cause (proven with a pty byte capture)

`ColorFormatter` prepends `\x1b[2K` (erase entire line) to the levelname to
clear a live spinner frame — but EL2 does not move the cursor. The spinner had
just painted `\r[|] set_repo remove` (exactly 19 columns), so the erased line's
text started at column 19. Follow-up lines land flush-left only because all
four workers log within one ~1 ms burst while the spinner repaints every
100 ms — the artifact recurs on the first log line of every spinner-wrapped
phase. With `NO_COLOR` on a TTY the erase was skipped entirely, leaving the
raw frame text in front of the line.

## Change

Screen management moved out of the formatter into a coordinated pair:

- `mtui/support/spinner.py`: a module-level paint lock + active-spinner
  registry; frames paint and erase under the lock, and a new
  `spinner_suspended()` context manager erases the visible frame with
  `\r\x1b[K` (CR first — the missing piece) and pauses repainting while held.
  Off a TTY spinners never register, so it writes nothing.
- `mtui/cli/colors/formatter.py`: `create_logger` installs a
  `SpinnerAwareStreamHandler` whose `emit()` runs under `spinner_suspended()`;
  the `\x1b[2K` injection is deleted from both format branches (this also
  fixes the `NO_COLOR`-on-TTY variant).
- `mtui/cli/prompter.py`: the interactive prompt suspends the spinner the same
  way instead of hand-rolling the erase.

Regression tests capture raw bytes through a pty (the investigation's repro
technique): a log line emitted mid-spin must be preceded by a clean
line-erase and render flush-left, in `always` and `never` color modes; the
no-TTY paths stay byte-identical no-ops.

Full gates green: ruff format/check, ty, 1748 tests.
