### PR TITLE
fix(export): match indented state headers within the host's own block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   prepare and downgrade checks now label the captured command output
   correctly as "stdout:" (it was mislabeled "stdin:"), and an "errocode"
   typo in the downgrade check's exit-106 warning is fixed.
+- MANUAL `export` now writes the per-host package-version lines into templates
+  that use the indented `      before:` / `      after:` state headers, and
+  bounds that lookup to the current host's own block so it can no longer
+  wander into a neighbouring host's section. The indented-header lookup could
+  never match (a formatting bug hidden by an unindented fallback), so on such
+  templates the version lines were omitted (with only a misleading
+  "before/after packages section not found" error) and the PASSED/FAILED
+  verdict was never filled in. Additionally, when a version line cannot be
+  written because the template is malformed (a state header as the very last
+  line), the export now logs a warning naming the host and package instead of
+  silently skipping the line.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/update_workflow/export/manual.py
+++ b/mtui/update_workflow/export/manual.py
@@ -1,5 +1,6 @@
 """An exporter for the manual workflow."""
 
+import contextlib
 import re
 from itertools import zip_longest
 from logging import getLogger
@@ -144,14 +145,43 @@ class ManualExport(BaseExport):
                 continue
             for state in ["before", "after"]:
                 versions[state] = {}
-                try:
-                    index = self.template.index("      {state}:\n", index) + 1
-                except ValueError:
-                    try:
-                        index = self.template.index(f"{state}:\n", index) + 1
-                    except ValueError:
-                        logger.error("%s packages section not found", state)
-                        continue
+
+                # Bound the header search to this host's own block, so it can
+                # never overshoot into a later host's section (nor, for that
+                # matter, undershoot into an earlier one). The block ends at
+                # the next "reference host:" line, or the end of the
+                # template. Recomputed on every iteration (rather than once
+                # per host) because inserting the "before" version lines
+                # shifts the position of everything after them, including
+                # the next host's header.
+                block_end = len(self.template)
+                for j in range(index + 1, len(self.template)):
+                    if "reference host:" in self.template[j]:
+                        block_end = j
+                        break
+
+                indented_index = None
+                unindented_index = None
+                with contextlib.suppress(ValueError):
+                    indented_index = self.template.index(
+                        f"      {state}:\n", index, block_end
+                    )
+                with contextlib.suppress(ValueError):
+                    unindented_index = self.template.index(
+                        f"{state}:\n", index, block_end
+                    )
+
+                if indented_index is None and unindented_index is None:
+                    logger.error("%s packages section not found", state)
+                    continue
+                # prefer whichever header form is nearest, rather than
+                # always favouring the indented one
+                if indented_index is None:
+                    index = unindented_index + 1
+                elif unindented_index is None:
+                    index = indented_index + 1
+                else:
+                    index = min(indented_index, unindented_index) + 1
 
                 for package in host.packages.values():
                     name = package.name
@@ -176,17 +206,32 @@ class ManualExport(BaseExport):
                                 index, f"\tpackage {name} is not installed\n"
                             )
                         index += 1
-                    except Exception:
-                        pass
+                    except IndexError:
+                        # the state header was the last template line, so there
+                        # is no line at ``index`` to inspect/overwrite. The
+                        # template is malformed; skip the line but say so
+                        # instead of silently dropping it from the report.
+                        logger.warning(
+                            "malformed template: cannot write %s version of "
+                            "package %s for host %s",
+                            state,
+                            name,
+                            hostname,
+                        )
             # if the package versions were not updated, set the result to
             # FAILED, otherwise to PASSED
             failed = False
             for package in versions["before"]:
-                # check if the packages have a higher version after the update
+                # check if the packages have a higher version after the update.
+                # ``after`` may be missing this package entirely if its section
+                # could not be located (e.g. a malformed template) -- skip the
+                # comparison for it rather than raising a KeyError and aborting
+                # the whole export.
+                after_version = versions["after"].get(package)
                 if (
-                    versions["after"][package] is not None
+                    after_version is not None
                     and versions["before"][package] is not None
-                    and not versions["before"][package] < versions["after"][package]
+                    and not versions["before"][package] < after_version
                 ):
                     failed = True
             if failed:

--- a/tests/test_export_manual.py
+++ b/tests/test_export_manual.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -124,10 +125,10 @@ def _pkg(name: str, before, after) -> MagicMock:
     return p
 
 
-def _host(packages: dict) -> MagicMock:
+def _host(packages: dict, hostname: str = "h1", system: str = "system1") -> MagicMock:
     host = MagicMock()
