### PR TITLE
ci(coverage): enable branch coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,26 @@ include = ["mtui/cli/notification.py"]
 [tool.ty.overrides.rules]
 unused-ignore-comment = "ignore"
 
+[tool.coverage.run]
+# Branch coverage records both directions of every conditional, not merely
+# whether the line executed. Most of mtui's branches are already exercised,
+# so the headline number only dips ~1.5pp, but new code (the codecov/patch
+# gate) must now cover the untaken guard arcs -- exactly where edge-case bugs
+# hide. Only active when a run passes --cov (CI); a plain pytest run is
+# unaffected.
+branch = true
+source = ["mtui"]
+
+[tool.coverage.report]
+# Suppress structurally-unreachable arcs that would otherwise show as
+# permanently-partial branches (type-checking-only imports, abstract stubs,
+# the __main__ guard).
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["mtui*"]


### PR DESCRIPTION
What
----
Enable branch coverage in `[tool.coverage.run]` (a `[tool.coverage]`
section did not exist before; coverage was driven solely by the CI
`--cov=./mtui` flag, so it ran in statement-only mode).

Why
---
In statement mode a conditional is "covered" the instant its line runs
once, even if only one direction is ever taken. A recent review found
several defects sitting in the never-exercised guard arc of files that
were otherwise 100% line-covered. Branch coverage turns that blind spot
into signal, and — via `codecov/patch` — forces new code to exercise both
directions of the conditionals it adds.

Impact (measured on main, full suite)
-------------------------------------
- Overall: **89.7% -> 88.2%** (-1.5pp) — comfortably above the codecov
  `project` target of 81.0, so no gate breaks.
- +2,508 branches tracked, 270 currently partial (new triage surface).
- Runtime unchanged (~identical). A plain `pytest` run (no `--cov`) is
  unaffected; only `--cov` runs (CI) measure branches.

An `exclude_also` list keeps structurally-unreachable arcs
(`TYPE_CHECKING` imports, abstract stubs, the `__main__` guard) from
registering as permanently-partial.

CI/codecov config need no changes: `--cov=./mtui --cov-report=xml` picks up
the setting and ships branch data to codecov automatically.

Gates
-----
`ruff format --check .`, `ruff check .`, `ty check`, and `pytest` (1841
passed) all green on the whole repo. No docs touched; internal CI change,
so no CHANGELOG entry.