### PR TITLE
fix(connection): close the channel when a command times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   message in the SVN log. The message was manually wrapped in `"` for a
   shell that is never involved — svn receives the argv list directly — so
   `commit -m fix the thing` recorded `"fix the thing"` verbatim.
+- A command that hits the inactivity timeout no longer leaks its SSH channel.
+  Both timeout paths (the non-interactive abort used under `mtui-mcp` and an
+  interactive "don't wait" answer) raised without closing the channel, so it
+  stayed registered on the paramiko transport and the remote command kept
+  running — repeated timeouts accumulated orphaned channels and remote
+  processes. The channel is now closed before the timeout error propagates,
+  and likewise when the wait-prompt is abandoned with Ctrl-D or Ctrl-C.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -401,81 +401,94 @@ class Connection:
             session = self.__run_command(command)
             counter += 1
 
-        while True:
-            buffer = b""
+        try:
+            while True:
+                buffer = b""
 
-            # wait for data to be transmitted. if the timeout is hit,
-            # ask the user on how to procceed
-            if select.select([session], [], [], self.timeout) == ([], [], []):
-                if not session:
-                    raise ConnectionError(
-                        f"Session lost during command execution on {self.hostname}"
-                    )
+                # wait for data to be transmitted. if the timeout is hit,
+                # ask the user on how to procceed
+                if select.select([session], [], [], self.timeout) == ([], [], []):
+                    if not session:
+                        raise ConnectionError(
+                            f"Session lost during command execution on {self.hostname}"
+                        )
 
