### PR TITLE
fix(config): treat blank ssl_verify as unset instead of disabling TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   still running, filtering its remaining INFO records before the capture
   handler saw them. The lowering is now reference-counted, so the level is
   restored only when the last concurrent capture ends.
+- A blank `[mtui] ssl_verify` value (`ssl_verify =`, usually an unfinished
+  edit) no longer turns TLS certificate verification off. The empty string
+  used to reach `requests` as a falsy `verify` — silently disabling
+  certificate checks for every HTTPS call (openQA, dashboard, TeReGen,
+  Gitea). A blank value is now treated exactly like an unset option: the
+  verifying default applies and a warning explains how to disable
+  verification explicitly (`ssl_verify = false`) if that was really meant.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -75,9 +75,11 @@ def _parse_ssl_verify(raw: str) -> bool | str:
     must exist: a typo like ``false1`` or a missing file would otherwise
     surface only at the first HTTPS call as an opaque ``OSError`` deep
     inside :mod:`requests`, so it is rejected here at parse time and the
-    option falls back to its (verifying) default. A blank value keeps its
-    historical requests semantics (verification off) but warns, since it
-    is almost always an unfinished edit.
+    option falls back to its (verifying) default. A blank value is treated
+    as unset (verification stays on) and warns: it is almost always an
+    unfinished edit, and passing it through as ``""`` would silently hand
+    requests a falsy ``verify`` — TLS off for every call. Only an explicit
+    ``false`` spelling disables verification.
 
     Raises:
         ValueError: If the value is neither a boolean spelling nor the
@@ -87,10 +89,10 @@ def _parse_ssl_verify(raw: str) -> bool | str:
     token = raw.strip()
     if not token:
         logger.warning(
-            "blank ssl_verify disables TLS verification; write "
-            "'ssl_verify = false' to make that explicit"
+            "blank ssl_verify treated as unset: TLS verification stays "
+            "enabled; write 'ssl_verify = false' to disable it explicitly"
         )
-        return False
+        return _default_verify()
     lowered = token.lower()
     if lowered in _TRUE_STRINGS:
         return _default_verify()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,17 +257,32 @@ def test_ssl_verify_explicit_true_equals_unset_default(tmpdir, monkeypatch):
     assert config.Config(cfg_file).ssl_verify == "/etc/ssl/ca-bundle.pem"
 
 
-def test_ssl_verify_blank_keeps_verification_off_with_warning(
-    tmpdir, caplog, monkeypatch
-):
-    """A blank value historically disabled verification; that must survive."""
+def test_ssl_verify_blank_treated_as_unset_stays_secure(tmpdir, caplog, monkeypatch):
+    """A blank value must NOT disable TLS verification.
+
+    ``ssl_verify =`` is almost always an unfinished edit, not intent.
+    Historically the blank passed through as a falsy ``verify`` and turned
+    certificate verification off for every HTTPS call (requests treats
+    ""/False as CERT_NONE). It now falls back to the secure default, with
+    a warning; only an explicit false spelling disables verification.
+    """
     monkeypatch.setattr(config, "system_ca_bundle", lambda: None)
     cfg_file = Path(tmpdir.join("ssl.cfg"))
     cfg_file.write_text("[mtui]\nssl_verify =\n")
     with caplog.at_level("WARNING", logger="mtui.config"):
         cfg = config.Config(cfg_file)
-    assert cfg.ssl_verify is False
+    assert cfg.ssl_verify is True
     assert any("blank ssl_verify" in r.message for r in caplog.records)
+
+
+def test_ssl_verify_blank_prefers_system_bundle(tmpdir, caplog, monkeypatch):
+    """The blank fallback is the same default as an unset option."""
+    monkeypatch.setattr(config, "system_ca_bundle", lambda: "/etc/ssl/ca-bundle.pem")
+    cfg_file = Path(tmpdir.join("ssl.cfg"))
+    cfg_file.write_text("[mtui]\nssl_verify =  \n")
+    with caplog.at_level("WARNING", logger="mtui.config"):
+        cfg = config.Config(cfg_file)
+    assert cfg.ssl_verify == "/etc/ssl/ca-bundle.pem"
 
 
 def test_unexpected_fixup_error_keeps_traceback(tmpdir, caplog):

--- a/tests/test_support_http.py
+++ b/tests/test_support_http.py
@@ -138,10 +138,18 @@ def test_parse_ssl_verify_false_spellings(raw):
     assert _parse_ssl_verify(raw) is False
 
 
-def test_parse_ssl_verify_blank_disables_with_warning(caplog):
-    """A blank value keeps its historical requests semantics (verify off)."""
+def test_parse_ssl_verify_blank_stays_secure_with_warning(caplog, monkeypatch):
+    """A blank value must fall back to the verifying default, not disable TLS.
+
+    Passing the empty string through would hand requests a falsy ``verify``
+    (CERT_NONE) — verification silently off for every HTTPS call. Blank is
+    treated as unset; only an explicit false spelling disables.
+    """
+    import mtui.support.config as _config
+
+    monkeypatch.setattr(_config, "system_ca_bundle", lambda: None)
     with caplog.at_level("WARNING", logger="mtui.config"):
-        assert _parse_ssl_verify("  ") is False
+        assert _parse_ssl_verify("  ") is True
     assert any("blank ssl_verify" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## What

A blank `[mtui] ssl_verify` value (`ssl_verify =` — almost always an unfinished edit, not intent) disabled TLS certificate verification for **every** outbound HTTPS call (openQA, QEM dashboard, TeReGen, Gitea). `_parse_ssl_verify` returned the stripped empty string, which reached `requests` as a falsy `verify` — CERT_NONE. Since #260 this at least warned, but the warning still left TLS off; the review flagged the remaining downgrade as the one security finding (#26).

## Fix

Blank is now treated exactly like an **unset** option: it falls back to the verifying default (`_default_verify()` — system CA bundle, else certifi `True`), keeping a warning that points at `ssl_verify = false` as the explicit way to disable. Only the documented false spellings turn verification off.

This intentionally changes the historical blank-disables behaviour: an accidental empty value must fail **secure**, and anyone who genuinely wants verification off has an explicit spelling for it.

## Tests

- `test_ssl_verify_blank_treated_as_unset_stays_secure` and `test_parse_ssl_verify_blank_stays_secure_with_warning` — rewritten from the two tests that pinned the insecure behaviour; blank now yields the verifying default plus the warning. **Revert-verified.**
- `test_ssl_verify_blank_prefers_system_bundle` — the blank fallback is identical to unset (prefers the system CA bundle).

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #26 (security) from the recent code review.
