### PR TITLE
fix(export): make re-exports idempotent and stop over-deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   on hosts whose `/etc/os-release` single-quotes its values (permitted by the
   os-release spec). The parser's character classes matched a double quote or
   a literal pipe — `["|]` — instead of double-or-single quote.
+- Re-exporting a testreport no longer degrades the template. Manual and
+  kernel re-exports used to stack an empty duplicate `Links for update
+  logs:` header per run (the links were de-duplicated, the header was not) —
+  new links now go under the existing section, and empty duplicate headers
+  stacked by earlier exports are cleaned up so damaged templates converge.
+  The kernel re-export also duplicated the "All installation tests done in
+  openQA" notice on every run; it is now inserted only once and stacked
+  copies are reduced back to one.
+- An auto-workflow `export` on a template without a `Links for update logs:`
+  section no longer deletes everything from the install-tests section to the
+  end of the file (export footer and any appended notes included). The
+  fallback boundary looked for a line exactly equal to `## export MTUI:`,
+  which never matches the real footer; it now scans for the footer as a
+  substring.
+- Re-exporting a manual testreport now actually refreshes stale per-command
+  result lines (`… : SUCCEEDED`/`FAILED`/`INTERNAL ERROR`) for hosts in the
+  current session. The host-tracking pattern required two spaces after
+  `reference host:` (the template emits one) and compared the whole match
+  instead of the hostname, so the cleanup never removed anything; other
+  hosts' sections remain untouched.
 - `mtui-mcp` no longer corrupts a `commit`/`lock` call that also carries a
   `template` argument, nor a backgrounded `run` that fans out across several
   loaded templates. A `-m`/`-c` message or a `run` command line no longer

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -66,10 +66,20 @@ class AutoExport(BaseExport):
             while end > start and self.template[end - 1] == "\n":
                 end -= 1
         except ValueError:
