### PR TITLE
fix(cli): stop ColorFormatter corrupting records for downstream handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Colorized log formatting no longer corrupts the record for other handlers
+  on the same logger: the formatter used to overwrite each record's
+  `levelname` in place, so any second handler (a file handler, a test log
+  capture) saw the ANSI-wrapped name instead of `WARNING`/`ERROR`. The
+  substitution is now scoped to the colorized handler's own formatting.
+  Debug-level caller attribution is also resolved from the calling frame's
+  own globals rather than `inspect.getmodule`, which returned "unknown"
+  under import hooks that report a different file path than the code object
+  records.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/cli/colors/formatter.py
+++ b/mtui/cli/colors/formatter.py
@@ -2,6 +2,7 @@
 
 import inspect
 import logging
+from types import FrameType
 
 from ...support.spinner import spinner_suspended
 from .mode import colors_enabled
@@ -56,7 +57,7 @@ class ColorFormatter(logging.Formatter):
                 module, function = "unknown", "unknown"
             else:
                 frame, function = frame_info
-                module = mo.__name__ if (mo := inspect.getmodule(frame)) else "unknown"
+                module = frame.f_globals.get("__name__", "unknown")
             suffix = f" [{module!s}:{function!s}]"
             if not colors_enabled():
                 return levelname.lower() + suffix
@@ -72,7 +73,7 @@ class ColorFormatter(logging.Formatter):
         return COLOR_SEQ.format(30 + COLORS[levelname]) + levelname.lower() + RESET_SEQ
 
     @staticmethod
-    def _find_caller_frame() -> tuple[object, str] | None:
+    def _find_caller_frame() -> tuple[FrameType, str] | None:
         """Walks the stack until the first frame outside the logging machinery.
 
         Returns:
@@ -81,10 +82,22 @@ class ColorFormatter(logging.Formatter):
             ``contextlib``, or `None` if no such frame exists.
 
         """
-        skip_modules = {"logging", "mtui.cli.colors.formatter", "contextlib"}
+        # mutmut's mutation trampoline interposes a wrapper frame between
+        # every function and its caller; treat it as logging machinery so
+        # caller attribution stays on the real call site during mutation
+        # runs. Inert in production -- the module is never loaded there.
+        # Module names come from ``f_globals`` rather than
+        # ``inspect.getmodule``: the latter maps filenames back to modules
+        # and returns None when an import hook reports a different path
+        # than the code object records (pytest's rewriter under mutmut).
+        skip_modules = {
+            "logging",
+            "mtui.cli.colors.formatter",
+            "contextlib",
+            "mutmut.mutation.trampoline",
+        }
         for frame_info in inspect.getouterframes(inspect.currentframe()):
-            module = inspect.getmodule(frame_info.frame)
-            module_name = module.__name__ if module else ""
+            module_name = frame_info.frame.f_globals.get("__name__", "")
             top_level = module_name.partition(".")[0]
             if module_name in skip_modules or top_level == "logging":
                 continue
