### PR TITLE
fix(hosts): render lock timestamps in actual UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   written because the template is malformed (a state header as the very last
   line), the export now logs a warning naming the host and package instead of
   silently skipping the line.
+- The lock time shown in "locked by" messages (e.g. by `list_locks` and
+  `update`) is now actually UTC, as its label has always claimed. The shared
+  lock timestamp was converted to the tester's local timezone before being
+  formatted with the "UTC" suffix, so anyone outside UTC saw a time wrong by
+  their UTC offset.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/hosts/target/locks.py
+++ b/mtui/hosts/target/locks.py
@@ -3,7 +3,7 @@
 import errno
 import os
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
@@ -376,7 +376,11 @@ class TargetLock:
         return self._lock.comment
 
     def time(self) -> str:
-        """Returns the time the lock was created.
+        """Returns the time the lock was created, rendered in UTC.
+
+        The epoch timestamp is shared between testers in different
+        timezones, so it is converted timezone-aware to match the
+        literal "UTC" label in the output.
 
         Returns:
             The time the lock was created, or ``"unknown"`` when the stored
@@ -388,7 +392,7 @@ class TargetLock:
         """
         self.load()
         try:
-            ts = datetime.fromtimestamp(float(self._lock.timestamp))
+            ts = datetime.fromtimestamp(float(self._lock.timestamp), tz=UTC)
         except (ValueError, OverflowError, OSError):
             logger.debug(
                 "%s: malformed lock timestamp %r",

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -288,6 +288,41 @@ class TestTargetLock:
         result = lock.time()
         assert "UTC" in result
 
+    def test_time_converts_epoch_to_utc(self, lock):
+        """time() renders the epoch timestamp in UTC, as its label claims.
+
+        The exact string is asserted: a timezone-aware UTC conversion yields
+        the same result on any host, whereas a naive (local-time) conversion
+        would only match on hosts whose local timezone happens to be UTC.
+        """
+        mock_file = MagicMock()
+        mock_file.readline.return_value = "0:testuser:12345"
+        lock.connection.sftp_open.return_value = mock_file
+
+        assert lock.time() == "Thursday, 01.01.1970 00:00 UTC"
+
+    def test_time_is_utc_regardless_of_local_timezone(self, lock, monkeypatch):
+        """time() must not shift with the tester's local timezone.
+
+        Locks are shared between testers in different timezones, so the
+        displayed time must be canonical UTC. With TZ=America/New_York a
+        naive local-time conversion of 1720000000 would render 05:46 (EDT,
+        UTC-4) under the hardcoded "UTC" label instead of the true 09:46.
+        """
+        mock_file = MagicMock()
+        mock_file.readline.return_value = "1720000000:testuser:12345"
+        lock.connection.sftp_open.return_value = mock_file
+
+        monkeypatch.setenv("TZ", "America/New_York")
+        time.tzset()
+        try:
+            assert lock.time() == "Wednesday, 03.07.2024 09:46 UTC"
+        finally:
+            # monkeypatch restores TZ only at teardown; re-apply the process
+            # timezone here so no stale zone leaks into later tests.
+            monkeypatch.undo()
+            time.tzset()
+
     def test_time_malformed_timestamp_returns_unknown(self, lock):
         """A non-numeric timestamp must not raise (mirrors age_seconds).
 


### PR DESCRIPTION
## What
`TargetLock.time()` converted the lock's epoch timestamp with `datetime.fromtimestamp()` — the **local** timezone — but formatted it with a literal `UTC` suffix. Any tester outside UTC saw lock times wrong by their UTC offset in `list_locks` output and the `update` lock warning.

## Fix
Timezone-aware conversion (`datetime.fromtimestamp(ts, tz=timezone.utc)`); output format otherwise unchanged.

## Tests
Exact expected string for a fixed epoch, plus a TZ-forced case (`TZ=America/New_York` + `time.tzset`) that fails under local-time conversion regardless of the host timezone. Revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
