### PR TITLE
fix(cli): stop confirmation prompts from erasing the last command from REPL history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   shell, so the escaping was delivered verbatim — a message like
   `does not build` reached osc as `'does not build'` and `won't build` became
   garbled. The message and comment are now passed through unmodified.
+- Answering a yes/no confirmation prompt (e.g. `approve`, `remove_host`,
+  `regenerate` overwrite, or `q` at the pager) no longer erases the last
+  command from your REPL history. The prompt used to scrub the newest
+  entry from `~/.mtui_history`, which — since the answer itself is never
+  written there — silently deleted the real command you had just run,
+  from both the up-arrow stack and the persisted file.
 - An unscoped multi-template fan-out of a host-phase command (e.g. `lock`,
   `run`) no longer fails the whole fan-out — or, for `lock`, pretends to
   succeed — when a loaded template has no connected host. A host-less template

--- a/mtui/cli/_history.py
+++ b/mtui/cli/_history.py
@@ -13,8 +13,11 @@ Public surface:
 * :func:`get_history` — memoised :class:`FileHistory` accessor keyed on the
   resolved absolute path.
 * :func:`pop_last_entry` — drop the most recent entry from both the
-  in-memory cache and the on-disk file. Used to scrub a yes/no answer
-  typed at :func:`prompt_user` so it does not pollute the up-arrow stack.
+  in-memory cache and the on-disk file. A standalone utility with no
+  current caller: :func:`mtui.cli.term.prompt_user` used to call it to
+  scrub a yes/no answer, but the answer is now read through an ephemeral
+  in-memory history and never reaches this shared file, so the pop was
+  removed.
 """
 
 from __future__ import annotations
@@ -73,9 +76,10 @@ def get_history(path: Path) -> FileHistory:
 def pop_last_entry(path: Path) -> str | None:
     """Remove and return the most recent history entry at ``path``.
 
-    Mirrors the legacy ``readline.remove_history_item`` call previously
-    living in :func:`mtui.cli.term.prompt_user`: keeps confirmation answers
-    (``y``/``n``) out of the up-arrow stack and out of the persisted file.
+    Mirrors the legacy ``readline.remove_history_item`` behaviour. It once
+    scrubbed a yes/no answer typed at :func:`mtui.cli.term.prompt_user`, but
+    that caller now reads through an ephemeral in-memory history and no longer
+    needs (or calls) this; it is retained as a standalone utility.
 
     Both the on-disk file and any in-memory deque held by a cached
     :class:`FileHistory` for the same path are updated, so the next prompt

--- a/mtui/cli/term.py
+++ b/mtui/cli/term.py
@@ -17,8 +17,6 @@ from collections.abc import Callable, Collection
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import InMemoryHistory
 
-from ._history import default_history_path, pop_last_entry
-
 
 def termsize() -> tuple[int, int]:
     """Gets the size of the terminal.
@@ -103,7 +101,6 @@ def prompt_user(
 
     """
     result = False
-    response = ""
 
     if not interactive:
         print(text)  # noqa: T201
