### PR TITLE
test(openqa): pin dashboard/search/updateid data-path behavior

### DIFF
--- a/tests/test_dashboard_openqa_pins.py
+++ b/tests/test_dashboard_openqa_pins.py
@@ -1,0 +1,375 @@
+"""Mutation-killing pinning tests for ``DashboardAutoOpenQA``.
+
+A full mutmut run left survivors in code the suite executes but never
+asserts on. These tests pin the exact current behavior:
+
+- ``_normalize_job``: full output-dict equality for both sources,
+  including the job-level vs. setting-level precedence for
+  DISTRI/FLAVOR/ARCH/VERSION/BUILD and the aggregate-only
+  product/repohash/incidents keys.
+- ``_get_logs_url``: every ``URLs`` field (distri/arch/version/url/
+  result) and the config-backed DISTRI fallback.
+- ``_pretty_print_section``: the ``other`` counter increments, the
+  singular ``(1 arch)`` fold suffix, and the per-group failed-jobs loop
+  continuing past groups without concrete failures.
+- ``_load_jobs``: settings without an ``id`` are skipped without
+  aborting the rest.
+- ``_job_url``: trailing-slash host normalization.
+"""
+
+from __future__ import annotations
+
+from mtui.data_sources.qem_dashboard import DashboardAutoOpenQA, QEMIncident
+from mtui.types import RequestReviewID
+from mtui.types.urls import URLs
+
+OPENQA_HOST = "https://openqa.example.com"
+
+
+def _make_dashboard(mock_config) -> DashboardAutoOpenQA:
+    """Build a DashboardAutoOpenQA without hitting the API."""
+    rrid = RequestReviewID("SUSE:Maintenance:12358:199773")
+    incident = QEMIncident.__new__(QEMIncident)
+    incident.rrid = rrid
+    incident.incident_number = 12358
+    incident.client = None  # type: ignore[assignment]
+    incident.data = {"number": 12358, "packages": ["bash"]}
+    return DashboardAutoOpenQA(mock_config, OPENQA_HOST, incident, rrid)
+
+
+def _incident_job(
+    job_id: int,
+    name: str,
+    result: str,
+    *,
+    version: str = "15-SP5",
+    flavor: str = "Server-DVD-Incidents",
+    arch: str = "x86_64",
+) -> dict:
+    return {
+        "id": job_id,
+        "test": name,
+        "result": result,
+        "source": "incident",
+        "settings": {
+            "DISTRI": "sle",
+            "FLAVOR": flavor,
+            "ARCH": arch,
+            "VERSION": version,
+            "BUILD": ":12358:bash",
+        },
+    }
+
+
+# --- _normalize_job -----------------------------------------------------------
+
+
+def test_normalize_job_incident_prefers_job_level_values():
+    """Job-level distri/flavor/arch/version/build win over the setting."""
+    setting = {
+        "id": 7,
+        "flavor": "Flavor-setting",
+        "arch": "arch-setting",
+        "version": "ver-setting",
+        "build": "build-setting",
+        "settings": {"DISTRI": "distri-setting"},
+    }
+    job = {
+        "job_id": 101,
+        "name": "qam-incidentinstall",
+        "status": "passed",
+        "job_group": "Maintenance: Single Incidents",
+        "group_id": 42,
+        "obsolete": True,
+        "distri": "distri-job",
+        "flavor": "Flavor-job",
+        "arch": "arch-job",
+        "version": "ver-job",
+        "build": "build-job",
+    }
+
+    normalized = DashboardAutoOpenQA._normalize_job(job, "incident", setting)
+
+    assert normalized == {
+        "id": 101,
+        "test": "qam-incidentinstall",
+        "result": "passed",
+        "source": "incident",
+        "job_group": "Maintenance: Single Incidents",
+        "group_id": 42,
+        "obsolete": True,
+        "settings": {
+            "DISTRI": "distri-job",
+            "FLAVOR": "Flavor-job",
+            "ARCH": "arch-job",
+            "VERSION": "ver-job",
+            "BUILD": "build-job",
+        },
+        "dashboard_setting": setting,
+    }
+    # The setting rides along by identity, not by copy.
+    assert normalized["dashboard_setting"] is setting
+
+
+def test_normalize_job_incident_falls_back_to_setting_values():
+    """Missing job-level values fall back to the setting: DISTRI from the
+    nested settings dict, FLAVOR/ARCH/VERSION/BUILD from the setting itself."""
+    setting = {
+        "id": 7,
+        "flavor": "Flavor-setting",
+        "arch": "arch-setting",
+        "version": "ver-setting",
+        "build": "build-setting",
+        "settings": {"DISTRI": "distri-setting"},
+    }
+    job = {"job_id": 102, "name": "qam-x", "status": "failed"}
+
+    normalized = DashboardAutoOpenQA._normalize_job(job, "incident", setting)
+
+    assert normalized == {
+        "id": 102,
+        "test": "qam-x",
+        "result": "failed",
+        "source": "incident",
+        "job_group": None,
+        "group_id": None,
+        "obsolete": False,
+        "settings": {
+            "DISTRI": "distri-setting",
+            "FLAVOR": "Flavor-setting",
+            "ARCH": "arch-setting",
+            "VERSION": "ver-setting",
+            "BUILD": "build-setting",
+        },
+        "dashboard_setting": setting,
+    }
+    # Not an aggregate job: no aggregate-only keys sneak in.
+    assert "product" not in normalized
+    assert "repohash" not in normalized
+    assert "incidents" not in normalized
+
+
+def test_normalize_job_aggregate_adds_product_repohash_incidents():
+    setting = {
+        "id": 23,
+        "product": "SLES-15-SP5",
+        "repohash": "abc123",
+        "incidents": [12358, 999],
+        "flavor": "Server-DVD-Updates",
+        "arch": "x86_64",
+        "version": "15-SP5",
+        "build": "20240101-1",
+        "settings": {"DISTRI": "sle"},
+    }
+    job = {"job_id": 201, "name": "mau-webserver", "status": "softfailed"}
+
+    normalized = DashboardAutoOpenQA._normalize_job(job, "aggregate", setting)
+
+    assert normalized == {
+        "id": 201,
+        "test": "mau-webserver",
+        "result": "softfailed",
+        "source": "aggregate",
+        "job_group": None,
+        "group_id": None,
+        "obsolete": False,
+        "settings": {
+            "DISTRI": "sle",
+            "FLAVOR": "Server-DVD-Updates",
+            "ARCH": "x86_64",
+            "VERSION": "15-SP5",
+            "BUILD": "20240101-1",
+        },
+        "dashboard_setting": setting,
+        "product": "SLES-15-SP5",
+        "repohash": "abc123",
+        "incidents": [12358, 999],
+    }
+
+
+def test_normalize_job_aggregate_none_incidents_becomes_empty_list():
+    """`incidents: null` from the dashboard normalizes to [] (not None)."""
+    setting = {"id": 23, "product": "P", "repohash": "r", "incidents": None}
+    job = {"job_id": 202, "name": "mau", "status": "passed"}
+
+    normalized = DashboardAutoOpenQA._normalize_job(job, "aggregate", setting)
+
+    assert normalized["incidents"] == []
+    assert normalized["product"] == "P"
+    assert normalized["repohash"] == "r"
+
+
+def test_normalize_job_tolerates_null_setting_settings():
+    """`settings: null` on the setting behaves like a missing dict."""
+    setting = {"id": 7, "settings": None, "flavor": "F"}
+    job = {"job_id": 103, "name": "qam-y", "status": "passed"}
+
+    normalized = DashboardAutoOpenQA._normalize_job(job, "incident", setting)
+
+    assert normalized["settings"]["DISTRI"] is None
+    assert normalized["settings"]["FLAVOR"] == "F"
+
+
+# --- _get_logs_url --------------------------------------------------------------
+
+
+def test_get_logs_url_pins_every_urls_field(mock_config):
+    """distri/arch/version/url/result all map from the job settings, with
+    the configured install distri (and '') as fallbacks for missing keys."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        {
+            "test": "qam-incidentinstall",
+            "result": "passed",
+            "id": 1001,
+            "settings": {"DISTRI": "opensuse", "ARCH": "aarch64", "VERSION": "15-SP6"},
+        },
+        {
+            # Missing DISTRI/ARCH/VERSION keys: config default + '' fallbacks.
+            "test": "qam-incidentinstall",
+            "result": "softfailed",
+            "id": 1002,
+            "settings": {},
+        },
+        {
+            # Not an install job: filtered out.
+            "test": "qam-regression",
+            "result": "passed",
+            "id": 1003,
+            "settings": {},
+        },
+        {
+            # Failed install job: filtered out.
+            "test": "qam-incidentinstall",
+            "result": "failed",
+            "id": 1004,
+            "settings": {},
+        },
+    ]
+
+    urls = dashboard._get_logs_url(jobs)
+
+    assert urls == [
+        URLs(
+            "opensuse",
+            "aarch64",
+            "15-SP6",
+            f"{OPENQA_HOST}/tests/1001/file/install-logs.tar",
+            "passed",
+        ),
+        URLs(
+            "sle",
+            "",
+            "",
+            f"{OPENQA_HOST}/tests/1002/file/install-logs.tar",
+            "softfailed",
+        ),
+    ]
+
+
+def test_get_logs_url_empty_jobs_returns_none(mock_config):
+    dashboard = _make_dashboard(mock_config)
+    assert dashboard._get_logs_url([]) is None
+    assert dashboard._get_logs_url(None) is None
+
+
+# --- _pretty_print_section -------------------------------------------------------
+
+
+def test_pretty_print_counts_multiple_other_jobs(mock_config):
+    """Two same-group 'other'-bucket jobs count as 2, not 1."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        _incident_job(4000, "qam-parallel-a", "parallel_failed"),
+        _incident_job(4001, "qam-parallel-b", "parallel_failed"),
+        _incident_job(4002, "qam-pass", "passed"),
+    ]
+
+    out = "".join(dashboard._pretty_print(jobs))
+
+    assert "other: 2" in out
+    assert "total: 3" in out
+
+
+def test_pretty_print_single_arch_fold_uses_singular_arch(mock_config):
+    """A one-arch folded group renders '(1 arch)', not '(1 arches)'."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [_incident_job(5000, "qam-ok", "passed")]
+
+    out = "".join(dashboard._pretty_print(jobs))
+
+    assert "(1 arch)" in out
+    assert "(1 arches)" not in out
+
+
+def test_pretty_print_failed_jobs_loop_skips_group_without_concrete_failures(
+    mock_config,
+):
+    """A problem group whose issues live only in 'other' is skipped in the
+    Failed jobs listing, but later groups with real failures still render."""
+    dashboard = _make_dashboard(mock_config)
+    jobs = [
+        # First problem group: only a parallel_failed job (no failed_by_group
+        # entry) -- the failed-jobs loop must continue past it.
+        _incident_job(6000, "qam-parallel", "parallel_failed", flavor="Flavor-A"),
+        # Second problem group: a concrete failure that must still be listed.
+        _incident_job(6001, "qam-dead", "failed", flavor="Flavor-B"),
+    ]
+
+    out = "".join(dashboard._pretty_print(jobs))
+
+    assert "Failed jobs:" in out
+    assert "15-SP5 / Flavor-B / x86_64 (1 failed):" in out
+    assert "qam-dead" in out
+    # The other-only group still shows up in the Summary as a problem group.
+    assert "flavor: Flavor-A" in out
+    assert "other: 1" in out
+
+
+# --- _load_jobs: malformed settings are skipped, not fatal -------------------------
+
+
+def test_load_jobs_skips_settings_without_id(mock_config):
+    """A settings entry lacking 'id' is dropped; later entries still load."""
+    dashboard = _make_dashboard(mock_config)
+
+    class _FakeClient:
+        @staticmethod
+        def incident_settings(_n):
+            return [{"settings": {}}, {"id": 11, "settings": {}}]
+
+        @staticmethod
+        def update_settings(_n):
+            return [{"settings": {}}, {"id": 21, "settings": {}}]
+
+        @staticmethod
+        def incident_jobs(sid):
+            return [{"job_id": 1000 + sid, "name": f"qam-{sid}", "status": "passed"}]
+
+        @staticmethod
+        def update_jobs(sid):
+            return [{"job_id": 2000 + sid, "name": f"mau-{sid}", "status": "passed"}]
+
+    dashboard.client = _FakeClient()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
+    jobs = dashboard._load_jobs()
+
+    assert [job["test"] for job in jobs] == ["qam-11", "mau-21"]
+
+
+# --- _job_url ----------------------------------------------------------------------
+
+
+def test_job_url_strips_trailing_slash_from_host():
+    assert (
+        DashboardAutoOpenQA._job_url("https://openqa.example.com/", 42)
+        == "https://openqa.example.com/tests/42"
+    )
+    assert (
+        DashboardAutoOpenQA._job_url("https://openqa.example.com", 42)
+        == "https://openqa.example.com/tests/42"
+    )
+
+
+def test_job_url_none_job_id_is_empty():
+    assert DashboardAutoOpenQA._job_url(OPENQA_HOST, None) == ""

--- a/tests/test_oqa_search_pins.py
+++ b/tests/test_oqa_search_pins.py
@@ -1,0 +1,916 @@
+"""Mutation-killing pinning tests for ``mtui.data_sources.oqa_search``.
+
+A full mutmut run left survivors in code the suite executes but never
+asserts on. These tests pin the exact current behavior of the search
+module (and its HTTP helpers) so those mutants die:
+
+- ``incident_jobs``: dict-key fallbacks, the ``group`` field, and the
+  obsoleted-job ``continue`` (not ``break``).
+- ``_scan_aggregated_for_version``: the day-walk keeps going backward
+  past per-day errors and queries strictly older build dates.
+- ``_query_version_status`` / ``_render_version_row``: the third
+  RUNNING state, which no existing test exercised.
+- ``single_incidents`` / ``aggregated_updates``: error rows for HTTP
+  failures and the per-item ``continue`` on invalid versions/groups.
+- ``render_overview`` / ``_render_build_check``: golden line-by-line
+  output instead of substring checks.
+- ``get_incident_info``: first-entry BUILD selection and the
+  ``_fallback_build`` except path.
+- ``build_checks``: per-log HTTP failure fallback and the exact fold
+  boundary (>4) plus folded first/last content.
+- ``extract_test_results``: IGNORECASE on custom patterns and exact
+  matched-line content on the visual-separator branch.
+- ``_get_json`` / ``_fetch_url_content``: bounded timeout and the
+  ``_HTTPError`` message carrying the cause text.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import responses
+
+from mtui.data_sources import oqa_search
+from mtui.data_sources.oqa_search import http as oqa_http
+from mtui.data_sources.oqa_search.results import (
+    BuildCheckResult,
+    GroupResult,
+    JobResult,
+    VersionResult,
+)
+from mtui.support.http import HTTP_TIMEOUT
+
+OPENQA = "https://openqa.example.com"
+DASHBOARD = "https://dashboard.example.com"
+QAM = "https://qam.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Drop the job-group lru_cache before and after every test."""
+    oqa_search._fetch_openqa_groups.cache_clear()
+    yield
+    oqa_search._fetch_openqa_groups.cache_clear()
+
+
+def _register_job_groups(*groups: dict) -> None:
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/job_groups",
+        json=list(groups),
+        status=200,
+    )
+
+
+def _core_incidents_group() -> dict:
+    return {"id": 490, "name": "SLE 15 SP5 Core Incidents", "template": "tpl"}
+
+
+def _core_aggregated_group() -> dict:
+    return {"id": 367, "name": "Core Maintenance Updates 15-SP5", "template": "tpl"}
+
+
+def _build_param(call) -> str:
+    """Extract the ``build`` query parameter from a recorded request."""
+    return parse_qs(urlparse(call.request.url).query)["build"][0]
+
+
+def _date_candidates(t0: datetime, t1: datetime, days_back: int) -> set[str]:
+    """Acceptable ``YYYYMMDD-1`` builds for ``days_back`` days before now.
+
+    Computed from timestamps taken just before and just after the call
+    under test so a midnight rollover mid-test cannot flake.
+    """
+    return {f"{(t - timedelta(days=days_back)).strftime('%Y%m%d')}-1" for t in (t0, t1)}
+
+
+# --- incident_jobs -----------------------------------------------------------
+
+
+@responses.activate
+def test_incident_jobs_obsoleted_in_middle_does_not_stop_the_loop():
+    """An obsoleted job mid-list is skipped; later jobs still appear."""
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                {"id": 1, "test": "a_first", "result": "passed", "settings": {}},
+                {"id": 2, "test": "b_stale", "result": "obsoleted", "settings": {}},
+                {"id": 3, "test": "c_last", "result": "failed", "settings": {}},
+            ]
+        },
+        status=200,
+    )
+
+    rows = oqa_search.incident_jobs(":12358:bash", OPENQA)
+
+    # The job AFTER the obsoleted one survives (continue, not break).
+    assert [r.test for r in rows] == ["c_last", "a_first"]  # sorted by result
+
+
+@responses.activate
+def test_incident_jobs_pins_every_field_and_fallback_defaults():
+    """Each JobResult field maps from the documented job key with its default."""
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                # Fully populated job: pins the happy-path key mapping,
+                # including the never-before-asserted `group` field.
+                {
+                    "id": 7,
+                    "test": "fips_smoke",
+                    "result": "passed",
+                    "group": "Maintenance: Core",
+                    "state": "done",
+                    "settings": {"ARCH": "s390x"},
+                },
+                # Empty job: pins every .get() default.
+                {},
+            ]
+        },
+        status=200,
+    )
+
+    rows = oqa_search.incident_jobs(":12358:bash", OPENQA)
+
+    assert rows == [
+        JobResult(
+            job_id=0,
+            test="",
+            arch="",
+            result="",
+            group="",
+            url=f"{OPENQA}/t",
+            state="",
+        ),
+        JobResult(
+            job_id=7,
+            test="fips_smoke",
+            arch="s390x",
+            result="passed",
+            group="Maintenance: Core",
+            url=f"{OPENQA}/t7",
+            state="done",
+        ),
+    ]
+
+
+@responses.activate
+def test_incident_jobs_arch_falls_back_to_job_key_and_name():
+    """ARCH prefers settings, falls back to the job's arch; test falls back to name."""
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs",
+        json={
+            "jobs": [
+                {
+                    "id": 9,
+                    "name": "from_name",
+                    "result": "passed",
+                    "arch": "aarch64",
+                    "settings": {},
+                }
+            ]
+        },
+        status=200,
+    )
+
+    rows = oqa_search.incident_jobs(":12358:bash", OPENQA)
+
+    assert rows[0].test == "from_name"
+    assert rows[0].arch == "aarch64"
+
+
+# --- _query_version_status: the RUNNING state --------------------------------
+
+
+@responses.activate
+def test_single_incidents_running_status():
+    """No failed jobs + scheduled/running jobs -> RUNNING with a count."""
+    _register_job_groups(_core_incidents_group())
+    responses.add(  # running query comes first in _query_version_status
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 1}, {"id": 2}],
+        status=200,
+    )
+    responses.add(  # failed query
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    rows = oqa_search.single_incidents(":12358:bash", ["15-SP5"], OPENQA)
+
+    assert rows == [
+        VersionResult(
+            version="15-SP5",
+            url=(
+                f"{OPENQA}/tests/overview"
+                "?distri=sle&version=15-SP5&build=:12358:bash&groupid=490"
+            ),
+            status="running",
+            running_count=2,
+        )
+    ]
+    # The first overview request carried the running-state filter.
+    running_request_url = responses.calls[1].request.url or ""
+    assert "state=scheduled" in running_request_url
+    assert "state=running" in running_request_url
+
+
+@responses.activate
+def test_single_incidents_failed_beats_running():
+    """Failed jobs win over running ones in the status resolution."""
+    _register_job_groups(_core_incidents_group())
+    responses.add(  # running: non-empty
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 1}],
+        status=200,
+    )
+    responses.add(  # failed: non-empty
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 2}, {"id": 3}],
+        status=200,
+    )
+
+    rows = oqa_search.single_incidents(":12358:bash", ["15-SP5"], OPENQA)
+
+    assert rows[0].status == "failed"
+    assert rows[0].failed_count == 2
+    assert rows[0].running_count == 0
+
+
+# --- single_incidents error paths ---------------------------------------------
+
+
+@responses.activate
+def test_single_incidents_unknown_version_continues_to_next_version():
+    """An unrecognized version yields a failed row but does not stop the loop."""
+    _register_job_groups(_core_incidents_group())
+    responses.add(  # running for 15-SP5
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+    responses.add(  # failed for 15-SP5
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    rows = oqa_search.single_incidents(":12358:bash", ["99-SP99", "15-SP5"], OPENQA)
+
+    assert len(rows) == 2
+    assert rows[0].version == "99-SP99"
+    assert rows[0].status == "failed"
+    assert "99-SP99" in rows[0].note
+    # The version AFTER the bad one is still resolved (continue, not break).
+    assert rows[1].version == "15-SP5"
+    assert rows[1].status == "passed"
+
+
+@responses.activate
+def test_single_incidents_http_error_becomes_failed_row_with_note():
+    """A 500 from openQA converts into a failed row with a query-failed note."""
+    _register_job_groups(_core_incidents_group())
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        status=500,
+    )
+
+    rows = oqa_search.single_incidents(":12358:bash", ["15-SP5"], OPENQA)
+
+    assert len(rows) == 1
+    assert rows[0].version == "15-SP5"
+    assert rows[0].status == "failed"
+    assert rows[0].url == ""
+    assert rows[0].note.startswith("openQA query failed: ")
+    assert "500" in rows[0].note
+
+
+# --- _scan_aggregated_for_version day-walk ------------------------------------
+
+
+@responses.activate
+def test_scan_aggregated_day_error_walks_back_to_previous_day():
+    """A failing day-0 query is skipped; day 1 (yesterday) is still tried."""
+    responses.add(  # day 0 "all" query errors
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        status=500,
+    )
+    responses.add(  # day 1 "all" query finds a job
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 999}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/999",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "12358"}}},
+        status=200,
+    )
+    responses.add(  # running
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+    responses.add(  # failed
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    t0 = datetime.now()
+    row = oqa_search._scan_aggregated_for_version(OPENQA, "15-SP5", 2, 367, 12358)
+    t1 = datetime.now()
+
+    assert row.status == "passed"
+    # The day-walk queried today first, then strictly one day earlier --
+    # not the same day again and not a day in the future.
+    assert _build_param(responses.calls[0]) in _date_candidates(t0, t1, 0)
+    assert _build_param(responses.calls[1]) in _date_candidates(t0, t1, 1)
+    # The result URL points at yesterday's build.
+    assert any(b in row.url for b in _date_candidates(t0, t1, 1))
+
+
+@responses.activate
+def test_scan_aggregated_missing_job_id_walks_back_to_previous_day():
+    """A day whose first job has no id is skipped, not the end of the walk."""
+    responses.add(  # day 0: job without an id
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"name": "no-id-here"}],
+        status=200,
+    )
+    responses.add(  # day 1: usable job
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 555}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/555",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "12358"}}},
+        status=200,
+    )
+    responses.add(  # running
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+    responses.add(  # failed
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    t0 = datetime.now()
+    row = oqa_search._scan_aggregated_for_version(OPENQA, "15-SP5", 2, 367, 12358)
+    t1 = datetime.now()
+
+    assert row.status == "passed"
+    assert any(b in row.url for b in _date_candidates(t0, t1, 1))
+
+
+@responses.activate
+def test_scan_aggregated_job_issues_error_walks_back_to_previous_day():
+    """A failing job-issues lookup skips the day instead of aborting."""
+    responses.add(  # day 0: job exists ...
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 111}],
+        status=200,
+    )
+    responses.add(  # ... but its issues lookup fails
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/111",
+        status=500,
+    )
+    responses.add(  # day 1: usable job
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 222}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/222",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "12358"}}},
+        status=200,
+    )
+    responses.add(  # running
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+    responses.add(  # failed
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    t0 = datetime.now()
+    row = oqa_search._scan_aggregated_for_version(OPENQA, "15-SP5", 2, 367, 12358)
+    t1 = datetime.now()
+
+    assert row.status == "passed"
+    assert any(b in row.url for b in _date_candidates(t0, t1, 1))
+
+
+@responses.activate
+def test_scan_aggregated_status_query_error_returns_failed_row():
+    """An _HTTPError from the status resolution becomes a failed row + note."""
+    responses.add(  # day 0 "all": a matching job
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 999}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/999",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "12358"}}},
+        status=200,
+    )
+    responses.add(  # running query inside _query_version_status errors
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        status=500,
+    )
+
+    row = oqa_search._scan_aggregated_for_version(OPENQA, "15-SP5", 2, 367, 12358)
+
+    assert row.version == "15-SP5"
+    assert row.status == "failed"
+    assert row.url == ""
+    assert row.note.startswith("openQA query failed: ")
+
+
+# --- aggregated_updates --------------------------------------------------------
+
+
+@responses.activate
+def test_aggregated_updates_invalid_group_continues_to_next_group():
+    """An unknown group is skipped; the next group still produces results."""
+    _register_job_groups(_core_aggregated_group())
+    responses.add(  # core, day 0: no jobs -> missing row after the window
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    out = oqa_search.aggregated_updates(
+        12358, ["15-SP5"], 1, ["bogus-group", "core"], OPENQA
+    )
+
+    assert len(out) == 1
+    assert out[0].group == "core"
+    assert out[0].versions[0].status == "missing"
+
+
+@responses.activate
+def test_aggregated_updates_incident_filter_skips_non_matching_days():
+    """A day whose jobs test other incidents is skipped, so the filter
+    (and the int() conversion feeding it) actually discriminates."""
+    _register_job_groups(_core_aggregated_group())
+    responses.add(  # day 0: job testing a DIFFERENT incident
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 111}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/111",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "99999"}}},
+        status=200,
+    )
+    responses.add(  # day 1: job covering OUR incident
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[{"id": 222}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/222",
+        json={"job": {"settings": {"INCIDENT_TEST_ISSUES": "12358,777"}}},
+        status=200,
+    )
+    responses.add(  # running
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+    responses.add(  # failed
+        responses.GET,
+        f"{OPENQA}/api/v1/jobs/overview",
+        json=[],
+        status=200,
+    )
+
+    t0 = datetime.now()
+    # Pass the incident id as a string to pin the int() conversion.
+    out = oqa_search.aggregated_updates("12358", ["15-SP5"], 2, ["core"], OPENQA)
+    t1 = datetime.now()
+
+    row = out[0].versions[0]
+    assert row.status == "passed"
+    # Day 0 did NOT match (its issues lack 12358): the result is day 1's build.
+    assert any(b in row.url for b in _date_candidates(t0, t1, 1))
+
+
+# --- render_overview golden output ---------------------------------------------
+
+
+def test_render_overview_golden_full_sections():
+    """Exact line-by-line output: headers, blank lines, rows, build checks."""
+    single = [
+        VersionResult(version="15-SP5", url="https://oqa/u1", status="passed"),
+        VersionResult(
+            version="15-SP4", url="https://oqa/u2", status="failed", failed_count=3
+        ),
+    ]
+    aggregated = [
+        GroupResult(
+            group="core",
+            versions=[
+                VersionResult(version="15-SP5", url="https://oqa/agg", status="passed")
+            ],
+        )
+    ]
+    build_checks = [
+        BuildCheckResult(
+            url="https://qam/xz.log",
+            matches=["[   28s] All 9 tests passed"],
+        )
+    ]
+
+    assert oqa_search.render_overview(single, aggregated, build_checks) == [
+        "## OpenQA Overview",
+        "",
+        "### Single Incidents - Core",
+        "",
+        "- 15-SP5 -> https://oqa/u1",
+        "  - PASSED",
+        "- 15-SP4 -> https://oqa/u2",
+        "  - FAILED (3 jobs)",
+        "",
+        "### Aggregated Updates - Core",
+        "",
+        "- 15-SP5 -> https://oqa/agg",
+        "  - PASSED",
+        "",
+        "### Build Checks",
+        "",
+        "- https://qam/xz.log",
+        "  - All 9 tests passed",
+        "",
+    ]
+
+
+def test_render_overview_golden_empty_input():
+    """Exact placeholder output when there is nothing to show."""
+    assert oqa_search.render_overview([], [], []) == [
+        "## OpenQA Overview",
+        "",
+        "_No openQA builds for this incident yet._",
+        "",
+        "### Build Checks",
+        "",
+        "_No build checks for this incident._",
+        "",
+    ]
+
+
+# --- _render_version_row branch matrix ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        (
+            VersionResult(
+                version="15-SP5", url="https://u", status="running", running_count=4
+            ),
+            ["- 15-SP5 -> https://u", "  - RUNNING/SCHEDULED (4 jobs)"],
+        ),
+        (
+            VersionResult(version="15-SP5", url="https://u", status="running"),
+            ["- 15-SP5 -> https://u", "  - RUNNING/SCHEDULED"],
+        ),
+        (
+            VersionResult(version="15-SP5", url="", status="missing", note="no build"),
+            ["- 15-SP5: no build"],
+        ),
+        (
+            VersionResult(version="15-SP5", url="https://u", status="failed"),
+            ["- 15-SP5 -> https://u", "  - FAILED"],
+        ),
+        (
+            VersionResult(
+                version="15-SP5",
+                url="https://u",
+                status="failed",
+                failed_count=2,
+                note="flaky",
+            ),
+            ["- 15-SP5 -> https://u", "  - FAILED (2 jobs)", "  - note: flaky"],
+        ),
+        (
+            VersionResult(version="15-SP5", url="", status="passed"),
+            ["- 15-SP5", "  - PASSED"],
+        ),
+    ],
+)
+def test_render_version_row_branches(row, expected):
+    assert oqa_search._render_version_row(row) == expected
+
+
+# --- _render_build_check folded branch -------------------------------------------
+
+
+def test_render_build_check_folded_summary_order():
+    """Folded entries emit first-match, summary, last-match in that order."""
+    entry = BuildCheckResult(
+        url="https://q/x.log",
+        matches=["[   1s] first summary line", "[   9s] last summary line"],
+        summary="(3 more results, 5 passed, 1 failed)",
+    )
+    assert oqa_search._render_build_check(entry) == [
+        "- https://q/x.log",
+        "  - first summary line",
+        "  - (3 more results, 5 passed, 1 failed)",
+        "  - last summary line",
+        "",
+    ]
+
+
+def test_render_build_check_no_matches_hint():
+    assert oqa_search._render_build_check(BuildCheckResult(url="https://q/y.log")) == [
+        "- https://q/y.log",
+        "  - No test results found (try using a custom pattern with --test-pattern)",
+        "",
+    ]
+
+
+# --- get_incident_info -------------------------------------------------------------
+
+
+@responses.activate
+def test_get_incident_info_uses_first_entry_build_and_filters_versions():
+    """BUILD comes from entry 0; only sle-DISTRI entries contribute versions."""
+    responses.add(
+        responses.GET,
+        f"{DASHBOARD}/api/incident_settings/12358",
+        json=[
+            # Entry 0 (its BUILD wins); no "flavor" key at all.
+            {
+                "settings": {"BUILD": ":12358:bash-first", "DISTRI": "sle"},
+                "version": "15-SP5",
+            },
+            # Different BUILD: must NOT be picked.
+            {
+                "settings": {"BUILD": ":12358:bash-second", "DISTRI": "sle"},
+                "version": "12-SP3",
+                "flavor": "Server-TERADATA",
+            },
+            # Non-sle DISTRI: excluded from versions.
+            {
+                "settings": {"BUILD": "x", "DISTRI": "opensuse"},
+                "version": "16.0",
+                "flavor": "X",
+            },
+            # No "settings" key: excluded from versions, must not crash.
+            {"version": "15-SP9", "flavor": "Y"},
+        ],
+        status=200,
+    )
+
+    build, versions = oqa_search.get_incident_info(DASHBOARD, 12358)
+
+    assert build == ":12358:bash-first"
+    assert versions == ["12-SP3-TERADATA", "15-SP5"]
+
+
+@responses.activate
+def test_get_incident_info_missing_build_key_falls_back():
+    """Entry 0 without settings.BUILD triggers the /incidents fallback."""
+    responses.add(
+        responses.GET,
+        f"{DASHBOARD}/api/incident_settings/12358",
+        json=[{"settings": {"DISTRI": "sle"}, "version": "15-SP5"}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{DASHBOARD}/api/incidents/12358",
+        json={"packages": ["bash"]},
+        status=200,
+    )
+
+    build, versions = oqa_search.get_incident_info(DASHBOARD, 12358)
+
+    assert build == ":12358:bash"
+    assert versions is None
+
+
+# --- build_checks -------------------------------------------------------------------
+
+_BC_BASE = f"{QAM}/testreports/SUSE:Maintenance:12358:199773/build_checks"
+
+
+@responses.activate
+def test_build_checks_per_log_error_yields_bare_result_and_continues():
+    """A single failing log becomes a bare entry; later logs still parse."""
+    responses.add(
+        responses.GET,
+        _BC_BASE,
+        body='<a href="bash.one.log">1</a><a href="bash.two.log">2</a>',
+        status=200,
+        content_type="text/html",
+    )
+    responses.add(responses.GET, f"{_BC_BASE}/bash.one.log", status=500)
+    responses.add(
+        responses.GET,
+        f"{_BC_BASE}/bash.two.log",
+        body="3 widgets",
+        status=200,
+    )
+
+    out = oqa_search.build_checks(
+        "Maintenance", 12358, 199773, ["bash"], QAM, r"\d+ widgets"
+    )
+
+    assert out == [
+        BuildCheckResult(url=f"{_BC_BASE}/bash.one.log", matches=[], summary=""),
+        BuildCheckResult(
+            url=f"{_BC_BASE}/bash.two.log", matches=["3 widgets"], summary=""
+        ),
+    ]
+
+
+@responses.activate
+def test_build_checks_exactly_four_matches_not_folded():
+    """The fold triggers strictly above four matches; four stay verbatim."""
+    responses.add(
+        responses.GET,
+        _BC_BASE,
+        body='<a href="bash.x86_64.log">x</a>',
+        status=200,
+        content_type="text/html",
+    )
+    responses.add(
+        responses.GET,
+        f"{_BC_BASE}/bash.x86_64.log",
+        body="1 widgets\n2 widgets\n3 widgets\n4 widgets",
+        status=200,
+    )
+
+    out = oqa_search.build_checks(
+        "Maintenance", 12358, 199773, ["bash"], QAM, r"\d+ widgets"
+    )
+
+    assert len(out) == 1
+    assert out[0].summary == ""
+    assert out[0].matches == ["1 widgets", "2 widgets", "3 widgets", "4 widgets"]
+
+
+@responses.activate
+def test_build_checks_fold_keeps_true_first_and_last_lines():
+    """Folded matches are exactly the first and last matched lines."""
+    responses.add(
+        responses.GET,
+        _BC_BASE,
+        body='<a href="bash.x86_64.log">x</a>',
+        status=200,
+        content_type="text/html",
+    )
+    responses.add(
+        responses.GET,
+        f"{_BC_BASE}/bash.x86_64.log",
+        body="1 widgets\n2 widgets\n3 widgets\n4 widgets\n5 widgets",
+        status=200,
+    )
+
+    out = oqa_search.build_checks(
+        "Maintenance", 12358, 199773, ["bash"], QAM, r"\d+ widgets"
+    )
+
+    assert len(out) == 1
+    assert out[0].matches == ["1 widgets", "5 widgets"]
+    assert out[0].summary == "(3 more results, 0 passed, 0 failed)"
+
+
+# --- extract_test_results -------------------------------------------------------------
+
+
+def test_extract_test_results_custom_pattern_is_case_insensitive():
+    """The user's pattern matches regardless of case (re.IGNORECASE)."""
+    out = oqa_search.extract_test_results("FOO 3 WIDGETS", r"\d+ widgets")
+    assert out == ["FOO 3 WIDGETS"]
+
+
+def test_extract_test_results_separator_lines_kept_verbatim():
+    """Visual-separator lines are appended as-is (original line, in order)."""
+    log = "\n".join(
+        [
+            "[   12s] === 5 tests passed ===",
+            "[   13s] just some chatter",
+            "[   14s] === 3 tests total ===",
+        ]
+    )
+    assert oqa_search.extract_test_results(log) == [
+        "[   12s] === 5 tests passed ===",
+        "[   14s] === 3 tests total ===",
+    ]
+
+
+# --- HTTP helpers: _get_json / _fetch_url_content ---------------------------------------
+
+
+@responses.activate
+def test_get_json_http_status_error_raises_with_cause_text():
+    responses.add(responses.GET, f"{OPENQA}/api/v1/boom", status=500)
+    with pytest.raises(oqa_http._HTTPError, match="500 Server Error"):
+        oqa_http._get_json(f"{OPENQA}/api/v1/boom")
+
+
+@responses.activate
+def test_get_json_invalid_json_raises_with_cause_text():
+    responses.add(
+        responses.GET, f"{OPENQA}/api/v1/notjson", body="not json", status=200
+    )
+    with pytest.raises(oqa_http._HTTPError, match="Expecting value"):
+        oqa_http._get_json(f"{OPENQA}/api/v1/notjson")
+
+
+@responses.activate
+def test_fetch_url_content_http_status_error_raises_with_cause_text():
+    responses.add(responses.GET, f"{QAM}/gone", status=500)
+    with pytest.raises(oqa_http._HTTPError, match="500 Server Error"):
+        oqa_http._fetch_url_content(f"{QAM}/gone")
+
+
+class _CapturingSession:
+    """Fake session recording the kwargs of the single get() call."""
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+        self.captured: dict = {}
+
+    def get(self, url, **kwargs):
+        self.captured = {"url": url, **kwargs}
+        session = self
+
+        class _Resp:
+            text = session.payload
+
+            @staticmethod
+            def raise_for_status() -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict:
+                return {"ok": True}
+
+        return _Resp()
+
+
+def test_get_json_passes_bounded_timeout(monkeypatch):
+    fake = _CapturingSession('{"ok": true}')
+    monkeypatch.setattr(oqa_http, "_session", lambda: fake)
+
+    assert oqa_http._get_json(f"{OPENQA}/api/v1/x") == {"ok": True}
+    assert fake.captured["timeout"] == HTTP_TIMEOUT
+
+
+def test_fetch_url_content_passes_bounded_timeout(monkeypatch):
+    fake = _CapturingSession("hello")
+    monkeypatch.setattr(oqa_http, "_session", lambda: fake)
+
+    assert oqa_http._fetch_url_content(f"{QAM}/index") == "hello"
+    assert fake.captured["timeout"] == HTTP_TIMEOUT

--- a/tests/test_updateid_pins.py
+++ b/tests/test_updateid_pins.py
@@ -1,0 +1,207 @@
+"""Mutation-killing pinning tests for ``mtui.types.updateid``.
+
+A full mutmut run left survivors in ``UpdateID._checkout`` because the
+existing tests patch ``testreport_factory``, ``_vcs_checkout``,
+``prompt_user`` and ``_regenerate`` as MagicMocks without asserting the
+call arguments, so argument-drop/reorder mutants pass unnoticed. These
+tests pin:
+
+- the exact arguments of ``testreport_factory``, ``tr.read``,
+  ``_vcs_checkout`` and ``_regenerate``;
+- the real ``prompt_user`` accept lists (``["yes", "y"]``) by patching
+  the low-level ``_read_line`` instead of ``prompt_user`` itself;
+- that non-interactive mode never reads input and honors the delete
+  prompt's ``default=True``;
+- ``shutil.rmtree(..., ignore_errors=True)`` on the accepted delete;
+- ``UpdateID.tr_factory``'s kind-to-class dispatch.
+"""
+
+from __future__ import annotations
+
+from errno import ENOENT
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from mtui.support.exceptions import InvalidGiteaHashError
+from mtui.support.messages import TestReportNotLoadedError
+from mtui.test_reports.obs_report import OBSTestReport
+from mtui.test_reports.pi_report import PITestReport
+from mtui.test_reports.sl_report import SLTestReport
+from mtui.test_reports.svn_io import TemplateIOError
+from mtui.types import RequestReviewID
+from mtui.types.updateid import AutoOBSUpdateID, UpdateID
+
+RRID = "SUSE:Maintenance:12358:199773"
+
+
+def _make_updateid(read_side_effect=None) -> tuple[AutoOBSUpdateID, MagicMock]:
+    """AutoOBSUpdateID with a mocked factory; ``read`` behavior injectable."""
+    uid = AutoOBSUpdateID(RRID)
+    tr_mock = MagicMock(name="testreport")
+    if read_side_effect is not None:
+        tr_mock.read.side_effect = read_side_effect
+    uid.testreport_factory = MagicMock(return_value=tr_mock)
+    return uid, tr_mock
+
+
+def _hash_mismatch(uid: AutoOBSUpdateID) -> InvalidGiteaHashError:
+    return InvalidGiteaHashError(uid.id, "oldhash", "newhash")
+
+
+# --- call-argument pins ---------------------------------------------------------
+
+
+def test_checkout_happy_path_forwards_config_prompter_and_trpath(mock_config, tmp_path):
+    """factory gets (config, prompter=...); read gets template_dir/<id>/log."""
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    factory = MagicMock(return_value=tr_mock)
+    uid.testreport_factory = factory
+    prompter = MagicMock(name="prompter")
+
+    tr = uid._checkout(mock_config, interactive=False, prompter=prompter)
+
+    assert tr is tr_mock
+    factory.assert_called_once_with(mock_config, prompter=prompter)
+    tr_mock.read.assert_called_once_with(tmp_path / str(uid.id) / "log")
+
+
+def test_checkout_svn_checkout_gets_config_svnpath_and_id(mock_config, tmp_path):
+    """The ENOENT retry checks out (config, config.svn_path, id) then re-reads."""
+    mock_config.template_dir = tmp_path
+    enoent = TemplateIOError(ENOENT, "No such file or directory", "log")
+    uid, tr_mock = _make_updateid(read_side_effect=[enoent, None])
+    vcs_mock = MagicMock(name="vcs_checkout")
+    uid._vcs_checkout = vcs_mock
+
+    tr = uid._checkout(mock_config, interactive=False)
+
+    assert tr is tr_mock
+    vcs_mock.assert_called_once_with(mock_config, mock_config.svn_path, uid.id)
+    trpath = tmp_path / str(uid.id) / "log"
+    assert tr_mock.read.call_args_list == [call(trpath), call(trpath)]
+
+
+def test_checkout_regenerate_gets_config_teregen_paths_and_prompter(
+    mock_config, tmp_path
+):
+    """Accepting the offer calls _regenerate(config, teregen, trdir, trpath, p)."""
+    mock_config.template_dir = tmp_path
+    uid, _tr_mock = _make_updateid()
+    _tr_mock.read.side_effect = _hash_mismatch(uid)
+    prompter = MagicMock(name="prompter")
+    fresh = MagicMock(name="fresh_testreport")
+
+    with (
+        patch("mtui.types.updateid.TeReGen") as teregen_cls,
+        patch("mtui.types.updateid.prompt_user", return_value=True),
+        patch.object(uid, "_regenerate", return_value=fresh) as regen_mock,
+    ):
+        result = uid._checkout(mock_config, interactive=True, prompter=prompter)
+
+    assert result is fresh
+    teregen_cls.assert_called_once_with(mock_config)
+    trdir = tmp_path / str(uid.id)
+    regen_mock.assert_called_once_with(
+        mock_config, teregen_cls.return_value, trdir, trdir / "log", prompter
+    )
+
+
+# --- real prompt_user accept lists (patch _read_line, not prompt_user) -----------
+
+
+def test_checkout_regenerate_offer_accepts_literal_yes(mock_config, tmp_path):
+    """Typing 'yes' at the regenerate offer takes the regeneration path."""
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    tr_mock.read.side_effect = _hash_mismatch(uid)
+    fresh = MagicMock(name="fresh_testreport")
+
+    with (
+        patch("mtui.types.updateid.TeReGen"),
+        patch("mtui.cli.term._read_line", return_value="yes") as read_mock,
+        patch.object(uid, "_regenerate", return_value=fresh),
+    ):
+        result = uid._checkout(mock_config, interactive=True)
+
+    assert result is fresh
+    read_mock.assert_called_once()
+
+
+def test_checkout_force_continue_accepts_literal_yes(mock_config, tmp_path):
+    """Declining the offer, then typing 'y' at force-continue loads anyway.
+
+    Uses the short literal deliberately: the accept list is ["yes", "y"]
+    and the sibling tests already cover "yes", so this pins the "y"
+    element against accept-list mutants.
+    """
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    tr_mock.read.side_effect = _hash_mismatch(uid)
+
+    with (
+        patch("mtui.types.updateid.TeReGen"),
+        patch("mtui.cli.term._read_line", side_effect=["no", "y"]) as read_mock,
+    ):
+        result = uid._checkout(mock_config, interactive=True)
+
+    assert result is tr_mock
+    assert read_mock.call_count == 2
+
+
+def test_checkout_delete_prompt_accepts_literal_yes_and_rmtree_ignores_errors(
+    mock_config, tmp_path
+):
+    """Declining offer+force, then 'yes' at delete removes trdir tolerantly."""
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    tr_mock.read.side_effect = _hash_mismatch(uid)
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        patch("mtui.types.updateid.TeReGen"),
+        patch("mtui.cli.term._read_line", side_effect=["no", "no", "yes"]),
+        patch("mtui.types.updateid.shutil.rmtree") as rmtree_mock,
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=True)
+
+    rmtree_mock.assert_called_once_with(trdir, ignore_errors=True)
+
+
+def test_checkout_non_interactive_never_reads_input(mock_config, tmp_path):
+    """interactive=False reaches every prompt without touching the terminal,
+    and the delete prompt's default=True removes the stale checkout."""
+    mock_config.template_dir = tmp_path
+    uid, tr_mock = _make_updateid()
+    tr_mock.read.side_effect = _hash_mismatch(uid)
+    trdir = tmp_path / str(uid.id)
+    trdir.mkdir(parents=True)
+
+    with (
+        patch("mtui.types.updateid.TeReGen"),
+        patch("mtui.cli.term._read_line") as read_mock,
+        pytest.raises(TestReportNotLoadedError),
+    ):
+        uid._checkout(mock_config, interactive=False)
+
+    read_mock.assert_not_called()
+    # Offer and force-continue default to False; delete defaults to True.
+    assert not trdir.exists()
+
+
+# --- tr_factory dispatch ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rrid", "expected_cls"),
+    [
+        ("SUSE:SLFO:1.1:20", SLTestReport),
+        ("SUSE:PI:34556:1", PITestReport),
+        ("SUSE:Maintenance:1:1", OBSTestReport),
+    ],
+)
+def test_tr_factory_dispatches_kind_to_report_class(rrid, expected_cls):
+    assert UpdateID.tr_factory(RequestReviewID(rrid)) is expected_cls


### PR DESCRIPTION
## What
51 pinning tests (3 new files) for the openQA data path (~409 survivors): `DashboardAutoOpenQA._normalize_job` field mapping and `_get_logs_url` selection, `_pretty_print_section` layout, `oqa_search` incident/aggregate version scans and result classification, and `UpdateID._checkout`'s prompt flow — including the real `prompt_user` accept lists (both `"yes"` and `"y"` literals, via the low-level reader rather than mocking `prompt_user` away).

Part of the mutation-testing campaign (config and methodology in #298): these clusters were `covered-but-unasserted` — the suite executed the code but pinned nothing, so mutants survived. Every new test was **mutation-verified**: a representative mutant was hand-applied to the production code and the test shown to fail, then the tree restored byte-identical. Adversarially reviewed (pin-quality + hermeticity lenses, refute-by-default verification) before opening. Tests-only; all tests live in new files, so no conflicts with the open fix PRs.
