### PR TITLE
fix(commands): correct user-facing help and message strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   spaces (e.g. `NAME=Fedora` or `VERSION_ID=15.6`). Such values
   previously never matched, so the export footer and the `commit` line
   silently reported an empty distro/version on those systems.
+- Corrected user-facing typos: `uninstall --help` described its positional as
+  "package to install" (copy-paste from `install`) and now says "package to
+  uninstall"; `terms` printed "available terminals scripts:" / logged "Aviable
+  term scripts" and now says "available terminal scripts:" / "Available term
+  scripts"; a failed openQA connection logged "Cannont connect to openQA" and
+  now logs "Cannot connect to openQA".
 - `export` in the AUTO and KERNEL workflows no longer fails with
   "No refhosts defined" when no reference hosts are connected. These
   workflows build the template from openQA/dashboard data and never touch a

--- a/mtui/commands/terms.py
+++ b/mtui/commands/terms.py
@@ -43,9 +43,11 @@ class Terms(Command):
                     logger.exception("running %s failed", filename)
             else:
                 logger.error("Term script not found")
-                logger.info("Aviable term scripts: %s", " ".join(self.config.termnames))
+                logger.info(
+                    "Available term scripts: %s", " ".join(self.config.termnames)
+                )
         else:
-            self.println("available terminals scripts:")
+            self.println("available terminal scripts:")
             self.println(" ".join(self.config.termnames))
 
     @staticmethod

--- a/mtui/commands/zypper.py
+++ b/mtui/commands/zypper.py
@@ -66,7 +66,7 @@ class Uninstall(Command):
     @classmethod
     def _add_arguments(cls, parser: ArgumentParser) -> None:
         """Adds arguments to the command's argument parser."""
-        parser.add_argument("package", nargs="+", type=str, help="package to install")
+        parser.add_argument("package", nargs="+", type=str, help="package to uninstall")
         cls._add_hosts_arg(parser)
         cls._add_template_arg(parser)
 

--- a/mtui/data_sources/openqa/base.py
+++ b/mtui/data_sources/openqa/base.py
@@ -72,7 +72,7 @@ class OpenQA(ABC):
             logger.debug("Openqa returned code: %s", e.args[2])
             return None
         except openqa_client.exceptions.ConnectionError as e:
-            logger.error("Cannont connect to openQA - %s", self.host)
+            logger.error("Cannot connect to openQA - %s", self.host)
             logger.debug("openqa_client returned: %s", e)
             return None
         except requests.exceptions.RequestException as e:

--- a/tests/test_cmd_terms.py
+++ b/tests/test_cmd_terms.py
@@ -34,7 +34,7 @@ def test_terms_no_termname_lists_available(mock_config):
     Terms(args, mock_config, sys_mock, prompt)()
 
     written = "".join(c.args[0] for c in sys_mock.stdout.write.call_args_list)
-    assert "available terminals scripts:" in written
+    assert "available terminal scripts:" in written
     assert "xterm gnome" in written
 
 
@@ -42,8 +42,9 @@ def test_terms_missing_termname_logs_error(mock_config, caplog):
     prompt = _prompt(HostsGroup([_target("h1")]))
     mock_config.termnames = ["xterm"]
     args = Namespace(termname="missing", hosts=None)
-    caplog.set_level(logging.ERROR, logger="mtui.command.terms")
+    caplog.set_level(logging.INFO, logger="mtui.command.terms")
 
     Terms(args, mock_config, MagicMock(), prompt)()
 
     assert any("Term script not found" in r.message for r in caplog.records)
+    assert any("Available term scripts: xterm" in r.message for r in caplog.records)

--- a/tests/test_cmd_zypper.py
+++ b/tests/test_cmd_zypper.py
@@ -1,12 +1,13 @@
-"""Tests for the `install` (zypper) command."""
+"""Tests for the `install` and `uninstall` (zypper) commands."""
 
 from __future__ import annotations
 
 import logging
+import sys
 from argparse import Namespace
 from unittest.mock import MagicMock
 
-from mtui.commands.zypper import Install
+from mtui.commands.zypper import Install, Uninstall
 from mtui.hosts.target.hostgroup import HostsGroup
 
 
@@ -49,3 +50,18 @@ def test_install_swallows_exception(mock_config, caplog):
     Install(args, mock_config, MagicMock(), prompt)()
 
     assert any("failed to install" in r.message for r in caplog.records)
+
+
+def test_uninstall_help_describes_package_to_uninstall():
+    """``uninstall --help`` must not carry Install's copy-pasted help text.
+
+    Asserted directly on the parser action's ``help`` attribute rather than
+    the rendered help text: argparse's ``HelpFormatter`` wraps to the
+    terminal width (honoring a ``COLUMNS`` env var ahead of the (80, 24)
+    fallback), so a narrow width could otherwise wrap "package to uninstall"
+    across lines and make a substring check fail on correct code.
+    """
+    parser = Uninstall.argparser(sys)
+    package_action = next(a for a in parser._actions if a.dest == "package")
+
+    assert package_action.help == "package to uninstall"

--- a/tests/test_openqa_connector.py
+++ b/tests/test_openqa_connector.py
@@ -111,7 +111,7 @@ class TestGetJobsErrorHandling:
         )
         with caplog.at_level("ERROR", logger="mtui.connector.openqa"):
             assert auto_oqa._get_jobs() is None
-        assert any("openQA" in r.message for r in caplog.records)
+        assert any("Cannot connect to openQA" in r.message for r in caplog.records)
 
     def test_requests_exception_logs_and_returns_none(self, auto_oqa, caplog):
         """A requests failure openqa_client does not wrap is caught too.


### PR DESCRIPTION
## What
User-visible string fixes found while triaging mutation survivors:

- `uninstall --help` described its positional as **"package to install"** (copy-paste from Install) → "package to uninstall".
- `terms`: "Aviable term scripts" → "Available term scripts"; "available terminals scripts" → "available terminal scripts".
- openQA connector: "Cannont connect to openQA" → "Cannot connect to openQA".

## Tests
Existing assertions updated; the uninstall help text is pinned via the argparse action's `.help` attribute (terminal-width-independent — review catch). Revert-verified.

Part of the mutation-testing campaign; adversarially reviewed (3 lenses + refute-by-default verification).
