### PR TITLE
fix(checks): correct zypper exit-104 reason and stdout log labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   own globals rather than `inspect.getmodule`, which returned "unknown"
   under import hooks that report a different file path than the code object
   records.
+- A zypper exit code 104 during `update` is now reported as "package not
+  found" instead of the misleading "update stack locked". Zypper's 104 is
+  `ZYPPER_EXIT_INF_CAP_NOT_FOUND` (the requested package/capability does not
+  exist), not a ZYpp-lock condition, so the old message sent testers chasing
+  a lock that was never there; the `update` check now matches the `install`
+  check's mapping. Additionally, the failure logs of the update, install,
+  prepare and downgrade checks now label the captured command output
+  correctly as "stdout:" (it was mislabeled "stdin:"), and an "errocode"
+  typo in the downgrade check's exit-106 warning is fixed.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/update_workflow/checks/downgrade.py
+++ b/mtui/update_workflow/checks/downgrade.py
@@ -24,7 +24,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
     """
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -33,7 +33,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("update stack locked", hostname)
     if "System management is locked" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -51,7 +51,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         logger.critical("%s: zypper returned with errorcode 104:\n%s", hostname, stderr)
         raise UpdateError("Unspecified Error", hostname)
     if exitcode == 106:
-        logger.warning("%s: zypper returned with errocode 106:\n%s", hostname, stderr)
+        logger.warning("%s: zypper returned with errorcode 106:\n%s", hostname, stderr)
 
 
 #: A dictionary that maps system configurations to downgrade check functions.

--- a/mtui/update_workflow/checks/install.py
+++ b/mtui/update_workflow/checks/install.py
@@ -26,7 +26,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         return
     if exitcode in (104, 4, 5, 8):
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -38,7 +38,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         or "System management is locked" in stderr
     ):
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -47,7 +47,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("update stack locked", hostname)
     if "Error:" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -62,7 +62,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         )
         raise UpdateError("Dependency Error", hostname)
     logger.critical(
-        '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+        '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
         hostname,
         stdin,
         stdout,

--- a/mtui/update_workflow/checks/prepare.py
+++ b/mtui/update_workflow/checks/prepare.py
@@ -24,7 +24,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
     """
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -33,7 +33,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("update stack locked", hostname)
     if "System management is locked" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -49,7 +49,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("Dependency Error", hostname)
     if "Error:" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,

--- a/mtui/update_workflow/checks/update.py
+++ b/mtui/update_workflow/checks/update.py
@@ -25,13 +25,13 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
     """
     if "zypper" in stdin and exitcode == 104:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
             stderr,
         )
-        raise UpdateError("update stack locked", hostname)
+        raise UpdateError("package not found", hostname)
     if "zypper" in stdin and exitcode == 106:
         logger.warning("%s: zypper returns exitcode 106:\n%s", hostname, stderr)
     if "Additional rpm output" in stdout:
@@ -42,7 +42,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         print(stdout[start:end].replace("warning", yellow("warning")))  # noqa: T201
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -51,7 +51,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("update stack locked", hostname)
     if "System management is locked" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,
@@ -67,7 +67,7 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         raise UpdateError("Dependency Error", hostname)
     if "Error:" in stderr:
         logger.critical(
-            '%s: command "%s" failed:\nstdin:\n%s\nstderr:\n%s',
+            '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
             hostname,
             stdin,
             stdout,

--- a/tests/test_checks_downgrade.py
+++ b/tests/test_checks_downgrade.py
@@ -50,10 +50,14 @@ def test_zypper_lock_branches_logging_is_well_formed(monkeypatch) -> None:
         zypper("h", "out", "in pkg", "System management is locked", 0)
 
 
-def test_zypper_system_management_locked_raises() -> None:
-    """A "System management is locked" stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "System management is locked", 0)
+def test_zypper_system_management_locked_raises(caplog) -> None:
+    """A "System management is locked" stderr raises and labels payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.downgrade"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "System management is locked", 0)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_dep_conflict_raises() -> None:
@@ -73,7 +77,23 @@ def test_zypper_exitcode_106_warns_but_no_raise(caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="mtui.checks.downgrade"):
         result = zypper("h", "", "in pkg", "", 106)
     assert result is None
-    assert any("errocode 106" in r.message for r in caplog.records)
+    assert any("errorcode 106" in r.message for r in caplog.records)
+
+
+def test_zypper_failure_log_labels_stdout_as_stdout(caplog) -> None:
+    """The failure log labels the stdout payload "stdout:", not "stdin:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.downgrade"),
+        pytest.raises(UpdateError),
+    ):
+        zypper(
+            "h",
+            "OUT-PAYLOAD",
+            "in pkg",
+            "A ZYpp transaction is already in progress.",
+            0,
+        )
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_downgrade_checks_dispatch_keys() -> None:

