### PR TITLE
fix(commands): stop openqa_jobs --failed listing unfinished jobs as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
+  failures. openQA reports an unfinished job's result as `none`, which the
+  filter treated as "not passing" — during active testing an in-progress
+  build looked like it had a dozen failures (all red, counted as `none=12`
+  in the summary), risking a wrong verdict. Unfinished jobs are now
+  excluded from `--failed`, and the listing shows their actual state
+  (`running`, `scheduled`, ...) in yellow instead of a red `none`. When the
+  filter leaves nothing, the message now distinguishes an in-progress build
+  ("No failed openQA jobs ...; 12 of 12 still pending") from a build with no
+  jobs at all.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/commands/openqa_jobs.py
+++ b/mtui/commands/openqa_jobs.py
@@ -7,7 +7,10 @@ per-version PASSED/FAILED/RUNNING summary that ``openqa_overview`` prints.
 
 By default ``obsoleted`` jobs (superseded by a later retrigger) are dropped; only
 the current run matters. Use ``--all`` to keep them, ``--failed`` to show only
-non-passing jobs, and ``--arch`` to filter by architecture.
+non-passing jobs, and ``--arch`` to filter by architecture. Jobs that have not
+finished (scheduled/running — openQA reports their result as ``none``) are
+pending, not failures: ``--failed`` excludes them and the listing shows their
+state in yellow instead of a red ``none``.
 """
 
 from __future__ import annotations
@@ -28,6 +31,23 @@ logger = getLogger("mtui.commands.openqa_jobs")
 # openQA results that count as "not a failure" for the --failed filter.
 _PASSING = frozenset({"passed", "softfailed"})
 _NEUTRAL = frozenset({"obsoleted", "skipped"})
+# A job that has not finished yet: openQA keeps ``result`` at ``none``
+# (some API paths omit it entirely) until the job is done. Pending work
+# is not a failure -- it must neither pass the --failed filter nor be
+# painted red.
+_PENDING = frozenset({"none", ""})
+
+
+def _display_result(job) -> str:
+    """The label to print/count for a job.
+
+    An unfinished job's ``result`` is the meaningless ``none``; its
+    ``state`` (``scheduled``, ``running``, ...) is what a tester wants
+    to see instead.
+    """
+    if job.result in _PENDING:
+        return job.state or "pending"
+    return job.result
 
 
 class OpenQAJobs(Command):
@@ -96,28 +116,41 @@ class OpenQAJobs(Command):
         jobs = oqa.incident_jobs(build, url_openqa, include_obsoleted=self.args.all)
         if self.args.arch:
             jobs = [j for j in jobs if j.arch == self.args.arch]
+        total = len(jobs)
+        pending = sum(1 for j in jobs if j.result in _PENDING)
         if self.args.failed:
             jobs = [
-                j for j in jobs if j.result not in _PASSING and j.result not in _NEUTRAL
+                j
+                for j in jobs
+                if j.result not in _PASSING
+                and j.result not in _NEUTRAL
+                and j.result not in _PENDING
             ]
 
         if not jobs:
-            self.println(yellow(f"No openQA jobs for build {build!r}"))
+            if self.args.failed and total:
+                # Jobs exist, none failed (yet). Saying "no jobs" here would
+                # make an in-progress build indistinguishable from an empty
+                # or all-passed one, so name the pending work explicitly.
+                note = f"; {pending} of {total} still pending" if pending else ""
+                self.println(yellow(f"No failed openQA jobs for build {build!r}{note}"))
+            else:
+                self.println(yellow(f"No openQA jobs for build {build!r}"))
             return
 
-        counts = Counter(j.result for j in jobs)
+        counts = Counter(_display_result(j) for j in jobs)
         summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
         self.println(f"openQA jobs for build {build} ({len(jobs)}): {summary}")
         self.println("")
         for j in jobs:
             if j.result in _PASSING:
                 colour = green
-            elif j.result in _NEUTRAL:
+            elif j.result in _NEUTRAL or j.result in _PENDING:
                 colour = yellow
             else:
                 colour = red
             self.println(
-                f"  {colour(j.result.ljust(15))} {j.arch:<8} {j.test}  {j.url}"
+                f"  {colour(_display_result(j).ljust(15))} {j.arch:<8} {j.test}  {j.url}"
             )
 
     @staticmethod

--- a/mtui/data_sources/oqa_search/results.py
+++ b/mtui/data_sources/oqa_search/results.py
@@ -43,9 +43,12 @@ class JobResult:
 
     ``result`` is openQA's job result: ``passed``, ``softfailed``,
     ``failed``, ``parallel_failed``, ``incomplete``, ``skipped`` or
-    ``obsoleted`` (superseded by a retrigger). ``test`` is the scenario
-    name (the meaningful field for judging relevance — unlike the full
-    job name it does not embed the build string).
+    ``obsoleted`` (superseded by a retrigger). A job that has not
+    finished carries result ``none`` — its ``state`` (``scheduled``,
+    ``running``, ...; ``done`` once finished) tells what it is actually
+    doing. ``test`` is the scenario name (the meaningful field for
+    judging relevance — unlike the full job name it does not embed the
+    build string).
     """
 
     job_id: int