-            try:
-                end = self.template.index("## export MTUI:", start)
-            except ValueError:
-                end = len(self.template)
+            # Substring scan for the footer: the actual line is
+            # '## export MTUI:<version>, ... by <user>\n', never exactly
+            # '## export MTUI:', so list.index() could not match it -- end
+            # ran to len(template) and the replacement deleted everything
+            # after the Install-tests section (footer included, plus any
+            # free-text notes a tester had appended).
+            end = next(
+                (
+                    i
+                    for i in range(max(start, 0), len(self.template))
+                    if "## export MTUI:" in self.template[i]
+                ),
+                len(self.template),
+            )
 
         block = [
             "##############\n",

--- a/mtui/update_workflow/export/base.py
+++ b/mtui/update_workflow/export/base.py
@@ -98,13 +98,38 @@ class BaseExport(ABC):
                 o = i + 1
                 break
 
-        index = len(self.template)
-        if "## export MTUI:" in self.template[-1]:
-            index -= 1
-        self.template.insert(index, "\n")
-        self.template.insert(index + 1, "Links for update logs:\n")
-        self.template.insert(index + 2, "\n")
-        index += 2
+        marker = "Links for update logs:\n"
+        try:
+            # Reuse an existing section: manual/kernel exports run this on
+            # every export, and unconditionally inserting a fresh header
+            # stacked empty 'Links for update logs:' sections that grew
+            # with each re-export (the links themselves were de-duplicated,
+            # the header was not). New links are appended after the
+            # section's existing links.
+            index = self.template.index(marker) + 1
+            self._drop_empty_link_sections(marker, index)
+            if index >= len(self.template) or (
+                self.template[index] != "\n"
+                and str(self.config.reports_url) not in self.template[index]
+            ):
+                # Hand-trimmed template: the header is followed directly by
+                # foreign content (e.g. the export footer). Restore the
+                # canonical blank so the links land inside the section, not
+                # after the footer.
+                self.template.insert(index, "\n")
+            while (
+                index + 1 < len(self.template)
+                and str(self.config.reports_url) in self.template[index + 1]
+            ):
+                index += 1
+        except ValueError:
+            index = len(self.template)
+            if "## export MTUI:" in self.template[-1]:
+                index -= 1
+            self.template.insert(index, "\n")
+            self.template.insert(index + 1, marker)
+            self.template.insert(index + 2, "\n")
+            index += 2
 
         add_empty_line = False
         for fn in filenames:
@@ -114,8 +139,47 @@ class BaseExport(ABC):
                 self.template.insert(index, install_log)
                 add_empty_line = True
 
-        if add_empty_line:
+        if add_empty_line and (
+            index + 1 >= len(self.template) or self.template[index + 1] != "\n"
+        ):
             self.template.insert(index + 1, "\n")
+
+    def _drop_empty_link_sections(self, marker: str, search_from: int) -> None:
+        """Remove empty duplicate 'Links for update logs:' headers.
+
+        Pre-fix exports stacked one fresh header per run while the links
+        stayed under the original section, so damaged templates carry
+        trailing header blocks with nothing but blanks under them. They
+        would otherwise survive forever (``dedup_lines`` never collapses
+        blank-separated duplicates). A duplicate section that does hold
+        links is left alone -- never delete content.
+
+        Args:
+            marker: The section header line.
+            search_from: Index to start scanning at (just past the first,
+                kept, header).
+
+        """
+        i = search_from
+        while True:
+            try:
+                j = self.template.index(marker, i)
+            except ValueError:
+                return
+            k = j + 1
+            while k < len(self.template) and self.template[k] == "\n":
+                k += 1
+            if (
+                k < len(self.template)
+                and str(self.config.reports_url) in (self.template[k])
+            ):
+                i = k  # a section with real links: keep it
+                continue
+            # Empty duplicate: drop the header, its trailing blanks, and the
+            # framing blank the old code inserted before it.
+            start = j - 1 if j > 0 and self.template[j - 1] == "\n" else j
+            del self.template[start:k]
+            i = start
 
     def dedup_lines(self) -> None:
         """Deduplicates lines in the template."""
@@ -214,8 +278,17 @@ class BaseExport(ABC):
     def install_results(self) -> None:
         """Adds installation results to the template."""
         index = self.template.index("Test results by product-arch:\n", 0)
-        self.template.insert(
-            index + 3,
-            "All installation tests done in openQA please see installlogs section\n",
-        )
-        self.template.insert(index + 4, "\n")
+        line = "All installation tests done in openQA please see installlogs section\n"
+        # Idempotent: on a kernel re-export the previous run's notice is
+        # still there, separated from a fresh insert by the blank line, so
+        # dedup_lines() never collapsed them and the notice multiplied with
+        # every export. Copies stacked by pre-fix exports are dropped so a
+        # damaged template converges back to a single notice.
+        while self.template.count(line) > 1:
+            extra = len(self.template) - 1 - self.template[::-1].index(line)
+            del self.template[extra]
+            if extra < len(self.template) and self.template[extra] == "\n":
+                del self.template[extra]
+        if line not in self.template:
+            self.template.insert(index + 3, line)
+            self.template.insert(index + 4, "\n")

--- a/mtui/update_workflow/export/manual.py
+++ b/mtui/update_workflow/export/manual.py
@@ -240,9 +240,26 @@ class ManualExport(BaseExport):
         c_host = None
         tmp_template = []
         for line in self.template:
-            match = re.search(r"reference host:\s (.*)$", line)
+            # Track which host section we are in so only the *current
+            # session's* hosts get their stale result lines refreshed. The
+            # old pattern required two spaces after the colon (the template
+            # emits one) and read group(0) (the whole match, never a bare
+            # hostname), so no stale line was ever removed. The host line
+            # itself is kept -- it is the section header.
+            match = re.search(r"reference host:\s+([^)\s]+)", line)
             if match:
-                c_host = match.group(0)
+                c_host = match.group(1)
+                tmp_template.append(line)
+                continue
+
+            if c_host is not None and line.startswith("comment:"):
+                # End of this host's block (same boundary convention as the
+                # verdict loop above). Without the reset the deletion window
+                # bled past the last host section and ate tester-authored
+                # lines like 'reproducer : FAILED before update' from the
+                # regression-tests notes.
+                tmp_template.append(line)
+                c_host = None
                 continue
 
             if (

--- a/tests/test_export_idempotency.py
+++ b/tests/test_export_idempotency.py
@@ -1,0 +1,356 @@
+"""Re-export idempotency tests for the export pipeline.
+
+Regression tests for four related bugs: every one of them made a second
+`export` of the same testreport degrade the template instead of being a
+no-op refresh (duplicate headers/notices, over-deletion to end of file,
+dead stale-line cleanup).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from mtui.update_workflow.export.auto import AutoExport
+from mtui.update_workflow.export.kernel import KernelExport
+from mtui.update_workflow.export.manual import ManualExport
+
+FOOTER = "## export MTUI:12.0, paramiko 3.5 on SLES-15 (kernel: 6.4) by tester\n"
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.template_dir = tmp_path
+    cfg.install_logs = "install_logs"
+    cfg.reports_url = "https://reports"
+    cfg.distro = "SLES"
+    cfg.distro_ver = "15"
+    cfg.distro_kernel = "5.14"
+    cfg.session_user = "tester"
+    return cfg
+
+
+def _manual(tmp_path: Path, template: list[str], results=None) -> ManualExport:
+    return ManualExport(
+        _config(tmp_path),
+        MagicMock(),
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid="SUSE:Maintenance:12358:199773",
+        interactive=False,
+        results=list(results or []),
+    )
+
+
+def _kernel(tmp_path: Path, template: list[str]) -> KernelExport:
+    return KernelExport(
+        _config(tmp_path),
+        MagicMock(),
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid="SUSE:Maintenance:12358:199773",
+        interactive=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 31: auto install_results must bound its replacement at the export footer
+# ---------------------------------------------------------------------------
+
+
+def test_auto_install_results_bounds_at_footer(tmp_path: Path) -> None:
+    """No 'Links for update logs:' section: the fallback bound is the footer.
+
+    The footer line is '## export MTUI:<version> ...', never exactly
+    '## export MTUI:', so the old list.index() fallback raised ValueError
+    and the replacement ran to len(template) -- deleting the footer.
+    """
+    template = [
+        "some intro\n",
+        "##############\n",
+        "Install tests:\n",
+        "##############\n",
+        "\n",
+        "old status line\n",
+        "\n",
+        FOOTER,
+    ]
+    openqa = MagicMock()
+    openqa.auto.results = []
+    exporter = AutoExport(
+        _config(tmp_path),
+        openqa,
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid="SUSE:Maintenance:12358:199773",
+        interactive=False,
+    )
+
+    exporter.install_results()
+
+    assert exporter.template.count(FOOTER) == 1  # footer survived
+    assert exporter.template[-1] == FOOTER
+    assert "Install tests:\n" in exporter.template
+    assert "old status line\n" not in exporter.template  # section body replaced
+
+
+# ---------------------------------------------------------------------------
+# 32: installlogs_lines must reuse an existing 'Links for update logs:' header
+# ---------------------------------------------------------------------------
+
+
+def test_installlogs_lines_reuses_existing_header(tmp_path: Path) -> None:
+    """Re-export: no second (empty) 'Links for update logs:' section.
+
+    The links were de-duplicated but the header was not, so manual/kernel
+    re-exports stacked an empty header block per run.
+    """
+    rrid = "SUSE:Maintenance:12358:199773"
+    old_link = f"https://reports/{rrid}/install_logs/old.log\n"
+    template = [
+        "body\n",
+        "\n",
+        "Links for update logs:\n",
+        "\n",
+        old_link,
+        "\n",
+        FOOTER,
+    ]
+    exporter = _manual(tmp_path, template)
+
+    exporter.installlogs_lines(["old.log", "new.log"])
+
+    tpl = list(exporter.template)
+    assert tpl.count("Links for update logs:\n") == 1
+    assert tpl.count(old_link) == 1  # still de-duplicated
+    new_link = f"https://reports/{rrid}/install_logs/new.log\n"
+    assert tpl.count(new_link) == 1
+    # both links live under the one header, before the footer
+    header = tpl.index("Links for update logs:\n")
+    assert header < tpl.index(new_link) < tpl.index(FOOTER)
+
+
+def test_installlogs_lines_twice_is_idempotent(tmp_path: Path) -> None:
+    """Two identical calls (two exports) leave exactly one section."""
+    template = ["body\n", FOOTER]
+    exporter = _manual(tmp_path, template)
+
+    exporter.installlogs_lines(["a.log"])
+    exporter.installlogs_lines(["a.log"])
+
+    tpl = list(exporter.template)
+    assert tpl.count("Links for update logs:\n") == 1
+    rrid = "SUSE:Maintenance:12358:199773"
+    assert tpl.count(f"https://reports/{rrid}/install_logs/a.log\n") == 1
+
+
+# ---------------------------------------------------------------------------
+# 33: base install_results notice must not multiply on kernel re-export
+# ---------------------------------------------------------------------------
+
+
+def test_kernel_install_notice_not_duplicated_on_reexport(tmp_path: Path) -> None:
+    notice = "All installation tests done in openQA please see installlogs section\n"
+    template = [
+        "Test results by product-arch:\n",
+        "(x)\n",
+        "(y)\n",
+        "\n",
+        "tail\n",
+    ]
+    exporter = _kernel(tmp_path, template)
+
+    exporter.install_results()
+    exporter.install_results()  # second export
+
+    assert list(exporter.template).count(notice) == 1
+
+
+# ---------------------------------------------------------------------------
+# 34: manual install_results stale-result cleanup must actually work
+# ---------------------------------------------------------------------------
+
+
+def _session_host(hostname: str, system: str) -> MagicMock:
+    host = MagicMock()
+    host.hostname = hostname
+    host.system = system
+    host.packages = {}
+    return host
+
+
+def test_manual_install_results_strips_stale_lines_for_session_hosts(
+    tmp_path: Path,
+) -> None:
+    """Stale per-command result lines are refreshed for session hosts only.
+
+    The old tracking regex required two spaces after 'reference host:'
+    (the template emits one) and read group(0), so c_host never matched a
+    bare hostname and no stale line was ever removed.
+    """
+    template = [
+        "system1 (reference host: h1)\n",
+        "old-cmd : FAILED\n",
+        "good line\n",
+        "othersys (reference host: elsewhere)\n",
+        "their-cmd : SUCCEEDED\n",
+    ]
+    exporter = _manual(tmp_path, template, results=[_session_host("h1", "system1")])
+
+    exporter.install_results()
+
+    tpl = list(exporter.template)
+    # both host section headers survive
+    assert "system1 (reference host: h1)\n" in tpl
+    assert "othersys (reference host: elsewhere)\n" in tpl
+    # the session host's stale result line is gone, its other content kept
+    assert "old-cmd : FAILED\n" not in tpl
+    assert "good line\n" in tpl
+    # a host NOT in this session keeps its result lines untouched
+    assert "their-cmd : SUCCEEDED\n" in tpl
+
+
+def test_manual_cleanup_stops_at_host_section_end(tmp_path: Path) -> None:
+    """The deletion window must not bleed past the host block.
+
+    c_host used to stay armed after the last host section, so
+    tester-authored lines like 'reproducer : FAILED before update' in the
+    regression-tests notes were silently deleted on every export
+    (adversarial-review catch on the revived cleanup).
+    """
+    template = [
+        "system1 (reference host: h1)\n",
+        "old-cmd : FAILED\n",
+        "comment: (none)\n",
+        "\n",
+        "regression tests:\n",
+        "=================\n",
+        "bsc#1234 reproducer : FAILED before update\n",
+        "bsc#1234 reproducer : SUCCEEDED after update\n",
+        "\n",
+    ]
+    exporter = _manual(tmp_path, template, results=[_session_host("h1", "system1")])
+
+    exporter.install_results()
+
+    tpl = list(exporter.template)
+    assert "old-cmd : FAILED\n" not in tpl  # in-section stale line removed
+    # tester content after the host block survives
+    assert "bsc#1234 reproducer : FAILED before update\n" in tpl
+    assert "bsc#1234 reproducer : SUCCEEDED after update\n" in tpl
+    assert "comment: (none)\n" in tpl
+
+
+def test_installlogs_trailing_blank_does_not_accumulate(tmp_path: Path) -> None:
+    """A re-export that adds one new link must not add another blank line.
+
+    The section already ends with a blank; the trailing-blank insert is
+    guarded, or every kernel re-export with a new arch log would grow the
+    gap before the footer (adversarial-review catch: the guard was
+    untested).
+    """
+    rrid = "SUSE:Maintenance:12358:199773"
+    old_link = f"https://reports/{rrid}/install_logs/old.log\n"
+    template = [
+        "Links for update logs:\n",
+        "\n",
+        old_link,
+        "\n",
+        FOOTER,
+    ]
+    exporter = _manual(tmp_path, template)
+
+    exporter.installlogs_lines(["new.log"])
+
+    tpl = list(exporter.template)
+    new_link = f"https://reports/{rrid}/install_logs/new.log\n"
+    assert tpl.count(new_link) == 1
+    # exactly one blank between the links and the footer
+    footer_at = tpl.index(FOOTER)
+    assert tpl[footer_at - 1] == "\n"
+    assert tpl[footer_at - 2] != "\n"
+
+
+def test_installlogs_converges_damaged_stacked_headers(tmp_path: Path) -> None:
+    """Templates damaged by the old bug converge back to one section.
+
+    Pre-fix exports stacked one empty header per run; nothing ever
+    removed them (dedup_lines only collapses adjacent identical non-blank
+    lines), so the junk was re-uploaded with every future export.
+    """
+    rrid = "SUSE:Maintenance:12358:199773"
+    old_link = f"https://reports/{rrid}/install_logs/old.log\n"
+    template = [
+        "body\n",
+        "\n",
+        "Links for update logs:\n",
+        "\n",
+        old_link,
+        "\n",
+        "\n",
+        "Links for update logs:\n",
+        "\n",
+        "\n",
+        "Links for update logs:\n",
+        "\n",
+        FOOTER,
+    ]
+    exporter = _manual(tmp_path, template)
+
+    exporter.installlogs_lines(["old.log"])
+
+    tpl = list(exporter.template)
+    assert tpl.count("Links for update logs:\n") == 1
+    assert tpl.count(old_link) == 1
+    assert tpl[-1] == FOOTER
+
+
+def test_installlogs_hand_trimmed_section_keeps_links_before_footer(
+    tmp_path: Path,
+) -> None:
+    """Header directly followed by the footer: links must not land after it.
+
+    A hand-edited template whose empty links section lost its blank line
+    used to get the new link inserted AFTER the '## export MTUI:' footer
+    (adversarial-review catch on the reuse walk).
+    """
+    template = [
+        "body\n",
+        "Links for update logs:\n",
+        FOOTER,
+    ]
+    exporter = _manual(tmp_path, template)
+
+    exporter.installlogs_lines(["a.log"])
+
+    tpl = list(exporter.template)
+    rrid = "SUSE:Maintenance:12358:199773"
+    link = f"https://reports/{rrid}/install_logs/a.log\n"
+    assert tpl.index("Links for update logs:\n") < tpl.index(link) < tpl.index(FOOTER)
+    assert tpl[-1] == FOOTER
+
+
+def test_kernel_install_notice_converges_from_damaged_template(
+    tmp_path: Path,
+) -> None:
+    """Notices stacked by pre-fix exports are reduced back to one."""
+    notice = "All installation tests done in openQA please see installlogs section\n"
+    template = [
+        "Test results by product-arch:\n",
+        "(x)\n",
+        "(y)\n",
+        notice,
+        "\n",
+        notice,
+        "\n",
+        notice,
+        "\n",
+        "tail\n",
+    ]
+    exporter = _kernel(tmp_path, template)
+
+    exporter.install_results()
+
+    tpl = list(exporter.template)
+    assert tpl.count(notice) == 1
+    assert "tail\n" in tpl


### PR DESCRIPTION
## What

Four related defects in how the export pipeline mutates the template — every one of them made a **second `export` of the same testreport degrade the file** instead of being a no-op refresh. Bundled because they're the same subsystem (`update_workflow/export/`) and the same failure theme.

### #32 — duplicate empty `Links for update logs:` headers
`installlogs_lines()` inserted a fresh header block on every call. Individual links were de-duplicated, the header was not; `dedup_lines()` only collapses adjacent identical non-blank lines, so manual/kernel re-exports stacked an empty header section per run.

### #33 — the openQA install notice multiplied on kernel re-export
`BaseExport.install_results()` inserted "All installation tests done in openQA…" unconditionally; the old and new copies end up separated by the inserted blank line, so the notice grew by one on every export.

### #31 — auto export over-deleted to end of file
With no `Links for update logs:` section, `AutoExport.install_results()` bounded its replacement with `list.index("## export MTUI:")` — exact-equality against a line that is really `## export MTUI:<version>, … by <user>`. The lookup always raised, `end` ran to `len(template)`, and the replacement deleted the footer and any notes a tester had appended after the install-tests section.

### #34 — manual stale-result cleanup was dead code
The host-tracking regex required **two** spaces after `reference host:` (the template emits one) and read `group(0)` — the whole match, never a bare hostname — so `c_host` never matched the session's hosts and no stale `<cmd> : SUCCEEDED/FAILED/INTERNAL ERROR` line was ever removed.

## Fix

- `installlogs_lines()` reuses an existing header: the insertion index walks past the section's existing links and new links are appended there; the trailing blank is only added when missing. Empty duplicate headers stacked by pre-fix exports are dropped so damaged templates **converge** (link-bearing duplicates are never touched), and a hand-trimmed section (header directly followed by the footer) gets its canonical blank restored so links can't land after the footer.
- The install notice is inserted only when absent; copies stacked by pre-fix exports are reduced back to one.
- The footer is located with a substring scan — matching the two other places that already test `"## export MTUI:" in line`.
- The host-tracking pattern captures the hostname (`reference host:\s+([^)\s]+)`, `group(1)`); the host header line is kept, and — **adversarial-review catch on the revived cleanup** — `c_host` resets at the host block's `comment:` boundary (the verdict loop's existing convention), so the deletion window cannot bleed past the last host section and eat tester-authored notes like `reproducer : FAILED before update` from the regression-tests section.

## Tests

New `tests/test_export_idempotency.py`, **each fix revert-verified independently**:
- `test_auto_install_results_bounds_at_footer` — footer survives, section body still replaced.
- `test_installlogs_lines_reuses_existing_header` + `test_installlogs_lines_twice_is_idempotent` — one header, links merged and de-duplicated, order header < links < footer.
- `test_kernel_install_notice_not_duplicated_on_reexport` — notice appears once after two exports.
- `test_manual_install_results_strips_stale_lines_for_session_hosts` — session host's stale line removed, its other content and both host headers kept, non-session host untouched.
- Review-amendment coverage (each revert-verified): `test_manual_cleanup_stops_at_host_section_end`, `test_installlogs_trailing_blank_does_not_accumulate`, `test_installlogs_converges_damaged_stacked_headers`, `test_installlogs_hand_trimmed_section_keeps_links_before_footer`, `test_kernel_install_notice_converges_from_damaged_template`.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves findings #31, #32, #33 and #34 from the recent code review.
