### PR TITLE
fix(registry): tear down the replaced report when re-adding an RRID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   entry from `~/.mtui_history`, which — since the answer itself is never
   written there — silently deleted the real command you had just run,
   from both the up-arrow stack and the persisted file.
+- Replacing an already-loaded template in the registry (e.g. `regenerate`
+  rebuilding a report without a prior `unload`) now tears the previous report
+  down — releasing its host-arbitration pool claims and closing its refhost SSH
+  connections — instead of silently overwriting it. Repeated `regenerate`
+  cycles no longer leak file descriptors or leave stale arbiter claims that
+  could block later slot re-acquisition on the same refhost pool.
 - An unscoped multi-template fan-out of a host-phase command (e.g. `lock`,
   `run`) no longer fails the whole fan-out — or, for `lock`, pretends to
   succeed — when a loaded template has no connected host. A host-less template

--- a/mtui/template_registry.py
+++ b/mtui/template_registry.py
@@ -69,17 +69,31 @@ class TemplateRegistry:
         """Insert (or replace) ``report`` keyed by its RRID.
 
         The first template added becomes active. Re-adding an existing RRID
-        replaces the stored report but does not change the active pointer.
+        replaces the stored report but does not change the active pointer; the
+        previously stored report is torn down first (its host-arbitration/pool
+        claims released and its refhost connections closed via
+        :meth:`_teardown`) so a bare ``add`` overwrite -- e.g. ``regenerate``
+        rebuilding a template without a prior :meth:`remove` -- never leaks the
+        old report's SSH sockets or leaves stale arbiter claims behind.
+        Re-adding the *same* object is a no-op that never tears it down.
 
         A :class:`NullTestReport` (empty RRID) is the sentinel a *failed* load
         returns; it is never keyed into the collection. Keying it would leave a
         phantom empty-RRID entry that breaks every unscoped fan-out with
         ``TestReportNotLoadedError``. Such a report is silently ignored here so
-        a failed load leaves the registry unchanged.
+        a failed load leaves the registry unchanged (in particular it must not
+        tear down whatever template is currently loaded).
         """
         rrid = str(report.id)
         if not rrid:
             return
+        # Replacing an existing RRID with a *different* report: tear the old one
+        # down (release pool claims, close its targets) so the overwrite does
+        # not leak the previous report's connections. Re-adding the identical
+        # object must not self-close, hence the ``old is not report`` guard.
+        old = self._entries.get(rrid)
+        if old is not None and old is not report:
+            self._teardown(old)
         # Wire host-arbitration ownership so connect_targets can draw distinct
         # pool hosts; reports stay legacy (remote-lock-only) until this is set.
         report._arbiter = self.arbiter  # noqa: SLF001