-    host.hostname = "h1"
-    host.system = "system1"
+    host.hostname = hostname
+    host.system = system
     host.packages = packages
     return host
 
@@ -160,6 +161,205 @@ def test_fillup_flips_verdict_from_package_versions(
     exporter._fillup_hosts_to_template()
     assert expected in exporter.template
     assert "=> PASSED/FAILED\n" not in exporter.template
+
+
+def test_fillup_inserts_versions_under_indented_state_headers(
+    tmp_path: Path,
+) -> None:
+    """Templates using the indented ``      before:`` form get the versions.
+
+    Real (generator-produced) templates indent the state headers with six
+    spaces inside each host block; the primary lookup must match them and the
+    package-version lines must land directly underneath.
+    """
+    exporter = _make(tmp_path, results=[_host({"bash": _pkg("bash", 1, 2)})])
+    exporter.template = [
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "      before:\n",
+        "      after:\n",
+        "\n",
+        "=> PASSED/FAILED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+    exporter._fillup_hosts_to_template()
+    tpl = exporter.template
+    assert tpl[tpl.index("      before:\n") + 1] == "\tbash-1\n"
+    assert tpl[tpl.index("      after:\n") + 1] == "\tbash-2\n"
+    assert "=> PASSED\n" in tpl
+
+
+def test_fillup_unindented_fallback_still_works_per_host_block(
+    tmp_path: Path,
+) -> None:
+    """The unindented ``before:`` fallback still works, in the right block.
+
+    One host block uses the indented headers, the following one the
+    unindented (mtui-generated) form: each host's versions must land in its
+    own block — the indented host must not fall through to the unindented
+    lookup and write into the later host's section.
+    """
+    exporter = _make(
+        tmp_path,
+        results=[
+            _host({"alpha": _pkg("alpha", 1, 2)}),
+            _host({"beta": _pkg("beta", 3, 4)}, hostname="h2", system="system2"),
+        ],
+    )
+    exporter.template = [
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "      before:\n",
+        "      after:\n",
+        "\n",
+        "=> PASSED/FAILED\n",
+        "\n",
+        "comment: (none)\n",
+        "\n",
+        "system2 (reference host: h2)\n",
+        "--------------\n",
+        "before:\n",
+        "after:\n",
+        "\n",
+        "=> PASSED/FAILED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+    exporter._fillup_hosts_to_template()
+    tpl = exporter.template
+    # h1's versions sit under h1's indented headers ...
+    assert tpl[tpl.index("      before:\n") + 1] == "\talpha-1\n"
+    assert tpl[tpl.index("      after:\n") + 1] == "\talpha-2\n"
+    # ... and h2's under its own unindented headers (fallback path).
+    assert tpl[tpl.index("before:\n") + 1] == "\tbeta-3\n"
+    assert tpl[tpl.index("after:\n") + 1] == "\tbeta-4\n"
+
+
+def test_fillup_unindented_block_before_indented_block_stays_isolated(
+    tmp_path: Path,
+) -> None:
+    """Mirrored ordering: unindented host block *before* an indented one.
+
+    This is the realistic layout that ``_fillup_hosts_to_template``'s own
+    new-host-insertion loop produces: a freshly added host gets unindented
+    ``before:``/``after:`` headers inserted *above* any pre-existing
+    (generator-produced) indented block. Each host's versions must land in
+    its own block and each host's own PASSED/FAILED placeholder must be
+    flipped from that host's own package versions, rather than the first
+    host's lookup overshooting into the second host's indented headers.
+    """
+    exporter = _make(
+        tmp_path,
+        results=[
+            _host({"alpha": _pkg("alpha", 1, 2)}),  # increases -> PASSED
+            _host(
+                {"beta": _pkg("beta", 4, 3)}, hostname="h2", system="system2"
+            ),  # decreases -> FAILED
+        ],
+    )
+    exporter.template = [
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "before:\n",
+        "after:\n",
+        "\n",
+        "=> PASSED/FAILED\n",
+        "\n",
+        "comment: (none)\n",
+        "\n",
+        "system2 (reference host: h2)\n",
+        "--------------\n",
+        "      before:\n",
+        "      after:\n",
+        "\n",
+        "=> PASSED/FAILED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+    exporter._fillup_hosts_to_template()
+    tpl = exporter.template
+
+    h2_header = tpl.index("system2 (reference host: h2)\n")
+
+    # h1's versions land under h1's own unindented headers, above h2 entirely ...
+    h1_before = tpl.index("before:\n")
+    h1_after = tpl.index("after:\n")
+    assert h1_before < h2_header
+    assert h1_after < h2_header
+    assert tpl[h1_before + 1] == "\talpha-1\n"
+    assert tpl[h1_after + 1] == "\talpha-2\n"
+
+    # ... and h2's under its own indented headers, below h2's header, with no
+    # cross-contamination between the two blocks.
+    h2_before = tpl.index("      before:\n")
+    h2_after = tpl.index("      after:\n")
+    assert h2_before > h2_header
+    assert h2_after > h2_header
+    assert tpl[h2_before + 1] == "\tbeta-4\n"
+    assert tpl[h2_after + 1] == "\tbeta-3\n"
+    assert "\talpha-1\n" not in tpl[h2_header:]
+    assert "\tbeta-4\n" not in tpl[:h2_header]
+
+    # each host's own verdict is flipped from its own data, not the other's.
+    assert "=> PASSED/FAILED\n" not in tpl
+    assert "=> PASSED\n" in tpl[:h2_header]
+    assert "=> FAILED\n" in tpl[h2_header:]
+    assert "=> FAILED\n" not in tpl[:h2_header]
+    assert "=> PASSED\n" not in tpl[h2_header:]
+
+
+def test_fillup_missing_after_section_does_not_raise_keyerror(
+    tmp_path: Path,
+) -> None:
+    """A missing ``after`` section must not crash the whole export.
+
+    If a host's ``after:`` header cannot be located at all (e.g. a malformed
+    template that never defines one), ``versions["after"]`` stays empty. The
+    verdict computation must skip the version comparison for those packages
+    instead of indexing into the empty dict and raising ``KeyError`` -- which
+    would otherwise escape ``_fillup_hosts_to_template`` and abort the whole
+    export with no template written at all.
+    """
+    exporter = _make(tmp_path, results=[_host({"bash": _pkg("bash", 1, 2)})])
+    exporter.template = [
+        "system1 (reference host: h1)\n",
+        "before:\n",
+        "\n",
+        "comment: (none)\n",  # no "after:" header anywhere in this block
+    ]
+    # must not raise KeyError
+    exporter._fillup_hosts_to_template()
+    assert "\tbash-1\n" in exporter.template
+
+
+def test_fillup_warns_when_version_line_cannot_be_written(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed template warns per package instead of silently skipping.
+
+    When a state header is the very last template line there is no line after
+    it to inspect, so the version line cannot be written. The export must
+    still complete, but with a warning naming the host and package rather
+    than swallowing the error and silently omitting the line.
+    """
+    exporter = _make(tmp_path, results=[_host({"bash": _pkg("bash", 1, 2)})])
+    exporter.template = [
+        "system1 (reference host: h1)\n",
+        "before:\n",
+        "\n",
+        "after:\n",  # last line: nothing after it to hold the version line
+    ]
+    with caplog.at_level(logging.WARNING, logger="mtui.export.manual"):
+        exporter._fillup_hosts_to_template()
+    warnings = [r for r in caplog.records if "malformed template" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "bash" in warnings[0].getMessage()
+    assert "h1" in warnings[0].getMessage()
+    # the export still completed: the intact section was filled ...
+    assert "\tbash-1\n" in exporter.template
+    # ... and the unwritable one was skipped.
+    assert "\tbash-2\n" not in exporter.template
 
 
 def test_fillup_leaves_already_set_verdict_untouched(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
Two defects in `ManualExport._fillup_hosts_to_template`, found by mutation testing:

1. **Dormant lookup** — the primary state-header lookup read `self.template.index("      {state}:\n", index)`: the f-prefix was lost, so the literal `{state}` could never match. On templates with six-space-indented `      before:` / `      after:` headers the version lines were silently omitted and the verdict never filled.
2. **Silent swallow** — a bare `except Exception: pass` around the version-line write hid malformed-template errors, producing reports without the very data reviewers verify.

## Fix
The f-prefix is restored and the per-host state-header search is **bounded to the host's own block** (nearest match of both header forms before the next `(reference host:` line) — the adversarial review proved an unbounded search would write host A's versions into host B's block whenever a newly created unindented section precedes an indented one. The bare except is narrowed to `IndexError` with a warning naming state, package and host.

## Tests
Indented-header placement, mixed indented/unindented blocks in **both orders**, and malformed-template warning — each revert-verified (behavioral failure on reverted code).

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
