### PR TITLE
fix(reports): default testplatform/products/repositories in JSONParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `shell` mirror had the same defect, plus a sharper edge: it decoded each
   1024-byte chunk separately, so even a valid multibyte character straddling
   a chunk boundary killed the shell; it now uses an incremental decoder.
+- Loading a report whose `metadata.json` omits (or nulls) the `testplatform`
+  or `products` key no longer breaks later commands. The parser stored the
+  raw `None` over the report's list defaults, so a PI/SL report load died in
+  repository parsing with a `TypeError`, and on other report kinds
+  `list_metadata` and refhost autoconnect crashed the same way. Both keys now
+  fall back to an empty list, like the sibling `jira`/`bugs`/`packages` keys
+  already did. An explicitly null `repositories` key — which crashed the
+  parse itself (`frozenset(None)`) — is guarded the same way.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/test_reports/metadata_parsers.py
+++ b/mtui/test_reports/metadata_parsers.py
@@ -87,8 +87,8 @@ class JSONParser:
         results.rating = data.get("rating")
         results.repository = data.get("repository")
         results.category = data.get("category")
-        results.testplatforms = data.get("testplatform")
-        results.products = data.get("products")
+        results.testplatforms = data.get("testplatform") or []
+        results.products = data.get("products") or []
         results.realid = data.get("id")
         results.giteapr = data.get("gitea_pr")
         results.giteaprapi = data.get("gitea_pr_api")
@@ -98,7 +98,7 @@ class JSONParser:
         for prod, pkgvers in (data.get("packages") or {}).items():
             pkgs = {pkg: ver for pkg, _, ver in (p.split() for p in pkgvers)}
             packages[prod] = pkgs
-        results.repositories = frozenset(data.get("repositories", []))
+        results.repositories = frozenset(data.get("repositories") or [])
         results.packages = packages
 
 

--- a/tests/test_metadata_parsers.py
+++ b/tests/test_metadata_parsers.py
@@ -144,10 +144,16 @@ def test_json_parser_parse_tolerates_missing_optional_keys():
     results.jira = {}
     results.bugs = {}
 
-    # Minimal metadata: the list/dict-shaped keys are absent entirely, and one
-    # is explicitly null. Previously `.get()` returned None and iterating /
-    # `.items()` raised TypeError.
-    data = {"rrid": "SUSE:Maintenance:1:1", "packages": None}
+    # Minimal metadata: the list/dict-shaped keys are absent entirely
+    # (testplatform among them), and packages/products/repositories are
+    # explicitly null. Previously `.get()` returned None and iterating /
+    # `.items()` / `frozenset()` raised TypeError.
+    data = {
+        "rrid": "SUSE:Maintenance:1:1",
+        "packages": None,
+        "products": None,
+        "repositories": None,
+    }
 
     JSONParser.parse(results, data)
 
@@ -155,6 +161,11 @@ def test_json_parser_parse_tolerates_missing_optional_keys():
     assert results.bugs == {}
     assert results.packages == {}
     assert results.repositories == frozenset()
+    # None here silently overwrote the [] defaults of TestReport.__init__ and
+    # blew up much later (reporepoparse / list_metadata / autoconnect iterate
+    # these); they must stay lists.
+    assert results.testplatforms == []
+    assert results.products == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`JSONParser.parse` defensively guards `jira`/`bugs`/`packages`/`repositories` against absent or null JSON keys (there is a regression test for exactly this class of bug), but assigned `data.get("testplatform")` and `data.get("products")` **raw**. A `metadata.json` without those keys (or with them null) stored `None` over the `[]` defaults `TestReport.__init__` sets, and nothing later converts it back:

- a PI/SL report load dies in `reporepoparse` iterating `None` (`TypeError`), aborting the load;
- on other report kinds, `list_metadata` (`_show_yourself_data`) and refhost autoconnect (`for tp in self.testplatforms`) raise the same way.

This is the same defect already fixed for the sibling keys, left unfixed for these two.

## Fix

Mirror the sibling guards: `data.get("testplatform") or []` and `data.get("products") or []`, so both attributes always stay lists.

The adjacent `repositories` line had the same latent hole one line below (flagged in adversarial review): `frozenset(data.get("repositories", []))` tolerates only an *absent* key — an explicitly null value crashed the parse itself with `TypeError`. Guarded the same way (`or []`).

## Tests

Extended `test_json_parser_parse_tolerates_missing_optional_keys`: `testplatform` absent, `products`/`packages`/`repositories` explicitly null — lists/dict/frozenset defaults must come out. **Revert-verified** (both the products/testplatforms assignments and the repositories guard).

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #12 from the recent code review.
