### PR TITLE
fix(support): write atomic files as UTF-8, not the locale codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `update`/`downgrade`, which recorded fine. The callers now pass flat
   strings, and a failed history write logs a warning instead of hiding
   the error (the write stays best-effort and never breaks the operation).
+- Writing a testreport (and every other atomic file write, e.g. the
+  refhosts.yml cache) now always encodes UTF-8 on disk, matching the UTF-8
+  read path. The write previously used the process locale codec, so under a
+  non-UTF-8 locale a template containing non-ASCII content (bug summaries,
+  maintainer names) either failed with `UnicodeEncodeError` — losing the
+  edits — or silently wrote mojibake that the next load misread. The
+  refhosts.yml store now reads with explicit UTF-8 to match (it read with
+  the locale codec, which would have mis-decoded the now-UTF-8 cache).
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -46,7 +46,10 @@ class Refhosts:
         parse failures propagate.
         """
         try:
-            with hostmap.open() as f:
+            # Explicit UTF-8: the HTTPS-downloaded cache is written UTF-8
+            # (atomic_write_file), so reading with the locale codec would
+            # mis-decode non-ASCII content under a non-UTF-8 locale.
+            with hostmap.open(encoding="utf-8") as f:
                 raw = YAML(typ="safe").load(f)
         except Exception:
             logger.error("failed to parse refhosts.yml")

--- a/mtui/support/fileops.py
+++ b/mtui/support/fileops.py
@@ -77,7 +77,14 @@ def atomic_write_file(data: bytes | str, path: Path) -> None:
     fd, fname = mkstemp(dir=path.parent)
 
     try:
-        with os.fdopen(fd, "w") as f:
+        # Explicit UTF-8: without it fdopen uses the locale codec, while
+        # the readers of what we write here are UTF-8 (FileList.load and
+        # the refhosts.yml store open with encoding="utf-8"; downloaded
+        # openQA logs are kept byte-identical to the server payload).
+        # Under a non-UTF-8 locale a template with non-ASCII content
+        # (bug summaries, maintainer names) either died with
+        # UnicodeEncodeError -- losing the edits -- or wrote mojibake.
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(data)
         move(fname, path)
     except BaseException:

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -87,6 +87,46 @@ def test_atomic_write(create_temp):
     atomic_write_file(data.encode(), Path(path) / "bytes")
 
 
+def test_atomic_write_non_ascii_is_utf8_on_disk(create_temp):
+    """The write encoding matches the UTF-8 read path, byte for byte."""
+    target = Path(create_temp) / "utf8.txt"
+    atomic_write_file("Bjørn — テスト", target)
+    assert target.read_bytes() == "Bjørn — テスト".encode()
+
+
+def test_atomic_write_non_ascii_survives_non_utf8_locale(create_temp):
+    """Writing non-ASCII must not depend on the process locale.
+
+    fdopen without an explicit encoding uses the locale codec, while the
+    read path (FileList.load, downloaded payloads) is UTF-8. Under a
+    non-UTF-8 locale (LC_ALL=C with PEP 538/540 coercion disabled) a
+    template containing 'Bjørn' died with UnicodeEncodeError, losing the
+    edits. Reproduced in a subprocess because the interpreter's locale
+    and UTF-8 mode are fixed at startup.
+    """
+    import subprocess
+    import sys
+
+    target = Path(create_temp) / "out.txt"
+    code = (
+        "from pathlib import Path\n"
+        "from mtui.support.fileops import atomic_write_file\n"
+        f"atomic_write_file('Bj\\u00f8rn', Path({str(target)!r}))\n"
+    )
+    env = dict(os.environ)
+    env.update(LC_ALL="C", LANG="C", PYTHONUTF8="0", PYTHONCOERCECLOCALE="0")
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,  # the assertion below reports stderr on failure
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert target.read_bytes() == "Bjørn".encode()
+
+
 def test_atomic_write_creates_missing_parent(create_temp):
     """The destination directory is created if absent (e.g. ~/.cache/mtui)."""
     target = Path(create_temp) / "missing" / "nested" / "refhosts.yml"

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -226,6 +226,54 @@ class TestRefhosts:
             refhost.Refhosts(broken)
         assert any("failed to parse refhosts.yml" in r.message for r in caplog.records)
 
+    def test_parse_refhosts_reads_utf8_regardless_of_locale(self, tmp_path):
+        """The cache is written UTF-8, so it must be read UTF-8 too.
+
+        atomic_write_file persists the HTTPS-downloaded refhosts.yml as
+        UTF-8; reading it back with the locale codec would mis-decode
+        non-ASCII content into mojibake (or die with UnicodeDecodeError)
+        under a non-UTF-8 locale. Reproduced in a subprocess because the
+        locale and UTF-8 mode are fixed at interpreter startup.
+        """
+        import os
+        import subprocess
+        import sys
+
+        yml = tmp_path / "refhosts.yml"
+        yml.write_bytes(
+            (
+                "default:\n"
+                "  - name: bjørn-host\n"
+                "    arch: x86_64\n"
+                "    product:\n"
+                "      name: sles\n"
+                "      version:\n"
+                "        major: 15\n"
+            ).encode()
+        )
+        # The assertion runs inside the subprocess (comparing in-memory
+        # strings; printing the non-ASCII name under LC_ALL=C would die
+        # on the stdout codec instead of testing the file read).
+        code = (
+            "from pathlib import Path\n"
+            "from mtui.hosts import refhost\n"
+            f"rh = refhost.Refhosts(Path({str(yml)!r}))\n"
+            "assert [h.name for h in rh.data] == ['bj\\u00f8rn-host']\n"
+            "print('OK')\n"
+        )
+        env = dict(os.environ)
+        env.update(LC_ALL="C", LANG="C", PYTHONUTF8="0", PYTHONCOERCECLOCALE="0")
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,  # the assertion below reports stderr on failure
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip() == "OK"
+
     def test_parse_refhosts_drops_malformed_host_and_logs(self, tmp_path, caplog):
         """Rows missing required fields are logged at ERROR and dropped."""
         bad = tmp_path / "bad.yml"


### PR DESCRIPTION
## What

`atomic_write_file` decodes incoming bytes as UTF-8 but wrote them via `os.fdopen(fd, "w")` with **no explicit encoding** — the process locale codec. Every read path is explicitly UTF-8 (`FileList.load` opens with `encoding="utf-8"`; downloaded payloads are UTF-8 documents), so the write was asymmetric. Under a non-UTF-8 locale (a genuinely installed C/latin locale, or `PYTHONUTF8=0` / `PYTHONCOERCECLOCALE=0` automation), writing a testreport template containing non-ASCII (bug summaries, maintainer names) raised `UnicodeEncodeError` out of the `FileList` context manager — losing the user's edits — or silently wrote mojibake that the next UTF-8 load misread.

## Fix

`os.fdopen(fd, "w", encoding="utf-8")` — the write now matches the read path byte for byte, regardless of locale.

Adversarial review caught the one consumer whose *read* side also used the locale codec: the refhosts.yml store (the HTTPS resolver persists the downloaded cache through `atomic_write_file`), which would have mis-decoded the now-UTF-8 cache under a non-UTF-8 locale. It now opens with explicit UTF-8 as well — which also covers user-supplied `refhosts.yml` files.

## Tests

- `test_atomic_write_non_ascii_survives_non_utf8_locale` — reproduces the original failure in a **subprocess** with `LC_ALL=C`, `PYTHONUTF8=0`, `PYTHONCOERCECLOCALE=0` (locale and UTF-8 mode are fixed at interpreter startup, so it can't be simulated in-process); asserts the write succeeds and the on-disk bytes are UTF-8. **Revert-verified**: the old code dies with `UnicodeEncodeError` in that environment.
- `test_atomic_write_non_ascii_is_utf8_on_disk` — byte-for-byte on-disk assertion in the normal environment.
- `test_parse_refhosts_reads_utf8_regardless_of_locale` — a UTF-8 refhosts.yml with a non-ASCII hostname parses correctly in the same C-locale subprocess environment. **Revert-verified** against the encoding-less `open()`.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #27 from the recent code review.
