### PR TITLE
fix(export): don't require refhosts for AUTO/KERNEL export fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `export` in the AUTO and KERNEL workflows no longer fails with
+  "No refhosts defined" when no reference hosts are connected. These
+  workflows build the template from openQA/dashboard data and never touch a
+  connected host, so fanning `export` out across loaded templates now runs
+  each one instead of skipping host-less templates and erroring when every
+  template was skipped. MANUAL export, which reports per-host results, keeps
+  requiring a connected host.
 - Under the acceptance-test harness (`ACCTEST_ROWS`/`ACCTEST_COLS`, no
   controlling TTY) the terminal geometry is no longer transposed: the
   fallback returned (rows, cols) while the normal path returns

--- a/mtui/commands/_command.py
+++ b/mtui/commands/_command.py
@@ -252,6 +252,26 @@ class Command(ABC):
             help="Act on every loaded template (the default for this command)",
         )
 
+    def _requires_hosts(self, report) -> bool:
+        """Whether this command needs a connected host on ``report`` to act.
+
+        Gates the fan-out host-less skip in :meth:`run`: a template with no
+        connected host is skipped (and, when every template is skipped,
+        :class:`NoRefhostsDefinedError` is raised) only for commands that
+        actually operate over hosts. Host-independent commands override this to
+        return ``False`` so they still run on a host-less template instead of
+        being skipped. The default is ``True`` (host-phase behaviour).
+
+        Args:
+            report: The :class:`TestReport` about to be acted on. Subclasses
+                may inspect it (e.g. its ``workflow``) to decide per-report.
+
+        Returns:
+            ``True`` if a connected host is required, ``False`` otherwise.
+
+        """
+        return True
+
     def _resolve_templates(self):
         """Return the ordered list of reports this invocation should act on.
 
@@ -307,7 +327,10 @@ class Command(ABC):
         front (warning, never collected) when the invocation named no ``-t``
         hosts; if every template got skipped that way the command ran nowhere
         and :class:`NoRefhostsDefinedError` is raised instead of reporting
-        success.
+        success. The host-less skip is additionally gated by
+        :meth:`_requires_hosts`, so host-independent commands (e.g. ``export``
+        in the AUTO/KERNEL workflow, which build the template from openQA data)
+        are never skipped for lack of a connected host.
         """
         resolved = self._resolve_templates()
 
@@ -332,7 +355,7 @@ class Command(ABC):
         skipped: list[str] = []
         for report in resolved:
             rrid = str(report.id)
-            if skippable and not report.targets:
+            if skippable and not report.targets and self._requires_hosts(report):
                 logger.warning(
                     "%s skipped on %s: no connected hosts", self.command, rrid
                 )

--- a/mtui/commands/export.py
+++ b/mtui/commands/export.py
@@ -29,6 +29,17 @@ class Export(Command):
     command = "export"
     scope = "fanout"
 
+    def _requires_hosts(self, report) -> bool:
+        """Export needs a connected host only in the MANUAL workflow.
+
+        AUTO and KERNEL exports build the template from openQA/dashboard data
+        and never touch a connected host, so a host-less template must not be
+        skipped (nor make an all-host-less fan-out raise
+        :class:`NoRefhostsDefinedError`). MANUAL export reports per-host results
+        and keeps the host-phase behaviour.
+        """
+        return report.workflow not in (Workflow.AUTO, Workflow.KERNEL)
+
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
         """Adds arguments to the command's argument parser."""

--- a/tests/test_cmd_export.py
+++ b/tests/test_cmd_export.py
@@ -10,7 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mtui.commands.export import Export
-from mtui.support.messages import TestReportNotLoadedError
+from mtui.hosts.target.hostgroup import HostsGroup
+from mtui.support.messages import NoRefhostsDefinedError, TestReportNotLoadedError
 from mtui.types import Workflow
 
 
@@ -100,3 +101,85 @@ def test_export_without_metadata_raises(mock_config):
             MagicMock(),
             prompt,
         )()
