### PR TITLE
fix(commands): stop list_packages printing literal 'None' for absent packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   hand-edited or rotated); a line whose first field is not a parseable
   timestamp used to raise out of the command, dropping every remaining
   host's history. Such lines are now skipped like the too-few-fields case.
+- `list_packages -p <pkg>` no longer prints the literal word `None` for a
+  queried package that is not part of the loaded update. The state column
+  now behaves exactly like the no-update case: blank when the package is
+  installed, `not installed` when it is not — and a not-installed package's
+  empty version no longer renders as a literal `None` either.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/commands/listpackages.py
+++ b/mtui/commands/listpackages.py
@@ -95,7 +95,13 @@ class ListPackages(Command):
                         # if package p is in target.packages it alwas has set required --> from metadata
                         wanted = target.packages[p].required
                     except KeyError:
-                        state = None
+                        # Queried package that is not part of the update:
+                        # there is no wanted version to compare against, so
+                        # mirror the no-metadata branch exactly -- blank when
+                        # installed, "not installed" when the querier found
+                        # nothing. `state = None` here rendered the literal
+                        # word "None".
+                        state = "" if v else self.state_map[None]
                     else:
                         state = self._vers2state(v, wanted)
                 else:
@@ -106,7 +112,9 @@ class ListPackages(Command):
                 if len(str(v)) > column_size[1]:
                     column_size[1] = len(str(v)) + 1
 
-                host_output.append([p, v, state])
+                # A not-installed package has no version; v is None and the
+                # {1!s} format printed the literal "None" in every branch.
+                host_output.append([p, v if v is not None else "", state])
 
             format_output = f"{{0:{column_size[0]}}}: {{1!s:{column_size[1]}}} {{2}}"
             for line in host_output:

--- a/tests/test_cmd_listpackages.py
+++ b/tests/test_cmd_listpackages.py
@@ -60,3 +60,57 @@ def test_list_packages_accepts_template_flags():
     ns = ListPackages.parse_args("-T SUSE:Maintenance:1:1", sys_mock)
     assert ns.template == "SUSE:Maintenance:1:1"
     assert ListPackages.parse_args("--all-templates", sys_mock).all_templates is True
+
+
+def test_list_packages_blank_state_for_package_not_in_update(mock_config):
+    """A queried package that is not part of the update gets a blank state.
+
+    The KeyError branch set ``state = None``, which the output formatter
+    rendered as the literal word "None" -- inconsistent with the
+    no-metadata branch, which uses "" for the same no-state case.
+    """
+    prompt = _prompt()
+    prompt.metadata.get_package_list.return_value = ["bash"]
+    target = MagicMock()
+    target.hostname = "host1"
+    target.system = "sys"
+    target.packages = {}  # nothing from the update on this host -> KeyError
+    hosts = MagicMock()
+    hosts.query_versions.return_value = [(target, {"somepkg": "1.0"})]
+    prompt.targets.select.return_value = hosts
+    sys_mock = MagicMock()
+    args = Namespace(wanted=False, package=["somepkg"], hosts=None)
+
+    ListPackages(args, mock_config, sys_mock, prompt)()
+
+    written = "".join(c.args[0] for c in sys_mock.stdout.write.call_args_list)
+    assert "somepkg" in written
+    assert "None" not in written
+
+
+def test_list_packages_not_installed_state_for_absent_package(mock_config):
+    """A queried package neither in the update nor installed says so.
+
+    The KeyError branch must mirror the no-metadata branch exactly: the
+    querier returns None for a package rpm reports as not installed, and
+    the row must read "not installed" -- with no literal "None" anywhere
+    (the version column used to render one too).
+    """
+    prompt = _prompt()
+    prompt.metadata.get_package_list.return_value = ["bash"]
+    target = MagicMock()
+    target.hostname = "host1"
+    target.system = "sys"
+    target.packages = {}
+    hosts = MagicMock()
+    hosts.query_versions.return_value = [(target, {"ghostpkg": None})]
+    prompt.targets.select.return_value = hosts
+    sys_mock = MagicMock()
+    args = Namespace(wanted=False, package=["ghostpkg"], hosts=None)
+
+    ListPackages(args, mock_config, sys_mock, prompt)()
+
+    written = "".join(c.args[0] for c in sys_mock.stdout.write.call_args_list)
+    assert "ghostpkg" in written
+    assert "not installed" in written
+    assert "None" not in written


### PR DESCRIPTION
## What

With an update loaded, `list_packages -p <pkg>` for a package that is not part of the update printed the literal word **`None`** in the state column. The `KeyError` branch (package absent from `target.packages`) set `state = None`, which the row formatter rendered verbatim — while the parallel no-metadata branch already uses `""` for exactly the same no-state case.

## Fix

Mirror the no-metadata branch **exactly** in the `KeyError` branch: `state = "" if v else self.state_map[None]` — blank when the package is installed, blue `not installed` when the version querier returned `None` for it (adversarial review caught that a bare `""` was only half the parity). And since a not-installed package has no version, the version column no longer renders its `None` as a literal `None` either — in any branch.

## Tests

- `test_list_packages_blank_state_for_package_not_in_update` — a queried, installed package outside the update renders with a blank state; `None` appears nowhere. **Revert-verified.**
- `test_list_packages_not_installed_state_for_absent_package` — a queried package neither in the update nor installed reads `not installed`, with no literal `None` anywhere (state or version column). **Revert-verified.**

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #17 from the recent code review.
