### PR TITLE
fix(cli): return (width, height) from the termsize ACCTEST fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Under the acceptance-test harness (`ACCTEST_ROWS`/`ACCTEST_COLS`, no
+  controlling TTY) the terminal geometry is no longer transposed: the
+  fallback returned (rows, cols) while the normal path returns
+  (width, height), so the pager wrapped at the row count and printed a
+  column-count of lines per page.
 - `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
   failures. openQA reports an unfinished job's result as `none`, which the
   filter treated as "not passing" — during active testing an in-progress

--- a/mtui/cli/term.py
+++ b/mtui/cli/term.py
@@ -37,7 +37,10 @@ def termsize() -> tuple[int, int]:
         if not (k_rows in env and k_cols in env):
             raise
 
-        return int(env[k_rows]), int(env[k_cols])
+        # Same ordering as the normal path below -- (width, height), i.e.
+        # (cols, rows). This used to return (rows, cols), transposing the
+        # terminal geometry for every caller under the acceptance harness.
+        return int(env[k_cols]), int(env[k_rows])
 
     return int(width), int(height)
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -188,3 +188,25 @@ def test_page_non_interactive_writer_receives_each_line():
     captured: list[str] = []
     page(["alpha", "beta\n", "gamma\r\n"], interactive=False, writer=captured.append)
     assert captured == ["alpha", "beta", "gamma"]
+
+
+def test_termsize_fallback_matches_normal_path_order(monkeypatch):
+    """The ACCTEST fallback must return (width, height) like the ioctl path.
+
+    It returned (rows, cols) -- the transposed geometry -- so under the
+    acceptance harness page() wrapped lines at the row count and printed
+    a column-count of lines per page, and the SSH PTY got swapped
+    dimensions.
+    """
+    from mtui.cli import term as term_mod
+
+    def _no_tty(*_a, **_kw):
+        raise OSError("not a tty")
+
+    monkeypatch.setattr(term_mod.fcntl, "ioctl", _no_tty)
+    monkeypatch.setenv("ACCTEST_ROWS", "24")
+    monkeypatch.setenv("ACCTEST_COLS", "80")
+
+    width, height = term_mod.termsize()
+
+    assert (width, height) == (80, 24)


### PR DESCRIPTION
## What

Under the acceptance-test harness (`ACCTEST_ROWS`/`ACCTEST_COLS`, no controlling TTY) `termsize()` returned the **transposed geometry**: the ioctl path unpacks TIOCGWINSZ as (rows, cols) and returns `(width, height)`, but the fallback returned `int(env["ACCTEST_ROWS"]), int(env["ACCTEST_COLS"])` — (rows, cols). Every caller unpacks `width, height = termsize()`, so `page()` wrapped lines at the row count and printed a column-count of lines per page, and the interactive SSH PTY got swapped dimensions.

## Fix

The fallback returns `(cols, rows)`, matching the normal path's ordering.

## Tests

- `test_termsize_fallback_matches_normal_path_order` — ioctl forced to raise, `ACCTEST_ROWS=24 ACCTEST_COLS=80` ⇒ `(80, 24)`. **Revert-verified.**

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #15 from the recent code review.
