### PR TITLE
fix(oscqam): stop shlex-quoting reject messages and comments passed as argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   swallows the template-scoping flag, so the message stays intact, the call
   is scoped to the intended template (instead of silently fanning out to
   every one), and no stray `-T <RRID>` leaks into the remote command.
+- `qam reject` messages and `qam comment` text are no longer corrupted with
+  literal quote characters. They were being run through `shlex.quote` before
+  being placed into the `osc` argv list, but that list is executed without a
+  shell, so the escaping was delivered verbatim — a message like
+  `does not build` reached osc as `'does not build'` and `won't build` became
+  garbled. The message and comment are now passed through unmodified.
 - An unscoped multi-template fan-out of a host-phase command (e.g. `lock`,
   `run`) no longer fails the whole fan-out — or, for `lock`, pretends to
   succeed — when a loaded template has no connected host. A host-less template

--- a/mtui/data_sources/oscqam.py
+++ b/mtui/data_sources/oscqam.py
@@ -2,7 +2,6 @@
 
 from logging import getLogger
 from shlex import join as shlex_join
-from shlex import quote
 from subprocess import DEVNULL, CalledProcessError, TimeoutExpired, run
 
 from ..support.config import Config
@@ -56,8 +55,15 @@ class OSC:
     ) -> bool:
         """Constructs and executes `osc qam` commands safely.
 
-        This method builds the command as a list of arguments to
-        prevent command injection vulnerabilities.
+        The command is built as an argv list and handed to
+        ``subprocess.run`` without ``shell=True``, so each element is
+        passed verbatim to ``execve`` and no shell ever interprets the
+        tokens -- that alone is what prevents command injection. Because
+        there is no shell, ``shlex.quote`` must NOT be applied to the
+        message or comment: it would only add shell-escaping syntax that
+        osc then receives as literal characters, corrupting the recorded
+        text (e.g. ``does not build`` -> ``'does not build'``).
+        ``shlex_join`` is used solely to render the readable debug log.
 
         Args:
             operation: The `qam` subcommand to perform (e.g., 'approve').
@@ -83,7 +89,7 @@ class OSC:
 
         # Conditionally add optional arguments to the command list.
         reason_args = ["-R", reason] if reason else []
-        message_args = ["-M", quote(message)] if message else []
+        message_args = ["-M", message] if message else []
 
         # Add a specific workaround for 'PI' kinds which have a different RRID format
         # that oscqam does not expect by default.
@@ -98,7 +104,7 @@ class OSC:
 
         # must be converted to str -> shlex.join accepts only str or bytestr
         rrid_args = [str(self.rrid.review_id)]
-        comment_args = [quote(comment)] if comment else []
+        comment_args = [comment] if comment else []
 
         # Combine all parts into the final command list in the correct order.
         command: list[str] = (

--- a/tests/test_oscqam.py
+++ b/tests/test_oscqam.py
@@ -1,6 +1,7 @@
 """Tests for the mtui connector oscqam module."""
 
 import logging
+import shlex
 from subprocess import (
     DEVNULL,
     CalledProcessError,
@@ -127,6 +128,65 @@ class TestOSCCommandBuilding:
         assert "-A" in cmd
         api_index = cmd.index("-A")
         assert cmd[api_index + 1] == "https://api.suse.de"
+
+
+# Payloads that shell-quoting would corrupt but argv-mode execution must carry
+# byte-for-byte: spaces, an apostrophe (the worst shlex.quote case), embedded
+# double + mixed quotes, non-ASCII, and a value that looks like an option.
+_VERBATIM_PAYLOADS = [
+    "does not build",
+    "won't build",
+    'has "double" quotes',
+    "mixes ' and \" quotes",
+    "naïve café ☃",
+    "--looks-like-a-flag",
+]
+
+
+class TestOSCArgvVerbatim:
+    """Message/comment must reach osc verbatim, never shlex-quoted.
+
+    The command is an argv list run without ``shell=True``; adding
+    ``shlex.quote`` would ship literal quote characters to osc and
+    corrupt the recorded rejection message / comment.
+    """
+
+    def _argv(self, mock_run):
+        return mock_run.call_args[0][0]
+
+    @pytest.mark.parametrize("message", _VERBATIM_PAYLOADS)
+    def test_reject_message_is_verbatim_argv_element(self, mock_run, osc, message):
+        """The reject message appears as one raw argv element after -M."""
+        osc.reject(["qam-sle"], "bug found", message)
+
+        cmd = self._argv(mock_run)
+        assert message in cmd  # exact string, not a quoted variant
+        assert cmd[cmd.index("-M") + 1] == message
+        # no shell-escaping artifacts leaked into any argv element
+        assert not any(x.startswith("'") for x in cmd)
+
+    @pytest.mark.parametrize("comment", _VERBATIM_PAYLOADS)
+    def test_comment_is_verbatim_argv_element(self, mock_run, osc, comment):
+        """The comment appears as one raw argv element (last position)."""
+        osc.comment(comment)
+
+        cmd = self._argv(mock_run)
+        assert comment in cmd
+        assert cmd[-1] == comment
+        assert not any(x.startswith("'") for x in cmd)
+
+    def test_debug_log_still_renders_safely(self, mock_run, osc, caplog):
+        """shlex_join quotes for the debug log only, not the argv itself."""
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+            osc.reject(["qam-sle"], "bug found", "won't build")
+        cmd = self._argv(mock_run)
+        # The real argv element stays raw (verbatim, no shell escaping)...
+        assert cmd[cmd.index("-M") + 1] == "won't build"
+        # ...while the debug log renders the whole command shlex-quoted for
+        # display: the apostrophe message shows up escaped, never verbatim.
+        assert f"Executing command: {shlex.join(cmd)}" in caplog.text
+        assert shlex.quote("won't build") in caplog.text
+        assert "won't build" not in caplog.text
 
 
 class TestOSCInvocation:


### PR DESCRIPTION
## What

`OSC.__operation` builds the `osc qam` invocation as a Python **list** and runs it via `subprocess.run(command, ...)` with **no `shell=True`** — every element goes verbatim to `execve`. Yet the reject message (`-M`) and the comment were wrapped in `shlex.quote()` first. With no shell to interpret them, that escaping is delivered to `osc` as literal characters:

- `does not build` → osc records it as `'does not build'` (literal surrounding single quotes)
- `won't build` → osc records the garbled `'won'"'"'t build'`

(`-R`/reason was already passed unquoted, so the treatment was also inconsistent.)

The fix drops the `shlex.quote()` calls so the message and comment reach `osc` byte-for-byte, and removes the now-unused import. The misleading docstring — which claimed the quoting "prevent[s] command injection" — is corrected: injection is prevented by **argv-mode execution** (no shell), not by escaping; `shlex.join` remains solely for the human-readable debug log.

## Security

This removes no defense. Command/shell injection is impossible here because the command is an argv list executed without a shell; `shlex.quote` only adds POSIX *shell* escaping, which was pure corruption in this context. Verified across the whole flow that these values are never concatenated into a shell (the only `shell=True` in the tree is the unrelated `lrun` command, which never sees them) and are otherwise only rendered by `shlex.join` for logging.

## Tests

`tests/test_oscqam.py::TestOSCArgvVerbatim` asserts the raw message/comment appear as a single verbatim argv element in the list passed to `subprocess.run`, parametrized over adversarial payloads (spaces, apostrophe, embedded/mixed quotes, non-ASCII, a leading-dash value). A debug-log test confirms `shlex.join` still quotes for *display only* while the argv stays raw. Verified by revert: re-adding `shlex.quote` fails these tests.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` (1854 passed) — all green on the whole repo. No docs touched.

This resolves the highest-severity item from the recent code review that was not a parity bug (the other two highs are addressed in #268).
