### PR TITLE
test: make the suite mutation-ready (hermetic under in-process reruns)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ tags
 
 # Claude Code session artefacts
 .claude/
+
+# mutmut mutation-testing working tree
+mutants/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,18 @@ markers = [
   "network: tests that perform real network I/O",
 ]
 
+[tool.mutmut]
+# Mutation-testing config. Run with:
+#   uv run --with 'mutmut>=3.6' mutmut run
+# ``source_paths`` must be the whole package: mutmut copies it into a
+# ``mutants/`` tree that has to ``import mtui``, and a single-file scope
+# breaks that import. ``do_not_mutate_patterns`` drops the log-message
+# mutants that otherwise dominate the survivor list -- every ``logger``
+# call spawns several string/level mutants that no test should pin -- so
+# the surviving mutants reflect real logic gaps rather than logging noise.
+source_paths = ["mtui/"]
+do_not_mutate_patterns = ['(logger|self\.log)\.(debug|info|warning|error|exception|critical)']
+
 [tool.ruff]
 target-version = "py313"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from json import loads
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -9,6 +10,23 @@ from mtui.types.rpmver import RPMVersion
 from mtui.types.systems import System
 
 __root__: Path = Path(__file__).parent / "fixtures"
+
+# mutmut's stats run re-resolves the relative [tool.mutmut] source_paths
+# against the *current* working directory on every trampoline hit, so any
+# test that chdir()s away from the package root crashes stats collection
+# with FileNotFoundError. Pin the resolution to absolute paths once, while
+# the CWD is still the mutants root. Inert outside `mutmut run`.
+if os.environ.get("MUTANT_UNDER_TEST") == "stats":
+    # mutmut is never a project dependency; `uv run --with mutmut` supplies
+    # it for mutation runs only, so ty resolves against a venv without it.
+    from mutmut.configuration import (  # ty: ignore[unresolved-import]
+        Config as _MutmutConfig,
+    )
+
+    _mutmut_config = _MutmutConfig.get()
+    _mutmut_config.source_paths = [
+        p.resolve(strict=True) for p in _mutmut_config.source_paths
+    ]
 
 
 @pytest.fixture

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -59,6 +59,9 @@ class TestEnsureDirExists:
             os.chmod(subdir, 0o755)
 
     def test_on_create(self, create_temp):
+        # Class-level state survives repeated in-process pytest runs
+        # (mutmut re-enters pytest.main in one interpreter); start clean.
+        type(self)._callback_paths.clear()
         d = self.mkpath(create_temp, "c")
         ensure_dir_exists(d, on_create=self._callback)
         assert self._callback_paths == [d]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,8 +4,27 @@ import logging
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mtui.cli.argparse import ArgsParseFailureError
 from mtui.main import main, run_mtui
+
+
+@pytest.fixture(autouse=True)
+def _restore_mtui_logger():
+    """Undo main()'s wiring of the process-global 'mtui' logger.
+
+    ``main()`` attaches a real stream handler (bound to the current,
+    soon-to-be-closed capture stream) and sets the level; left in place
+    it corrupts every later test that logs under ``mtui.*`` — including
+    repeated in-process pytest runs under mutmut.
+    """
+    logger = logging.getLogger("mtui")
+    saved_handlers = logger.handlers[:]
+    saved_level = logger.level
+    yield
+    logger.handlers[:] = saved_handlers
+    logger.setLevel(saved_level)
 
 
 def test_main_args_parse_failure(monkeypatch):

--- a/tests/test_mcp_main.py
+++ b/tests/test_mcp_main.py
@@ -31,6 +31,24 @@ import pytest
 
 from mtui.mcp import main as mcp_main
 
+
+@pytest.fixture(autouse=True)
+def _restore_mtui_mcp_logger():
+    """Undo main()'s wiring of the process-global 'mtui-mcp' logger.
+
+    ``main()`` attaches a real stream handler (bound to the current,
+    soon-to-be-closed capture stream) and sets the level; left in place
+    it leaks into later tests and into repeated in-process pytest runs
+    under mutmut.
+    """
+    logger = logging.getLogger("mtui-mcp")
+    saved_handlers = logger.handlers[:]
+    saved_level = logger.level
+    yield
+    logger.handlers[:] = saved_handlers
+    logger.setLevel(saved_level)
+
+
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
 # --------------------------------------------------------------------------- #

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -31,6 +31,21 @@ from mtui.mcp.session import McpCommandError, McpSession
 from mtui.support.concurrency import ContextExecutor
 
 
+@pytest.fixture(autouse=True)
+def _unbind_test_commands():
+    """Drop command registrations a test makes in its own body.
+
+    ``Command.__init_subclass__`` binds names process-globally at class
+    creation; a test-local class would collide with itself when pytest
+    re-runs in the same interpreter (mutmut re-enters pytest.main), so
+    remove whatever a test added once it finishes.
+    """
+    before = set(Command.registry)
+    yield
+    for name in set(Command.registry) - before:
+        del Command.registry[name]
+
+
 def _config(tmp_path: Path) -> MagicMock:
     """Build a MagicMock Config with just the attributes NullTestReport reads."""
     cfg = MagicMock()

--- a/tests/test_products_sle.py
+++ b/tests/test_products_sle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -122,7 +123,11 @@ from mtui.types import Product
     ],
 )
 def test_normalize_first_element(fn, before, expected_first) -> None:
-    out = fn(before)
+    # The normalize functions mutate their argument in place, and the
+    # parametrize table above is built once per module import. Feed each
+    # call a copy so the table survives repeated in-process pytest runs
+    # (mutmut re-enters pytest.main in one interpreter).
+    out = fn(deepcopy(before))
     assert out[0][0] == expected_first
 
 


### PR DESCRIPTION
## What
Groundwork for mutation testing (mutmut 3.6), modeled on openSUSE/repose:

- **`[tool.mutmut]`** in pyproject.toml: `source_paths` covers the whole package (the `mutants/` copy must `import mtui`); `do_not_mutate_patterns` drops logger-call mutants so survivors reflect real logic gaps. Inert for the normal toolchain; `mutants/` gitignored.
- **Hermeticity under in-process reruns** — mutmut re-enters `pytest.main()` repeatedly in one interpreter, which exposed tests leaking process-global state:
  - `test_products_sle`: parametrize tables are built once per import and the normalize functions mutate their argument in place → deepcopy per call;
  - `test_main`/`test_mcp_main`: `main()` wires real handlers + levels onto the process-global `mtui`/`mtui-mcp` loggers → restored after each test;
  - `test_mcp_session`: test-body `Command` subclasses register globally via `__init_subclass__` and collide with themselves on rerun → unbound afterwards;
  - `test_fileops`: class-level callback state cleared;
  - conftest: pins mutmut's relative `source_paths` to absolute during stats collection (it re-resolves against the live CWD on every trampoline hit, so `chdir()`ing tests crashed the run). Env-guarded; inert in CI.

With this plus the ColorFormatter PR, the suite passes three consecutive in-process pytest runs — the property mutation testing needs. The first full run: 15,293 mutants, 63.2% kill rate; the surfaced bugs are fixed in the sibling PRs of this series.
