### PR TITLE
fix(support): parse unquoted os-release values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   every compound LTSS flavor (e.g. `SLES-LTSS-ERICSSON`) is normalized to its
   own product name with a clean version, instead of leaving any flavor
   suffix dangling.
+- The local system detection now parses `/etc/os-release` files with
+  unquoted values, which the os-release spec allows for values without
+  spaces (e.g. `NAME=Fedora` or `VERSION_ID=15.6`). Such values
+  previously never matched, so the export footer and the `commit` line
+  silently reported an empty distro/version on those systems.
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/support/systemcheck.py
+++ b/mtui/support/systemcheck.py
@@ -14,12 +14,20 @@ def detect_system() -> tuple[str, str, str]:
         A tuple containing the distribution, version ID, and kernel version.
 
     """
-    # A quote class, not alternation: inside [...] the | was a literal
-    # pipe, so single-quoted values (NAME='openSUSE', permitted by the
-    # os-release spec) never matched and the export footer lost its
-    # distro/version.
-    _distro = re.compile(r'NAME=["\'](.*)["\']')
-    _v_id = re.compile(r'VERSION_ID=["\'](.*)["\']')
+    # os-release values may be double-quoted, single-quoted or bare
+    # (NAME=Fedora and VERSION_ID=15.6 are spec-legal). The quoted
+    # alternatives use a greedy ``.*`` with no trailing anchor -- same as
+    # the old mandatory-quote regex -- so quoted parsing (including
+    # spec-legal backslash-escaped quotes embedded in the value) stays
+    # byte-identical to before. Only the bare alternative is anchored
+    # with ``\s*$``: unlike a quote character, there is nothing in the
+    # bare value itself to mark where it ends, so without the anchor a
+    # multi-word or otherwise invalid unquoted value (e.g. a stray
+    # ``NAME=SUSE Linux``, which the spec forbids) would silently
+    # truncate at the first space instead of failing to match.
+    _value = r"""(?:"(.*)"|'(.*)'|([^\s"']*)\s*$)"""
+    _distro = re.compile("NAME=" + _value)
+    _v_id = re.compile("VERSION_ID=" + _value)
     distro = ""
     verid = ""
     kernel = ""
@@ -28,10 +36,10 @@ def detect_system() -> tuple[str, str, str]:
         with open("/etc/os-release", encoding="utf-8") as f:
             for line in f:
                 if d := _distro.match(line):
-                    distro = d.group(1)
+                    distro = d.group(1) or d.group(2) or d.group(3) or ""
                     continue
                 if v := _v_id.match(line):
-                    verid = v.group(1)
+                    verid = v.group(1) or v.group(2) or v.group(3) or ""
                     continue
     except Exception:
         verid = "None"

--- a/tests/test_systemcheck.py
+++ b/tests/test_systemcheck.py
@@ -50,6 +50,83 @@ def test_detect_system_single_quoted_os_release(monkeypatch):
     assert kernel == "6.12.0"
 
 
+def test_detect_system_unquoted_os_release(monkeypatch):
+    """Bare (unquoted) os-release values must parse too.
+
+    The os-release spec allows values without spaces to be written
+    unquoted (Fedora ships NAME=Fedora); the old regexes required
+    quotes, so such files silently yielded an empty distro/version in
+    the export footer and commit line.
+    """
+    mock_os_release = "NAME=Fedora\nVERSION_ID=42"
+    mock_version = "Linux version 6.12.0"
+
+    def mock_open_side_effect(path, mode="r", encoding="utf-8"):
+        if path == "/etc/os-release":
+            return mock_open(read_data=mock_os_release).return_value
+        if path == "/proc/version":
+            return mock_open(read_data=mock_version).return_value
+        raise FileNotFoundError
+
+    monkeypatch.setattr("builtins.open", mock_open_side_effect)
+
+    distro, verid, kernel = systemcheck.detect_system()
+
+    assert distro == "Fedora"
+    assert verid == "42"
+    assert kernel == "6.12.0"
+
+
+def test_detect_system_mixed_quoting_os_release(monkeypatch):
+    """Quoted and bare values may be mixed in one os-release file."""
+    mock_os_release = 'NAME="SLES"\nVERSION_ID=15.6'
+    mock_version = "Linux version 6.4.0"
+
+    def mock_open_side_effect(path, mode="r", encoding="utf-8"):
+        if path == "/etc/os-release":
+            return mock_open(read_data=mock_os_release).return_value
+        if path == "/proc/version":
+            return mock_open(read_data=mock_version).return_value
+        raise FileNotFoundError
+
+    monkeypatch.setattr("builtins.open", mock_open_side_effect)
+
+    distro, verid, kernel = systemcheck.detect_system()
+
+    assert distro == "SLES"
+    assert verid == "15.6"
+    assert kernel == "6.4.0"
+
+
+def test_detect_system_escaped_quotes_in_quoted_value(monkeypatch):
+    """Quoted values with spec-legal backslash-escaped inner quotes must
+    still parse (byte-identical to the pre-unquoted-value-support regex),
+    not silently fail to match.
+
+    A stricter quoted alternative (e.g. ``[^"]*`` instead of a greedy
+    ``.*``) stops at the first embedded quote and then fails to match at
+    all, leaving distro/verid empty -- the same silent-empty-footer bug
+    this branch otherwise fixes.
+    """
+    mock_os_release = 'NAME="SUSE \\"Leap\\""\nVERSION_ID="15.6"'
+    mock_version = "Linux version 6.12.0"
+
+    def mock_open_side_effect(path, mode="r", encoding="utf-8"):
+        if path == "/etc/os-release":
+            return mock_open(read_data=mock_os_release).return_value
+        if path == "/proc/version":
+            return mock_open(read_data=mock_version).return_value
+        raise FileNotFoundError
+
+    monkeypatch.setattr("builtins.open", mock_open_side_effect)
+
+    distro, verid, kernel = systemcheck.detect_system()
+
+    assert distro == 'SUSE \\"Leap\\"'
+    assert verid == "15.6"
+    assert kernel == "6.12.0"
+
+
 def test_system_info_default_prefix():
     """The export footer keeps the ``## export`` prefix."""
     s = systemcheck.system_info("openSUSE Leap", "16.0", "6.12.0", "mpluskal")


### PR DESCRIPTION
## What
`detect_system` parsed `/etc/os-release` with regexes that require quoted values. Spec-legal unquoted values (`NAME=Fedora`, `VERSION_ID=15.6`) silently never matched, so distro/version reported empty in the export footer and commit line.

## Fix
The patterns accept quoted or unquoted values. The quoted alternative keeps the old greedy semantics **byte-identical** (including values with embedded/escaped quotes — the review caught that a naive `[^"]*` alternation regressed those); the unquoted alternative captures up to whitespace.

## Tests
Unquoted, quoted (unchanged behavior), mixed, and escaped-quote fixtures. Revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
