### PR TITLE
fix(connection): re-raise sftp_remove errors so the rmdir fallback works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   two files with the same name in different subdirectories silently
   overwrote each other (only the last survived, while the per-file success
   log suggested both were transferred).
+- Removing a remote directory (e.g. via `FileDelete`/host cleanup) works
+  again, and a failed file removal is no longer reported as success. The
+  connection layer swallowed the SFTP error internally, so the target
+  layer's ENOENT tolerance and its directory `rmdir` fallback were dead
+  code; the error now propagates to the layer that handles it.
 - `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
   failures. openQA reports an unfinished job's result as `none`, which the
   filter treated as "not passing" — during active testing an in-progress

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -788,7 +788,13 @@ class Connection:
             with self._sftp() as sftp:
                 sftp.remove(str(path))
         except OSError:
-            logger.exception("Can't remove %s from %s", path, self.hostname)
+            # Re-raise: both callers (Target.sftp_remove's directory/rmdir
+            # fallback, TargetLock's ENOENT tolerance) carry their own
+            # ``except OSError`` logic that was dead code while this layer
+            # swallowed the error -- a failed removal (directory, permission
+            # denied) was silently reported as success.
+            logger.debug("Can't remove %s from %s", path, self.hostname, exc_info=True)
+            raise
 
     def sftp_rmdir(self, path: Path) -> None:
         """Deletes a remote directory.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -971,11 +971,21 @@ def test_sftp_remove_calls_paramiko_remove(conn_with_sftp, sftp_client):
     sftp_client.close.assert_called()
 
 
-def test_sftp_remove_logs_oserror(conn_with_sftp, sftp_client, caplog):
+def test_sftp_remove_reraises_oserror(conn_with_sftp, sftp_client, caplog):
+    """A failed removal must propagate, not be swallowed.
+
+    The old internal 'log and return' made Target.sftp_remove's whole
+    ENOENT / directory-rmdir fallback dead code: removing a directory (or
+    hitting permission denied) was silently reported as success and the
+    path was left in place.
+    """
     from pathlib import Path as _Path
 
     sftp_client.remove.side_effect = OSError("perm")
-    with caplog.at_level("ERROR", logger="mtui.connection"):
+    with (
+        caplog.at_level("DEBUG", logger="mtui.connection"),
+        pytest.raises(OSError, match="perm"),
+    ):
         conn_with_sftp.sftp_remove(_Path("/x"))
     assert any("Can't remove" in r.message for r in caplog.records)
 


### PR DESCRIPTION
## What

Removing a remote **directory** silently no-oped, and a **failed file removal was reported as success**. `Target.sftp_remove` distinguishes ENOENT from other failures and falls back to `sftp_rmdir` for directories — but only if `Connection.sftp_remove` raises. The connection layer caught `OSError` internally, logged it, and returned normally, so the whole target-layer except-branch (ENOENT debug, directory fallback, "unable to remove" warning) was **dead code**. `TargetLock`'s lockfile removal carries the same never-exercised ENOENT tolerance.

## Fix

`Connection.sftp_remove` logs at debug (the callers own the reporting) and **re-raises**. Both existing callers already carry the `except OSError` handling that was written for exactly this.

## Tests

- `test_sftp_remove_reraises_oserror` — updated from pinning the swallow to pinning the propagation. **Revert-verified.**
- The existing target-layer tests (`ENOENT`, rmdir fallback, rmdir-failure warning) now cover live code paths.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #22 from the recent code review.