@@ -54,3 +57,4 @@ class JobResult:
     result: str
     group: str = ""
     url: str = ""
+    state: str = ""

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -118,6 +118,7 @@ def incident_jobs(
                 result=result,
                 group=job.get("group", ""),
                 url=f"{url_openqa.rstrip('/')}/t{job.get('id', '')}",
+                state=job.get("state", ""),
             )
         )
     rows.sort(key=lambda r: (r.result, r.arch, r.test))

--- a/tests/test_cmd_openqa_jobs.py
+++ b/tests/test_cmd_openqa_jobs.py
@@ -1,0 +1,151 @@
+"""Tests for the ``openqa_jobs`` command's pending-job handling.
+
+Regression tests: a job that has not finished yet (openQA keeps its
+``result`` at ``none`` until the job is done) was counted as a failure
+by ``--failed`` and painted red in the listing, making an in-progress
+build look like it had a dozen failures.
+"""
+
+from argparse import Namespace
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mtui.commands.openqa_jobs import OpenQAJobs, _display_result
+from mtui.data_sources.oqa_search import JobResult
+from mtui.types import RequestReviewID
+
+
+def _job(result: str, state: str = "done", test: str = "t", arch: str = "x86_64"):
+    return JobResult(
+        job_id=1, test=test, arch=arch, result=result, url="u", state=state
+    )
+
+
+def _run(jobs, **arg_overrides) -> str:
+    """Run OpenQAJobs against canned jobs and return its stdout.
+
+    The colour helpers are patched to visible tags so the tests can
+    assert the colour *classification* without depending on the runtime
+    colour mode.
+    """
+    prompt = MagicMock()
+    prompt.metadata.__bool__ = lambda self: True
+    prompt.metadata.rrid = RequestReviewID("SUSE:Maintenance:1:1")
+    out = StringIO()
+    args = Namespace(
+        all=False,
+        failed=False,
+        arch=None,
+        url_openqa=None,
+        url_dashboard_qam=None,
+    )
+    for key, value in arg_overrides.items():
+        setattr(args, key, value)
+    config = MagicMock()
+    config.openqa_instance = "https://openqa.example.com"
+    config.qem_dashboard_api = "http://dashboard.example.com/api"
+    with (
+        patch("mtui.commands.openqa_jobs.oqa.set_verify"),
+        patch(
+            "mtui.commands.openqa_jobs.oqa.get_incident_info",
+            return_value=("build7", 0),
+        ),
+        patch("mtui.commands.openqa_jobs.oqa.incident_jobs", return_value=jobs),
+        patch("mtui.commands.openqa_jobs.green", lambda s: f"<G>{s}</G>"),
+        patch("mtui.commands.openqa_jobs.yellow", lambda s: f"<Y>{s}</Y>"),
+        patch("mtui.commands.openqa_jobs.red", lambda s: f"<R>{s}</R>"),
+    ):
+        OpenQAJobs(args, config, SimpleNamespace(stdout=out), prompt)()
+    return out.getvalue()
+
+
+def test_failed_excludes_pending_jobs():
+    """--failed must not list scheduled/running jobs as failures."""
+    output = _run(
+        [
+            _job("failed", test="real_failure"),
+            _job("none", state="running", test="still_running"),
+            _job("none", state="scheduled", test="not_started"),
+            _job("passed", test="ok"),
+        ],
+        failed=True,
+    )
+
+    assert "real_failure" in output
+    assert "still_running" not in output
+    assert "not_started" not in output
+    assert "ok" not in output
+    # The count summary reflects only the one genuine failure.
+    assert "(1): failed=1" in output
+
+
+def test_listing_shows_pending_state_in_yellow_not_a_red_none():
+    """An unfinished job shows its state, coloured like the neutral ones."""
+    output = _run(
+        [
+            _job("none", state="running", test="still_running"),
+            _job("none", state="scheduled", test="not_started"),
+            _job("passed", test="ok"),
+        ]
+    )
+
+    assert "<Y>running" in output
+    assert "<Y>scheduled" in output
+    assert "<G>passed" in output
+    # The meaningless raw result must not surface anywhere -- neither as a
+    # red row nor in the count summary.
+    assert "none" not in output
+    assert "passed=1, running=1, scheduled=1" in output
+
+
+def test_real_failures_still_red_and_listed():
+    """The fix must not soften genuine failures."""
+    output = _run([_job("failed"), _job("incomplete"), _job("parallel_failed")])
+
+    assert "<R>failed" in output
+    assert "<R>incomplete" in output
+    assert "<R>parallel_failed" in output
+
+
+def test_display_result_falls_back_to_pending_without_state():
+    """Old/degraded API data: no state either -- label it pending."""
+    assert _display_result(_job("", state="")) == "pending"
+    assert _display_result(_job("none", state="")) == "pending"
+    assert _display_result(_job("softfailed", state="done")) == "softfailed"
+
+
+def test_failed_on_all_pending_build_names_the_pending_work():
+    """--failed on an in-progress build must not claim there are no jobs.
+
+    With every job pending the filter empties the list; the old generic
+    "No openQA jobs" message made an in-progress build indistinguishable
+    from one with no jobs at all.
+    """
+    output = _run(
+        [
+            _job("none", state="running"),
+            _job("none", state="scheduled"),
+            _job("passed"),
+        ],
+        failed=True,
+    )
+
+    assert "No failed openQA jobs" in output
+    assert "2 of 3 still pending" in output
+    assert "No openQA jobs" not in output
+
+
+def test_failed_on_all_passed_build_reports_no_failed_jobs():
+    """--failed with only finished passing jobs: accurate, no pending note."""
+    output = _run([_job("passed"), _job("softfailed")], failed=True)
+
+    assert "No failed openQA jobs" in output
+    assert "pending" not in output
+
+
+def test_no_jobs_at_all_keeps_the_original_message():
+    """A genuinely empty build still reports no jobs."""
+    output = _run([], failed=True)
+
+    assert "No openQA jobs for build" in output

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -881,6 +881,46 @@ def test_incident_jobs_include_obsoleted():
     assert rows[0].result == "obsoleted"
 
 