@@ -103,7 +116,17 @@ class ColorFormatter(logging.Formatter):
         """
         record.message = record.getMessage()
         if self._fmt and self._fmt.find("%(levelname)") >= 0:
-            record.levelname = self.formatColor(record.levelname)
+            # Substitute the colorized levelname only for the duration of
+            # this handler's formatting: the record object is shared with
+            # every other handler in the chain (a file handler, pytest's
+            # caplog, ...), and leaking the ANSI-wrapped name corrupts
+            # their view of the record.
+            original_levelname = record.levelname
+            record.levelname = self.formatColor(original_levelname)
+            try:
+                return logging.Formatter.format(self, record)
+            finally:
+                record.levelname = original_levelname
 
         return logging.Formatter.format(self, record)
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -108,6 +108,11 @@ def test_color_formatter_full_record_no_color():
     rendered = fmt.format(record)
     assert "\033[" not in rendered
     assert rendered == "warning: watch out"
+    # format() must restore the original levelname even when colours are
+    # disabled: formatColor() still rewrites record.levelname (to its
+    # lowercased plain form) on this branch, so the downstream-handler
+    # corruption this formatter guards against applies here too.
+    assert record.levelname == "WARNING"
 
 
 def test_set_mode_round_trip():

--- a/tests/test_colorlog.py
+++ b/tests/test_colorlog.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mtui.cli import colors
 
 
@@ -30,5 +32,75 @@ def test_create_logger(capsys):
 
         # Check for debug message format
         assert "[tests.test_colorlog:test_create_logger]" in captured.err
+    finally:
+        # create_logger attaches a fresh handler to the process-global
+        # "test_logger" on every call; drop it so repeated in-process
+        # pytest runs (mutmut) don't accumulate handlers bound to closed
+        # capture streams.
+        logger.handlers.clear()
+        colors.set_mode(saved)
+
+
+def test_format_does_not_mutate_record_for_downstream_handlers():
+    """format() must not leak the colorized levelname into the shared record.
+
+    Every handler on a logger receives the same LogRecord object; if
+    ColorFormatter rewrote record.levelname in place, each later handler
+    (a file handler, pytest's caplog) would see the ANSI-wrapped name.
+    """
+    import logging
+
+    from mtui.cli.colors.formatter import ColorFormatter
+
+    saved = colors.get_mode()
+    colors.set_mode("always")
+    try:
+        formatter = ColorFormatter("%(levelname)s: %(message)s")
+        warning = logging.LogRecord(
+            "mtui.test", logging.WARNING, __file__, 1, "boom", None, None
+        )
+        out = formatter.format(warning)
+        assert "\033[" in out
+        assert warning.levelname == "WARNING"
+
+        # The DEBUG path takes the caller-attribution branch as well.
+        debug = logging.LogRecord(
+            "mtui.test", logging.DEBUG, __file__, 1, "detail", None, None
+        )
+        out = formatter.format(debug)
+        assert "\033[" in out
+        assert debug.levelname == "DEBUG"
+    finally:
+        colors.set_mode(saved)
+
+
+def test_format_restores_levelname_when_formatter_raises():
+    """The restore must happen even if the wrapped format() call raises.
+
+    format() colorizes record.levelname, then calls
+    logging.Formatter.format() inside a try/finally so the original
+    levelname is put back no matter what -- otherwise an exception
+    partway through formatting (a bad field in the format string, a
+    broken %-arg, ...) would leave the shared record permanently
+    corrupted for every other handler on the logger.
+    """
+    import logging
+
+    from mtui.cli.colors.formatter import ColorFormatter
+
+    saved = colors.get_mode()
+    colors.set_mode("always")
+    try:
+        # %(nonexistent)s does not exist on LogRecord, so
+        # logging.PercentStyle.format() raises ValueError while
+        # logging.Formatter.format() is still running -- after
+        # formatColor() has already substituted the colorized name in.
+        formatter = ColorFormatter("%(nonexistent)s %(levelname)s: %(message)s")
+        record = logging.LogRecord(
+            "mtui.test", logging.WARNING, __file__, 1, "boom", None, None
+        )
+        with pytest.raises(ValueError, match="nonexistent"):
+            formatter.format(record)
+        assert record.levelname == "WARNING"
     finally:
         colors.set_mode(saved)


### PR DESCRIPTION
## What
`ColorFormatter.format()` rewrote `record.levelname` **in place** with the ANSI-colorized string. `LogRecord` objects are shared by every handler on the logger chain, so any second handler — a file handler, pytest's caplog — received the escaped name instead of `WARNING`/`ERROR`, breaking level-based filtering and assertions downstream.

## Fix
The colorized name is substituted only for the duration of this formatter's own `format()` call and restored in a `finally`. Additionally, DEBUG caller attribution now reads the module name from the calling frame's `f_globals` instead of `inspect.getmodule()` (which maps filenames back to modules and renders `[unknown:...]` whenever an import hook reports a different path than the code object records), and the frame walk skips a mutation-testing trampoline frame when one is interposed (module never loaded in production).

## Tests
Regression test pins levelname preservation for WARNING and DEBUG records, with colors enabled **and disabled**, and across an exception from the underlying `Formatter.format` (review catches). The colorlog test also drops its handler on exit so repeated in-process pytest runs don't accumulate handlers bound to closed streams. Revert-verified.

Found while preparing the suite for the mutation-testing campaign; adversarially reviewed.
