### PR TITLE
fix(cli): complete partial tilde paths and stop hiding siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   lock timestamp was converted to the tester's local timezone before being
   formatted with the "UTC" suffix, so anyone outside UTC saw a time wrong by
   their UTC offset.
+- Tab completion of file paths now works for partial paths under `~`: typing
+  e.g. `put ~/Doc<TAB>` offers `~`-expanded matches such as
+  `/home/user/Documents/`. Previously the completer appended a `/` to the
+  expanded text unconditionally, so a partial basename like `~/Doc` was
+  treated as the non-existent directory `$HOME/Doc/` and no completions were
+  offered at all; typing the exact directory name (`~/Documents`, no
+  trailing slash) already worked, but input that already ended in `/` (bare
+  `~/`, or `~/Documents/`) got a second slash appended on top of the one
+  already typed, e.g. `$HOME//Documents`. Directory candidates (including
+  bare `~`'s home-directory entries) are now suffixed with `/`, matching
+  shell convention, so a following `TAB` descends into them.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/cli/completion.py
+++ b/mtui/cli/completion.py
@@ -51,7 +51,11 @@ def complete_choices(
         hostnames: A list of hostnames to include in the completion choices.
 
     Returns:
-        A list of possible completion strings.
+        A list of possible completion strings. A candidate that equals
+        ``text`` exactly is included alongside any longer candidate
+        that shares the same prefix (e.g. typing ``Doc`` fully still
+        offers a sibling ``Documents``) rather than short-circuiting
+        to just the exact match.
 
     """
     if not hostnames:
@@ -73,14 +77,14 @@ def complete_choices(
             if line in s:
                 choices = choices - set(s)
 
-    endchoices: list[str] = []
-    for c in choices:
-        if text == c:
-            return [c]
-        if text == c[0 : len(text)]:
-            endchoices.append(c)
-
-    return endchoices
+    # Every candidate sharing ``text`` as a prefix is a match — this
+    # already includes an exact match, since ``c[0:len(text)] == text``
+    # trivially holds when ``c == text``. Do not special-case (and
+    # short-circuit on) an exact match: iterating a set has no defined
+    # order, so returning early the moment one is found would silently
+    # drop other, longer candidates depending on iteration order (e.g.
+    # a directory named "Doc" sitting next to "Documents").
+    return [c for c in choices if text == c[0 : len(text)]]
 
 
 def complete_choices_filelist(
@@ -100,22 +104,30 @@ def complete_choices_filelist(
 
     Returns:
         A list of possible completion strings, including file and
-        directory names.
+        directory names. A leading ``~``/``~user`` in ``text`` is
+        expanded first (:func:`os.path.expanduser` semantics), so the
+        file candidates for a tilde path come back as absolute paths.
+        Directory candidates are suffixed with ``/`` (shell
+        convention) so a following TAB descends into their contents.
+        A tilde path that already names an existing directory (a bare
+        ``~``/``~user``, or ``~/some/existing/dir`` typed with no
+        trailing slash) behaves as if the trailing slash had already
+        been typed -- descending straight into it -- *unless* a
+        sibling entry shares the same prefix (e.g. a directory ``Doc``
+        next to ``Documents``), in which case forcing the descent
+        would silently hide that sibling, so the parent's entries are
+        listed instead.
 
     """
-    dirname = ""
-    filename = ""
+    is_tilde = text.startswith("~")
+    if is_tilde:
+        text = os.path.expanduser(text)
 
-    if text.startswith("~"):
-        text = text.replace("~", os.path.expanduser("~"), 1)
-        text += "/"
-
-    if "/" in text:
-        dirname = "/".join(text.split("/")[:-1])
-        dirname += "/"
-
-    if not dirname:
-        dirname = "./"
+    # List the directory portion of the typed path (everything up to and
+    # including the last ``/``; the current directory when there is none).
+    # The typed basename prefix is matched by complete_choices() against
+    # the rebuilt ``dirname + entry`` candidates.
+    dirname = text[: text.rindex("/") + 1] if "/" in text else "./"
 
     # Tab-completion fires on every keystroke, including transient
     # typos like ``,/`` (missed shift on ``./``). A missing directory,
@@ -126,6 +138,26 @@ def complete_choices_filelist(
     except (FileNotFoundError, NotADirectoryError, PermissionError):
         entries = []
 
-    synonyms += [(dirname + i,) for i in entries if i.startswith(filename)]
+    if is_tilde and not text.endswith("/") and os.path.isdir(text):
+        # The tilde-expanded text itself names an existing directory
+        # (bare "~"/"~user", or e.g. "~/Documents" typed in full). Its
+        # "parent" (the directory `dirname` currently points at, e.g.
+        # the home directory's own parent for a bare "~") is never
+        # what the user means to browse. Force the descent only when
+        # unambiguous: no sibling of the parent shares this basename
+        # as a prefix (that sibling would otherwise vanish once we
+        # switch to listing the directory itself).
+        basename = text[len(dirname) :]
+        if sum(1 for e in entries if e.startswith(basename)) <= 1:
+            text += "/"
+            dirname = text
+            try:
+                entries = os.listdir(dirname)
+            except (FileNotFoundError, NotADirectoryError, PermissionError):
+                entries = []
+
+    synonyms += [
+        (dirname + i + ("/" if os.path.isdir(dirname + i) else ""),) for i in entries
+    ]
 
     return complete_choices(synonyms, line, text, hostnames)

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -221,6 +221,140 @@ def test_adapter_matches_complete_choices_for_run():
 
 
 # --------------------------------------------------------------------------- #
+# Tilde (home directory) expansion in file-path completion                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_filelist_tilde_partial_path_completes(tmp_path, monkeypatch):
+    """``~/Doc`` offers the home entries matching the partial basename.
+
+    Regression: the helper used to append ``/`` to the tilde-expanded
+    text, so ``~/Doc`` was treated as the (non-existent) directory
+    ``$HOME/Doc/`` — ``os.listdir`` of it yielded nothing and no
+    completions were ever offered for a partial path under ``~``.
+    ``os.path.expanduser`` resolves ``~`` from ``$HOME`` on POSIX, so
+    pointing ``HOME`` at ``tmp_path`` keeps the test hermetic without
+    changing the CWD. The single match is a directory, so it carries a
+    trailing ``/`` (shell convention, lets a following TAB descend).
+    """
+    (tmp_path / "Documents").mkdir()
+    (tmp_path / "Downloads").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert complete_choices_filelist([], "put ~/Doc", "~/Doc") == [
+        f"{tmp_path}/Documents/"
+    ]
+
+
+def test_filelist_tilde_exact_directory_lists_contents(tmp_path, monkeypatch):
+    """``~/`` (an exact existing directory) offers every entry in it.
+
+    Also locks in the candidate shape: single ``/`` separators (the old
+    unconditional ``text += '/'`` produced ``$HOME//<entry>``), each
+    suffixed with its own trailing ``/`` since both entries are
+    directories.
+    """
+    (tmp_path / "Documents").mkdir()
+    (tmp_path / "Downloads").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert set(complete_choices_filelist([], "put ~/", "~/")) == {
+        f"{tmp_path}/Documents/",
+        f"{tmp_path}/Downloads/",
+    }
+
+
+def test_filelist_bare_tilde_lists_home_contents(tmp_path, monkeypatch):
+    """A bare ``~`` (no trailing slash, no further path) lists $HOME itself.
+
+    Regression: ``os.path.expanduser("~")`` yields ``$HOME`` with *no*
+    trailing slash, so naively taking "everything up to the last '/'"
+    as the directory to list resolves to $HOME's own *parent* —
+    listing sibling home directories instead of $HOME's contents, and
+    (via ``complete_choices``'s prefix match) offering only $HOME
+    itself as a single dead-end candidate. $HOME must be listed
+    directly, exactly like the old (pre-tilde-completion-fix) code did.
+    """
+    (tmp_path / "Documents").mkdir()
+    (tmp_path / "Downloads").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert set(complete_choices_filelist([], "put ~", "~")) == {
+        f"{tmp_path}/Documents/",
+        f"{tmp_path}/Downloads/",
+    }
+
+
+def test_filelist_tilde_exact_directory_no_trailing_slash_descends(
+    tmp_path, monkeypatch
+):
+    """``~/Documents`` (full name, no trailing slash) lists its contents.
+
+    Regression: typing the exact, unambiguous directory name used to
+    dead-end on re-offering ``$HOME/Documents`` itself (an exact match
+    against its own listing in its parent) instead of descending into
+    it, unlike the old code which forced a trailing slash onto any
+    tilde path and so always listed the named directory's contents.
+    """
+    docs = tmp_path / "Documents"
+    docs.mkdir()
+    (docs / "alpha.txt").write_text("")
+    (docs / "beta.txt").write_text("")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert set(complete_choices_filelist([], "put ~/Documents", "~/Documents")) == {
+        f"{docs}/alpha.txt",
+        f"{docs}/beta.txt",
+    }
+
+
+def test_filelist_tilde_subdirectory_partial_filters_by_basename(tmp_path, monkeypatch):
+    """``~/Documents/al`` lists ``~/Documents`` and narrows by basename."""
+    docs = tmp_path / "Documents"
+    docs.mkdir()
+    (docs / "alpha.txt").write_text("")
+    (docs / "beta.txt").write_text("")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert complete_choices_filelist([], "put ~/Documents/al", "~/Documents/al") == [
+        f"{docs}/alpha.txt"
+    ]
+
+
+def test_filelist_tilde_directory_sibling_is_not_hidden(tmp_path, monkeypatch):
+    """A directory whose name is a prefix of a sibling directory's name.
+
+    Regression: forcing the descent whenever the typed (expanded) text
+    names an existing directory would, for ``~/Doc`` here, silently
+    swallow the sibling ``Documents`` — the parent's entries must be
+    listed instead whenever another entry shares the same prefix.
+    """
+    (tmp_path / "Doc").mkdir()
+    (tmp_path / "Documents").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert set(complete_choices_filelist([], "put ~/Doc", "~/Doc")) == {
+        f"{tmp_path}/Doc/",
+        f"{tmp_path}/Documents/",
+    }
+
+
+def test_filelist_tilde_file_does_not_hide_prefixed_directory_sibling(
+    tmp_path, monkeypatch
+):
+    """A *file* whose name exactly matches the typed text must not hide
+    a directory sharing that prefix.
+
+    Regression: ``complete_choices`` used to short-circuit the moment
+    it found a candidate equal to ``text``, discarding any other
+    prefix match already collected (or not yet visited) depending on
+    set-iteration order — here that would drop ``Documents`` because
+    the file ``Doc`` matches ``text`` exactly.
+    """
+    (tmp_path / "Doc").write_text("")
+    (tmp_path / "Documents").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert set(complete_choices_filelist([], "put ~/Doc", "~/Doc")) == {
+        f"{tmp_path}/Doc",
+        f"{tmp_path}/Documents/",
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Error robustness                                                            #
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## What
Tilde completion was broken for partial paths: `complete_choices_filelist` expanded `~` and then unconditionally appended `/`, so `~/Doc<TAB>` listed the non-existent directory `/home/user/Doc/` and offered nothing. A dead filter (`filename` always `''`) masked the intended per-basename filtering.

## Fix
Tilde expansion no longer forces a slash; the directory to list and the basename prefix are derived properly. From the adversarial review: a tilde path naming an existing directory (or bare `~`) now **descends into it when unambiguous**, directory candidates carry a trailing `/`, and `complete_choices()` no longer short-circuits on an exact text match (which dropped same-prefix siblings depending on set order — this also benefits the other completers using it).

## Tests
Partial prefix, bare `~`, exact-directory-without-slash, dir/dir and file/dir sibling cases — each revert-verified against its specific production hunk; no `chdir` anywhere.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
