### PR TITLE
fix(connection): decode command and shell output tolerantly, not strict UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   filter leaves nothing, the message now distinguishes an in-progress build
   ("No failed openQA jobs ...; 12 of 12 still pending") from a build with no
   jobs at all.
+- A command whose output contains non-UTF-8 bytes (a Latin-1 locale, `rpm`
+  metadata with odd bytes, `cat` of a binary) is no longer recorded as
+  failed. The final decode of the captured stdout/stderr was strict, so a
+  single invalid byte raised `UnicodeDecodeError` out of the SSH run; the
+  command — which may have exited 0 — was then logged as "failed to run"
+  with exit code -1 and its whole output lost. Undecodable bytes are now
+  replaced (U+FFFD) and the rest of the output is preserved, matching the
+  tolerant per-line debug logging that already existed. The interactive
+  `shell` mirror had the same defect, plus a sharper edge: it decoded each
+  1024-byte chunk separately, so even a valid multibyte character straddling
+  a chunk boundary killed the shell; it now uses an incremental decoder.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -5,6 +5,7 @@ functionality for running commands, transferring files, and opening
 remote shells on a remote host.
 """
 
+import codecs
 import errno
 import logging
 import select
@@ -479,8 +480,12 @@ class Connection:
         exitcode = session.recv_exit_status()
 
         self.close_session(session)
-        self.stdout = stdout.decode("utf-8")
-        self.stderr = stderr.decode("utf-8")
+        # "replace", not strict: command output is arbitrary bytes (binary
+        # dumps, non-UTF-8 locales, odd rpm metadata). A strict decode would
+        # raise here and turn a successful command into a phantom failure
+        # with its output lost -- mirror the tolerant per-line decode above.
+        self.stdout = stdout.decode("utf-8", "replace")
+        self.stderr = stderr.decode("utf-8", "replace")
         return exitcode
 
     def __invoke_shell(self, width: int, height: int) -> Channel | None:
@@ -522,6 +527,13 @@ class Connection:
             tty.setraw(sys.stdin.fileno())
             tty.setcbreak(sys.stdin.fileno())
 
+            # The PTY stream arrives in arbitrary 1024-byte chunks, so a
+            # plain per-chunk strict decode would raise on any non-UTF-8
+            # byte -- and even on a valid multibyte character straddling a
+            # chunk boundary -- killing the interactive shell mid-use. The
+            # incremental decoder buffers partial sequences across chunks
+            # and replaces genuinely invalid bytes instead.
+            decoder = codecs.getincrementaldecoder("utf-8")("replace")
             while True:
                 r, _, _ = select.select([session, sys.stdin], [], [])
                 if session in r:
@@ -529,7 +541,7 @@ class Connection:
                         x = session.recv(1024)
                         if len(x) == 0:
                             break
-                        sys.stdout.write(x.decode())
+                        sys.stdout.write(decoder.decode(x))
                         sys.stdout.flush()
                     except TimeoutError:
                         pass

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -133,6 +133,35 @@ def test_run_command_success(mock_ssh_client, mock_ssh_config, mock_path):
     mock_session.exec_command.assert_called_once_with("ls -l")
 
 
+def test_run_tolerates_non_utf8_output(mock_ssh_client, mock_ssh_config, mock_path):
+    """Non-UTF-8 bytes in command output must not blow up run().
+
+    Command output is arbitrary bytes (Latin-1 locales, binary dumps, odd
+    rpm metadata). The final decode used to be strict, so one bad byte
+    raised UnicodeDecodeError out of run(); Target.run() swallowed it and
+    recorded a successful command as failed (exitcode -1) with its output
+    lost. Undecodable bytes must instead be replaced and the rest kept.
+    """
+    conn = Connection("test_host", 22, 300)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+
+    mock_session.recv_exit_status.return_value = 0
+    # \xe9 is Latin-1 'é', invalid as a UTF-8 sequence here.
+    mock_session.recv.side_effect = [b"caf\xe9 ok\n", b""]
+    mock_session.recv_stderr.side_effect = [b"warn\xff\n", b""]
+    mock_session.recv_ready.side_effect = [True, False]
+    mock_session.recv_stderr_ready.side_effect = [True, False]
+
+    with patch("select.select", return_value=([mock_session], [], [])):
+        exit_code = conn.run("rpm -qi weird-package")
+
+    assert exit_code == 0
+    assert conn.stdout == "caf� ok\n"
+    assert conn.stderr == "warn�\n"
+
+
 def test_run_closes_stdin_after_exec(mock_ssh_client, mock_ssh_config, mock_path):
     """run() must close the channel's write half so the remote command's
     stdin gets EOF and can't block forever waiting for input."""

