### PR TITLE
test(export): pin export idempotency and template-mutation behavior

### DIFF
--- a/tests/test_export_base_pins.py
+++ b/tests/test_export_base_pins.py
@@ -1,0 +1,449 @@
+"""Mutation-killing pins for ``mtui.update_workflow.export.base``.
+
+A full mutmut run left survivors in code the export suite executes but
+never asserts on. These tests pin the exact template layout produced by
+``BaseExport.inject_openqa``, ``installlogs_lines``, ``_writer``,
+``add_sysinfo`` and ``dedup_lines`` (full-list equality instead of the
+membership checks the older tests use), so structural mutants -- index
+arithmetic, marker text, blank-line framing, prompt handling -- no
+longer survive.
+
+All fixtures are local; no network, no chdir, everything under
+``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mtui.support.systemcheck import system_info
+from mtui.update_workflow.export.base import BaseExport
+
+RRID = "SUSE:Maintenance:12358:199773"
+FOOTER = "## export MTUI:12.0, paramiko 3.5 on SLES-15 (kernel: 6.4) by tester\n"
+END_MARKER = "End of openQA Incidents results\n"
+SCCR = "source code change review:\n"
+LINKS = "Links for update logs:\n"
+
+
+class _Probe(BaseExport):
+    """Concrete BaseExport so the shared helpers can be driven directly."""
+
+    def get_logs(self, *args, **kwds) -> list[Path]:
+        return []
+
+    def run(self, *args, **kwds):
+        return self.template
+
+
+def _config(tmp_path: Path | None = None) -> MagicMock:
+    cfg = MagicMock()
+    if tmp_path is not None:
+        cfg.template_dir = tmp_path
+    cfg.install_logs = "install_logs"
+    cfg.reports_url = "https://reports"
+    cfg.distro = "SLES"
+    cfg.distro_ver = "15"
+    cfg.distro_kernel = "5.14"
+    cfg.session_user = "tester"
+    return cfg
+
+
+def _probe(
+    template: list[str],
+    *,
+    tmp_path: Path | None = None,
+    auto_pp: list[str] | None = None,
+    force: bool = False,
+    interactive: bool = False,
+) -> _Probe:
+    openqa = MagicMock()
+    if auto_pp is not None:
+        openqa.auto.pp = auto_pp
+    return _Probe(
+        _config(tmp_path),
+        openqa,
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=force,
+        rrid=RRID,
+        interactive=interactive,
+    )
+
+
+def _link(name: str) -> str:
+    return f"https://reports/{RRID}/install_logs/{name}\n"
+
+
+# ---------------------------------------------------------------------------
+# inject_openqa: golden-list pins (position, marker text, legacy titles,
+# missing-end-marker fallback)
+# ---------------------------------------------------------------------------
+
+_PP = ["Results from openQA jobs:\n", "new result\n"]
+
+# What one injection into a section-less template body looks like: the pp
+# lines land immediately before the blank line preceding the
+# 'source code change review:' header, then the end-marker trio follows.
+_INJECTED = [
+    "intro\n",
+    "Results from openQA jobs:\n",
+    "new result\n",
+    "\n",
+    END_MARKER,
+    "\n",
+    "\n",
+    SCCR,
+]
+
+
+def test_inject_openqa_replaces_current_section_exact_layout() -> None:
+    """Old section (title..end marker) removed, new block at exact position."""
+    exporter = _probe(
+        [
+            "intro\n",
+            "Results from openQA jobs:\n",
+            "old result\n",
+            END_MARKER,
+            "\n",
+            SCCR,
+        ],
+        auto_pp=_PP,
+    )
+
+    exporter.inject_openqa()
+
+    assert list(exporter.template) == _INJECTED
+
+
+def test_inject_openqa_second_run_reuses_own_end_marker() -> None:
+    """The next export's removal finds the marker the previous one wrote.
+
+    The steady state is not a perfect no-op: each cycle leaves one extra
+    blank line behind (removal keeps the post-marker blank while the
+    insertion adds a fresh framing pair). Pinning the exact second-run
+    list keeps the marker text and the removal window honest.
+    """
+    exporter = _probe(
+        [
+            "intro\n",
+            "Results from openQA jobs:\n",
+            "old result\n",
+            END_MARKER,
+            "\n",
+            SCCR,
+        ],
+        auto_pp=_PP,
+    )
+
+    exporter.inject_openqa()
+    exporter.inject_openqa()
+
+    assert list(exporter.template) == [
+        "intro\n",
+        "\n",
+        "Results from openQA jobs:\n",
+        "new result\n",
+        "\n",
+        END_MARKER,
+        "\n",
+        "\n",
+        SCCR,
+    ]
+
+
+def test_inject_openqa_removes_legacy_incidents_openqa_title() -> None:
+    """'Results from incidents openQA jobs:' sections are still replaced."""
+    exporter = _probe(
+        [
+            "intro\n",
+            "Results from incidents openQA jobs:\n",
+            "old result\n",
+            END_MARKER,
+            "\n",
+            SCCR,
+        ],
+        auto_pp=_PP,
+    )
+
+    exporter.inject_openqa()
+
+    assert list(exporter.template) == _INJECTED
+
+
+def test_inject_openqa_removes_legacy_openqa_incidents_title() -> None:
+    """'Results from openQA incidents jobs:' sections are still replaced."""
+    exporter = _probe(
+        [
+            "intro\n",
+            "Results from openQA incidents jobs:\n",
+            "old result\n",
+            END_MARKER,
+            "\n",
+            SCCR,
+        ],
+        auto_pp=_PP,
+    )
+
+    exporter.inject_openqa()
+
+    assert list(exporter.template) == _INJECTED
+
+
+def test_inject_openqa_missing_end_marker_bounds_at_review_header() -> None:
+    """Without the end marker the removal stops just above 'source code...'."""
+    exporter = _probe(
+        [
+            "intro\n",
+            "Results from openQA jobs:\n",
+            "old result\n",
+            "\n",
+            SCCR,
+        ],
+        auto_pp=_PP,
+    )
+
+    exporter.inject_openqa()
+
+    assert list(exporter.template) == _INJECTED
+
+
+# ---------------------------------------------------------------------------
+# installlogs_lines: exact-layout pins for the header-reuse walk, the
+# footer fallback, the hand-trimmed guard and the HAS_UNTRACKED offset
+# ---------------------------------------------------------------------------
+
+
+def test_installlogs_appends_new_link_into_existing_section_exact() -> None:
+    exporter = _probe(["body\n", "\n", LINKS, "\n", _link("old.log"), "\n", FOOTER])
+
+    exporter.installlogs_lines(["old.log", "new.log"])
+
+    assert list(exporter.template) == [
+        "body\n",
+        "\n",
+        LINKS,
+        "\n",
+        _link("old.log"),
+        _link("new.log"),
+        "\n",
+        FOOTER,
+    ]
+
+
+def test_installlogs_twice_is_idempotent_exact() -> None:
+    exporter = _probe(["body\n", FOOTER])
+
+    exporter.installlogs_lines(["a.log"])
+    first = list(exporter.template)
+    exporter.installlogs_lines(["a.log"])
+
+    assert first == [
+        "body\n",
+        "\n",
+        LINKS,
+        "\n",
+        _link("a.log"),
+        "\n",
+        FOOTER,
+    ]
+    assert list(exporter.template) == first
+
+
+def test_installlogs_converges_damaged_stacked_headers_exact() -> None:
+    exporter = _probe(
+        [
+            "body\n",
+            "\n",
+            LINKS,
+            "\n",
+            _link("old.log"),
+            "\n",
+            "\n",
+            LINKS,
+            "\n",
+            "\n",
+            LINKS,
+            "\n",
+            FOOTER,
+        ]
+    )
+
+    exporter.installlogs_lines(["old.log"])
+
+    assert list(exporter.template) == [
+        "body\n",
+        "\n",
+        LINKS,
+        "\n",
+        _link("old.log"),
+        FOOTER,
+    ]
+
+
+def test_installlogs_new_section_lands_before_trailing_footer() -> None:
+    """The footer check reads the LAST line, not line 1 of the template."""
+    exporter = _probe(["body1\n", "body2\n", "body3\n", FOOTER])
+
+    exporter.installlogs_lines(["a.log"])
+
+    assert list(exporter.template) == [
+        "body1\n",
+        "body2\n",
+        "body3\n",
+        "\n",
+        LINKS,
+        "\n",
+        _link("a.log"),
+        "\n",
+        FOOTER,
+    ]
+
+
+def test_installlogs_header_directly_followed_by_link_untouched() -> None:
+    """No spurious blank is inserted when links follow the header directly."""
+    template = ["body\n", LINKS, _link("old.log"), "\n", FOOTER]
+    exporter = _probe(list(template))
+
+    exporter.installlogs_lines(["old.log"])
+
+    assert list(exporter.template) == template
+
+
+def test_installlogs_hand_trimmed_header_gets_canonical_blank_exact() -> None:
+    """Header directly followed by the footer: restored blank, link inside."""
+    exporter = _probe(["body\n", LINKS, FOOTER])
+
+    exporter.installlogs_lines(["a.log"])
+
+    assert list(exporter.template) == [
+        "body\n",
+        LINKS,
+        "\n",
+        _link("a.log"),
+        "\n",
+        FOOTER,
+    ]
+
+
+def test_installlogs_dedup_window_starts_right_after_untracked_marker() -> None:
+    """A link on the line directly after HAS_UNTRACKED suppresses re-adding."""
+    template = [
+        "HAS_UNTRACKED_CHANGES: NO\n",
+        _link("x.log"),
+        "\n",
+        LINKS,
+        "\n",
+        FOOTER,
+    ]
+    exporter = _probe(list(template))
+
+    exporter.installlogs_lines(["x.log"])
+
+    assert list(exporter.template) == template
+
+
+# ---------------------------------------------------------------------------
+# _writer: the exists-and-not-force paths (same content, prompt accepted,
+# prompt declined, force, OSError)
+# ---------------------------------------------------------------------------
+
+
+def test_writer_same_content_returns_without_prompting(tmp_path: Path) -> None:
+    fn = tmp_path / "h1.log"
+    fn.write_text("a\nb")
+    exporter = _probe([""], tmp_path=tmp_path)
+
+    with patch("mtui.update_workflow.export.base.prompt_user") as prompt:
+        exporter._writer(fn, ["a", "b"])
+
+    prompt.assert_not_called()
+    assert fn.read_text() == "a\nb"
+    assert list(tmp_path.iterdir()) == [fn]  # no timestamp sidecar
+
+
+def test_writer_force_overwrites_without_prompting(tmp_path: Path) -> None:
+    fn = tmp_path / "h1.log"
+    fn.write_text("old")
+    exporter = _probe([""], tmp_path=tmp_path, force=True)
+
+    with patch("mtui.update_workflow.export.base.prompt_user") as prompt:
+        exporter._writer(fn, ["new"])
+
+    prompt.assert_not_called()
+    assert fn.read_text() == "new"
+
+
+def test_writer_prompt_accepted_overwrites(tmp_path: Path) -> None:
+    fn = tmp_path / "h1.log"
+    fn.write_text("old")
+    exporter = _probe([""], tmp_path=tmp_path, interactive=True)
+
+    with patch(
+        "mtui.update_workflow.export.base.prompt_user", return_value=True
+    ) as prompt:
+        exporter._writer(fn, ["new"])
+
+    assert fn.read_text() == "new"
+    # The accepted answers and the interactive flag are part of the
+    # behavioral contract (which input overwrites a tester's file).
+    args = prompt.call_args.args
+    assert args[1] == ["y", "Y", "yes", "Yes", "YES"]
+    assert args[2] is True
+
+
+def test_writer_prompt_declined_writes_timestamp_sidecar(tmp_path: Path) -> None:
+    fn = tmp_path / "h1.log"
+    fn.write_text("old")
+    exporter = _probe([""], tmp_path=tmp_path)
+
+    with (
+        patch("mtui.update_workflow.export.base.prompt_user", return_value=False),
+        patch(
+            "mtui.update_workflow.export.base.timestamp",
+            return_value="1111111111",
+        ),
+    ):
+        exporter._writer(fn, ["new"])
+
+    assert fn.read_text() == "old"  # original untouched
+    sidecar = tmp_path / "h1.1111111111"
+    assert sidecar.read_text() == "new"
+
+
+def test_writer_oserror_is_logged_not_raised(tmp_path: Path, caplog) -> None:
+    fn = tmp_path / "missing-dir" / "x.log"
+    exporter = _probe([""], tmp_path=tmp_path)
+
+    with caplog.at_level("ERROR", logger="mtui.export.base"):
+        exporter._writer(fn, ["data"])  # must not raise
+
+    assert any("Failed to write" in r.message for r in caplog.records)
+    assert not fn.exists()
+
+
+# ---------------------------------------------------------------------------
+# add_sysinfo: the exact footer and its four config-derived arguments
+# ---------------------------------------------------------------------------
+
+
+def test_add_sysinfo_appends_exact_footer() -> None:
+    exporter = _probe(["a\n", "b\n"])
+    expected = system_info("SLES", "15", "5.14", "tester")
+
+    exporter.add_sysinfo()
+
+    assert list(exporter.template) == ["a\n", "b\n", expected]
+
+
+# ---------------------------------------------------------------------------
+# dedup_lines: adjacent duplicate text lines collapse, blank runs survive
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_lines_collapses_text_duplicates_keeps_blank_runs() -> None:
+    exporter = _probe(["a\n", "a\n", "\n", "\n", "b\n", "b\n", "b\n", "\n"])
+
+    exporter.dedup_lines()
+
+    assert list(exporter.template) == ["a\n", "\n", "\n", "b\n", "\n"]

--- a/tests/test_export_downloader_pins.py
+++ b/tests/test_export_downloader_pins.py
@@ -1,0 +1,141 @@
+"""Mutation-killing pins for ``mtui.update_workflow.export.downloader``.
+
+The pre-existing tests assert only that a filename fragment appears
+somewhere in the dispatched URL, leaving the URL construction, the local
+filename format, and the errormode/verify forwarding unobserved. These
+tests pin the exact values, plus the multi-host accumulation and the
+unknown-job fallback in ``download_logs``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from mtui.support.messages import ResultsMissingError
+from mtui.update_workflow.export.downloader import (
+    _installlog,
+    _resultlog,
+    download_logs,
+    downloader,
+)
+
+# ---------------------------------------------------------------------------
+# _resultlog / _installlog: exact URL, local path, errormode and verify
+# ---------------------------------------------------------------------------
+
+
+def test_resultlog_builds_exact_url_and_local_path() -> None:
+    test = {"test_id": "1", "arch": "x", "name": "ltp"}
+    with patch("mtui.update_workflow.export.downloader._subdl") as subdl:
+        _resultlog("http://h", test, "/res", None, "tolerant")
+
+    subdl.assert_called_once_with(
+        "http://h/tests/1/file/result_array.json",
+        "/res/h-x-ltp.json",
+        test,
+        "tolerant",
+        True,
+    )
+
+
+def test_resultlog_forwards_verify_policy() -> None:
+    test = {"test_id": "1", "arch": "x", "name": "ltp"}
+    with patch("mtui.update_workflow.export.downloader._subdl") as subdl:
+        _resultlog("http://h", test, "/res", None, "full", verify=False)
+
+    assert subdl.call_args.args[3] == "full"
+    assert subdl.call_args.args[4] is False
+
+
+def test_installlog_builds_exact_url_and_local_path() -> None:
+    test = {"test_id": "1", "arch": "x", "name": "install_kernel"}
+    with patch("mtui.update_workflow.export.downloader._subdl") as subdl:
+        _installlog("http://h", test, None, "/installs", "tolerant")
+
+    subdl.assert_called_once_with(
+        "http://h/tests/1/file/update_kernel-zypper.log",
+        "/installs/h-zypper-x.log",
+        test,
+        "tolerant",
+        True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# download_logs: ltp jobs route end-to-end through _resultlog
+# ---------------------------------------------------------------------------
+
+
+def _oqa_host(host: str, *results: tuple[str, str, str]) -> MagicMock:
+    mock = MagicMock()
+    mock.host = host
+    mock.results = []
+    for name, test_id, arch in results:
+        result = MagicMock()
+        result.name = name
+        result.test_id = test_id
+        result.arch = arch
+        mock.results.append(result)
+    return mock
+
+
+def test_download_logs_ltp_full_mode_raises_results_missing() -> None:
+    """An 'ltp' job dispatches through the real _resultlog; a failed
+    download under errormode='full' surfaces as ResultsMissingError."""
+    host = _oqa_host("http://h", ("ltp_syscalls", "7", "x86_64"))
+    with (
+        patch(
+            "mtui.update_workflow.export.downloader.get_bytes",
+            side_effect=requests.exceptions.HTTPError("404"),
+        ) as get_bytes,
+        pytest.raises(ResultsMissingError),
+    ):
+        download_logs([host], "/res", "/inst", "full")
+
+    get_bytes.assert_called_once_with(
+        "http://h/tests/7/file/result_array.json", verify=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# download_logs: results from every host are accumulated
+# ---------------------------------------------------------------------------
+
+
+def test_download_logs_downloads_results_of_all_hosts() -> None:
+    h1 = _oqa_host("http://h1", ("install_x", "1", "a1"))
+    h2 = _oqa_host("http://h2", ("install_x", "2", "a2"))
+    install = MagicMock()
+
+    with patch.dict(downloader, {"install": install}):
+        download_logs([h1, h2], "/res", "/inst", "tolerant")
+
+    assert install.call_count == 2
+    assert {c.args[0] for c in install.call_args_list} == {
+        "http://h1",
+        "http://h2",
+    }
+
+
+# ---------------------------------------------------------------------------
+# download_logs: unknown job names fall back to the quiet _emptylog
+# ---------------------------------------------------------------------------
+
+
+def test_download_logs_unknown_job_name_is_skipped_via_emptylog() -> None:
+    host = _oqa_host("http://h", ("boot_x", "9", "z"))
+
+    with patch("mtui.update_workflow.export.downloader._emptylog") as emptylog:
+        download_logs([host], "/res", "/inst", "tolerant")
+
+    emptylog.assert_called_once_with(
+        "http://h",
+        {"name": "boot_x", "test_id": "9", "arch": "z"},
+        "/res",
+        "/inst",
+        "tolerant",
+        True,
+    )

--- a/tests/test_export_workflows_pins.py
+++ b/tests/test_export_workflows_pins.py
@@ -1,0 +1,727 @@
+"""Mutation-killing pins for the manual/auto/kernel export workflows.
+
+Survivors from a full mutmut run showed the host-section creation in
+``ManualExport._fillup_hosts_to_template``, the section replacement in
+``AutoExport.install_results``, the regression-section rewrite in
+``KernelExport.kernel_results`` and the ``get_logs`` call contracts were
+executed by the suite but never asserted on. These tests pin the exact
+template layouts and call arguments those paths produce today.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import ANY, MagicMock, patch
+
+from mtui.support.http import HTTP_TIMEOUT
+from mtui.types import URLs
+from mtui.update_workflow.export.auto import AutoExport
+from mtui.update_workflow.export.kernel import KernelExport
+from mtui.update_workflow.export.manual import ManualExport
+
+RRID = "SUSE:Maintenance:12358:199773"
+FOOTER = "## export MTUI:12.0, paramiko 3.5 on SLES-15 (kernel: 6.4) by tester\n"
+
+
+def _config(tmp_path: Path | None = None) -> MagicMock:
+    cfg = MagicMock()
+    if tmp_path is not None:
+        cfg.template_dir = tmp_path
+    cfg.install_logs = "install_logs"
+    cfg.reports_url = "https://reports"
+    cfg.distro = "SLES"
+    cfg.distro_ver = "15"
+    cfg.distro_kernel = "5.14"
+    cfg.session_user = "tester"
+    cfg.ssl_verify = True
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# ManualExport._fillup_hosts_to_template
+# ---------------------------------------------------------------------------
+
+
+def _pkg(name: str, before, after) -> MagicMock:
+    p = MagicMock()
+    p.name = name
+    p.before = before
+    p.after = after
+    return p
+
+
+def _host(hostname: str, system: str, packages: dict) -> MagicMock:
+    h = MagicMock()
+    h.hostname = hostname
+    h.system = system
+    h.packages = packages
+    return h
+
+
+def _manual(template: list[str], results: list) -> ManualExport:
+    return ManualExport(
+        _config(),
+        MagicMock(),
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+        results=results,
+    )
+
+
+def test_fillup_creates_full_host_section_under_product_arch_anchor() -> None:
+    """Missing host section: the whole block is created two lines below the
+    'Test results by product-arch:' anchor, package versions included."""
+    exporter = _manual(
+        [
+            "Test results by product-arch:\n",
+            "#############################\n",
+            "\n",
+            "tail\n",
+        ],
+        [_host("h1", "system1", {"bash": _pkg("bash", 2, 3)})],
+    )
+
+    exporter._fillup_hosts_to_template()
+
+    assert list(exporter.template) == [
+        "Test results by product-arch:\n",
+        "#############################\n",
+        "\n",
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-2\n",
+        "after:\n",
+        "\tbash-3\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+        "\n",
+        "\n",
+        "tail\n",
+    ]
+
+
+def test_fillup_creates_host_section_under_deprecated_platform_anchor() -> None:
+    """Older templates use 'Test results by test platform:' as the anchor."""
+    exporter = _manual(
+        [
+            "Test results by test platform:\n",
+            "====\n",
+            "\n",
+            "tail\n",
+        ],
+        [_host("h1", "system1", {"bash": _pkg("bash", 2, 3)})],
+    )
+
+    exporter._fillup_hosts_to_template()
+
+    assert list(exporter.template) == [
+        "Test results by test platform:\n",
+        "====\n",
+        "\n",
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-2\n",
+        "after:\n",
+        "\tbash-3\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+        "\n",
+        "\n",
+        "tail\n",
+    ]
+
+
+def test_fillup_substitutes_hostname_into_placeholder_host_line() -> None:
+    """A 'reference host: ?' section is claimed for the session host."""
+    exporter = _manual(
+        [
+            "system1 (reference host: ?)\n",
+            "--------------\n",
+            "before:\n",
+            "after:\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+        ],
+        [_host("h1", "system1", {"bash": _pkg("bash", 2, 3)})],
+    )
+
+    exporter._fillup_hosts_to_template()
+
+    assert list(exporter.template) == [
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-2\n",
+        "after:\n",
+        "\tbash-3\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+
+
+def test_fillup_overwrites_stale_version_and_marks_missing_package() -> None:
+    """An already-exported version line is overwritten in place; a package
+    with no 'before' version gets the 'is not installed' line."""
+    exporter = _manual(
+        [
+            "system1 (reference host: h1)\n",
+            "--------------\n",
+            "before:\n",
+            "\tbash-1\n",
+            "after:\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+        ],
+        [
+            _host(
+                "h1",
+                "system1",
+                {"bash": _pkg("bash", 2, 3), "zsh": _pkg("zsh", None, 5)},
+            )
+        ],
+    )
+
+    exporter._fillup_hosts_to_template()
+
+    assert list(exporter.template) == [
+        "system1 (reference host: h1)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-2\n",
+        "\tpackage zsh is not installed\n",
+        "after:\n",
+        "\tbash-3\n",
+        "\tzsh-5\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+
+
+def test_fillup_fills_both_hosts_and_flips_both_verdicts() -> None:
+    """Two session hosts: each section gets its own versions and verdict."""
+    exporter = _manual(
+        [
+            "sysA (reference host: hA)\n",
+            "--------------\n",
+            "before:\n",
+            "after:\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+            "\n",
+            "sysB (reference host: hB)\n",
+            "--------------\n",
+            "before:\n",
+            "after:\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+        ],
+        [
+            _host("hA", "sysA", {"bash": _pkg("bash", 1, 2)}),
+            _host("hB", "sysB", {"bash": _pkg("bash", 2, 2)}),
+        ],
+    )
+
+    exporter._fillup_hosts_to_template()
+
+    assert list(exporter.template) == [
+        "sysA (reference host: hA)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-1\n",
+        "after:\n",
+        "\tbash-2\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+        "\n",
+        "sysB (reference host: hB)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-2\n",
+        "after:\n",
+        "\tbash-2\n",
+        "\n",
+        "=> FAILED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+
+
+def test_fillup_missing_anchor_still_fills_later_hosts(caplog) -> None:
+    """No anchor for the first host aborts section creation (break, not
+    return): the second host's pre-existing section is still filled."""
+    exporter = _manual(
+        [
+            "sysB (reference host: hB)\n",
+            "--------------\n",
+            "before:\n",
+            "after:\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+        ],
+        [
+            _host("hA", "sysA", {"bash": _pkg("bash", 1, 2)}),
+            _host("hB", "sysB", {"bash": _pkg("bash", 1, 2)}),
+        ],
+    )
+
+    with caplog.at_level("ERROR", logger="mtui.export.manual"):
+        exporter._fillup_hosts_to_template()
+
+    assert any("update results section not found" in r.message for r in caplog.records)
+    assert list(exporter.template) == [
+        "sysB (reference host: hB)\n",
+        "--------------\n",
+        "before:\n",
+        "\tbash-1\n",
+        "after:\n",
+        "\tbash-2\n",
+        "\n",
+        "=> PASSED\n",
+        "\n",
+        "comment: (none)\n",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# ManualExport.get_logs: the written file path equals the linked name
+# ---------------------------------------------------------------------------
+
+
+def test_manual_get_logs_writes_exact_path_and_filtered_content(
+    tmp_path: Path,
+) -> None:
+    host = MagicMock()
+    host.hostname = "h1"
+    zypper = MagicMock()
+    zypper.command = "zypper in bash"
+    zypper.stdout = "ok"
+    tu = MagicMock()
+    tu.command = "transactional-update pkg install foo"
+    tu.stdout = "applied"
+    noise = MagicMock()
+    noise.command = "ls"
+    noise.stdout = "junk"
+    host.hostlog = [zypper, noise, tu]
+
+    exporter = ManualExport(
+        _config(tmp_path),
+        MagicMock(),
+        [""],  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+        results=[host],
+    )
+
+    with patch.object(exporter, "_writer") as writer:
+        out = exporter.get_logs(["h1"])
+
+    assert out == ["h1.log"]
+    writer.assert_called_once_with(
+        tmp_path / RRID / "install_logs" / "h1.log",
+        [
+            "log from h1:\n",
+            "# zypper in bash\nok\n",
+            "# transactional-update pkg install foo\napplied\n",
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AutoExport.install_results: exact section replacement and creation
+# ---------------------------------------------------------------------------
+
+_URL = URLs(
+    "sle",
+    "x86_64",
+    "15-SP7",
+    "https://openqa.example.com/tests/1001/file/install-logs.tar",
+    "passed",
+)
+_STATUS = "Installation tests done in openQA with following results: PASSED\n"
+_JOB = "sle_15-SP7_x86_64 => PASSED: https://openqa.example.com/tests/1001\n"
+
+
+def _auto(template: list[str], results: list, force: bool = False) -> AutoExport:
+    openqa = MagicMock()
+    openqa.auto.results = results
+    return AutoExport(
+        _config(),
+        openqa,
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=force,
+        rrid=RRID,
+        interactive=False,
+    )
+
+
+def test_auto_install_results_replaces_section_exact_layout() -> None:
+    """The stale section body is replaced in place: exactly one banner, one
+    'Install tests:' header, and the fresh status/job lines."""
+    exporter = _auto(
+        [
+            "intro\n",
+            "##############\n",
+            "Install tests:\n",
+            "##############\n",
+            "\n",
+            "old status\n",
+            "\n",
+            "old job line\n",
+            "\n",
+            "Links for update logs:\n",
+            "\n",
+            FOOTER,
+        ],
+        [_URL],
+    )
+
+    exporter.install_results()
+
+    assert exporter.template.count("Install tests:\n") == 1
+    assert list(exporter.template) == [
+        "intro\n",
+        "##############\n",
+        "Install tests:\n",
+        "##############\n",
+        "\n",
+        _STATUS,
+        "\n",
+        _JOB,
+        "\n",
+        "\n",
+        "Links for update logs:\n",
+        "\n",
+        FOOTER,
+    ]
+
+
+def test_auto_install_results_creates_section_before_footer() -> None:
+    exporter = _auto(["intro\n", FOOTER], [_URL])
+
+    exporter.install_results()
+
+    assert list(exporter.template) == [
+        "intro\n",
+        "##############\n",
+        "Install tests:\n",
+        "##############\n",
+        "\n",
+        _STATUS,
+        "\n",
+        _JOB,
+        "\n",
+        FOOTER,
+    ]
+
+
+def test_auto_install_results_creates_section_at_eof_without_footer() -> None:
+    exporter = _auto(["intro\n"], [_URL])
+
+    exporter.install_results()
+
+    assert list(exporter.template) == [
+        "intro\n",
+        "##############\n",
+        "Install tests:\n",
+        "##############\n",
+        "\n",
+        _STATUS,
+        "\n",
+        _JOB,
+        "\n",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AutoExport.run: the install_logs_current guard around get_logs
+# ---------------------------------------------------------------------------
+
+# NOTE: the guard tests list membership, not substring containment, so only
+# a template LINE that equals the sentinel exactly (no status suffix, no
+# newline) marks the logs as current. Real status lines carry a suffix and
+# never match -- pinned below as current behavior.
+_SENTINEL = "Installation tests done in openQA with following results:"
+
+
+def _run_auto(template: list[str], force: bool) -> tuple[MagicMock, MagicMock]:
+    exporter = _auto(template, [], force=force)
+    with (
+        patch.object(exporter, "install_results"),
+        patch.object(exporter, "inject_openqa"),
+        patch.object(exporter, "inject_overview"),
+        patch.object(exporter, "get_logs", return_value=[]) as get_logs,
+        patch.object(exporter, "installlogs_lines") as installlogs,
+        patch.object(exporter, "add_sysinfo"),
+        patch.object(exporter, "dedup_lines"),
+    ):
+        exporter.run()
+    return get_logs, installlogs
+
+
+def test_auto_run_skips_log_download_when_results_line_current() -> None:
+    get_logs, installlogs = _run_auto(["intro\n", _SENTINEL, "tail\n"], force=False)
+
+    get_logs.assert_not_called()
+    installlogs.assert_not_called()
+
+
+def test_auto_run_force_redownloads_logs() -> None:
+    get_logs, installlogs = _run_auto(["intro\n", _SENTINEL, "tail\n"], force=True)
+
+    get_logs.assert_called_once()
+    installlogs.assert_called_once_with([])
+
+
+def test_auto_run_downloads_logs_when_results_line_absent() -> None:
+    get_logs, installlogs = _run_auto(["intro\n", "tail\n"], force=False)
+
+    get_logs.assert_called_once()
+    installlogs.assert_called_once_with([])
+
+
+def test_auto_run_status_suffixed_line_does_not_count_as_current() -> None:
+    """Membership is per-line equality: a real '... results: PASSED' line
+    does not satisfy the guard, so logs are (re)downloaded."""
+    get_logs, _ = _run_auto(["intro\n", _STATUS, "tail\n"], force=False)
+
+    get_logs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AutoExport._openqa_installog_to_template: unset ssl_verify stays secure,
+# and the request targets the result's URL
+# ---------------------------------------------------------------------------
+
+
+def test_installog_download_unset_ssl_verify_defaults_to_verifying() -> None:
+    cfg = _config()
+    cfg.ssl_verify = None
+    exporter = AutoExport(
+        cfg,
+        MagicMock(),
+        [],  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+    )
+    response = MagicMock()
+    response.text = "line\n"
+    response.raise_for_status.return_value = None
+    session = MagicMock()
+    session.get.return_value = response
+
+    with patch(
+        "mtui.update_workflow.export.auto.build_session", return_value=session
+    ) as build_session:
+        out = exporter._openqa_installog_to_template(_URL)
+
+    assert out == ["line\n"]
+    build_session.assert_called_once_with(True)
+    session.get.assert_called_once_with(_URL.url, timeout=HTTP_TIMEOUT)
+
+
+# ---------------------------------------------------------------------------
+# KernelExport.kernel_results: placeholder replacement preserves tester
+# notes; re-export bulk-replaces the section; legacy pes.suse.de anchor
+# ---------------------------------------------------------------------------
+
+
+def _kernel(template: list[str], pp_groups: list[list[str]]) -> KernelExport:
+    openqa = MagicMock()
+    groups = []
+    for pp in pp_groups:
+        g = MagicMock()
+        g.pp = pp
+        groups.append(g)
+    openqa.kernel = groups
+    return KernelExport(
+        _config(),
+        openqa,
+        template,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+    )
+
+
+def test_kernel_results_first_export_replaces_placeholder_keeps_notes() -> None:
+    """Only the placeholder line is consumed; tester notes on either side
+    survive, and the header block has its exact framing blanks."""
+    exporter = _kernel(
+        [
+            "regression tests:\n",
+            "my notes\n",
+            "(put your details here)\n",
+            "more notes\n",
+            "\n",
+            "build log review:\n",
+        ],
+        [["r1\n", "r2\n"]],
+    )
+
+    exporter.kernel_results()
+
+    tpl = list(exporter.template)
+    assert tpl[:2] == ["regression tests:\n", "my notes\n"]
+    assert tpl[2].startswith("Results added on ")
+    assert tpl[3:] == [
+        "\n",
+        "Results from openQA:\n",
+        "\n",
+        "r1\n",
+        "r2\n",
+        "more notes\n",
+        "\n",
+        "\n",
+        "build log review:\n",
+    ]
+
+
+def test_kernel_results_reexport_bulk_replaces_section_body() -> None:
+    """Placeholder gone: everything between 'regression tests:' and
+    'build log review:' is replaced with the fresh results."""
+    exporter = _kernel(
+        [
+            "regression tests:\n",
+            "Results added on OLD\n",
+            "\n",
+            "Results from openQA:\n",
+            "\n",
+            "old-r1\n",
+            "stale notes\n",
+            "\n",
+            "build log review:\n",
+        ],
+        [["r1\n"]],
+    )
+
+    exporter.kernel_results()
+
+    tpl = list(exporter.template)
+    assert tpl[0] == "regression tests:\n"
+    assert tpl[1].startswith("Results added on ")
+    assert "OLD" not in tpl[1]
+    assert tpl[2:] == [
+        "\n",
+        "Results from openQA:\n",
+        "\n",
+        "r1\n",
+        "\n",
+        "build log review:\n",
+    ]
+
+
+def test_kernel_results_reexport_uses_legacy_pes_anchor() -> None:
+    """With the legacy pes.suse.de line present, deletion starts below it,
+    preserving the lines above."""
+    exporter = _kernel(
+        [
+            "regression tests:\n",
+            "keep me\n",
+            "    * https://pes.suse.de/QA_Maintenance/kernel-default/\n",
+            "old results\n",
+            "\n",
+            "build log review:\n",
+        ],
+        [["r1\n"]],
+    )
+
+    exporter.kernel_results()
+
+    tpl = list(exporter.template)
+    assert tpl[:3] == [
+        "regression tests:\n",
+        "keep me\n",
+        "    * https://pes.suse.de/QA_Maintenance/kernel-default/\n",
+    ]
+    assert tpl[3].startswith("Results added on ")
+    assert tpl[4:] == [
+        "\n",
+        "Results from openQA:\n",
+        "\n",
+        "r1\n",
+        "\n",
+        "build log review:\n",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# KernelExport.get_logs: the download_logs call contract
+# ---------------------------------------------------------------------------
+
+
+def test_kernel_get_logs_download_contract(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    cfg.ssl_verify = None  # unset config must still resolve to verifying
+    exporter = KernelExport(
+        cfg,
+        MagicMock(),
+        [""],  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+    )
+    exporter.openqa = MagicMock()
+    exporter.openqa.kernel = []
+    in_path = tmp_path / RRID / "install_logs"
+    in_path.mkdir(parents=True)
+    (in_path / "foo.log").write_text("x")
+    res_path = tmp_path / RRID / "results"
+
+    with (
+        patch("mtui.update_workflow.export.kernel.download_logs") as dl,
+        patch("mtui.update_workflow.export.kernel.ensure_dir_exists") as ensure,
+    ):
+        out = exporter.get_logs()
+
+    ensure.assert_called_once_with(res_path)
+    dl.assert_called_once_with(ANY, res_path, in_path, "tolerant", True)
+    assert out == ["foo.log"]
+
+
+def test_kernel_get_logs_forwards_ssl_verify_override(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    cfg.ssl_verify = False
+    exporter = KernelExport(
+        cfg,
+        MagicMock(),
+        [""],  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        force=False,
+        rrid=RRID,
+        interactive=False,
+    )
+    exporter.openqa = MagicMock()
+    exporter.openqa.kernel = []
+
+    with (
+        patch("mtui.update_workflow.export.kernel.download_logs") as dl,
+        patch("mtui.update_workflow.export.kernel.ensure_dir_exists"),
+    ):
+        exporter.get_logs()
+
+    assert dl.call_args.args[4] is False

--- a/tests/test_overview_inject_pins.py
+++ b/tests/test_overview_inject_pins.py
@@ -1,0 +1,136 @@
+"""Mutation-killing pins for ``overview_inject`` re-export safety.
+
+The existing idempotency tests count markers and blank lines but never
+diff the non-owned lines, so mutants that eat a neighboring section
+header or a tester-authored line survived. These tests pin that
+re-exports leave everything outside the BEGIN/END markers intact, and
+that aggregated data is rendered by default.
+"""
+
+from __future__ import annotations
+
+from mtui.data_sources.oqa_search import (
+    OVERVIEW_BEGIN_MARKER,
+    OVERVIEW_END_MARKER,
+    GroupResult,
+    VersionResult,
+)
+from mtui.update_workflow.export.overview_inject import inject_overview
+
+BEGIN_LINE = OVERVIEW_BEGIN_MARKER + "\n"
+END_LINE = OVERVIEW_END_MARKER + "\n"
+
+
+def _single() -> list[VersionResult]:
+    return [VersionResult(version="15-SP5", url="https://oqa/u1", status="passed")]
+
+
+def _aggregated() -> list[GroupResult]:
+    return [
+        GroupResult(
+            group="core",
+            versions=[
+                VersionResult(version="15-SP5", url="https://oqa/agg", status="passed")
+            ],
+        )
+    ]
+
+
+def _template() -> list[str]:
+    return [
+        "Maintenance Test Update Installer\n",
+        "\n",
+        "regression tests:\n",
+        "-----------------\n",
+        "\n",
+        "(put your details here)\n",
+        "\n",
+        "build log review:\n",
+        "-----------------\n",
+    ]
+
+
+def test_inject_overview_reexport_is_exact_noop() -> None:
+    """Re-injecting identical data reproduces the template byte for byte.
+
+    Full-list equality (unlike marker/blank counting) catches removal
+    windows that grow into non-owned lines -- e.g. eating the
+    'build log review:' header that follows the block's trailing blank.
+    """
+    template = _template()
+    inject_overview(template, _single(), _aggregated(), [])
+    after_first = list(template)
+    assert "build log review:\n" in after_first
+
+    inject_overview(template, _single(), _aggregated(), [])
+
+    assert list(template) == after_first
+
+
+def test_inject_overview_keeps_user_line_directly_after_end_marker() -> None:
+    """Only a BLANK line after the end marker is swallowed on re-export;
+    tester text glued right below the block must survive."""
+    template = [
+        "regression tests:\n",
+        "-----------------\n",
+        "\n",
+        BEGIN_LINE,
+        "old row\n",
+        END_LINE,
+        "user note after\n",
+        "\n",
+        "build log review:\n",
+    ]
+
+    inject_overview(template, _single(), [], [])
+
+    assert "user note after\n" in template
+    assert "old row\n" not in template
+    assert "build log review:\n" in template
+
+
+def test_inject_overview_keeps_user_line_directly_above_begin_marker() -> None:
+    """The leading-blank swallow must not fire when the line above the
+    begin marker is tester text."""
+    template = [
+        "regression tests:\n",
+        "user note above\n",
+        BEGIN_LINE,
+        "old row\n",
+        END_LINE,
+        "\n",
+        "build log review:\n",
+    ]
+
+    inject_overview(template, _single(), [], [])
+
+    assert "user note above\n" in template
+    assert "old row\n" not in template
+
+
+def test_inject_overview_renders_aggregated_rows_by_default() -> None:
+    """Without skip_aggregated the aggregated section reaches the report."""
+    template = _template()
+
+    inject_overview(template, _single(), _aggregated(), [])
+
+    body = "".join(template)
+    assert "Aggregated Updates" in body
+    assert "https://oqa/agg" in body
+
+
+def test_inject_overview_no_next_header_keeps_single_gap() -> None:
+    """File ends on a blank with no next-section header: the block lands
+    after it without stacking a second blank above the begin marker."""
+    template = [
+        "regression tests:\n",
+        "-----------------\n",
+        "notes\n",
+        "\n",
+    ]
+
+    inject_overview(template, _single(), [], [])
+
+    begin = template.index(BEGIN_LINE)
+    assert template[begin - 1] == "\n"
+    assert template[begin - 2] != "\n"


### PR DESCRIPTION
## What
50 pinning tests (4 new files) for the export pipeline's biggest survivor clusters (~445 mutants): `inject_openqa` section replacement and re-export bounds, `installlogs_lines` idempotency/convergence, `_writer` overwrite/prompt/sidecar contract, `_fillup_hosts_to_template` section creation and version overwrites, AUTO/KERNEL `install_results`/`kernel_results` exact layouts, and downloader URL/path construction.

Notable: the re-export golden tests pin exact full-template equality, killing the `overview_inject` mutant class that could silently delete the `build log review:` header. Three suspected production quirks are documented in-test as pinned current behavior (AutoExport.run's `install_logs_current` guard never matches a real results line; `add_sysinfo`'s dead guard; `inject_openqa`'s one-blank-line drift per re-export) — follow-up material, deliberately not changed here.

Part of the mutation-testing campaign (config and methodology in #298): these clusters were `covered-but-unasserted` — the suite executed the code but pinned nothing, so mutants survived. Every new test was **mutation-verified**: a representative mutant was hand-applied to the production code and the test shown to fail, then the tree restored byte-identical. Adversarially reviewed (pin-quality + hermeticity lenses, refute-by-default verification) before opening. Tests-only; all tests live in new files, so no conflicts with the open fix PRs.