@@ -117,14 +114,6 @@ def prompt_user(
             result = True
     except (KeyboardInterrupt, EOFError):
         pass
-    finally:
-        if response:
-            # Defensive scrub: even with the ephemeral in-memory history
-            # used inside ``_read_line``, a stale ``readline``-era entry
-            # written by an older mtui (or a hand-edit) would still be
-            # popped, matching the previous behaviour the acceptance
-            # tests lock in.
-            pop_last_entry(default_history_path())
 
     return result
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mtui.cli import colors as colorctl
-from mtui.cli._history import default_history_path
+from mtui.cli._history import default_history_path, get_history
 from mtui.cli.colors import green
 from mtui.cli.term import ask_user, filter_ansi, page, prompt_user
 
@@ -68,54 +68,72 @@ def test_prompt_user_non_interactive_returns_default():
     assert prompt_user("? ", ["yes", "y"], False, default=False) is False
 
 
-def test_prompt_user_pops_history_after_answer():
-    """A typed confirmation answer triggers the defensive history scrub.
+def test_prompt_user_preserves_last_command_in_history(tmp_path, monkeypatch):
+    """A confirmation answer must not erase the user's last REPL command.
 
-    Even though the in-line ``InMemoryHistory`` keeps the answer out of
-    ``~/.mtui_history``, :func:`pop_last_entry` is still invoked so a
-    stale entry written by an older ``readline``-era mtui (or by a
-    hand-edit) gets cleaned up. Locking this contract keeps the
-    leftover answer out of the up-arrow stack and out of
-    acceptance-test history snapshots.
+    Regression guard for the history-scrub bug. ``prompt_user`` used to
+    pop the newest entry from the shared on-disk history in a ``finally``
+    block. Because the answer itself is read through an ephemeral
+    ``InMemoryHistory`` and never reaches that file, the entry actually
+    removed was the *real* command the user had just run in the REPL —
+    silently deleting it from both the up-arrow deque and the persisted
+    file. ``prompt_user`` must now leave history completely untouched.
     """
-    with (
-        _patch_prompt("y"),
-        patch("mtui.cli.term.pop_last_entry") as pop_mock,
-    ):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Point the shared history at a throwaway file under the fake HOME so
+    # any stray scrub would hit *this* file, not the developer's real one.
+    hist_path = default_history_path()
+    assert hist_path == tmp_path / ".mtui_history"
+
+    # Seed a genuine command line the way the REPL's PromptSession would.
+    history = get_history(hist_path)
+    history.append_string("approve -r joe")
+
+    with _patch_prompt("y"):
         assert prompt_user("Y? ", ("y",)) is True
-    pop_mock.assert_called_once_with(default_history_path())
+
+    # The real command survives in both the cached in-memory strings and
+    # the persisted file — prompt_user touched neither.
+    assert get_history(hist_path).get_strings()[-1] == "approve -r joe"
+    assert "approve -r joe" in hist_path.read_text()
 
 
-def test_prompt_user_does_not_pop_on_empty_input():
+def test_prompt_user_does_not_touch_history_on_empty_input(tmp_path, monkeypatch):
     """An empty submission must leave the history file alone.
 
-    Nothing was typed, so there is nothing to scrub. The previous
-    ``readline``-based code shared this property and tests relied on
-    it; preserved here so the migration is behaviourally inert.
+    Nothing was typed, so there is nothing to act on; the seeded command
+    stays put and the default is returned.
     """
-    with (
-        _patch_prompt(""),
-        patch("mtui.cli.term.pop_last_entry") as pop_mock,
-    ):
-        prompt_user("Y? ", ("y",), default=False)
-    pop_mock.assert_not_called()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    hist_path = default_history_path()
+    history = get_history(hist_path)
+    history.append_string("approve -r joe")
+
+    with _patch_prompt(""):
+        assert prompt_user("Y? ", ("y",), default=False) is False
+
+    assert get_history(hist_path).get_strings()[-1] == "approve -r joe"
+    assert "approve -r joe" in hist_path.read_text()
 
 
 @pytest.mark.parametrize("bail", [KeyboardInterrupt, EOFError])
-def test_prompt_user_bailout_returns_false(bail):
+def test_prompt_user_bailout_returns_false(bail, tmp_path, monkeypatch):
     """Ctrl-C / Ctrl-D at the confirmation reads as a "no" answer.
 
     Both interrupts must short-circuit to ``False`` regardless of
     ``default`` so a stray Ctrl-C never auto-confirms a destructive
     action, and so a closed stdin (EOF) does not propagate up and crash
-    the surrounding REPL loop.
+    the surrounding REPL loop. History must remain untouched either way.
     """
-    with (
-        _patch_prompt(bail),
-        patch("mtui.cli.term.pop_last_entry") as pop_mock,
-    ):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    hist_path = default_history_path()
+    history = get_history(hist_path)
+    history.append_string("approve -r joe")
+
+    with _patch_prompt(bail):
         assert prompt_user("Y? ", ("y",), default=True) is False
-    pop_mock.assert_not_called()
+
+    assert get_history(hist_path).get_strings()[-1] == "approve -r joe"
 
 
 def test_ask_user_returns_stripped_response():


### PR DESCRIPTION
## What

Answering any yes/no confirmation prompt in the REPL silently deleted the user's **last real command** from history.

`prompt_user` reads the answer via `_read_line`, which uses an ephemeral `InMemoryHistory` — so the answer never reaches the shared on-disk history (`~/.mtui_history`). But `prompt_user`'s `finally` block still ran `pop_last_entry(default_history_path())` on every non-empty answer, dropping the **newest** entry of that shared history. Since the answer was never written there, the newest entry was the genuine command the user had just typed and run in the REPL (persisted by the REPL's own `PromptSession`). So every confirmation — `approve`, `remove_host`, `regenerate` overwrite, `q` at the pager — erased one real command from both the up-arrow deque and the persisted file, in this and all future sessions.

The pop is a leftover from the readline era, where `input()` *did* push the answer onto the shared history (so popping scrubbed the answer). With prompt_toolkit's separate `InMemoryHistory` it is pure harm.

## Fix

- Remove the `finally` block that calls `pop_last_entry(...)` from `prompt_user`, and drop the now-unused import. `prompt_user` no longer touches history at all.
- Correct the now-stale `_history.py` docstrings that described `pop_last_entry` as scrubbing a `prompt_user` answer (no longer true).

The `pop_last_entry` helper itself is **kept** (a self-contained, tested utility in `_history.py`); it is now unused by production and could be removed in a separate cleanup if desired — out of scope here.

## Tests

- Replaced the old `test_prompt_user_pops_history_after_answer` (which *asserted the buggy pop*) with `test_prompt_user_preserves_last_command_in_history`: it seeds a real command into a tmp-`HOME` history via the actual memoised `FileHistory`, answers `y`, and asserts the command survives in **both** the in-memory strings and the on-disk file. **Revert-verified**: re-adding the pop makes exactly this test fail.
- De-mocked the empty-input and bailout tests (they patched `mtui.cli.term.pop_last_entry`, a name that no longer exists) and had them assert real, untouched history instead.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` (1841 passed) — all green on the whole repo. No docs touched.

Resolves finding #4 from the recent code review.
