### PR TITLE
fix(products): normalize compound SLE15 LTSS-ERICSSON versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the affected host. The exit status is still unaffected, but quitting
   already blocked until every disconnect finished before this fix and
   still does — only the visibility of the outcome changed, not the wait.
+- SLE 15 LTSS-ERICSSON products are now normalized to a dedicated
+  `SLES-LTSS-ERICSSON` product with the whole `-LTSS-ERICSSON` suffix
+  stripped from the version. Previously the generic LTSS check ran first, so
+  a version such as `15-SP4-LTSS-ERICSSON` was misfiled as `SLES-LTSS` with
+  `-ERICSSON` left dangling in the version string, breaking product matching
+  for those updates. A compound `LTSS-ERICSSON` branch now runs before the
+  generic ERICSSON and LTSS checks, matching the SLE 12 convention where
+  every compound LTSS flavor (e.g. `SLES-LTSS-ERICSSON`) is normalized to its
+  own product name with a clean version, instead of leaving any flavor
+  suffix dangling.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/test_reports/products/sle15.py
+++ b/mtui/test_reports/products/sle15.py
@@ -15,13 +15,17 @@ def normalize_sle15(x):
         x[0][0] = "SLES-LTSS-TERADATA"
         x[0][1] = x[0][1].replace("-LTSS-TERADATA", "")
         return x
-    if x[0][0] == "SLE-Product-SLES" and "LTSS" in x[0][1]:
-        x[0][0] = "SLES-LTSS"
-        x[0][1] = x[0][1].replace("-LTSS", "")
+    if x[0][0] == "SLE-Product-SLES" and "LTSS-ERICSSON" in x[0][1]:
+        x[0][0] = "SLES-LTSS-ERICSSON"
+        x[0][1] = x[0][1].replace("-LTSS-ERICSSON", "")
         return x
     if x[0][0] == "SLE-Product-SLES" and "ERICSSON" in x[0][1]:
         x[0][0] = "ERICSSON"
         x[0][1] = x[0][1].replace("-ERICSSON", "")
+        return x
+    if x[0][0] == "SLE-Product-SLES" and "LTSS" in x[0][1]:
+        x[0][0] = "SLES-LTSS"
+        x[0][1] = x[0][1].replace("-LTSS", "")
         return x
     if x[0][0] == "SLE-Product-SLES" and "TERADATA" in x[0][1]:
         x[0][0] = "SLES_TERADATA"

--- a/tests/test_products_sle.py
+++ b/tests/test_products_sle.py
@@ -77,6 +77,11 @@ from mtui.types import Product
         ),
         (
             normalize_sle15,
+            [["SLE-Product-SLES", "15-SP4-LTSS-ERICSSON", "x86_64"]],
+            "SLES-LTSS-ERICSSON",
+        ),
+        (
+            normalize_sle15,
             [["SLE-Product-SLES", "15-LTSS", "x86_64"]],
             "SLES-LTSS",
         ),
@@ -129,6 +134,16 @@ def test_normalize_first_element(fn, before, expected_first) -> None:
     # (mutmut re-enters pytest.main in one interpreter).
     out = fn(deepcopy(before))
     assert out[0][0] == expected_first
+
+
+def test_normalize_sle15_ltss_ericsson_strips_ericsson_from_version() -> None:
+    # A dedicated "LTSS-ERICSSON" compound branch must win over both the
+    # generic ERICSSON and generic LTSS branches, mirroring SLE12's
+    # "SLES-LTSS-ERICSSON" compound branch, and must strip the *whole*
+    # "-LTSS-ERICSSON" suffix so no dangling token is left in the version.
+    out = normalize_sle15([["SLE-Product-SLES", "15-SP4-LTSS-ERICSSON", "x86_64"]])
+    assert out[0][0] == "SLES-LTSS-ERICSSON"
+    assert out[0][1] == "15-SP4"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`normalize_sle15` checked its generic `LTSS` branch before `ERICSSON`, so a compound `...-LTSS-ERICSSON` version normalized to `SLES-LTSS` with `-ERICSSON` dangling in the version string — an unmatchable product.

## Fix
A dedicated `LTSS-ERICSSON` compound branch (mirroring `normalize_sle12` and the existing `LTSS-TERADATA` handling) produces `SLES-LTSS-ERICSSON` and strips the whole suffix, so `15-SP4-LTSS-ERICSSON` → (`SLES-LTSS-ERICSSON`, `15-SP4`); the specific-before-generic reorder stays. The adversarial review caught that the original reorder-only version of this fix still left `-LTSS` dangling — the compound branch and exact name+version assertions came out of that review.

## Tests
Compound, plain-LTSS and plain-ERICSSON cases pinning **both** the normalized name and the cleaned version string. Revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
