### PR TITLE
fix(mcp): refcount the mtui logger level across concurrent captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   still closed it, cutting SSH host connections out from under the active
   client's command. Staleness is now re-checked immediately before each
   eviction, so a just-re-activated session is spared.
+- Concurrent `mtui-mcp` commands no longer race on the shared `mtui` logger
+  level, which could silently drop captured `INFO` log lines from a reply.
+  Two overlapping calls (different templates or different client sessions)
+  each lowered/restored the process-global level around their log capture;
+  the first call to finish restored the stricter level while the other was
+  still running, filtering its remaining INFO records before the capture
+  handler saw them. The lowering is now reference-counted, so the level is
+  restored only when the last concurrent capture ends.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -45,6 +45,7 @@ import contextvars
 import io
 import logging
 import shlex
+import threading
 import time
 from logging import Handler, Logger, LogRecord, getLogger
 from types import SimpleNamespace
@@ -173,6 +174,41 @@ class _LogCaptureHandler(Handler):
             self._stream.write(f"{level}: {record.getMessage()}\n")
         except Exception:  # noqa: BLE001 - logging must never raise into callers
             self.handleError(record)
+
+
+# The ``mtui`` logger's level is process-global state, but commands on
+# different templates (or different client sessions) run concurrently in
+# worker threads. A plain save/lower/restore per call races: the first
+# call lowers WARNING -> INFO, an overlapping call observes INFO and saves
+# nothing, then the first call restores WARNING while the second is still
+# running -- silently filtering the second call's INFO records before its
+# capture handler sees them. Reference-count the lowering instead: the
+# first concurrent capture lowers and remembers the prior level, the last
+# one restores it.
+_cap_level_guard = threading.Lock()
+_cap_level_depth = 0
+_cap_level_prev: int | None = None
+
+
+def _push_capture_level() -> None:
+    """Lower the shared ``mtui`` logger to INFO for one capture (refcounted)."""
+    global _cap_level_depth, _cap_level_prev
+    with _cap_level_guard:
+        cap_logger = getLogger("mtui")
+        if _cap_level_depth == 0 and cap_logger.getEffectiveLevel() > logging.INFO:
+            _cap_level_prev = cap_logger.level
+            cap_logger.setLevel(logging.INFO)
+        _cap_level_depth += 1
+
+
+def _pop_capture_level() -> None:
+    """Undo one :func:`_push_capture_level`; the last pop restores the level."""
+    global _cap_level_depth, _cap_level_prev
+    with _cap_level_guard:
+        _cap_level_depth -= 1
+        if _cap_level_depth == 0 and _cap_level_prev is not None:
+            getLogger("mtui").setLevel(_cap_level_prev)
+            _cap_level_prev = None
 
 
 class McpCommandError(RuntimeError):
@@ -805,19 +841,19 @@ class McpSession:
         # The ``mtui`` logger defaults to an effective level of WARNING
         # (inherited from root), which would drop INFO records before any
         # handler sees them, so temporarily lower it to INFO for the call
-        # when it is currently stricter. The raw level is saved and
-        # restored in ``finally`` so a user's ``set_log_level`` choice is
-        # left untouched (under MCP that command targets the separate
-        # ``mtui-mcp`` logger, but restoring the exact prior value keeps
-        # this safe regardless).
+        # when it is currently stricter. Commands can overlap (different
+        # templates / different client sessions), so the lowering is
+        # reference-counted (:func:`_push_capture_level`): the first
+        # concurrent call lowers and remembers the prior level, the last
+        # one restores it in ``finally`` — a user's ``set_log_level``
+        # choice is left untouched (under MCP that command targets the
+        # separate ``mtui-mcp`` logger, but restoring the exact prior
+        # value keeps this safe regardless).
         cap_logger = getLogger("mtui")
         cap_token = object()
         cap_handler = _LogCaptureHandler(fake_sys.stdout, cap_token)
         token_reset = _capture_token.set(cap_token)
-        prev_cap_level = cap_logger.level
-        lowered_cap_level = cap_logger.getEffectiveLevel() > logging.INFO
-        if lowered_cap_level:
-            cap_logger.setLevel(logging.INFO)
+        _push_capture_level()
         cap_logger.addHandler(cap_handler)
         try:
             try:
@@ -868,8 +904,7 @@ class McpSession:
         finally:
             cap_logger.removeHandler(cap_handler)
             _capture_token.reset(token_reset)
