### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI lint + format
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
         with:
           args: "--version"
       - name: Check ruff style
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI typecheck
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
       - name: Sync dependencies
@@ -34,9 +34,9 @@ jobs:
       matrix:
         python-version: ['3.13', '3.14']
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -45,13 +45,13 @@ jobs:
       - name: Test run ${{ matrix.python-version }}
         run: uv run pytest -v --cov=./mtui --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         if: ${{ matrix.python-version == '3.14' }} 
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to CodeCov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         if: ${{ !cancelled() }} 
         with:
           files: junit.xml

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,13 @@
 pull_request_rules:
+  - name: automatic merge for dependabot updates
+    conditions:
+      - and: *base_checks
+      - and:
+          - base=main
+          - author=dependabot[bot]
+    actions:
+      merge:
+        method: squash
   - name: automatic merge
     conditions:
       - and: &base_checks


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.