@@ -96,6 +110,18 @@ class TemplateRegistry:
         order) becomes active, or ``None`` when the registry empties.
         """
         report = self._entries.pop(rrid)
+        self._teardown(report)
+        if self._active == rrid:
+            self._active = next(iter(self._entries), None)
+
+    def _teardown(self, report: TestReport) -> None:
+        """Release ``report``'s pool claims and close its refhost connections.
+
+        Shared best-effort teardown (mirrors ``McpSession._disconnect_targets``)
+        used by both :meth:`remove` and the replace path of :meth:`add`: drop
+        arbiter ownership and remote pool locks first (no-op when pool selection
+        was never used), then close every target, then clear the host group.
+        """
         # Drop arbiter ownership and remote pool locks before tearing down
         # the connections (no-op when pool selection was never used).
         self.release_claims(report)
@@ -106,8 +132,6 @@ class TemplateRegistry:
             with contextlib.suppress(Exception):
                 targets[name].close()
         targets.clear()
-        if self._active == rrid:
-            self._active = next(iter(self._entries), None)
 
     def get(self, rrid: str) -> TestReport:
         """Return the loaded report for ``rrid`` (raises ``KeyError`` if absent)."""

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -170,3 +170,53 @@ def test_remove_swallows_close_errors(registry):
     registry.add(r)
     registry.remove("a")  # must not raise
     assert len(registry) == 0
+
+
+def test_add_replace_tears_down_old_report(registry):
+    # Re-adding an RRID with a DIFFERENT report object (e.g. ``regenerate``
+    # rebuilding the template without a prior ``remove``) must tear the old
+    # report down instead of silently dropping it: release its pool claims,
+    # close its refhost connections, and clear its host group.
+    old = make_report("SUSE:Maintenance:1:1", hosts=["h1", "h2"])
+    old_targets = old.targets
+    h1, h2 = old_targets["h1"], old_targets["h2"]
+    registry.add(old)
+    new = make_report("SUSE:Maintenance:1:1", hosts=["h3"])
+    registry.add(new)
+    # Old report's connections closed and host group emptied.
+    assert h1.closed
+    assert h2.closed
+    assert len(old_targets) == 0
+    old.release_pool_claims.assert_called_once()
+    # Registry now serves the NEW report for that RRID; active still resolves.
+    assert len(registry) == 1
+    assert registry.get("SUSE:Maintenance:1:1") is new
+    assert registry.active is new
+
+
+def test_add_same_object_is_noop(registry):
+    # Re-adding the identical object must NOT tear it down: its connections
+    # stay open and its pool claims are not released.
+    r = make_report("SUSE:Maintenance:1:1", hosts=["h1"])
+    h1 = r.targets["h1"]
+    registry.add(r)
+    registry.add(r)  # idempotent re-add of the same object
+    assert not h1.closed
+    assert len(r.targets) == 1
+    r.release_pool_claims.assert_not_called()
+    assert registry.get("SUSE:Maintenance:1:1") is r
+    assert registry.active is r
+
+
+def test_add_sentinel_does_not_tear_down_loaded_report(registry):
+    # A failed load (empty-RRID sentinel) mid-session must leave the currently
+    # loaded report fully intact: no pool claims released, no targets closed.
+    r = make_report("SUSE:Maintenance:1:1", hosts=["h1"])
+    h1 = r.targets["h1"]
+    registry.add(r)
+    registry.add(make_report(""))  # failed load must not tear down the live one
+    assert not h1.closed
+    assert len(r.targets) == 1
+    r.release_pool_claims.assert_not_called()
+    assert registry.active is r
+    assert registry.rrids() == ["SUSE:Maintenance:1:1"]


### PR DESCRIPTION
## What

`TemplateRegistry.add()`'s **replace path** — re-adding a report for an RRID that is already loaded — overwrote the stored `TestReport` with a bare `self._entries[rrid] = report` (template_registry.py:87). It silently discarded the previous report **without releasing its host-arbitration pool claims or closing its refhost SSH connections**. This is asymmetric with `remove()`, which for exactly this teardown calls `release_claims(report)`, closes each target, and clears the host group.

This is the path `regenerate` takes:

```
regenerate -> _reload() -> prompt.load_update(AutoOBSUpdateID(X), autoconnect=False)
           -> self.templates.add(new_tr)      # no prior templates.remove(X)
```

`add()` finds `X` already in `_entries` and overwrites it. The old report's open SSH sockets/FDs are never closed and its arbiter claims (keyed `(registry.id, X)`) are never released — GC/`__del__` on paramiko connections is unreliable. Repeated `regenerate` cycles accumulate leaked file descriptors and stale claims, the latter of which can block later slot re-acquisition on the same refhost pool.

## Fix

Extract `remove()`'s teardown into a shared `_teardown(report)` helper and call it on `add()`'s replace path, so a replace releases claims and closes connections symmetrically with an explicit `remove()`. Two guards preserve existing behaviour:

- The empty-RRID (`NullTestReport`) sentinel returns **before** any teardown, so a *failed* load never disturbs the currently-loaded template.
- An `old is not report` check makes re-adding the **identical object** a genuine no-op that never self-closes.

The fix is at the registry layer, so it covers both the REPL (`repl.py:472`) and MCP (`session.py:476`) surfaces — the only two callers of `add()`.

**Arbiter safety:** old and new share the owner key `(registry.id, rrid)`, but `_teardown(old)` runs *before* the new report is wired (`_arbiter`/`_owner`) and both call sites defer `tr.autoconnect()` until after `add()` returns — so the new report holds zero claims when `release_owner()` frees the old ones. No cross-release, no double-close, no use-after-free.

## Tests

- `test_add_replace_tears_down_old_report` — replacing an RRID with a *different* object closes the old targets, clears its host group, releases its pool claims, and serves the new report (active pointer intact). **Revert-verified**: removing the replace-path block fails exactly this test at `assert h1.closed`.
- `test_add_same_object_is_noop` — re-adding the identical object leaves its connections open and claims held.
- `test_add_sentinel_does_not_tear_down_loaded_report` — a failed load (empty-RRID sentinel) mid-session leaves the live report fully intact.

Coverage of `mtui/template_registry.py` is 100% (all new lines).

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo (1844 passed). Docs untouched.

Resolves finding #11 from the recent code review.
