### PR TITLE
fix(support): match single-quoted os-release values in detect_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   unreadable. The base-product path already tolerated exactly this; the addon
   loop did not, so a single stale `.prod` entry made the whole host
   impossible to add. The offending addon is now skipped with a warning.
+- The testreport export/commit footer no longer loses the distro and version
+  on hosts whose `/etc/os-release` single-quotes its values (permitted by the
+  os-release spec). The parser's character classes matched a double quote or
+  a literal pipe — `["|]` — instead of double-or-single quote.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/support/systemcheck.py
+++ b/mtui/support/systemcheck.py
@@ -14,8 +14,12 @@ def detect_system() -> tuple[str, str, str]:
         A tuple containing the distribution, version ID, and kernel version.
 
     """
-    _distro = re.compile(r'NAME=["|](.*)["|]')
-    _v_id = re.compile(r'VERSION_ID=["|](.*)["|]')
+    # A quote class, not alternation: inside [...] the | was a literal
+    # pipe, so single-quoted values (NAME='openSUSE', permitted by the
+    # os-release spec) never matched and the export footer lost its
+    # distro/version.
+    _distro = re.compile(r'NAME=["\'](.*)["\']')
+    _v_id = re.compile(r'VERSION_ID=["\'](.*)["\']')
     distro = ""
     verid = ""
     kernel = ""

--- a/tests/test_systemcheck.py
+++ b/tests/test_systemcheck.py
@@ -24,6 +24,32 @@ def test_detect_system(monkeypatch):
     assert kernel == "test_kernel"
 
 
+def test_detect_system_single_quoted_os_release(monkeypatch):
+    """Single-quoted os-release values (spec-legal) must parse too.
+
+    The regexes used ["|] -- inside a character class | is a literal
+    pipe, not alternation -- so NAME='openSUSE' never matched and the
+    export footer rendered without distro/version.
+    """
+    mock_os_release = "NAME='openSUSE Tumbleweed'\nVERSION_ID='20260710'"
+    mock_version = "Linux version 6.12.0"
+
+    def mock_open_side_effect(path, mode="r", encoding="utf-8"):
+        if path == "/etc/os-release":
+            return mock_open(read_data=mock_os_release).return_value
+        if path == "/proc/version":
+            return mock_open(read_data=mock_version).return_value
+        raise FileNotFoundError
+
+    monkeypatch.setattr("builtins.open", mock_open_side_effect)
+
+    distro, verid, kernel = systemcheck.detect_system()
+
+    assert distro == "openSUSE Tumbleweed"
+    assert verid == "20260710"
+    assert kernel == "6.12.0"
+
+
 def test_system_info_default_prefix():
     """The export footer keeps the ``## export`` prefix."""
     s = systemcheck.system_info("openSUSE Leap", "16.0", "6.12.0", "mpluskal")


### PR DESCRIPTION
## What

On hosts whose `/etc/os-release` single-quotes its values (`NAME='openSUSE'` — permitted by the os-release spec and used by some derivatives/dev machines), the testreport export/commit footer rendered garbled — `## export MTUI:… on -  (kernel: …)` — with no distro or version. `detect_system()` compiled `NAME=["|](.*)["|]`: inside a character class `|` is a literal pipe, not alternation, so the classes matched a double quote **or a pipe**. SUSE's double-quoted format happened to work; single-quoted values never matched, leaving `distro`/`verid` empty.

## Fix

Real quote classes: `NAME=["'](.*)["']` and likewise `VERSION_ID`. No other behaviour change.

## Tests

- `test_detect_system_single_quoted_os_release` — a single-quoted os-release parses to the same fields the double-quoted one does. **Revert-verified**: on the old classes both fields come back empty.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #28 from the recent code review.