-            if lowered_cap_level:
-                cap_logger.setLevel(prev_cap_level)
+            _pop_capture_level()
             _current_display.reset(display_reset)
             _current_stdout.reset(stdout_reset)
 

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -404,6 +404,76 @@ def test_run_command_excludes_records_without_capture_token(tmp_path: Path) -> N
     assert "from a raw thread" not in out
 
 
+def test_concurrent_captures_keep_info_after_first_call_finishes(
+    tmp_path: Path,
+) -> None:
+    """A finishing command must not restore the logger level under a peer.
+
+    The ``mtui`` logger is process-global; two commands (different client
+    sessions here, different templates in production) capture
+    concurrently. The plain save/lower/restore raced: the first call
+    lowered WARNING->INFO, the overlapping call saw INFO and saved
+    nothing, then the first call's ``finally`` restored WARNING while the
+    second was still running — its INFO records were filtered at the
+    logger before its capture handler saw them and silently vanished from
+    the MCP reply. The lowering is now reference-counted; only the last
+    concurrent capture restores.
+    """
+    mtui_logger = logging.getLogger("mtui")
+    prev_level = mtui_logger.level
+    mtui_logger.setLevel(logging.WARNING)
+    a_entered = threading.Event()
+    a_proceed = threading.Event()
+    b_entered = threading.Event()
+    b_proceed = threading.Event()
+
+    class _FirstCommand(Command):
+        command = "_mcp_test_levelrace_first"
+
+        def __call__(self) -> None:  # pragma: no cover - exercised by test
+            a_entered.set()
+            assert a_proceed.wait(15)
+            self.println("first out")
+
+    class _SecondCommand(Command):
+        command = "_mcp_test_levelrace_second"
+
+        def __call__(self) -> None:  # pragma: no cover - exercised by test
+            b_entered.set()
+            assert b_proceed.wait(15)
+            # Logged after the first command has finished (and, before the
+            # fix, restored the level to WARNING out from under us).
+            logging.getLogger("mtui.commands._levelrace").info("late info")
+            self.println("second out")
+
+    try:
+        sess_a = _make_session(tmp_path)
+        sess_b = _make_session(tmp_path)
+
+        async def driver() -> tuple[str, str]:
+            a_task = asyncio.create_task(sess_a.run_command(_FirstCommand, []))
+            await asyncio.to_thread(a_entered.wait, 15)  # A lowered the level
+            b_task = asyncio.create_task(sess_b.run_command(_SecondCommand, []))
+            await asyncio.to_thread(b_entered.wait, 15)  # B's capture is live
+            a_proceed.set()
+            out_a = await a_task  # A finishes mid-B
+            b_proceed.set()
+            out_b = await b_task
+            return out_a, out_b
+
+        out_a, out_b = asyncio.run(driver())
+
+        assert "first out" in out_a
+        assert "second out" in out_b
+        assert "INFO: late info" in out_b
+        # The last concurrent capture restored the original level.
+        assert mtui_logger.level == logging.WARNING
+    finally:
+        a_proceed.set()
+        b_proceed.set()
+        mtui_logger.setLevel(prev_level)
+
+
 # --------------------------------------------------------------------------- #
 # close() releases host-arbitration pool claims (Phase 3B)                    #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Concurrent `mtui-mcp` commands raced on the process-global `mtui` logger level, silently dropping captured `INFO` lines from a reply. `_run_sync` lowers the logger to INFO around each command's log capture and restored a plain saved value in `finally`. Commands overlap (different per-RRID locks; different client sessions), so the dance raced:

1. Thread A lowers `WARNING → INFO`.
2. Thread B observes an effective INFO and records nothing to restore.
3. A finishes and puts WARNING back **while B is still running**.
4. Every INFO record B logs after that is filtered at the logger before B's capture handler sees it — missing from B's MCP reply.

## Fix

Reference-count the lowering (module-level `_push_capture_level`/`_pop_capture_level` under a `threading.Lock`): the first concurrent capture lowers and remembers the prior level, the last one restores it. A user's `set_log_level` choice is still honoured — restored exactly once, to the exact prior value.

## Tests

- `test_concurrent_captures_keep_info_after_first_call_finishes` — interleaves two **real `run_command` calls** on two sessions using events (deterministic, no timing sleeps): the first command finishes mid-way through the second, which then logs INFO; the record must still reach the second reply, and the original level must be restored at the end. **Revert-verified**: on the old save/restore the INFO line vanishes.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #25 from the recent code review.
