### PR TITLE
fix(hosts): tolerate unreadable addon product files on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   running — repeated timeouts accumulated orphaned channels and remote
   processes. The channel is now closed before the timeout error propagates,
   and likewise when the wait-prompt is abandoned with Ctrl-D or Ctrl-C.
+- Connecting a reference host no longer fails outright when one of its addon
+  product files under `/etc/products.d/` is a dangling symlink or otherwise
+  unreadable. The base-product path already tolerated exactly this; the addon
+  loop did not, so a single stale `.prod` entry made the whole host
+  impossible to add. The offending addon is now skipped with a warning.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/hosts/target/parsers/system.py
+++ b/mtui/hosts/target/parsers/system.py
@@ -91,10 +91,21 @@ def parse_system(connection: Connection) -> tuple[System, bool]:
 
         addons: set[Product] = set()
         for x in files:
-            with sftp.open(f"/etc/products.d/{x}") as f:
-                logger.debug("parsing - %s", x)
-                name, version, arch = product.parse_product(f)
-                addons.add(Product(name, version, arch))
+            # Mirror the base-product handling: a dangling symlink or
+            # otherwise unreadable addon .prod file must not abort the
+            # whole host connect -- warn and skip just that addon.
+            try:
+                with sftp.open(f"/etc/products.d/{x}") as f:
+                    logger.debug("parsing - %s", x)
+                    name, version, arch = product.parse_product(f)
+                    addons.add(Product(name, version, arch))
+            except OSError:
+                logger.warning(
+                    "%s: skipping unreadable addon product file "
+                    "/etc/products.d/%s (dangling symlink?)",
+                    connection.hostname,
+                    x,
+                )
         # SLE4SAP on sle12 contains also SLES repos :(
         if base.name == "SLES_SAP" and base.version.startswith("12"):
             addons.add(Product("SLES", base.version, base.arch))

--- a/tests/test_target_parsers.py
+++ b/tests/test_target_parsers.py
@@ -409,3 +409,58 @@ class TestParseSystem:
 
         addons = {(p.name, p.version) for p in system.get_addons()}
         assert ("sle-ha", "16.0") in addons
+
+
+class TestParseSystemAddonTolerance:
+    @patch("mtui.hosts.target.parsers.system.product")
+    def test_unreadable_addon_prod_is_skipped_not_fatal(
+        self, mock_product_module, caplog
+    ):
+        """A dangling/unreadable addon .prod must not abort the connect.
+
+        The base-product path already tolerates a dangling symlink; the
+        addon loop did not: sftp.open raised OSError, which propagated
+        out of parse_system into Target.connect and made the host
+        impossible to add at all.
+        """
+        conn, sftp = _mock_connection_with_sftp()
+        sftp.listdir.return_value = [
+            "SLES.prod",
+            "broken-addon.prod",
+            "sle-module-basesystem.prod",
+        ]
+        sftp.readlink.return_value = "SLES.prod"
+
+        base_file = MagicMock()
+        addon_file = MagicMock()
+
+        def _open(path, *args, **kwargs):
+            p = str(path)
+            if "transactional-update.conf" in p:
+                raise FileNotFoundError(p)
+            if "broken-addon" in p:
+                raise OSError("dangling symlink")
+            if "SLES.prod" in p:
+                return base_file
+            return addon_file
+
+        sftp.open.side_effect = _open
+        mock_product_module.parse_product.side_effect = [
+            ("SLES", "15-SP5", "x86_64"),
+            ("sle-module-basesystem", "15-SP5", "x86_64"),
+        ]
+
+        from mtui.hosts.target.parsers.system import parse_system
+
+        with caplog.at_level("WARNING", logger="mtui.targer.parsers.system"):
+            system, transactional = parse_system(conn)
+
+        assert system.get_base().name == "SLES"
+        assert transactional is False
+        # The readable addon survived; the broken one was skipped, warned.
+        addon_names = {a.name for a in system.get_addons()}
+        assert "sle-module-basesystem" in addon_names
+        assert any(
+            "skipping unreadable addon product file" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
## What

A single stale addon product file made a reference host **impossible to add**. The base-product read and the os-release fallback both deliberately catch `OSError` so a broken product file cannot kill the connect — but the addon loop had no such guard: `sftp.open()` on a dangling-symlink (or otherwise unreadable) `/etc/products.d/*.prod` entry raised `OSError` out of `parse_system` into `Target.connect()`, aborting the whole connect. `sftp.listdir` still returns the entry (it matches the `.prod` filter), so this is exactly the dangling-symlink case the base-product path already handles.

## Fix

Wrap the per-addon open/parse in `try/except OSError` that logs a warning naming the offending file and skips just that addon, mirroring the base-product handling.

## Tests

- `test_unreadable_addon_prod_is_skipped_not_fatal` — a host with a good base product, one dangling addon, and one readable addon connects fine: base parsed, readable addon kept, broken addon skipped with a warning. **Revert-verified**: the old loop propagates the `OSError`.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #20 from the recent code review.