--- a/tests/test_checks_install.py
+++ b/tests/test_checks_install.py
@@ -28,22 +28,50 @@ def test_zypper_exitcode_104_raises_package_not_found() -> None:
         zypper("h", "", "in pkg", "", 104)
 
 
-def test_zypper_zypp_transaction_lock_raises() -> None:
-    """A ZYpp transaction-in-progress stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "A ZYpp transaction is already in progress.", 1)
+def test_zypper_failure_log_labels_stdout_as_stdout(caplog) -> None:
+    """The failure log labels the stdout payload "stdout:", not "stdin:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.install"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "ERR-PAYLOAD", 104)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
-def test_zypper_system_management_lock_raises() -> None:
-    """A "System management is locked" stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "System management is locked", 1)
+def test_zypper_zypp_transaction_lock_raises(caplog) -> None:
+    """A ZYpp transaction-in-progress stderr raises and labels payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.install"),
+        pytest.raises(UpdateError),
+    ):
+        zypper(
+            "h",
+            "OUT-PAYLOAD",
+            "in pkg",
+            "A ZYpp transaction is already in progress.",
+            1,
+        )
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
-def test_zypper_rpm_error_raises() -> None:
-    """``Error:`` in stderr raises ``UpdateError("RPM Error", host)``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "Error: something bad", 1)
+def test_zypper_system_management_lock_raises(caplog) -> None:
+    """A "System management is locked" stderr raises and labels payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.install"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "System management is locked", 1)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
+
+
+def test_zypper_rpm_error_raises(caplog) -> None:
+    """``Error:`` in stderr raises ``UpdateError("RPM Error", host)`` labeling "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.install"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "Error: something bad", 1)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_unresolved_dep_raises() -> None:
@@ -52,10 +80,14 @@ def test_zypper_unresolved_dep_raises() -> None:
         zypper("h", "(c): c", "in pkg", "", 1)
 
 
-def test_zypper_unknown_error_raises_with_unknown_label() -> None:
-    """An exitcode with no special markers raises ``Unknown Error``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "", 99)
+def test_zypper_unknown_error_raises_with_unknown_label(caplog) -> None:
+    """An exitcode with no special markers raises "Unknown Error", labeling "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.install"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "", 99)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_install_checks_dispatch() -> None:

--- a/tests/test_checks_prepare.py
+++ b/tests/test_checks_prepare.py
@@ -41,10 +41,30 @@ def test_zypper_zypp_lock_logging_is_well_formed(monkeypatch) -> None:
         zypper("h", "out", "in pkg", "A ZYpp transaction is already in progress.", 0)
 
 
-def test_zypper_system_management_locked_raises() -> None:
-    """A "System management is locked" stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "System management is locked", 0)
+def test_zypper_failure_log_labels_stdout_as_stdout(caplog) -> None:
+    """The failure log labels the stdout payload "stdout:", not "stdin:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.prepare"),
+        pytest.raises(UpdateError),
+    ):
+        zypper(
+            "h",
+            "OUT-PAYLOAD",
+            "in pkg",
+            "A ZYpp transaction is already in progress.",
+            0,
+        )
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
+
+
+def test_zypper_system_management_locked_raises(caplog) -> None:
+    """A "System management is locked" stderr raises and labels payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.prepare"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "System management is locked", 0)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_unresolved_dep_raises() -> None:
@@ -53,10 +73,14 @@ def test_zypper_unresolved_dep_raises() -> None:
         zypper("h", "(c): c", "in pkg", "", 0)
 
 
