### PR TITLE
fix(mcp): re-validate staleness before each idle-sweep eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   exactly in that range: it survived the first export and vanished on every
   one after. The overview is now injected after the results stage, so both
   the refreshed kernel results and the overview block survive re-exports.
+- The `mtui-mcp` http idle sweeper no longer tears down a session that a
+  client re-activated while the same sweep round was running. The sweep
+  snapshotted the stale keys and then evicted them one by one; while one
+  eviction waited on a slow host disconnect, a client could be handed a
+  later stale-listed session (its idle clock freshly reset) — and the sweep
+  still closed it, cutting SSH host connections out from under the active
+  client's command. Staleness is now re-checked immediately before each
+  eviction, so a just-re-activated session is spared.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/mcp/registry.py
+++ b/mtui/mcp/registry.py
@@ -330,6 +330,23 @@ class SessionRegistry:
                     if now - touched >= self._idle_timeout
                 ]
                 for key in stale:
+                    # Re-validate right before evicting: while an earlier
+                    # eviction in this round awaited a slow close(),
+                    # get_or_create() may have handed this session back to
+                    # a client and refreshed its last-touch -- reaping it
+                    # now would tear down a session in active use. The
+                    # re-check and evict()'s pop run with no await in
+                    # between, so a refresh cannot slip into that gap.
+                    touched = self._last_touch.get(key)
+                    if touched is None:
+                        continue  # already evicted/released elsewhere
+                    if time.monotonic() - touched < self._idle_timeout:
+                        logger.info(
+                            "skipping sweep of MCP session (key=%s): "
+                            "re-activated during this sweep",
+                            key,
+                        )
+                        continue
                     logger.info("sweeping idle MCP session (key=%s)", key)
                     await self.evict(key)
         except asyncio.CancelledError:

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -425,6 +425,112 @@ def test_sweeper_disabled_when_idle_timeout_zero(tmp_path: Path) -> None:
     assert asyncio.run(driver()) is None
 
 
+def test_sweep_spares_session_reactivated_during_the_sweep(tmp_path: Path) -> None:
+    """A session re-activated while the sweep runs must not be reaped.
+
+    The sweep snapshots the stale keys, then evicts them one by one.
+    Eviction awaits ``close()``; while one eviction is blocked on a slow
+    close, ``get_or_create`` can hand a *later* stale key's session to a
+    client (refreshing its last-touch). The sweep used to evict it anyway,
+    closing SSH host connections out from under the active client.
+    Staleness is now re-validated immediately before each eviction.
+    """
+    reg = _registry(tmp_path, idle_timeout=4.0)  # sweep interval = 2s
+    import time as _time
+
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    k2_closed = {"n": 0}
+
+    async def driver() -> None:
+        s1 = await reg.get_or_create("k1")
+        s2 = await reg.get_or_create("k2")
+
+        async def _slow_close() -> None:
+            close_started.set()
+            await release_close.wait()
+
+        async def _k2_close() -> None:
+            k2_closed["n"] += 1
+
+        s1.close = _slow_close  # ty: ignore[invalid-assignment]
+        s2.close = _k2_close  # ty: ignore[invalid-assignment]
+
+        # Age both sessions well past the TTL so the next sweep round
+        # snapshots stale = [k1, k2] (insertion order).
+        aged = _time.monotonic() - 100
+        reg._last_touch["k1"] = aged  # noqa: SLF001
+        reg._last_touch["k2"] = aged  # noqa: SLF001
+
+        # Wait until the sweeper is mid-eviction of k1 (blocked in close),
+        # then do what a live client does: grab k2, refreshing its touch.
+        await asyncio.wait_for(close_started.wait(), timeout=10)
+        again = await reg.get_or_create("k2")
+        assert again is s2
+
+        # Let the k1 eviction finish; the sweep round proceeds to k2.
+        release_close.set()
+        await asyncio.sleep(0.5)
+
+        assert "k1" not in reg._sessions  # noqa: SLF001 -- genuinely idle: reaped
+        assert "k2" in reg._sessions  # noqa: SLF001 -- re-activated: spared
+        assert k2_closed["n"] == 0
+        await reg.aclose()
+
+    asyncio.run(driver())
+
+
+def test_sweep_skips_key_already_evicted_during_the_sweep(tmp_path: Path) -> None:
+    """A stale-listed key evicted by someone else mid-sweep is skipped.
+
+    While the sweep round is blocked in the first eviction's ``close()``,
+    a client disconnect can evict a later stale-listed key directly. When
+    the round reaches that key its last-touch is gone; the re-check must
+    skip it rather than close the session a second time.
+    """
+    reg = _registry(tmp_path, idle_timeout=4.0)  # sweep interval = 2s
+    import time as _time
+
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    k2_closed = {"n": 0}
+
+    async def driver() -> None:
+        s1 = await reg.get_or_create("k1")
+        s2 = await reg.get_or_create("k2")
+
+        async def _slow_close() -> None:
+            close_started.set()
+            await release_close.wait()
+
+        async def _k2_close() -> None:
+            k2_closed["n"] += 1
+
+        s1.close = _slow_close  # ty: ignore[invalid-assignment]
+        s2.close = _k2_close  # ty: ignore[invalid-assignment]
+
+        aged = _time.monotonic() - 100
+        reg._last_touch["k1"] = aged  # noqa: SLF001
+        reg._last_touch["k2"] = aged  # noqa: SLF001
+
+        # Mid-sweep (blocked in k1's close), a client disconnect evicts k2.
+        await asyncio.wait_for(close_started.wait(), timeout=10)
+        await reg.evict("k2")
+        assert k2_closed["n"] == 1
+
+        # The round proceeds to k2: last-touch is gone -> skipped, close
+        # is NOT called a second time.
+        release_close.set()
+        await asyncio.sleep(0.5)
+
+        assert "k1" not in reg._sessions  # noqa: SLF001
+        assert "k2" not in reg._sessions  # noqa: SLF001
+        assert k2_closed["n"] == 1
+        await reg.aclose()
+
+    asyncio.run(driver())
+
+
 def test_aclose_cancels_sweeper_and_closes_all(tmp_path: Path) -> None:
     """``aclose`` cancels the sweeper task and evicts every live session."""
     reg = _registry(tmp_path, idle_timeout=30.0)


### PR DESCRIPTION
## What

The `mtui-mcp` http idle sweeper could tear down a session that a client had just re-activated. `_sweep_loop` snapshots the stale keys, then evicts them one by one; `evict()` awaits `McpSession.close()`, which can take seconds (host disconnects). While one eviction was blocked in `close()`, `get_or_create()` could hand a *later* stale-listed session back to a client — refreshing its last-touch — yet the sweep still reached that key and evicted it, closing SSH host connections out from under the client's in-flight command.

## Fix

Re-validate staleness immediately before each eviction: skip the key if its last-touch was refreshed since the snapshot (or it is already gone). The re-check and `evict()`'s pop run with **no await in between**, so on the single-threaded event loop a refresh cannot slip into that gap — the previous exposure window was the full duration of every earlier `close()` in the round.

## Tests

- `test_sweep_spares_session_reactivated_during_the_sweep` — drives the **real sweeper**: two aged sessions, the first wedged in a slow `close()` (event-gated, no timing sleeps for the interleaving); mid-sweep a client re-acquires the second session. The first must be reaped, the second must survive un-closed. **Revert-verified**: on the old code the second session is evicted and its `close()` called.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #24 from the recent code review.
