### PR TITLE
ci: switch dependabot to the uv ecosystem so uv.lock gets updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
 ---
-# Dependabot keeps Python deps and GitHub Actions versions current.
+# Dependabot keeps Python deps (via the uv ecosystem, which updates both
+# pyproject.toml and uv.lock) and GitHub Actions versions current.
 # See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     target-branch: "main"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      python-minor-and-patch:
+      uv-minor-and-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## What

Dependabot was configured with the `pip` ecosystem, which tracks the
`pyproject.toml` manifest but never updates `uv.lock` — so the resolved
dependency set the project actually installs from (uv is the documented dev
path) drifts stale with no signal. Switch the entry to dependabot's native
`uv` ecosystem, which updates both `pyproject.toml` and `uv.lock`. Schedule,
target branch, PR limit, and the minor+patch grouping are unchanged (group
key renamed to match); the `github-actions` entry is untouched.

No CHANGELOG entry (internal CI change). Full local gate set green.
