### PR TITLE
fix(export): stop kernel re-export deleting the openqa_overview block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   fall back to an empty list, like the sibling `jira`/`bugs`/`packages` keys
   already did. An explicitly null `repositories` key — which crashed the
   parse itself (`frozenset(None)`) — is guarded the same way.
+- Re-exporting a kernel-workflow testreport no longer silently deletes the
+  injected `openqa_overview` block. From the second export on, the kernel
+  results stage clears the regression-section body to drop the previous
+  run's results — and the overview block, injected just before it, sat
+  exactly in that range: it survived the first export and vanished on every
+  one after. The overview is now injected after the results stage, so both
+  the refreshed kernel results and the overview block survive re-exports.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/update_workflow/export/kernel.py
+++ b/mtui/update_workflow/export/kernel.py
@@ -86,8 +86,14 @@ class KernelExport(BaseExport):
         """
         self.install_results()
         self.inject_openqa()
-        self.inject_overview()
+        # kernel_results() must run BEFORE inject_overview(). On a re-export
+        # (the "(put your details here)" placeholder is gone) kernel_results
+        # bulk-deletes the whole regression-section body up to
+        # "build log review:" to drop the previous run's results -- injecting
+        # the marker-bounded openqa_overview block first meant that deletion
+        # wiped it again on every export after the first.
         self.kernel_results()
+        self.inject_overview()
         filenames = self.get_logs()
         self.installlogs_lines(filenames)
         self.add_sysinfo()

--- a/tests/test_export_kernel.py
+++ b/tests/test_export_kernel.py
@@ -58,6 +58,64 @@ def test_kernel_results_inserts_results_into_regression_section(
     assert "Result line 1" in joined
 
 
+def test_reexport_keeps_openqa_overview_block(tmp_path: Path) -> None:
+    """The overview block must survive a re-export.
+
+    From the second export on, kernel_results' placeholder-absent branch
+    bulk-deletes the regression-section body up to "build log review:" to
+    drop the previous run's results. inject_overview used to run first in
+    run(), so the freshly injected marker-bounded openqa_overview block sat
+    exactly in that range and was deleted again on every export after the
+    first -- the report silently lost its overview data.
+
+    Runs the real run() pipeline (template-mutating stages live, the
+    network/filesystem stages patched out) twice, like a tester exporting,
+    refreshing results, and exporting again.
+    """
+    from mtui.data_sources.oqa_search import VersionResult
+
+    template = [
+        "regression tests:\n",
+        "(put your details here)\n",
+        "\n",
+        "build log review:\n",
+    ]
+    exporter = _make(tmp_path, template=template)
+    fake_result = MagicMock()
+    fake_result.pp = ["Result line 1\n"]
+    exporter.openqa.kernel = [fake_result]
+    exporter.openqa.auto = None  # inject_openqa: nothing to inject
+    overview = MagicMock()
+    overview.single_incidents = [
+        VersionResult(version="15-SP6", url="https://oqa/t1", status="passed")
+    ]
+    overview.aggregated_updates = []
+    overview.build_checks = []
+    overview.skip_aggregated = True
+    exporter.openqa.overview = overview
+
+    def _export_once() -> str:
+        with (
+            patch.object(exporter, "install_results"),
+            patch.object(exporter, "get_logs", return_value=[]),
+            patch.object(exporter, "installlogs_lines"),
+            patch.object(exporter, "add_sysinfo"),
+            patch.object(exporter, "dedup_lines"),
+        ):
+            exporter.run()
+        return "".join(exporter.template)
+
+    first = _export_once()
+    assert "openqa_overview begin" in first
+    assert "15-SP6" in first
+
+    second = _export_once()
+    # Exactly one overview block and one results run survive the re-export.
+    assert second.count("openqa_overview begin") == 1
+    assert "15-SP6" in second
+    assert second.count("Results from openQA:\n") == 1
+
+
 # ---------------------------------------------------------------------------
 # get_logs
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Re-exporting a kernel-workflow testreport silently deleted the injected `openqa_overview` block. `KernelExport.run()` ordered `inject_overview()` **before** `kernel_results()`:

- First export: `kernel_results` finds and removes only the `(put your details here)` placeholder — the overview block survives.
- Every export after that: the placeholder is gone, so `kernel_results`' except-branch bulk-deletes the whole regression-section body up to `build log review:` — exactly the range the marker-bounded overview block had just been spliced into. The overview data vanished on the second export and never came back.

## Fix

Reorder `run()`: `kernel_results()` first, `inject_overview()` after. The bulk delete now clears only the previous run's results (plus any stale overview block from an older export), then the fresh overview is inserted into the cleaned section. Layout is unchanged (kernel results, then overview, then `build log review:`).

## Tests

- `test_reexport_keeps_openqa_overview_block` — drives the **real `run()` pipeline twice** (network/filesystem stages patched out) like a tester exporting, refreshing, and exporting again: exactly one overview block and one results run must survive the re-export. **Revert-verified**: with the old ordering the block disappears on the second export.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #13 from the recent code review.
