### PR TITLE
fix(commands): surface host-teardown failures on quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   already typed, e.g. `$HOME//Documents`. Directory candidates (including
   bare `~`'s home-directory entries) are now suffixed with `/`, matching
   shell convention, so a following `TAB` descends into them.
+- `quit` (and `exit`/Ctrl-D) no longer hides host-teardown problems: a
+  disconnect that crashes, including one that only crashes after running
+  past the 45-second teardown window, is now reported as a warning naming
+  the affected host. The exit status is still unaffected, but quitting
+  already blocked until every disconnect finished before this fix and
+  still does — only the visibility of the outcome changed, not the wait.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/commands/quit.py
+++ b/mtui/commands/quit.py
@@ -2,11 +2,21 @@
 
 import concurrent.futures
 from contextlib import suppress
+from logging import getLogger
 
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices
 from ..support.concurrency import ContextExecutor
 from . import Command
+
+logger = getLogger("mtui.command.quit")
+
+#: How long (in seconds) ``quit`` waits for the parallel host teardown
+#: before reporting the remaining hosts as still disconnecting. This does
+#: not bound how long ``quit`` itself can block: the executor is still
+#: joined on exit, so a straggler past this timeout is merely reported
+#: early, not abandoned. Module-level so tests can patch it.
+CLOSE_TIMEOUT: float = 45
 
 
 class Quit(Command):
@@ -51,13 +61,46 @@ class Quit(Command):
                 report.release_pool_claims()
 
         # Close every loaded template's host group, not just the active one.
+        # Leaving the ``with`` block below still joins every worker thread
+        # (``Executor.__exit__`` is ``shutdown(wait=True)``) -- that join is
+        # pre-existing behaviour and is left untouched here, so quit keeps
+        # blocking until every close has actually finished, however long
+        # that takes. Only the *visibility* of the outcome changes: a
+        # straggler still running at the timeout gets a "still
+        # disconnecting" warning (not a final verdict, since it may yet
+        # succeed while the ``with`` block joins it), and is re-checked
+        # once the join has completed so an exception raised after the
+        # timeout is not silently dropped.
         with ContextExecutor() as executor:
-            futures = [
-                executor.submit(self._close_target, report.targets, target, args_)
+            futures = {
+                executor.submit(
+                    self._close_target, report.targets, target, args_
+                ): target
                 for report in self.templates.all()
                 for target in set(report.targets)
-            ]
-            concurrent.futures.wait(futures, timeout=45)
+            }
+            done, not_done = concurrent.futures.wait(futures, timeout=CLOSE_TIMEOUT)
+            for future in done:
+                if (exc := future.exception()) is not None:
+                    logger.warning(
+                        "failed to disconnect from %s: %s", futures[future], exc
+                    )
+            for future in not_done:
+                logger.warning(
+                    "still disconnecting from %s after %s seconds",
+                    futures[future],
+                    CLOSE_TIMEOUT,
+                )
+        # The ``with`` block above has just joined every straggler from
+        # ``not_done`` (the executor's own ``shutdown(wait=True)`` on
+        # exit), so every one of those futures is now guaranteed done.
+        # Re-check them: one that went on to raise had its failure reason
+        # dropped before this fix (only the timeout warning fired even
+        # though quit blocked for the close to finish anyway); one that
+        # went on to succeed needs no further warning.
+        for future in not_done:
+            if (exc := future.exception()) is not None:
+                logger.warning("failed to disconnect from %s: %s", futures[future], exc)
 
         # FileHistory writes synchronously on each ``append_string``, so the
         # on-disk file is already current. ``flush()`` is the canonical

--- a/tests/test_cmd_quit.py
+++ b/tests/test_cmd_quit.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import threading
 from argparse import Namespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from mtui.cli import _history, repl
+from mtui.commands import quit as quit_module
 from mtui.commands.quit import Quit
 from mtui.hosts.target.hostgroup import HostsGroup
 
@@ -84,6 +87,202 @@ def test_quit_history_flush_failure_does_not_abort_exit(mock_config):
     Quit(args, mock_config, sys_mock, prompt)()
 
     sys_mock.exit.assert_called_once_with(0)
+
+
+def test_quit_close_failure_logs_warning_with_hostname(mock_config, caplog):
+    """A crashing ``close()`` must not abort ``quit``, but must be visible.
+
+    Teardown is best-effort, so the exit still happens with status 0;
+    the failure has to surface as a warning naming the affected host.
+    """
+    t = _make_target("h1")
+    t.close.side_effect = KeyError("boom")
+    prompt = _prompt(HostsGroup([t]))
+    sys_mock = MagicMock()
+    args = Namespace(bootarg=None)
+
+    with caplog.at_level(logging.WARNING, logger="mtui.command.quit"):
+        Quit(args, mock_config, sys_mock, prompt)()
+
+    sys_mock.exit.assert_called_once_with(0)
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "mtui.command.quit" and r.levelno == logging.WARNING
+    ]
+    assert any("h1" in m and "failed to disconnect" in m for m in warnings)
+
+
+def test_quit_close_failure_names_the_failing_host_among_several(mock_config, caplog):
+    """The warning must name the host whose ``close()`` actually failed.
+
+    A single-host test cannot tell ``futures[future]`` (the correct
+    per-future lookup) apart from a broken mapping that reports an
+    arbitrary submitted host instead -- with only one host in the dict,
+    any lookup trivially returns that same host. Load two hosts where
+    only the second's ``close()`` raises and assert the failure warning
+    names exactly that host, never the one that closed cleanly.
+    """
+    t1 = _make_target("h1")
+    t2 = _make_target("h2")
+    t2.close.side_effect = KeyError("boom")
+    prompt = _prompt(HostsGroup([t1]), HostsGroup([t2]))
+    sys_mock = MagicMock()
+    args = Namespace(bootarg=None)
+
+    with caplog.at_level(logging.WARNING, logger="mtui.command.quit"):
+        Quit(args, mock_config, sys_mock, prompt)()
+
+    sys_mock.exit.assert_called_once_with(0)
+    t1.close.assert_called_once_with()
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "mtui.command.quit" and r.levelno == logging.WARNING
+    ]
+    failures = [m for m in warnings if "failed to disconnect" in m]
+    assert len(failures) == 1
+    assert "h2" in failures[0]
+    assert "h1" not in failures[0]
+
+
+def test_quit_clean_teardown_emits_no_warnings(mock_config, caplog):
+    """A fully successful teardown must not emit any warning at all.
+
+    Guards the fidelity of the teardown-visibility warnings: a
+    regression that logs unconditionally (e.g. iterating ``futures``
+    instead of ``not_done``) would train users to ignore every quit,
+    but the clean-path tests never inspected ``caplog`` before this.
+    """
+    t1 = _make_target("h1")
+    t2 = _make_target("h2")
+    prompt = _prompt(HostsGroup([t1]), HostsGroup([t2]))
+    sys_mock = MagicMock()
+    args = Namespace(bootarg=None)
+
+    with caplog.at_level(logging.WARNING, logger="mtui.command.quit"):
+        Quit(args, mock_config, sys_mock, prompt)()
+
+    sys_mock.exit.assert_called_once_with(0)
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "mtui.command.quit" and r.levelno == logging.WARNING
+    ]
+    assert warnings == []
+
+
+def test_quit_close_timeout_logs_warning_with_hostname(
+    mock_config, caplog, monkeypatch
+):
+    """A ``close()`` that hangs past the teardown timeout is reported.
+
+    The 45 s production timeout is patched down so the test stays fast;
+    a log handler releases the hung worker the moment the timeout
+    warning is emitted, so no arbitrary sleep is needed.
+    """
+    # ``raising=False``: the attribute only exists with the fix applied,
+    # and revert-verification must fail on the assertion, not on setattr.
+    monkeypatch.setattr(quit_module, "CLOSE_TIMEOUT", 0.05, raising=False)
+
+    hang = threading.Event()
+    t = _make_target("h1")
+    t.close.side_effect = lambda *args: hang.wait()
+    prompt = _prompt(HostsGroup([t]))
+    sys_mock = MagicMock()
+    args = Namespace(bootarg=None)
+
+    class _ReleaseOnWarning(logging.Handler):
+        """Unblocks the hung close as soon as the timeout warning fires."""
+
+        def emit(self, record: logging.LogRecord) -> None:
+            hang.set()
+
+    release = _ReleaseOnWarning(level=logging.WARNING)
+    quit_logger = logging.getLogger("mtui.command.quit")
+    quit_logger.addHandler(release)
+    # Backstop so a regression (warning never emitted) cannot hang the
+    # test run forever on the executor-shutdown join.
+    backstop = threading.Timer(5.0, hang.set)
+    backstop.start()
+    try:
+        with caplog.at_level(logging.WARNING, logger="mtui.command.quit"):
+            Quit(args, mock_config, sys_mock, prompt)()
+    finally:
+        quit_logger.removeHandler(release)
+        hang.set()
+        backstop.cancel()
+
+    sys_mock.exit.assert_called_once_with(0)
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "mtui.command.quit" and r.levelno == logging.WARNING
+    ]
+    assert any("h1" in m and "still disconnecting" in m for m in warnings)
+    # No final-verdict "failed to disconnect" warning: the straggler went
+    # on to succeed once released, so it must not also be reported as a
+    # failure.
+    assert not any("h1" in m and "failed to disconnect" in m for m in warnings)
+
+
+def test_quit_straggler_that_later_raises_logs_failure_warning(
+    mock_config, caplog, monkeypatch
+):
+    """A close still running at the timeout that later raises is not lost.
+
+    Before this fix, only the "still disconnecting" timeout warning
+    fired for a straggler; exiting the executor's ``with`` block still
+    joins that worker (``Executor.__exit__`` is ``shutdown(wait=True)``),
+    so quit blocks until the close actually finishes regardless -- but
+    the exception it eventually raised was silently dropped. The
+    straggler's failure reason must surface once the join completes.
+    """
+    monkeypatch.setattr(quit_module, "CLOSE_TIMEOUT", 0.05, raising=False)
+
+    hang = threading.Event()
+
+    def _close(*args):
+        hang.wait()
+        raise RuntimeError("late boom")
+
+    t = _make_target("h1")
+    t.close.side_effect = _close
+    prompt = _prompt(HostsGroup([t]))
+    sys_mock = MagicMock()
+    args = Namespace(bootarg=None)
+
+    class _ReleaseOnWarning(logging.Handler):
+        """Unblocks the hung close as soon as the timeout warning fires."""
+
+        def emit(self, record: logging.LogRecord) -> None:
+            hang.set()
+
+    release = _ReleaseOnWarning(level=logging.WARNING)
+    quit_logger = logging.getLogger("mtui.command.quit")
+    quit_logger.addHandler(release)
+    # Backstop so a regression (warning never emitted) cannot hang the
+    # test run forever on the executor-shutdown join.
+    backstop = threading.Timer(5.0, hang.set)
+    backstop.start()
+    try:
+        with caplog.at_level(logging.WARNING, logger="mtui.command.quit"):
+            Quit(args, mock_config, sys_mock, prompt)()
+    finally:
+        quit_logger.removeHandler(release)
+        hang.set()
+        backstop.cancel()
+
+    sys_mock.exit.assert_called_once_with(0)
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "mtui.command.quit" and r.levelno == logging.WARNING
+    ]
+    assert any("h1" in m and "still disconnecting" in m for m in warnings)
+    assert any(
+        "h1" in m and "failed to disconnect" in m and "late boom" in m for m in warnings
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## What
`quit` submitted per-host disconnects to a thread pool and only called `concurrent.futures.wait(futures, timeout=45)` — exceptions and timed-out closes were never inspected, so mtui exited 0 with every teardown failure invisible (mutation testing proved a close raising `KeyError` on every quit passes the whole suite).

## Fix
After the wait, every failed close is logged with its hostname; stragglers get a *"still disconnecting after N seconds"* notice and — since the executor's context exit joins them anyway (pre-existing behavior, unchanged) — their late failures are also reconciled and logged after the join, so no exception is ever silently dropped. Wording deliberately avoids promising a non-blocking exit.

## Tests
Failing close (warning names the right host), multi-host attribution, straggler-exception reconciliation, and a clean quit emitting no warnings — timeout constant patched for speed; all revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
