### PR TITLE
ci(release): publish GitHub releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+---
+name: release
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      # Version tags: 18.3.0, optionally with a pre-release suffix
+      # (18.3.0rc1). The project tags without a "v" prefix.
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # required for `gh release create`
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: '3.13'
+          cache-suffix: release
+
+      - name: Verify tag matches package version
+        run: |
+          pkg="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' mtui/__init__.py)"
+          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag '$GITHUB_REF_NAME' != mtui.__version__ '$pkg'"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME"
+          --title "$GITHUB_REF_NAME"
+          --generate-notes
+          dist/*


### PR DESCRIPTION
## What

Add `.github/workflows/release.yml`, triggered on version tags
(`MAJOR.MINOR.PATCH`, no `v` prefix, optional pre-release suffix like
`18.3.0rc1` — matching how the project already tags, e.g. `18.2.2`):

1. **Guard** the tag against `mtui.__version__` (`mtui/__init__.py`) and fail
   on mismatch, so a mistagged push is caught before anything is published.
2. **Build** the sdist and wheel with `uv build`.
3. **Publish** a GitHub release with `--generate-notes` and the artifacts
   attached.

Mirrors the workflow added to openSUSE/repose (#168) — the maintainer asked
for the same in mtui there.

## Notes

- Least-privilege: workflow-level `permissions: contents: read`, with the
  single job elevated to `contents: write` only for `gh release create`.
- Action SHAs and the setup-uv pin (`v8.1.0`) match the existing `ci.yml`
  for consistency; `timeout-minutes: 10` and a `release` cache-suffix.
- Verified locally: `uv build` produces `mtui-18.3.0{.tar.gz,-py3-none-any.whl}`,
  the tag-guard `sed` extracts `18.3.0` from `mtui/__init__.py`, and the YAML
  parses. Full repo gate set (ruff format/check, ty, 1741 tests) green.
- The `uses:` lines exceed yamllint's default 80-col rule, as every
  SHA-pinned line in the repo does; that is accommodated by the `.yamllint`
  policy introduced in the CI-hardening PR (#264).