+@responses.activate
+def test_incident_jobs_captures_job_state():
+    """The job ``state`` is kept so callers can tell pending from failed.
+
+    A job that has not finished carries result ``none``; without its
+    state (scheduled/running) the openqa_jobs command could not
+    distinguish in-progress work from a genuine failure.
+    """
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                {
+                    "id": 4,
+                    "test": "mau_extratests",
+                    "result": "none",
+                    "state": "running",
+                    "settings": {"ARCH": "x86_64"},
+                },
+                {
+                    "id": 5,
+                    "test": "fips_smoke",
+                    "result": "passed",
+                    "state": "done",
+                    "settings": {"ARCH": "x86_64"},
+                },
+            ]
+        },
+        status=200,
+    )
+
+    rows = oqa_search.incident_jobs(":git:5137:libica", OPENQA)
+
+    by_test = {r.test: r for r in rows}
+    assert by_test["mau_extratests"].state == "running"
+    assert by_test["mau_extratests"].result == "none"
+    assert by_test["fips_smoke"].state == "done"
+
+
 def test_incident_jobs_empty_build_makes_no_request():
     """A falsy build short-circuits with no HTTP call."""
     assert oqa_search.incident_jobs("", OPENQA) == []


### PR DESCRIPTION
## What

`openqa_jobs --failed` listed still-running/scheduled jobs as failures. openQA keeps an unfinished job's `result` at `none` (some API paths omit it), and `incident_jobs` returns every job for the build — but the `--failed` filter only excluded `_PASSING`/`_NEUTRAL`. During active testing an in-progress build looked like it had a dozen failures: every pending job printed red and counted in the summary (`none=12`), inviting a wrong reject verdict. The module docstring and `--failed` help ("failed / parallel_failed / incomplete") promised otherwise, and `JobResult` didn't even carry the job `state`, so pending work was indistinguishable from a genuine failure.

## Fix

- `JobResult` gains a `state` field (`scheduled`, `running`, ..., `done`), captured from the openQA API by `incident_jobs`.
- New `_PENDING = {"none", ""}` result set in the command: pending jobs are **excluded from `--failed`**, coloured **yellow** like the other neutral results, and displayed/counted via their state (`running`, `scheduled`, or `pending` when the API gives no state) instead of a meaningless red `none`.
- Genuine failures (`failed`/`incomplete`/`parallel_failed`) are untouched — still red, still listed.
- When `--failed` filters everything out, the message now distinguishes an in-progress build (`No failed openQA jobs for build 'X'; 2 of 3 still pending`) from a build with no jobs at all (adversarial-review follow-up: the generic "No openQA jobs" claim was factually wrong for an all-pending build).

## Tests

- `test_failed_excludes_pending_jobs` — a running and a scheduled job no longer pass `--failed`; the summary counts only the genuine failure. **Revert-verified.**
- `test_listing_shows_pending_state_in_yellow_not_a_red_none` — pending rows show `running`/`scheduled` in yellow; the raw `none` appears nowhere. **Revert-verified.**
- `test_real_failures_still_red_and_listed`, `test_display_result_falls_back_to_pending_without_state` — guard rails.
- `test_incident_jobs_captures_job_state` (connector) — `state` survives normalization. **Revert-verified.**
- `test_failed_on_all_pending_build_names_the_pending_work`, `test_failed_on_all_passed_build_reports_no_failed_jobs`, `test_no_jobs_at_all_keeps_the_original_message` — the three empty-after-filter shapes.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #6 from the recent code review.
