### PR TITLE
fix(hosts): record install/uninstall host history again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   now behaves exactly like the no-update case: blank when the package is
   installed, `not installed` when it is not — and a not-installed package's
   empty version no longer renders as a literal `None` either.
+- `install` and `uninstall` events are recorded in the per-host history
+  again (`/var/log/mtui.log`, shown by `list_history`). The history writer
+  was handed a nested package list, the resulting `TypeError` was silently
+  swallowed, and no install/uninstall entry was ever written — unlike
+  `update`/`downgrade`, which recorded fine. The callers now pass flat
+  strings, and a failed history write logs a warning instead of hiding
+  the error (the write stays best-effort and never breaks the operation).
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/hosts/target/target.py
+++ b/mtui/hosts/target/target.py
@@ -540,11 +540,12 @@ class Target:
             logger.warning(e)
             raise
 
-    def add_history(self, comment: str) -> None:
+    def add_history(self, comment: list[str]) -> None:
         """Adds a history entry to the target.
 
         Args:
-            comment: The history entry to add.
+            comment: The history entry's fields (flat strings; they are
+                ``:``-joined into the log line).
 
         """
         if self.state == "enabled":
@@ -562,7 +563,15 @@ class Target:
                 historyfile.write("{}:{}:{}\n".format(now, user, ":".join(comment)))
                 historyfile.close()
             except Exception:
-                pass
+                # Best-effort (a read-only or full remote fs must not break
+                # the operation), but never silent: the old bare pass hid a
+                # TypeError from a nested comment list for years, so no
+                # install/uninstall event was ever recorded.
+                logger.warning(
+                    "%s: failed to write history entry",
+                    self.hostname,
+                    exc_info=True,
+                )
 
     def sftp_listdir(self, path: Path) -> list[str]:
         """Lists the contents of a directory on the target.

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -414,7 +414,10 @@ class TestReport(ABC):
             packages: The packages to install.
 
         """
-        targets.add_history(["install", packages])
+        # Flat strings only: add_history ":".joins the list, and a nested
+        # packages list made that join raise (swallowed), so install events
+        # were silently never recorded -- unlike update/downgrade.
+        targets.add_history(["install", " ".join(packages)])
 
         targets.perform_install(packages)
 
@@ -426,7 +429,7 @@ class TestReport(ABC):
             packages: The packages to uninstall.
 
         """
-        targets.add_history(["uninstall", packages])
+        targets.add_history(["uninstall", " ".join(packages)])
         targets.perform_uninstall(packages)
 
     def _autolock_new_target(self, target: Target) -> None:

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -821,6 +821,22 @@ def test_add_history_writes_entry(mock_target):
     fh.close.assert_called_once()
 
 
+def test_add_history_writes_install_entry(mock_target):
+    """The exact shape perform_install sends must produce a written line.
+
+    The install/uninstall callers used to pass a NESTED list
+    (["install", ["nginx"]]); the ':'.join then raised TypeError, which
+    the old bare except swallowed -- so install/uninstall events were
+    silently never recorded, unlike update/downgrade.
+    """
+    mock_target.state = "enabled"
+    fh = MagicMock()
+    mock_target.connection.sftp_open.return_value = fh
+    mock_target.add_history(["install", "nginx curl"])
+    line = fh.write.call_args.args[0]
+    assert line.endswith(":install:nginx curl\n")
+
+
 def test_add_history_logs_when_open_fails(mock_target, caplog):
     mock_target.state = "enabled"
     mock_target.connection.sftp_open.side_effect = OSError("perm")
@@ -829,14 +845,20 @@ def test_add_history_logs_when_open_fails(mock_target, caplog):
     assert any("failed to open history file" in r.message for r in caplog.records)
 
 
-def test_add_history_swallows_write_failure(mock_target):
-    """Write/close failures are silently swallowed (current behaviour)."""
+def test_add_history_write_failure_warns_but_does_not_raise(mock_target, caplog):
+    """Write/close failures stay best-effort but are no longer silent.
+
+    The old bare ``except Exception: pass`` hid a real programming error
+    (nested comment list) for years; a warning keeps the operation alive
+    while making the next such bug visible.
+    """
     mock_target.state = "enabled"
     fh = MagicMock()
     fh.write.side_effect = OSError("write failed")
     mock_target.connection.sftp_open.return_value = fh
-    # Must not raise.
-    mock_target.add_history(["update", "msg"])
+    with caplog.at_level("WARNING", logger="mtui.target"):
+        mock_target.add_history(["update", "msg"])  # must not raise
+    assert any("failed to write history entry" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -685,19 +685,25 @@ def test_perform_prepare_delegates_with_package_list(tmp_path: Path) -> None:
 
 
 def test_perform_install_records_history_and_delegates(tmp_path: Path) -> None:
+    """The history entry must be flat strings: Target.add_history ':'-joins
+    it, and a nested packages list made that join raise (swallowed), so
+    install events were silently never recorded."""
     r = _make(tmp_path)
     targets = MagicMock()
-    r.perform_install(targets, ["bash"])
-    targets.add_history.assert_called_once()
-    targets.perform_install.assert_called_once_with(["bash"])
+    r.perform_install(targets, ["bash", "curl"])
+    targets.add_history.assert_called_once_with(["install", "bash curl"])
+    # The joined line every Target would write parses/records cleanly.
+    assert ":".join(targets.add_history.call_args.args[0]) == "install:bash curl"
+    targets.perform_install.assert_called_once_with(["bash", "curl"])
 
 
 def test_perform_uninstall_records_history_and_delegates(tmp_path: Path) -> None:
     r = _make(tmp_path)
     targets = MagicMock()
-    r.perform_uninstall(targets, ["bash"])
-    targets.add_history.assert_called_once()
-    targets.perform_uninstall.assert_called_once_with(["bash"])
+    r.perform_uninstall(targets, ["bash", "curl"])
+    targets.add_history.assert_called_once_with(["uninstall", "bash curl"])
+    assert ":".join(targets.add_history.call_args.args[0]) == "uninstall:bash curl"
+    targets.perform_uninstall.assert_called_once_with(["bash", "curl"])
 
 
 def test_perform_downgrade_records_history_and_delegates(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

`install` and `uninstall` events were **silently never recorded** in the per-host history (`/var/log/mtui.log`, shown by `list_history`). `Target.add_history` builds its log line with `":".join(comment)`, which needs flat strings — but `perform_install`/`perform_uninstall` passed a *nested* list (`["install", packages]`, where `packages` is argparse's `nargs="+"` list). The join raised `TypeError` inside a `try` whose bare `except Exception: pass` swallowed it: nothing was written, nothing surfaced. `update`/`downgrade` (all-string lists) recorded fine, which is why the gap went unnoticed.

## Fix

- Callers pass flat strings: `add_history(["install", " ".join(packages)])` (and uninstall likewise).
- `add_history`'s wrong `comment: str` annotation corrected to `list[str]`.
- The silent swallow around the write is now a **warning log** (`exc_info` included). Best-effort semantics are kept — a read-only or full remote filesystem still never breaks the operation — but the next such programming error will be visible instead of hidden for years.

## Tests

- `test_perform_install_records_history_and_delegates` / `..._uninstall_...` — the history entry is flat strings whose join is exactly `install:bash curl`. **Revert-verified** against the nested-list callers.
- `test_add_history_writes_install_entry` — the exact caller shape produces a written line ending `:install:nginx curl\n`.
- `test_add_history_write_failure_warns_but_does_not_raise` — replaces the old "silently swallowed" test; pins the new warning. **Revert-verified** against the bare `pass`.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #21 from the recent code review.
