### PR TITLE
fix(mcp): stop schema slimming eating properties named 'title'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   connection layer swallowed the SFTP error internally, so the target
   layer's ENOENT tolerance and its directory `rmdir` fallback were dead
   code; the error now propagates to the layer that handles it.
+- The `mtui-mcp` tool-schema slimming no longer deletes a tool parameter
+  (or nested object property) literally named `title` or `description`.
+  The pydantic-boilerplate strip treated every dict key as a schema
+  keyword — including the keys of a `properties` map, which are parameter
+  *names* — so such a parameter vanished from the schema while staying
+  listed in `required`, making the tool impossible to call correctly.
 - `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
   failures. openQA reports an unfinished job's result as `none`, which the
   filter treated as "not passing" — during active testing an in-progress

--- a/mtui/mcp/_slim.py
+++ b/mtui/mcp/_slim.py
@@ -114,20 +114,39 @@ def slim_tool_schema(schema: Any) -> Any:
       :data:`_TERSE_DESCRIPTIONS`.
 
     The input is not mutated; a new structure is returned.
+
+    The keys of a ``properties`` / ``$defs``-style map are *names*, not
+    schema keywords, so the transforms are suspended for that one level:
+    a tool parameter (or nested object property) literally named
+    ``title`` or ``description`` must survive -- dropping it left the
+    name dangling in ``required`` while its schema vanished.
     """
+    return _slim(schema, keys_are_names=False)
+
+
+#: Schema keywords whose value is a mapping of *names* to sub-schemas.
+_NAME_MAPS = frozenset({"properties", "patternProperties", "$defs", "definitions"})
+
+
+def _slim(schema: Any, *, keys_are_names: bool) -> Any:
     if isinstance(schema, dict):
         out: dict[str, Any] = {}
         for key, value in schema.items():
-            if key == "title":
-                continue
-            if key == "description" and isinstance(value, str):
-                out[key] = _TERSE_DESCRIPTIONS.get(value, value)
-                continue
-            out[key] = slim_tool_schema(value)
-        _flatten_nullable(out)
+            if not keys_are_names:
+                if key == "title":
+                    continue
+                if key == "description" and isinstance(value, str):
+                    out[key] = _TERSE_DESCRIPTIONS.get(value, value)
+                    continue
+            out[key] = _slim(
+                value,
+                keys_are_names=(not keys_are_names and key in _NAME_MAPS),
+            )
+        if not keys_are_names:
+            _flatten_nullable(out)
         return out
     if isinstance(schema, list):
-        return [slim_tool_schema(item) for item in schema]
+        return [_slim(item, keys_are_names=False) for item in schema]
     return schema
 
 

--- a/tests/test_mcp_slim.py
+++ b/tests/test_mcp_slim.py
@@ -121,9 +121,31 @@ def test_slim_registered_tools_reduces_bytes_keeps_count() -> None:
     assert len(tools) == before_count  # no tool lost
     # At least a 15% schema shrink (titles alone are ~16%).
     assert after_bytes < before_bytes * 0.85
-    # No residual boilerplate anywhere.
+
+    # No residual boilerplate anywhere. Structural, not a blob substring
+    # scan: a property legitimately NAMED "title" must be allowed to
+    # appear (the slimmer preserves it), only the schema KEYWORD "title"
+    # must be gone.
+    def _assert_no_title_keyword(node, keys_are_names=False):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if not keys_are_names:
+                    assert key != "title"
+                _assert_no_title_keyword(
+                    value,
+                    keys_are_names=(
+                        not keys_are_names
+                        and key
+                        in ("properties", "patternProperties", "$defs", "definitions")
+                    ),
+                )
+        elif isinstance(node, list):
+            for item in node:
+                _assert_no_title_keyword(item)
+
+    for t in tools.values():
+        _assert_no_title_keyword(t.parameters)
     blob = " ".join(json.dumps(t.parameters) for t in tools.values())
-    assert '"title"' not in blob
     assert '{"type": "null"}' not in blob
 
 
@@ -165,3 +187,45 @@ def test_cap_output_result_is_valid_utf8_on_codepoint_boundary() -> None:
     out = cap_output(text, 101)  # odd cut lands mid-codepoint
     out.encode("utf-8")  # must not raise
     assert "truncated" in out
+
+
+def test_slim_keeps_property_named_title() -> None:
+    """A parameter literally named ``title`` is a name, not a keyword.
+
+    The unconditional key skip deleted ``properties.title`` while the
+    name survived in ``required`` -- the tool then advertised a required
+    property with no schema, so the model could never supply it.
+    """
+    schema = {
+        "title": "tool_addBugArguments",
+        "type": "object",
+        "properties": {
+            "title": {"title": "Title", "type": "string"},
+            "description": {"title": "Description", "type": "string"},
+        },
+        "required": ["title", "description"],
+    }
+    out = slim_tool_schema(schema)
+    assert "title" not in out  # the schema keyword is still stripped
+    # the properties NAMED title/description survive, their keyword
+    # "title" stripped and types intact
+    assert out["properties"]["title"] == {"type": "string"}
+    assert out["properties"]["description"] == {"type": "string"}
+    assert out["required"] == ["title", "description"]
+
+
+def test_slim_keeps_nested_defs_property_names() -> None:
+    """$defs entries and nested object properties are names too."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "cfg": {
+                "type": "object",
+                "properties": {"title": {"type": "string", "title": "T"}},
+            },
+        },
+        "$defs": {"title": {"type": "integer", "title": "X"}},
+    }
+    out = slim_tool_schema(schema)
+    assert out["properties"]["cfg"]["properties"]["title"] == {"type": "string"}
+    assert out["$defs"]["title"] == {"type": "integer"}


### PR DESCRIPTION
## What

`slim_tool_schema` (the `mtui-mcp` token-slimming pass) **deleted any tool parameter literally named `title`**. It recursed the whole JSON schema skipping every dict key equal to `title` (and rewriting `description` values) — but on a `properties` map the keys are parameter *names*, not schema keywords. A parameter named `title` vanished from `properties` while staying in `required`: the tool advertised a required property with no schema, impossible to call correctly. Latent today (no current tool has such a parameter), but `title` is an ordinary flag name.

## Fix

The recursion tracks whether the current dict's keys are names (children of `properties`/`patternProperties`/`$defs`/`definitions`) and suspends the keyword transforms — title-drop, description-rewrite, nullable-flatten — for exactly that level; each property's own schema is slimmed normally. The transform is now actually meaning-preserving, as documented.

## Tests

- `test_slim_keeps_property_named_title` — properties named `title`/`description` survive (their *keyword* `title` still stripped), `required` intact. **Revert-verified.**
- `test_slim_keeps_nested_defs_property_names` — nested object properties and `$defs` entries named `title` survive. **Revert-verified.**

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves finding #23 from the recent code review.
