### PR TITLE
fix(cli): skip malformed history lines instead of aborting list_history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Gitea). A blank value is now treated exactly like an unset option: the
   verifying default applies and a warning explains how to disable
   verification explicitly (`ssl_verify = false`) if that was really meant.
+- `list_history` no longer aborts the whole listing when `/var/log/mtui.log`
+  contains a malformed line. The log is appended to over sftp by independent
+  mtui sessions, so concurrent writes can tear a line (and the file may be
+  hand-edited or rotated); a line whose first field is not a parseable
+  timestamp used to raise out of the command, dropping every remaining
+  host's history. Such lines are now skipped like the too-few-fields case.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/cli/display.py
+++ b/mtui/cli/display.py
@@ -85,14 +85,21 @@ class CommandPromptDisplay:
         self.println(f"history from {hostname} ({system}):")
         lines.reverse()
         for line in lines:
+            # Skip malformed lines instead of aborting the whole listing:
+            # /var/log/mtui.log is appended to over sftp by independent mtui
+            # sessions, so concurrent writes can tear a line (and the file
+            # may be hand-edited or rotated). Besides the too-few-fields
+            # IndexError, a torn line's leading field may not be a parseable
+            # timestamp -- float() then raises ValueError, and an absurd
+            # value can make fromtimestamp() raise OverflowError/OSError.
             try:
                 when = line.split(":")[0]
                 who = line.split(":")[1]
                 event = ":".join(line.split(":")[2:])
-            except IndexError:
+                time = datetime.fromtimestamp(float(when))
+            except (IndexError, ValueError, OverflowError, OSError):
                 continue
 
-            time = datetime.fromtimestamp(float(when))
             self.println(
                 "{}, {}: {}".format(time.strftime("%A, %d.%m.%Y %H:%M"), who, event)
             )

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -45,6 +45,32 @@ def test_list_history():
     assert "test command" in output_str
 
 
+def test_list_history_skips_malformed_lines():
+    """A torn/hand-edited log line is skipped, not fatal.
+
+    /var/log/mtui.log is appended to over sftp by independent mtui
+    sessions; interleaved writes can tear a line so its first field is
+    not a parseable timestamp. One bad line used to raise ValueError out
+    of list_history, aborting the whole command and dropping every
+    remaining host's history.
+    """
+    output = StringIO()
+    d = display.CommandPromptDisplay(output)
+    system = MockSystem("test_system")
+    lines = [
+        "1678886400:user:good before",
+        "update:foo: 1720166400:jdoe:install nginx",  # torn: non-numeric field
+        "no-colons-at-all",  # too few fields
+        "99999999999999999999:user:absurd timestamp",  # fromtimestamp overflow
+        "1678886401:user:good after",
+    ]
+    d.list_history("test_host", system, lines)
+    output_str = output.getvalue()
+    assert "good before" in output_str
+    assert "good after" in output_str
+    assert "install nginx" not in output_str
+
+
 def test_list_host():
     """Test list_host."""
     output = StringIO()


### PR DESCRIPTION
## What

One malformed line in `/var/log/mtui.log` aborted the entire `list_history` command. The per-line parse guards `IndexError` (too few fields) with `continue`, but the timestamp conversion sat outside that guard: a line whose first colon-delimited field is not a parseable float raised `ValueError` out of `list_history`, dropping every remaining host's history.

This happens in practice: the log is appended to over sftp by independent mtui sessions against shared reference hosts, so concurrent writes can interleave/tear a line — and the file may be hand-edited or rotated.

## Fix

Move the conversion (`float` + `datetime.fromtimestamp`) inside the guard and broaden it to the conversion's own failure modes: `ValueError` (non-numeric field) plus `OverflowError`/`OSError` (an absurd numeric value out of `fromtimestamp`'s range). A bad line is now skipped exactly like the too-few-fields case; good lines before and after it still print.

## Tests

- `test_list_history_skips_malformed_lines` — a torn line (`update:foo: 1720166400:...`), a no-colon fragment, and an absurd timestamp are each skipped while the surrounding good entries render. **Revert-verified**: the old code dies on the first unguarded conversion.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #14 from the recent code review.
