### PR TITLE
fix(commands): stop commit -m storing literal quotes in the SVN log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   edits — or silently wrote mojibake that the next load misread. The
   refhosts.yml store now reads with explicit UTF-8 to match (it read with
   the locale codec, which would have mis-decoded the now-UTF-8 cache).
+- `commit -m <message>` no longer stores literal double quotes around the
+  message in the SVN log. The message was manually wrapped in `"` for a
+  shell that is never involved — svn receives the argv list directly — so
+  `commit -m fix the thing` recorded `"fix the thing"` verbatim.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/commands/commit.py
+++ b/mtui/commands/commit.py
@@ -36,7 +36,10 @@ class Commit(Command):
         checkout = self.metadata.report_wd()
 
         if self.args.msg:
-            msg = ["-m", '"' + " ".join(self.args.msg[0]) + '"']
+            # No manual quoting: the argv list reaches svn without a shell,
+            # so wrapping in '"' stored literal double quotes in the SVN log
+            # message (a leftover from a former shell-based invocation).
+            msg = ["-m", " ".join(self.args.msg[0])]
         else:
             # No -m given: commit non-interactively with a generated message
             # reusing the testreport export footer (instead of letting svn

--- a/tests/test_cmd_commit.py
+++ b/tests/test_cmd_commit.py
@@ -88,7 +88,12 @@ def test_commit_default_message_reuses_export_footer(mock_config, tmp_path):
 
 
 def test_commit_explicit_message_passed_through(mock_config, tmp_path):
-    """An explicit -m message is still used verbatim."""
+    """An explicit -m message reaches svn verbatim -- no added quotes.
+
+    The argv list is executed without a shell, so the old manual '"'
+    wrapping stored literal double quotes in the SVN log message
+    ('"my message"' instead of 'my message').
+    """
     prompt = _prompt(tmp_path)
     mock_config.install_logs = "install_logs"
     args = Namespace(msg=[["my", "message"]])
@@ -99,7 +104,7 @@ def test_commit_explicit_message_passed_through(mock_config, tmp_path):
     ):
         Commit(args, mock_config, MagicMock(), prompt)()
 
-    assert _svn_ci_message(cc) == '"my message"'
+    assert _svn_ci_message(cc) == "my message"
 
 
 def test_commit_without_metadata_raises(mock_config):


### PR DESCRIPTION
## What

`commit -m fix the thing` recorded the SVN log message as `"fix the thing"` — with the surrounding double quotes stored verbatim in the commit. The `-m` branch manually wrapped the joined message in `"` for a shell that is never involved: `svn_commit_testreport` passes the argv list straight to `subprocess.check_call(["svn", "ci", *msg])`. The no-`-m` default path and `approve.py`'s SVN commit both pass their messages unquoted; the wrapping was a leftover from a former shell-based invocation.

## Fix

Drop the manual quoting: `msg = ["-m", " ".join(self.args.msg[0])]`.

## Tests

- `test_commit_explicit_message_passed_through` — updated from pinning the quoted behaviour to pinning the verbatim message (`my message`, no quotes). **Revert-verified.**

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #16 from the recent code review.