+
+
+# --- fan-out: host-less templates gated by _requires_hosts ---
+
+
+class _FakeReport:
+    """Minimal TestReport stand-in carrying id, workflow and empty targets."""
+
+    def __init__(self, rrid: str, workflow: Workflow):
+        self.id = rrid
+        self.workflow = workflow
+        self.targets = HostsGroup([])
+
+
+class _FakeRegistry:
+    """Minimal TemplateRegistry stand-in for fan-out resolution."""
+
+    def __init__(self, reports):
+        self._reports = {str(r.id): r for r in reports}
+
+    def all(self):
+        return list(self._reports.values())
+
+    def get(self, rrid):
+        return self._reports[rrid]
+
+    def __len__(self):
+        return len(self._reports)
+
+    @property
+    def active(self):
+        return next(iter(self._reports.values()))
+
+
+def _fanout_cmd(mock_config, reports):
+    """Build an Export whose __call__ only records the RRID it ran against."""
+    args = Namespace(
+        filename=None, hosts=None, force=False, template=None, all_templates=False
+    )
+    prompt = MagicMock()
+    prompt.templates = _FakeRegistry(reports)
+    prompt.metadata = prompt.templates.active
+    prompt.targets = prompt.templates.active.targets
+    prompt.display = MagicMock()
+    prompt.interactive = False  # exercise the multi-template fan-out branch
+    cmd = Export(args, mock_config, MagicMock(), prompt)
+    return cmd
+
+
+@pytest.mark.parametrize("workflow", [Workflow.AUTO, Workflow.KERNEL])
+def test_requires_hosts_false_for_auto_and_kernel(mock_config, workflow):
+    cmd = _fanout_cmd(mock_config, [_FakeReport("A", workflow)])
+    assert cmd._requires_hosts(_FakeReport("A", workflow)) is False
+
+
+def test_requires_hosts_true_for_manual(mock_config):
+    cmd = _fanout_cmd(mock_config, [_FakeReport("A", Workflow.MANUAL)])
+    assert cmd._requires_hosts(_FakeReport("A", Workflow.MANUAL)) is True
+
+
+@pytest.mark.parametrize("workflow", [Workflow.AUTO, Workflow.KERNEL])
+def test_fanout_hostless_auto_kernel_runs_without_error(mock_config, workflow):
+    """AUTO/KERNEL export over all-host-less templates runs, never skips."""
+    reports = [_FakeReport("A", workflow), _FakeReport("B", workflow)]
+    cmd = _fanout_cmd(mock_config, reports)
+    ran: list[str] = []
+    with patch.object(
+        Export, "__call__", lambda self: ran.append(str(self.metadata.id))
+    ):
+        cmd.run()  # must not raise NoRefhostsDefinedError
+    assert ran == ["A", "B"]
+
+
+def test_fanout_hostless_manual_still_raises(mock_config):
+    """MANUAL export over all-host-less templates keeps the host-phase error."""
+    reports = [_FakeReport("A", Workflow.MANUAL), _FakeReport("B", Workflow.MANUAL)]
+    cmd = _fanout_cmd(mock_config, reports)
+    with (
+        patch.object(Export, "__call__", lambda self: None),
+        pytest.raises(NoRefhostsDefinedError),
+    ):
+        cmd.run()


### PR DESCRIPTION
## Problem

Running `export` across loaded templates fails with `No refhosts defined` when no reference hosts are connected:

```
mtui-auto> export
warning: export skipped on SUSE:Maintenance:44759:413589: no connected hosts
warning: export skipped on SUSE:Maintenance:44848:414156: no connected hosts
info: export skipped (no connected host): SUSE:Maintenance:44759:413589, SUSE:Maintenance:44848:414156
error: No refhosts defined
```

The multi-template fan-out in `Command.run()` skips any template with no connected host and raises `NoRefhostsDefinedError` when every template is skipped. That is correct for host-phase commands (`update`, `reboot`, `run`), but wrong for `export` in the **AUTO** and **KERNEL** workflows, which build the template from openQA/dashboard data and never touch a connected host. Only `ManualExport` consumes the per-host `targets`.

The single-template dispatch path already bypasses the host check, so the failure only surfaced with two or more templates loaded (the common `mtui-auto` / MCP case).

## Fix

- Add an overridable `Command._requires_hosts(report) -> bool` hook (default `True`) and gate the fan-out host-less skip on it, keeping the base class generic.
- `Export` overrides it to return `False` for AUTO/KERNEL reports, so host-less templates are exported instead of skipped (and an all-host-less fan-out no longer raises).
- MANUAL export, which reports per-host results, keeps requiring a connected host — unchanged behaviour.

## Tests

Added to `tests/test_cmd_export.py`:
- `_requires_hosts` returns `False` for AUTO/KERNEL, `True` for MANUAL.
- AUTO/KERNEL export fanned out over all-host-less templates runs each and does not raise.
- MANUAL export over all-host-less templates still raises `NoRefhostsDefinedError`.

## Gate

Full repo, all green:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 1934 passed

Changelog entry added under `[Unreleased] -> Fixed`.