### PR TITLE
fix(commands): preserve the directory tree in put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   fallback returned (rows, cols) while the normal path returns
   (width, height), so the pager wrapped at the row count and printed a
   column-count of lines per page.
+- `put` of a directory now preserves the directory tree on the remote
+  hosts. Every nested file used to be uploaded flat under its basename, so
+  two files with the same name in different subdirectories silently
+  overwrote each other (only the last survived, while the per-file success
+  log suggested both were transferred).
 - `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
   failures. openQA reports an unfinished job's result as `none`, which the
   filter treated as "not passing" — during active testing an in-progress

--- a/mtui/commands/sftpcmd.py
+++ b/mtui/commands/sftpcmd.py
@@ -38,15 +38,28 @@ class SFTPPut(Command):
             logger.error("File %s not found", self.args.filename[0])
             return
 
-        transversed_files = []
+        # (local path, path relative to the upload root) pairs: a walked
+        # directory keeps its tree on the remote side. Flattening to the
+        # basename made d/a/config and d/b/config both land on the same
+        # remote path, silently clobbering the first with the second.
+        transversed_files: list[tuple[Path, Path]] = []
         for file in files:
             if file.is_file():
-                transversed_files.append(file)
+                transversed_files.append((file, Path(file.name)))
             elif file.is_dir():
+                # Resolve before walking: a '..'-shaped argument (put ..)
+                # would otherwise survive relative_to() as a literal '..'
+                # part and build a remote path that escapes the run's
+                # working directory into the shared target_tempdir.
+                walk_root = file.resolve()
                 # Path.walk is from 3.12
-                for root, _, folder_files in os.walk(file):
+                for root, _, folder_files in os.walk(walk_root):
                     transversed_files.extend(
-                        Path(root) / folder_file for folder_file in folder_files
+                        (
+                            Path(root) / folder_file,
+                            (Path(root) / folder_file).relative_to(walk_root.parent),
+                        )
+                        for folder_file in folder_files
                     )
             else:
                 logger.warning("Filename %s isn't file", file)
@@ -54,8 +67,9 @@ class SFTPPut(Command):
 
         # work only on enabled hosts
         targets = self.targets.select(enabled=True)
-        for filename in transversed_files:
-            remote = self.metadata.target_wd(filename.name)
+        for filename, relative in transversed_files:
+            # sftp_put creates the intermediate remote directories.
+            remote = self.metadata.target_wd(*relative.parts)
 
             targets.sftp_put(filename, remote)
             logger.info("uploaded %s to %s", filename, remote)

--- a/tests/test_cmd_sftpcmd.py
+++ b/tests/test_cmd_sftpcmd.py
@@ -79,3 +79,84 @@ def test_sftp_get_only_targets_enabled_hosts(mock_config):
     # perform_get receives a group containing only the enabled host.
     targets = prompt.metadata.perform_get.call_args.args[0]
     assert targets.names() == ["h1"]
+
+
+def test_sftp_put_directory_preserves_tree(mock_config, tmp_path):
+    """`put mydir/` keeps the tree; same-named files must not clobber.
+
+    The walk used to upload every nested file to target_wd(basename), so
+    d/sub1/test.sh and d/sub2/test.sh both landed on the same remote path
+    and the second silently overwrote the first.
+    """
+    d = tmp_path / "mydir"
+    (d / "sub1").mkdir(parents=True)
+    (d / "sub2").mkdir()
+    (d / "sub1" / "test.sh").write_text("one")
+    (d / "sub2" / "test.sh").write_text("two")
+
+    t = _target("h1")
+    hg = HostsGroup([t])
+    prompt = _prompt(hg)
+    prompt.metadata.target_wd.side_effect = lambda *p: Path("/remote").joinpath(*p)
+    args = Namespace(filename=[str(d)])
+
+    sent: list[tuple[Path, Path]] = []
+
+    def fake_sftp(self, local, remote):
+        sent.append((local, remote))
+
+    from mtui.hosts.target.hostgroup import HostsGroup as HG
+
+    original = HG.sftp_put
+    HG.sftp_put = fake_sftp  # ty: ignore[invalid-assignment]
+    try:
+        SFTPPut(args, mock_config, MagicMock(), prompt)()
+    finally:
+        HG.sftp_put = original
+
+    remotes = sorted(str(r) for _, r in sent)
+    assert remotes == [
+        "/remote/mydir/sub1/test.sh",
+        "/remote/mydir/sub2/test.sh",
+    ]
+    assert len(set(remotes)) == 2  # no clobbering
+
+
+def test_sftp_put_dotdot_stays_inside_working_directory(
+    mock_config, tmp_path, monkeypatch
+):
+    """`put ..` must not escape the run's remote working directory.
+
+    A literal '..' argument survived relative_to() as a '..' path part,
+    so the remote path resolved OUTSIDE the id-scoped directory into the
+    shared target_tempdir (adversarial-review catch on the tree fix).
+    """
+    base = tmp_path / "parent"
+    (base / "cwd").mkdir(parents=True)
+    (base / "top.txt").write_text("x")
+    monkeypatch.chdir(base / "cwd")
+
+    t = _target("h1")
+    hg = HostsGroup([t])
+    prompt = _prompt(hg)
+    prompt.metadata.target_wd.side_effect = lambda *p: Path("/remote").joinpath(*p)
+    args = Namespace(filename=[".."])
+
+    sent: list[tuple[Path, Path]] = []
+
+    def fake_sftp(self, local, remote):
+        sent.append((local, remote))
+
+    from mtui.hosts.target.hostgroup import HostsGroup as HG
+
+    original = HG.sftp_put
+    HG.sftp_put = fake_sftp  # ty: ignore[invalid-assignment]
+    try:
+        SFTPPut(args, mock_config, MagicMock(), prompt)()
+    finally:
+        HG.sftp_put = original
+
+    assert sent
+    for _, remote in sent:
+        assert ".." not in remote.parts  # confined under /remote
+        assert str(remote).startswith("/remote/parent/")


### PR DESCRIPTION
## What

`put mydir/` **flattened the tree and silently overwrote same-named files**. The walk collected every nested file but uploaded each to `target_wd(filename.name)` — basename only — so `mydir/sub1/test.sh` and `mydir/sub2/test.sh` both resolved to the same remote path; only the last survived while the per-file success log claimed both were transferred.

## Fix

Each walked file keeps its path relative to the uploaded directory's parent (so the directory name itself is included) and the remote path is built from those parts; `Connection.sftp_put` already creates the intermediate remote directories. Plain-file arguments still upload under their basename.

The walked directory is **resolved first** (adversarial-review catch): a `..`-shaped argument (`put ..`) would otherwise survive `relative_to()` as a literal `..` part and build a remote path escaping the run's working directory into the shared `target_tempdir`.

## Tests

- `test_sftp_put_directory_preserves_tree` — `mydir/sub1/test.sh` + `mydir/sub2/test.sh` land on two distinct structured remote paths. **Revert-verified**: the old code produces one clobbered path.
- `test_sftp_put_dotdot_stays_inside_working_directory` — `put ..` stays confined (no `..` parts in any remote path). **Revert-verified** against the unresolved walk.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #18 from the recent code review.