-def test_zypper_rpm_error_raises() -> None:
-    """``Error:`` in stderr raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "in pkg", "Error: foo", 0)
+def test_zypper_rpm_error_raises(caplog) -> None:
+    """``Error:`` in stderr raises ``UpdateError`` labeling the payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.prepare"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "in pkg", "Error: foo", 0)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_prepare_checks_dispatch() -> None:

--- a/tests/test_checks_update.py
+++ b/tests/test_checks_update.py
@@ -21,10 +21,26 @@ def test_zypper_clean_run_returns_none() -> None:
     assert zypper("h", "", "echo hi", "", 0) is None
 
 
-def test_zypper_zypper_in_stdin_exitcode_104_raises() -> None:
-    """``zypper`` in stdin + exitcode 104 raises ``UpdateError``."""
-    with pytest.raises(UpdateError):
+def test_zypper_zypper_in_stdin_exitcode_104_raises_package_not_found() -> None:
+    """Exitcode 104 (ZYPPER_EXIT_INF_CAP_NOT_FOUND) means "package not found".
+
+    Zypper's ZYpp-lock exit code is 7; 104 is capability/package not found,
+    so the raised reason must match the ``install`` check's mapping.
+    """
+    with pytest.raises(UpdateError) as ei:
         zypper("h", "", "zypper in pkg", "", 104)
+    assert ei.value.reason == "package not found"
+    assert ei.value.host == "h"
+
+
+def test_zypper_failure_log_labels_stdout_as_stdout(caplog) -> None:
+    """The failure log labels the stdout payload "stdout:", not "stdin:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.update"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "zypper in pkg", "ERR-PAYLOAD", 104)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_zypper_in_stdin_exitcode_106_warns(caplog) -> None:
@@ -45,16 +61,26 @@ def test_zypper_additional_rpm_output_printed(capsys) -> None:
     assert "warning" in captured.out
 
 
-def test_zypper_zypp_transaction_lock_raises() -> None:
-    """ZYpp transaction lock raises."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "echo", "A ZYpp transaction is already in progress.", 0)
+def test_zypper_zypp_transaction_lock_raises(caplog) -> None:
+    """ZYpp transaction lock raises and labels the payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.update"),
+        pytest.raises(UpdateError),
+    ):
+        zypper(
+            "h", "OUT-PAYLOAD", "echo", "A ZYpp transaction is already in progress.", 0
+        )
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
-def test_zypper_system_management_locked_raises() -> None:
-    """System management lock raises."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "echo", "System management is locked", 0)
+def test_zypper_system_management_locked_raises(caplog) -> None:
+    """System management lock raises and labels the payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.update"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "echo", "System management is locked", 0)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_unresolved_dep_raises() -> None:
@@ -63,10 +89,14 @@ def test_zypper_unresolved_dep_raises() -> None:
         zypper("h", "(c): c", "echo", "", 0)
 
 
-def test_zypper_rpm_error_raises() -> None:
-    """``Error:`` in stderr raises."""
-    with pytest.raises(UpdateError):
-        zypper("h", "", "echo", "Error: bad", 0)
+def test_zypper_rpm_error_raises(caplog) -> None:
+    """``Error:`` in stderr raises and labels the payload "stdout:"."""
+    with (
+        caplog.at_level(logging.CRITICAL, logger="mtui.checks.update"),
+        pytest.raises(UpdateError),
+    ):
+        zypper("h", "OUT-PAYLOAD", "echo", "Error: bad", 0)
+    assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
 def test_zypper_unsupported_package_printed_no_raise(capsys) -> None:


### PR DESCRIPTION
## What
Three defects in `update_workflow/checks/`, found by mutation testing:

1. `checks/update.py` mapped zypper exit **104** to `UpdateError("update stack locked")` — 104 is `ZYPPER_EXIT_INF_CAP_NOT_FOUND`; testers were shown a wrong failure reason (the lock code is 7). Now raises `"package not found"`, matching `checks/install.py`.
2. All four checks modules labeled the command's **stdout as `stdin:`** in the shared `logger.critical` failure log — misleading during failure diagnosis. Label fixed at all 13 sites.
3. `checks/downgrade.py` warned about `"errocode 106"` — typo fixed (test updated).

## Tests
Exit-104 classification asserted via `ei.value.reason`/`ei.value.host`; the stdout-label fix is pinned **per failure branch across all four modules** (the review showed a single-site pin let partial reverts pass). All revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