-                # Non-interactive (e.g. mtui-mcp): there is no human to ask
-                # whether to keep waiting, so a command that produced no output
-                # for the whole timeout window is treated as stuck and aborted,
-                # rather than looping forever (which previously wedged the run
-                # until the session was killed). The window is
-                # ``connection_timeout`` (default 300s); raise it in config for
-                # legitimately long, fully silent commands.
-                if not self._interactive:
-                    logger.warning(
-                        'command "%s" timed out on %s after %ss with no output; '
-                        "aborting (non-interactive session)",
-                        command,
-                        self.hostname,
-                        self.timeout,
+                    # Non-interactive (e.g. mtui-mcp): there is no human to ask
+                    # whether to keep waiting, so a command that produced no output
+                    # for the whole timeout window is treated as stuck and aborted,
+                    # rather than looping forever (which previously wedged the run
+                    # until the session was killed). The window is
+                    # ``connection_timeout`` (default 300s); raise it in config for
+                    # legitimately long, fully silent commands.
+                    if not self._interactive:
+                        logger.warning(
+                            'command "%s" timed out on %s after %ss with no output; '
+                            "aborting (non-interactive session)",
+                            command,
+                            self.hostname,
+                            self.timeout,
+                        )
+                        raise CommandTimeoutError
+
+                    # No prompt callback wired: silently wait. Matches the
+                    # long-standing Enter / Y default but emits a WARNING
+                    # so the silence is observable in logs.
+                    if self._timeout_prompt is None:
+                        logger.warning(
+                            'command "%s" timed out on %s; no prompt callback wired, '
+                            "waiting for completion",
+                            command,
+                            self.hostname,
+                        )
+                        continue
+
+                    # Prompt callback wired: ask the user. The callback is
+                    # responsible for any cross-thread serialisation (the
+                    # production wiring uses ``Prompter.ask`` which holds a
+                    # single lock so workers don't race for stdin).
+                    answer = self._timeout_prompt(
+                        f'command "{command}" timed out on {self.hostname}. wait? (Y/n) ',
                     )
+                    if answer.lower() not in ("no", "n", "ne", "nein"):
+                        continue
+                    # If the user don't want to wait, raise CommandTimeoutError
+                    # and procceed.
                     raise CommandTimeoutError
 
-                # No prompt callback wired: silently wait. Matches the
-                # long-standing Enter / Y default but emits a WARNING
-                # so the silence is observable in logs.
-                if self._timeout_prompt is None:
-                    logger.warning(
-                        'command "%s" timed out on %s; no prompt callback wired, '
-                        "waiting for completion",
-                        command,
-                        self.hostname,
-                    )
-                    continue
+                try:
+                    # wait for data on the session's stdout/stderr. if debug is enabled,
+                    # print the received data
+                    if session.recv_ready():
+                        buffer = session.recv(1024)
+                        stdout += buffer
+                        for line in buffer.decode("utf-8", "ignore").split("\n"):
+                            if line:
+                                logger.debug(line)
 
-                # Prompt callback wired: ask the user. The callback is
-                # responsible for any cross-thread serialisation (the
-                # production wiring uses ``Prompter.ask`` which holds a
-                # single lock so workers don't race for stdin).
-                answer = self._timeout_prompt(
-                    f'command "{command}" timed out on {self.hostname}. wait? (Y/n) ',
-                )
-                if answer.lower() not in ("no", "n", "ne", "nein"):
-                    continue
-                # If the user don't want to wait, raise CommandTimeoutError
-                # and procceed.
-                raise CommandTimeoutError
+                    if session.recv_stderr_ready():
+                        buffer = session.recv_stderr(1024)
+                        stderr += buffer
+                        for line in buffer.decode("utf-8", "ignore").split("\n"):
+                            if line:
+                                logger.debug(line)
 
-            try:
-                # wait for data on the session's stdout/stderr. if debug is enabled,
-                # print the received data
-                if session.recv_ready():
-                    buffer = session.recv(1024)
-                    stdout += buffer
-                    for line in buffer.decode("utf-8", "ignore").split("\n"):
-                        if line:
-                            logger.debug(line)
+                    if not buffer:
+                        break
 
-                if session.recv_stderr_ready():
-                    buffer = session.recv_stderr(1024)
-                    stderr += buffer
-                    for line in buffer.decode("utf-8", "ignore").split("\n"):
-                        if line:
-                            logger.debug(line)
-
-                if not buffer:
-                    break
-
-            except TimeoutError:
-                select.select([], [], [], 1)
+                except TimeoutError:
+                    select.select([], [], [], 1)
+        except BaseException:
+            # Abandoning the command must not leak its channel: without
+            # this close the Channel stays registered on the paramiko
+            # Transport (never reclaimed by GC) and the remote command
+            # keeps running -- repeated timeouts accumulated orphaned
+            # channels and remote processes until the connection died.
+            # BaseException, not just CommandTimeoutError: the wrapped
+            # region includes the interactive timeout prompt, so Ctrl-D
+            # (EOFError) or Ctrl-C (KeyboardInterrupt) at the prompt
+            # abandons the command the same way and must clean up too.
+            self.close_session(session)
+            raise
         # save the exitcode of the last command and return it
         exitcode = session.recv_exit_status()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -329,6 +329,57 @@ def test_run_command_timeout_noninteractive_aborts(
     ):
         conn.run("sleep infinity")
 
+    # Abandoning the command must not leak its channel: the Channel stays
+    # registered on the paramiko Transport (never reclaimed by GC) and the
+    # remote command keeps running until it is closed.
+    mock_session.close.assert_called_once()
+
+
+def test_run_command_timeout_declined_wait_closes_channel(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """The user-declines-to-wait timeout path must close the channel too."""
+    conn = Connection("test_host", 22, 300, timeout_prompt=lambda _text: "n")
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+
+    with (
+        patch("select.select", return_value=([], [], [])),
+        pytest.raises(CommandTimeoutError),
+    ):
+        conn.run("sleep 10")
+
+    mock_session.close.assert_called_once()
+
+
+def test_run_command_prompt_eof_closes_channel(
+    mock_ssh_client, mock_ssh_config, mock_path
+):
+    """Ctrl-D at the wait prompt abandons the command -- channel closed.
+
+    The prompt executes inside the guarded read loop; input() raising
+    EOFError (Ctrl-D) abandons the command exactly like answering 'n',
+    so it must not leak the channel either (adversarial-review catch:
+    an except limited to CommandTimeoutError missed this).
+    """
+
+    def _eof_prompt(_text: str) -> str:
+        raise EOFError
+
+    conn = Connection("test_host", 22, 300, timeout_prompt=_eof_prompt)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+
+    with (
+        patch("select.select", return_value=([], [], [])),
+        pytest.raises(EOFError),
+    ):
+        conn.run("sleep 10")
+
+    mock_session.close.assert_called_once()
+
 
 def test_run_command_timeout_callback_runs_on_calling_thread(
     mock_ssh_client, mock_ssh_config, mock_path


### PR DESCRIPTION
## What

A command that hit the inactivity timeout **leaked its SSH channel and orphaned the remote command**. `run()` raises `CommandTimeoutError` on two paths — the non-interactive abort (mtui-mcp) and an interactive "don't wait" answer — and neither called `close_session(session)`. The Channel stays registered on the paramiko Transport (kept in its internal channel map, so never reclaimed by GC) and the remote command keeps running. `Target.run()` catches the error and keeps using the same Connection, so over a session with several timeouts (e.g. hung zypper transactions under mtui-mcp) orphaned channels and still-running remote processes accumulated.

## Fix

Wrap the read loop in a close-and-reraise guard — one close point covering both raise sites. The loop body itself is unchanged (re-indented only); the normal EOF path still closes as before.

The guard catches `BaseException`, not just `CommandTimeoutError` (adversarial-review catch): the wrapped region includes the interactive timeout prompt, so **Ctrl-D** (`EOFError`) or **Ctrl-C** (`KeyboardInterrupt`) at the "wait? (Y/n)" prompt abandons the command exactly the same way and must release the channel too.

## Tests

- `test_run_command_timeout_noninteractive_aborts` — extended: the abandoned channel must be closed. **Revert-verified.**
- `test_run_command_timeout_declined_wait_closes_channel` — same assertion for the interactive decline path. **Revert-verified.**
- `test_run_command_prompt_eof_closes_channel` — Ctrl-D at the wait prompt propagates `EOFError` with the channel closed. **Revert-verified** against a `CommandTimeoutError`-only guard.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #19 from the recent code review.
