### PR TITLE
fix(reports): merge connected systems across rounds; close leaked targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   keyword — including the keys of a `properties` map, which are parameter
   *names* — so such a parameter vanished from the schema while staying
   listed in `required`, making the tool impossible to call correctly.
+- Connecting reference hosts in several rounds (e.g. template autoconnect,
+  which resolves recorded hosts and testplatform hosts separately) no longer
+  drops the earlier rounds from the "Hosts" metadata line: the connected-
+  systems map is now merged across rounds instead of rebuilt from the latest
+  one, and pruned together with inactive hosts.
+- A host-setup failure right after a successful SSH connect (e.g. the
+  connection dropping while the remote lock file is written) no longer leaks
+  the open SSH session; the half-set-up connection is closed before the host
+  is reported as failed — on Ctrl-C too, and equally for `add_host -t`,
+  which had the same leak.
 - `openqa_jobs --failed` no longer lists still-running or scheduled jobs as
   failures. openQA reports an unfinished job's result as `none`, which the
   filter treated as "not passing" — during active testing an in-progress

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -531,6 +531,7 @@ class TestReport(ABC):
             string, or `(False, False)` if the connection fails.
 
         """
+        target = None
         try:
             target = Target(
                 self.config,
@@ -563,14 +564,27 @@ class TestReport(ABC):
                 self._autolock_new_target(target)
         except KeyboardInterrupt:
             logger.warning("Connection to %s canceled by user", host)
+            self._close_failed_target(target)
             return False, False
         except Exception:
             logger.debug(format_exc())
             msg = f"failed to add host {host} to target list"
             logger.warning(msg)
+            # A failure after a successful connect (e.g. try_claim/lock
+            # writing the remote lock file) must not leak the open SSH
+            # session: it is not stored in self.targets, and paramiko
+            # transports are not reliably closed by GC.
+            self._close_failed_target(target)
             return False, False
         else:
             return target, new_system
+
+    @staticmethod
+    def _close_failed_target(target) -> None:
+        """Best-effort close of a target whose setup failed mid-way."""
+        if target is not None:
+            with suppress(Exception):
+                target.close()
 
     def connect_targets(self) -> None:
         """Connects to all targets."""
@@ -619,6 +633,10 @@ class TestReport(ABC):
             for host in list(targets.keys()):
                 del targets[host]
             targets = {}
+            # Discard the partially collected batch entirely: keeping
+            # new_systems entries whose Target objects were just dropped
+            # would merge phantom hosts into self.systems below.
+            new_systems = {}
             logger.warning("Connection to refhosts cancelled by user")
         finally:
             executor.shutdown(wait=False)
@@ -629,11 +647,19 @@ class TestReport(ABC):
         # sibling candidate in the same slot (RFC §5.7 backup-refhost).
         self._connect_pool_backups(hosts, targets, new_systems)
 
-        # We need to be sure that only the system property only have the  connected hosts
-        self.systems = {host: system for host, system in new_systems.items() if system}
+        # Merge: new_systems only holds hosts connected by THIS invocation
+        # (hosts already in self.targets are excluded above), so rebuilding
+        # self.systems from it dropped every earlier-connected host --
+        # autoconnect calls connect_targets twice, and list_metadata's
+        # "Hosts" line then showed only the second batch while self.targets
+        # (which accumulates) still held them all.
+        self.systems.update(
+            {host: system for host, system in new_systems.items() if system}
+        )
         for t in self.targets.copy():
             if not self.targets[t].connection.is_active():
                 del self.targets[t]
+                self.systems.pop(t, None)
 
         self.targets.update(
             {host: target for host, target in targets.items() if target}
@@ -739,6 +765,10 @@ class TestReport(ABC):
 
         except Exception:
             if hostname in self.targets:
+                # Same leak as connect_target: a failure after a successful
+                # connect() must close the open SSH session before the last
+                # reference to it is dropped.
+                self._close_failed_target(self.targets[hostname])
                 del self.targets[hostname]
             if hostname in self.systems:
                 del self.systems[hostname]

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -995,3 +995,130 @@ def test_list_versions_aggregates_by_host_then_package(tmp_path: Path) -> None:
     assert out == "ok"
     sink.assert_called_once()
     targets.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# connect_target / connect_targets: leak on late failure, systems merge
+# ---------------------------------------------------------------------------
+
+
+def test_connect_target_closes_target_when_lock_raises(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A failure after a successful connect must close the SSH session.
+
+    An error from autolock (target.lock) after connect() succeeded fell
+    into the broad except, which returned (False, False) without closing:
+    the open Target was never stored in self.targets, so the paramiko
+    transport leaked (GC does not reliably close it).
+    """
+    r = _make(tmp_path)
+    r.lock_comment = "testing of SUSE:Maintenance:12358:199773"
+    fake = MagicMock()
+    fake.system = "sys"
+    fake.lock.side_effect = RuntimeError("ssh dropped writing lock file")
+    monkeypatch.setattr(
+        "mtui.test_reports.testreport.Target", MagicMock(return_value=fake)
+    )
+    monkeypatch.setattr(r, "_verify_target_products", lambda *_a: None)
+
+    target, system = r.connect_target("h1")
+
+    assert (target, system) == (False, False)
+    fake.close.assert_called_once()
+
+
+def test_connect_targets_second_batch_keeps_first_batch_systems(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """self.systems must accumulate across connect_targets invocations.
+
+    autoconnect calls connect_targets twice; the second call rebuilt
+    self.systems from only the newly connected hosts, so the first
+    batch vanished from the "Hosts" line while self.targets kept them.
+    """
+    r = _make(tmp_path)
+
+    def _fake_connect(host):
+        t = MagicMock()
+        t.hostname = host
+        t.connection.is_active.return_value = True
+        return t, f"sys-{host}"
+
+    monkeypatch.setattr(r, "connect_target", _fake_connect)
+
+    r.hostnames = {"foo"}
+    r.connect_targets()
+    assert set(r.systems) == {"foo"}
+
+    r.hostnames = {"foo", "bar"}
+    r.connect_targets()  # only bar is new; foo is already connected
+
+    assert set(r.targets) == {"foo", "bar"}
+    assert set(r.systems) == {"foo", "bar"}  # foo must not vanish
+
+
+def test_connect_target_closes_target_on_keyboard_interrupt(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Ctrl-C after a successful connect must also close the session."""
+    r = _make(tmp_path)
+    r.lock_comment = "testing of SUSE:Maintenance:12358:199773"
+    fake = MagicMock()
+    fake.system = "sys"
+    fake.lock.side_effect = KeyboardInterrupt
+    monkeypatch.setattr(
+        "mtui.test_reports.testreport.Target", MagicMock(return_value=fake)
+    )
+    monkeypatch.setattr(r, "_verify_target_products", lambda *_a: None)
+
+    target, system = r.connect_target("h1")
+
+    assert (target, system) == (False, False)
+    fake.close.assert_called_once()
+
+
+def test_connect_targets_prunes_systems_of_inactive_targets(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A dropped connection leaves neither a target nor a systems entry."""
+    r = _make(tmp_path)
+
+    def _fake_connect(host):
+        t = MagicMock()
+        t.hostname = host
+        t.connection.is_active.return_value = True
+        return t, f"sys-{host}"
+
+    monkeypatch.setattr(r, "connect_target", _fake_connect)
+
+    r.hostnames = {"foo"}
+    r.connect_targets()
+    # foo's connection dies before the next round
+    r.targets["foo"].connection.is_active.return_value = False  # ty: ignore[unresolved-attribute]
+
+    r.hostnames = {"foo", "bar"}
+    r.connect_targets()
+
+    assert set(r.targets) == {"bar"}
+    # the stale systems entry must be gone with the inactive target
+    assert "foo" not in r.systems
+    assert "bar" in r.systems
+
+
+def test_add_target_closes_target_when_setup_fails(tmp_path: Path, monkeypatch) -> None:
+    """add_host -t: a post-connect failure must close the session too."""
+    r = _make(tmp_path)
+    r.lock_comment = "testing of SUSE:Maintenance:12358:199773"
+    fake = MagicMock()
+    fake.system = "sys"
+    fake.lock.side_effect = RuntimeError("lockfile write failed")
+    monkeypatch.setattr(
+        "mtui.test_reports.testreport.Target", MagicMock(return_value=fake)
+    )
+    monkeypatch.setattr(r, "_verify_target_products", lambda *_a: None)
+
+    r.add_target("h1")
+
+    assert "h1" not in r.targets
+    fake.close.assert_called_once()


### PR DESCRIPTION
## What

Two defects in the refhost connect path, bundled (same function pair in `testreport.py`):

**#29** — `connect_targets` rebuilt `self.systems` from only the hosts connected in the *current* invocation (already-connected hosts are excluded from the work set), while `self.targets` accumulates. `autoconnect` calls `connect_targets` twice, so the second call wiped the first batch from `self.systems`: both hosts stayed connected, but `list_metadata`'s "Hosts" line showed only the latest batch.

**#30** — `connect_target` **leaked the open SSH session** when `try_claim` or the autolock `target.lock()` raised *after* `connect()` succeeded: the broad except returned `(False, False)` without closing, and the target was never stored in `self.targets` (paramiko transports are not reliably closed by GC).

## Fix

- Merge `self.systems` with `update()` instead of rebuilding, and prune entries together with the inactive-target sweep. On Ctrl-C the partially collected `new_systems` batch is discarded too (adversarial-review catch: phantom hosts whose Target objects were just dropped could otherwise merge into `self.systems`).
- `connect_target` initialises `target = None` and both abort paths (`except Exception` and `KeyboardInterrupt`) close a half-set-up target best-effort (`_close_failed_target`). The sibling `add_target` path (`add_host -t`) had the identical leak (adversarial-review catch) and closes now as well.

## Tests

- `test_connect_targets_second_batch_keeps_first_batch_systems` — two rounds; the first round's host must not vanish from `systems`. **Revert-verified.**
- `test_connect_target_closes_target_when_lock_raises` — lock failure after connect ⇒ `(False, False)` *and* the session closed. **Revert-verified.**
- `test_connect_target_closes_target_on_keyboard_interrupt`, `test_add_target_closes_target_when_setup_fails`, `test_connect_targets_prunes_systems_of_inactive_targets` — review-amendment coverage, each revert-verified against a partial revert.

## Gates

`ruff format --check .`, `ruff check .`, `ty check`, `pytest` — all green on the whole repo.

Resolves findings #29 and #30 from the recent code review.