--- a/tests/test_connection_deep.py
+++ b/tests/test_connection_deep.py
@@ -237,6 +237,37 @@ def test_shell_handles_stdin_branch(
         conn.shell()
 
 
+def test_shell_tolerates_split_multibyte_and_invalid_bytes(
+    mock_ssh_client, mock_ssh_config, mock_path, monkeypatch
+):
+    """``shell()`` must survive non-UTF-8 output and chunk-split characters.
+
+    The PTY stream arrives in arbitrary 1024-byte chunks; a strict
+    per-chunk decode raised ``UnicodeDecodeError`` on a multibyte
+    character straddling a chunk boundary (or on any genuinely invalid
+    byte), killing the interactive session mid-use. The incremental
+    decoder buffers the split sequence and replaces the bad byte.
+    """
+    conn = Connection("h", 22, 300)
+    sess = MagicMock()
+    # 'é' (0xC3 0xA9) split across two chunks, plus a lone invalid 0xFF.
+    sess.recv.side_effect = [b"caf\xc3", b"\xa9 ok \xff!", b""]
+    mock_ssh_client.get_transport.return_value.open_session.return_value = sess
+    _stub_terminal(monkeypatch)
+    fake_stdout = MagicMock()
+    monkeypatch.setattr("mtui.hosts.connection.connection.sys.stdout", fake_stdout)
+
+    with patch(
+        "mtui.hosts.connection.connection.select.select",
+        return_value=([sess], [], []),
+    ):
+        conn.shell()
+
+    written = "".join(c.args[0] for c in fake_stdout.write.call_args_list)
+    assert "café ok " in written  # the split character survived intact
+    assert "�!" in written  # the invalid byte was replaced, not fatal
+
+
 # ---------------------------------------------------------------------------
 # __sftp_open returns None on AttributeError (line 523)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

A test command whose output contains a single non-UTF-8 byte was recorded as **failed with its output lost** — even when it exited 0. `Connection.run()` accumulates raw stdout/stderr bytes and decoded them strictly at the end; a Latin-1 locale, `rpm` metadata with odd bytes, or `cat` of a binary raised `UnicodeDecodeError` out of `run()`. `Target.run()`'s broad `except` swallowed it, logged "failed to run command", set exitcode `-1`, and left the captured output empty (it is reset on entry and was never assigned).

The per-line debug-logging path a few lines above already decoded tolerantly (`errors="ignore"`) — only the final decode was strict.

## Fix

Decode the accumulated stdout/stderr with `errors="replace"`: undecodable bytes become U+FFFD and the surrounding output survives. `replace` rather than the logging path's `ignore` — a visible replacement character is better evidence than silently dropped bytes.

The interactive `shell()` mirror one function below had the same defect class (flagged in adversarial review), with a sharper edge: it strictly decoded each 1024-byte PTY chunk separately, so even a *valid* multibyte character straddling a chunk boundary raised and killed the interactive session mid-use. It now feeds chunks through an incremental UTF-8 decoder (`errors="replace"`), which buffers split sequences across chunks.

## Tests

- `test_run_tolerates_non_utf8_output` — a command emitting `b"caf\xe9 ok\n"` / `b"warn\xff\n"` completes with exit code 0 and both streams captured (with U+FFFD in place of the bad bytes). **Revert-verified**: on the old strict decode the test dies with `UnicodeDecodeError`.
- `test_shell_tolerates_split_multibyte_and_invalid_bytes` — `é` split across two recv chunks survives intact and a lone `0xFF` is replaced, not fatal. **Revert-verified.**

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #9 from the recent code review.
