### PR TITLE
test(mcp): pin argv synthesis and schema generation

### DIFF
--- a/tests/test_mcp_argv_pins.py
+++ b/tests/test_mcp_argv_pins.py
@@ -1,0 +1,250 @@
+"""Mutation-killing pins for :func:`mtui.mcp._argv.kwargs_to_argv`.
+
+A full mutmut run left survivors in code paths the existing round-trip
+tests execute but never assert on. The tests here pin the behaviours
+those mutants change:
+
+* every ``continue`` in the main action loop keeps processing LATER
+  actions (a ``break`` there silently drops flags/positionals that
+  follow a const-routed group, a secondary shared-dest action, or a
+  ``None``-valued kwarg — mis-scoping the command);
+* the pre-scan over mutually exclusive groups keeps scanning after a
+  trivial/mismatched group so a later const group still routes;
+* ``store_false`` emits the flag on the *falsy* side only;
+* ``append`` + multi ``nargs`` (``*``/``+``) emits the flag once into
+  the positional tail, not once per element;
+* subparser / SUPPRESS-dest actions never contribute argv nor stop
+  the encoding.
+
+Each test was verified to fail against a hand-applied representative
+mutant before the pristine code was restored.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mtui.commands import Command  # noqa: E402
+from mtui.mcp._argv import kwargs_to_argv  # noqa: E402
+from mtui.mcp._schema import build_parameters  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Const-routed groups must not stop the main loop                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_setrepo_const_group_does_not_stop_later_kwargs() -> None:
+    """``set_repo`` emits template and hosts *after* the const-routed group.
+
+    The ``-A``/``-R`` const actions are skipped in the main loop (they
+    were already routed by the pre-scan); a ``break`` there instead of
+    ``continue`` would silently drop ``--target`` and ``--template``,
+    running the command against the wrong scope.
+    """
+    parser = Command.registry["set_repo"].argparser(__import__("sys"))
+    build_parameters(parser)  # attaches the synthetic-routing metadata
+    argv = kwargs_to_argv(
+        parser,
+        {
+            "operation": "add",
+            "hosts": ["h1", "h2"],
+            "template": "SUSE:Maintenance:1:1",
+        },
+    )
+    assert argv == [
+        "--add",
+        "--target",
+        "h1",
+        "--target",
+        "h2",
+        "--template",
+        "SUSE:Maintenance:1:1",
+    ]
+    parsed = parser.parse_args(argv)
+    assert parsed.operation == "add"
+    assert parsed.hosts == ["h1", "h2"]
+    assert parsed.template == "SUSE:Maintenance:1:1"
+
+
+def test_const_scan_skips_trivial_groups_and_processes_later_ones() -> None:
+    """The mutex-group pre-scan must *continue* past non-matching groups.
+
+    Guards for "fewer than two members", "not all StoreConst" and
+    "distinct dests" must skip just that group: a ``break`` would leave
+    a later const group unrouted and the main loop would then emit the
+    group's FIRST flag for any truthy value (``--up`` for ``dir='down'``).
+    Same for a const group whose dest is absent or ``None`` in kwargs.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    g1 = parser.add_mutually_exclusive_group()
+    g1.add_argument("--solo", action="store_true")  # < 2 members
+    g2 = parser.add_mutually_exclusive_group()
+    g2.add_argument("--alpha", dest="alpha")  # not all StoreConst
+    g2.add_argument("--beta", dest="beta")
+    g3 = parser.add_mutually_exclusive_group()
+    g3.add_argument("--fast", dest="speed", action="store_true")  # distinct
+    g3.add_argument("--slow", dest="slowness", action="store_true")  # dests
+    g4 = parser.add_mutually_exclusive_group()
+    g4.add_argument("--enable", dest="mode", action="store_const", const="on")
+    g4.add_argument("--disable", dest="mode", action="store_const", const="off")
+    g5 = parser.add_mutually_exclusive_group()
+    g5.add_argument("--up", dest="direction", action="store_const", const="up")
+    g5.add_argument("--down", dest="direction", action="store_const", const="down")
+
+    # First const group present-but-None, second supplied: only the
+    # second may emit, and it must emit the flag matching the const.
+    assert kwargs_to_argv(parser, {"mode": None, "direction": "down"}) == ["--down"]
+    # Absent first const dest, supplied second. The chosen const must
+    # differ from the group's FIRST member: a break-instead-of-continue
+    # mutant leaves g5 unrouted and the legacy truthy fallback emits the
+    # first flag (--up) regardless of the value -- "down" catches that.
+    assert kwargs_to_argv(parser, {"direction": "down"}) == ["--down"]
+    assert kwargs_to_argv(parser, {"direction": "up"}) == ["--up"]
+    # Plain routing sanity for the first const group.
+    assert kwargs_to_argv(parser, {"mode": "off"}) == ["--disable"]
+
+
+# --------------------------------------------------------------------------- #
+# Main loop continues past skipped/None-valued actions                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_secondary_shared_dest_action_does_not_stop_loop() -> None:
+    """A second action sharing a dest is skipped; later actions still emit.
+
+    Without the schema pre-scan (raw parser), only the FIRST action of a
+    shared dest re-emits the kwarg. The secondary action's ``continue``
+    must not terminate the loop — the ``--after`` flag declared later
+    must still be encoded.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-a", "--alpha", dest="val")
+    group.add_argument("-b", "--beta", dest="val")
+    parser.add_argument("-x", "--after", action="store_true")
+
+    argv = kwargs_to_argv(parser, {"val": "V", "after": True})
+    assert argv == ["--alpha", "V", "--after"]
+
+
+def test_none_positional_does_not_stop_loop() -> None:
+    """An unsupplied (``None``) optional positional must not eat the tail."""
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("maybe", nargs="?")
+    parser.add_argument("rest", nargs="*")
+
+    argv = kwargs_to_argv(parser, {"maybe": None, "rest": ["r1", "r2"]})
+    assert argv == ["r1", "r2"]
+
+
+def test_none_optional_flag_does_not_stop_loop() -> None:
+    """A ``None``-valued optional flag must not eat later positionals."""
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("-o", "--opt")
+    parser.add_argument("pos", nargs="*")
+
+    argv = kwargs_to_argv(parser, {"opt": None, "pos": ["a", "b"]})
+    assert argv == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# store_false / append-multi generic branches                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_store_false_emits_flag_only_when_value_falsy() -> None:
+    """``store_false``: flag iff the kwarg is the "off" side; tail survives."""
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("--no-color", dest="color", action="store_false")
+    parser.add_argument("tail", nargs="*")
+
+    # False -> flag emitted, and the loop continues to the tail.
+    assert kwargs_to_argv(parser, {"color": False, "tail": ["t1"]}) == [
+        "--no-color",
+        "t1",
+    ]
+    # True (the default side) -> no flag.
+    assert kwargs_to_argv(parser, {"color": True, "tail": ["t1"]}) == ["t1"]
+    parsed = parser.parse_args(["--no-color"])
+    assert parsed.color is False
+
+
+@pytest.mark.parametrize("nargs", ["*", "+"])
+def test_append_multi_nargs_emits_flag_once_in_tail(nargs: str) -> None:
+    """``append`` + ``nargs='*'``/``'+'`` re-emits one flag then every token.
+
+    Emitting ``--words a --words b`` instead would make argparse rebuild
+    ``[['a'], ['b']]`` (or swallow the repeated flag), corrupting the
+    value; the flag+tokens must also land in the positional tail, i.e.
+    after ordinary flags.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("--words", action="append", nargs=nargs)
+    parser.add_argument("-x", "--xflag", action="store_true")
+
+    argv = kwargs_to_argv(parser, {"words": ["a", "b"], "xflag": True})
+    assert argv == ["--xflag", "--words", "a", "b"]
+    parsed = parser.parse_args(argv)
+    assert parsed.words == [["a", "b"]]
+
+
+def test_short_only_option_falls_back_to_short_flag() -> None:
+    """An option with only a short form is emitted with that short form."""
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("-z", dest="z")
+
+    assert kwargs_to_argv(parser, {"z": "v"}) == ["-z", "v"]
+
+
+# --------------------------------------------------------------------------- #
+# Subparser / SUPPRESS actions and synthetic routing                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_subparser_and_suppress_actions_are_ignored_not_fatal() -> None:
+    """Subparser and SUPPRESS-dest actions contribute nothing and don't stop.
+
+    The dest index must skip both (a ``break`` there would empty the
+    index and drop every later kwarg), and the main loop must tolerate
+    an action whose dest is missing from the index without a KeyError.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_subparsers()
+    parser.add_argument("--ghost", dest=argparse.SUPPRESS)
+    parser.add_argument("--flag")
+
+    assert kwargs_to_argv(parser, {"flag": "v"}) == ["--flag", "v"]
+    assert kwargs_to_argv(parser, {}) == []
+
+
+def test_loadtemplate_synthetic_routing_ignores_underlying_dest() -> None:
+    """Once synthetic routing owns a group, the raw dest kwarg is inert.
+
+    The main loop must skip the underlying actions by identity; keying
+    the skip-set off anything else would re-emit ``--auto-review-id``
+    with the stray ``update`` value appended after the synthetic pass.
+    """
+    parser = Command.registry["load_template"].argparser(__import__("sys"))
+    build_parameters(parser)
+    argv = kwargs_to_argv(
+        parser,
+        {"auto_review_id": "SUSE:Maintenance:1:1", "update": "SUSE:Maintenance:9:9"},
+    )
+    assert argv == ["--auto-review-id", "SUSE:Maintenance:1:1"]
+
+
+def test_loadtemplate_kernel_id_alone_still_emits() -> None:
+    """A synthetic kwarg that is simply absent must not stop the synthetic pass.
+
+    ``kernel_review_id`` is the SECOND entry of the synthetic map; when
+    ``auto_review_id`` is not in kwargs at all (as opposed to ``None``),
+    the pass must continue to the kernel entry.
+    """
+    parser = Command.registry["load_template"].argparser(__import__("sys"))
+    build_parameters(parser)
+    argv = kwargs_to_argv(parser, {"kernel_review_id": "SUSE:Maintenance:2:2"})
+    assert argv == ["--kernel-review-id", "SUSE:Maintenance:2:2"]

--- a/tests/test_mcp_schema_pins.py
+++ b/tests/test_mcp_schema_pins.py
@@ -1,0 +1,307 @@
+"""Mutation-killing pins for :mod:`mtui.mcp._schema`.
+
+A full mutmut run left survivors in schema-synthesis code the suite
+executes but never asserts on. The tests here pin:
+
+* ``_base_type``: a real ``type=int`` CLI option becomes a JSON-Schema
+  ``integer`` (not ``string``), and an unmapped ``type=`` callable falls
+  back to ``str`` with a WARNING instead of crashing;
+* ``action_to_parameter``: ``store_true``/``store_false``/``store_const``
+  defaults (``False``/``True``/``False``) and descriptions, preservation
+  of real scalar defaults, optionality of ``nargs='?'`` positionals, and
+  ``nargs=N`` array bounds;
+* ``_scan_shared_dest_groups``: the group scan continues past trivial /
+  mismatched groups (a ``break`` would leave a later shared-dest group
+  to the legacy duplicate-dest path) and keys the synthesised parameter
+  off the group's FIRST member;
+* ``build_parameters``: every special-cased action (subparsers,
+  SUPPRESS dest, emit-at, skip, duplicate dest) is skipped with
+  ``continue`` semantics so trailing actions still become parameters,
+  and de-duplication really tracks names.
+
+Each test was verified to fail against a hand-applied representative
+mutant before the pristine code was restored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import logging
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from pydantic import TypeAdapter  # noqa: E402
+
+from mtui.commands import Command  # noqa: E402
+from mtui.mcp._schema import (  # noqa: E402
+    _base_type,
+    action_to_parameter,
+    build_parameters,
+)
+
+
+def _params_by_name(command: str) -> dict[str, inspect.Parameter]:
+    parser = Command.registry[command].argparser(__import__("sys"))
+    return {p.name: p for p in build_parameters(parser)}
+
+
+def _schema_of(param: inspect.Parameter) -> dict:
+    """Render the JSON schema pydantic derives from a parameter annotation."""
+    return TypeAdapter(param.annotation).json_schema()
+
+
+# --------------------------------------------------------------------------- #
+# _base_type                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_int_typed_option_maps_to_integer_schema() -> None:
+    """``updates --limit`` (``type=int``, ``default=0``) stays an integer.
+
+    Collapsing the type table to ``str`` would advertise a string field
+    to every MCP client; dropping the real default would widen the
+    schema to nullable.
+    """
+    params = _params_by_name("updates")
+    limit = params["limit"]
+    assert limit.default == 0
+    assert _schema_of(limit).get("type") == "integer"
+
+
+def test_unknown_type_callable_falls_back_to_str_with_warning(caplog) -> None:
+    """An unmapped ``type=`` callable degrades to ``str`` and warns.
+
+    Inverting the membership test would instead crash with a KeyError
+    for unknown types (and route known types through the fallback).
+    """
+
+    def bespoke(raw: str) -> str:  # pragma: no cover - never called
+        return raw
+
+    parser = argparse.ArgumentParser(prog="probe")
+    action = parser.add_argument("--weird", type=bespoke)
+
+    with caplog.at_level(logging.WARNING, logger="mtui.mcp.schema"):
+        result = _base_type(action)
+
+    assert result is str
+    assert any("unknown argparse type" in r.message for r in caplog.records)
+
+
+def test_known_nargs_shapes_produce_no_warning(caplog) -> None:
+    """Scalar / ``?`` / ``+`` / REMAINDER shapes never hit the nargs fallback.
+
+    The ``nargs is None or nargs == "?"`` guard degrades gracefully when
+    mutated (same return value) but starts logging spurious warnings;
+    pin the quiet path.
+    """
+    with caplog.at_level(logging.WARNING, logger="mtui.mcp.schema"):
+        _params_by_name("export")  # nargs="?" positional
+        _params_by_name("updates")  # plain scalars
+        _params_by_name("openqa_overview")  # nargs="+" choices
+    assert not any("unknown argparse nargs" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# action_to_parameter                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_store_true_defaults_false_with_description() -> None:
+    """``add_host --keep-mode`` (store_true) defaults to ``False``.
+
+    A flipped default would silently invert the flag for every MCP
+    client that omits it.
+    """
+    params = _params_by_name("add_host")
+    keep_mode = params["keep_mode"]
+    assert keep_mode.default is False
+    field = keep_mode.annotation.__metadata__[0]
+    assert field.description == (
+        "do not switch to the manual workflow when in automatic mode"
+    )
+
+
+def test_store_false_defaults_true_with_description() -> None:
+    """A ``store_false`` action defaults to ``True`` and keeps its help text.
+
+    No mtui command uses ``store_false`` today; pin the generic branch
+    directly so the inverted-default mutant cannot hide behind that.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    action = parser.add_argument(
+        "--no-color", dest="color", action="store_false", help="disable color output"
+    )
+    result = action_to_parameter(action)
+    assert result is not None
+    name, annotation, default = result
+    assert name == "color"
+    assert default is True
+    field = annotation.__metadata__[0]
+    assert field.description == "disable color output"
+    assert TypeAdapter(annotation).json_schema().get("type") == "boolean"
+
+
+def test_store_const_defaults_false_and_synthesises_description() -> None:
+    """``store_const`` flags default to ``False``; help-less ones still get one."""
+    params = _params_by_name("update")
+    for flag in ("newpackage", "noprepare"):
+        assert params[flag].default is False
+
+    parser = argparse.ArgumentParser(prog="probe")
+    action = parser.add_argument(
+        "--fast", dest="mode", action="store_const", const="fast"
+    )
+    result = action_to_parameter(action)
+    assert result is not None
+    name, annotation, default = result
+    assert name == "mode"
+    assert default is False
+    assert annotation.__metadata__[0].description == "sets mode='fast'"
+
+
+def test_scalar_default_preserved_and_choices_become_enum() -> None:
+    """``openqa_overview --days`` keeps ``default=5`` and its 1-30 enum."""
+    params = _params_by_name("openqa_overview")
+    days = params["days"]
+    assert days.default == 5
+    schema = _schema_of(days)
+    assert schema.get("enum") == list(range(1, 31))
+
+
+def test_nargs_one_positional_is_required_scalar() -> None:
+    """``set_timeout timeout`` (``nargs=1``, ``type=int``) is a required scalar."""
+    params = _params_by_name("set_timeout")
+    timeout = params["timeout"]
+    assert timeout.default is inspect.Parameter.empty  # required
+    schema = _schema_of(timeout)
+    assert schema.get("type") == "integer"
+
+
+def test_optional_positional_is_nullable_and_not_required() -> None:
+    """``export filename`` (``nargs='?'``) is optional and nullable.
+
+    Mutating the ``("?", "*", REMAINDER)`` membership would make the
+    positional required for every MCP client.
+    """
+    params = _params_by_name("export")
+    filename = params["filename"]
+    assert filename.default is None
+    schema = _schema_of(filename)
+    assert {"type": "string"} in schema.get("anyOf", [])
+    assert {"type": "null"} in schema.get("anyOf", [])
+
+
+def test_nargs_plus_list_carries_min_items() -> None:
+    """``nargs='+'`` becomes an array with ``minItems=1``."""
+    params = _params_by_name("openqa_overview")
+    schema = _schema_of(params["aggregated_groups"])
+    assert schema.get("type") == "array"
+    assert schema.get("minItems") == 1
+
+
+def test_nargs_n_list_carries_exact_bounds() -> None:
+    """``nargs=2`` becomes an array bounded to exactly two items."""
+    parser = argparse.ArgumentParser(prog="probe")
+    action = parser.add_argument("--pair", nargs=2, help="two values")
+    result = action_to_parameter(action)
+    assert result is not None
+    _, annotation, _ = result
+    schema = TypeAdapter(annotation).json_schema()
+    assert schema.get("type") == "array"
+    assert schema.get("minItems") == 2
+    assert schema.get("maxItems") == 2
+
+
+# --------------------------------------------------------------------------- #
+# _scan_shared_dest_groups                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_scan_continues_past_trivial_and_mismatched_groups(caplog) -> None:
+    """Groups that don't match a recognised shape must not stop the scan.
+
+    A ``break`` on the "fewer than two members" or "distinct dests"
+    guard would leave the LAST group unhandled, sending its members
+    through the legacy duplicate-dest path (one boolean param + a
+    WARNING) instead of one Literal enum.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    g1 = parser.add_mutually_exclusive_group()
+    g1.add_argument("--solo", action="store_true")  # < 2 members
+    g2 = parser.add_mutually_exclusive_group()
+    g2.add_argument("--fast", dest="fast", action="store_true")  # distinct
+    g2.add_argument("--slow", dest="slow", action="store_true")  # dests
+    g3 = parser.add_mutually_exclusive_group()
+    g3.add_argument("--enable", dest="mode", action="store_const", const="on")
+    g3.add_argument("--disable", dest="mode", action="store_const", const="off")
+
+    with caplog.at_level(logging.WARNING, logger="mtui.mcp.schema"):
+        params = build_parameters(parser)
+
+    names = [p.name for p in params]
+    assert names.count("mode") == 1
+    (mode,) = (p for p in params if p.name == "mode")
+    schema = TypeAdapter(mode.annotation).json_schema()
+    enums = [alt.get("enum") for alt in schema.get("anyOf", []) if "enum" in alt]
+    assert enums == [["on", "off"]]
+    assert not any("duplicate dest" in r.message for r in caplog.records)
+
+
+def test_scan_emits_group_parameter_at_first_member_position() -> None:
+    """The synthesised group parameter lands at the FIRST member's slot.
+
+    With a plain option declared between the two group members, keying
+    ``emit_at`` off the second member would reorder the parameter list.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--enable", dest="mode", action="store_const", const="on")
+    parser.add_argument("--mid")
+    group.add_argument("--disable", dest="mode", action="store_const", const="off")
+
+    names = [p.name for p in build_parameters(parser)]
+    assert names == ["mode", "mid"]
+
+
+# --------------------------------------------------------------------------- #
+# build_parameters main loop                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_parameters_processes_actions_after_every_special_case(
+    caplog,
+) -> None:
+    """Trailing actions survive each specially-handled action kind.
+
+    One parser stacks, in order: an ordinary option, a subparsers
+    action, a SUPPRESS-dest action, a shared-dest const group (emit-at
+    plus skip slots), a genuine duplicate dest, and a final ordinary
+    option. Each special case must be skipped with ``continue``
+    semantics — any ``break`` drops ``last`` (and friends) from the
+    schema; a broken ``seen`` set either duplicates ``dup`` or loses
+    the duplicate-dest warning.
+    """
+    parser = argparse.ArgumentParser(prog="probe")
+    parser.add_argument("--first")
+    parser.add_subparsers()
+    parser.add_argument("--ghost", dest=argparse.SUPPRESS)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--enable", dest="mode", action="store_const", const="on")
+    group.add_argument("--disable", dest="mode", action="store_const", const="off")
+    parser.add_argument("--dup-a", dest="dup")
+    parser.add_argument("--dup-b", dest="dup")
+    parser.add_argument("--last")
+
+    with caplog.at_level(logging.WARNING, logger="mtui.mcp.schema"):
+        params = build_parameters(parser)
+
+    names = [p.name for p in params]
+    assert names == ["first", "mode", "dup", "last"]
+    duplicate_warnings = [
+        r for r in caplog.records if "duplicate dest 'dup'" in r.message
+    ]
+    assert len(duplicate_warnings) == 1

--- a/tests/test_mcp_tools_pins.py
+++ b/tests/test_mcp_tools_pins.py
@@ -1,0 +1,326 @@
+"""Mutation-killing pins for the runtime wiring in :mod:`mtui.mcp.tools`.
+
+A full mutmut run showed that no test ever *invokes* a generated
+wrapper with a request ``ctx`` present, calls the fanned-out
+``config_show``/``config_set`` tools, or reads any tool's
+``description`` — so mutants that drop the per-request Context, the
+session provider, the subcommand argv prefix, or the tool description
+all survived. The tests here drive the registered tools end to end
+against a spy session/provider and pin:
+
+* ``ctx`` is stripped from kwargs and forwarded (not discarded) into
+  both session resolution and ``run_command``/``start_jobs``;
+* the subparser fan-out passes the real provider and prepends the
+  subcommand to the argv (``config_set`` -> ``['set', attr, value]``);
+* tool descriptions come from the command docstring / subparser usage;
+* slow commands run in the foreground unless ``background=True``, and
+  the multi-job background message names every started job;
+* the synthetic "exactly one required" guard reports the supplied
+  names and count, and is NOT enforced for non-required groups.
+
+Each test was verified to fail against a hand-applied representative
+mutant before the pristine code was restored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from mtui.commands import Command  # noqa: E402
+from mtui.mcp.registry import DEFAULT_SESSION_KEY  # noqa: E402
+from mtui.mcp.session import McpCommandError  # noqa: E402
+from mtui.mcp.tools import _make_wrapper, build_tools  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Spy plumbing                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class SpySession:
+    """Session + provider double recording every dispatch.
+
+    Mirrors the dual shape of :class:`McpSession` (which is both the
+    stdio session provider and the session itself): ``get_or_create``
+    records the resolution key and returns ``self``; ``run_command`` /
+    ``start_jobs`` record ``(cls, argv, ctx)`` without touching hosts.
+    """
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+        self.run_calls: list[tuple[type, list[str], Any]] = []
+        self.job_calls: list[tuple[type, list[str], Any]] = []
+        self.result = "SPY-RESULT"
+        self.job_ids = ["job-1"]
+
+    async def get_or_create(self, key: str) -> Any:
+        # ``Any`` return: the SessionProvider protocol promises an
+        # ``McpSession``; this double records the key and stands in for it.
+        self.keys.append(key)
+        return self
+
+    async def run_command(
+        self, cmd_cls: type, argv: list[str], ctx: Any | None = None
+    ) -> str:
+        self.run_calls.append((cmd_cls, argv, ctx))
+        return self.result
+
+    async def start_jobs(
+        self, cmd_cls: type, argv: list[str], *, ctx: Any | None = None
+    ) -> list[str]:
+        self.job_calls.append((cmd_cls, argv, ctx))
+        return list(self.job_ids)
+
+
+@pytest.fixture
+def spy() -> SpySession:
+    return SpySession()
+
+
+@pytest.fixture
+def mcp() -> FastMCP:
+    return FastMCP(name="mtui-pins")
+
+
+@pytest.fixture
+def registered_names(mcp: FastMCP, spy: SpySession) -> list[str]:
+    return build_tools(mcp, spy)
+
+
+def _tool(mcp: FastMCP, name: str):
+    tool = mcp._tool_manager.get_tool(name)  # noqa: SLF001
+    assert tool is not None, f"tool {name!r} not registered"
+    return tool
+
+
+def _fake_ctx() -> SimpleNamespace:
+    """Minimal stand-in for the FastMCP request Context.
+
+    Only ``.session`` is read (by the registry's session-key
+    derivation), so a bare namespace suffices.
+    """
+    return SimpleNamespace(session=object())
+
+
+# --------------------------------------------------------------------------- #
+# ctx forwarding                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_wrapper_forwards_ctx_to_session_resolution_and_run(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """A supplied ``ctx`` reaches both ``get_or_create`` and ``run_command``.
+
+    This is the progress-heartbeat contract from the module docstring:
+    discarding ``ctx`` (or popping the wrong key) would resolve the
+    default session and silence ``notifications/progress`` for every
+    long-running command.
+    """
+    ctx = _fake_ctx()
+    tool = _tool(mcp, "whoami")
+
+    out = asyncio.run(tool.fn(ctx=ctx))
+
+    assert out == "SPY-RESULT"
+    assert spy.keys == [str(id(ctx.session))]
+    assert len(spy.run_calls) == 1
+    cls, argv, forwarded_ctx = spy.run_calls[0]
+    assert cls is Command.registry["whoami"]
+    assert argv == []
+    assert forwarded_ctx is ctx
+
+
+def test_wrapper_without_ctx_uses_default_session_key(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """Direct calls without a request Context resolve the default session."""
+    asyncio.run(_tool(mcp, "whoami").fn())
+    assert spy.keys == [DEFAULT_SESSION_KEY]
+    assert spy.run_calls[0][2] is None
+
+
+def test_wrapper_strips_ctx_from_encoded_argv(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """``ctx`` never leaks into the argv handed to the command parser."""
+    ctx = _fake_ctx()
+    asyncio.run(_tool(mcp, "add_host").fn(target=["h1"], ctx=ctx))
+
+    _, argv, forwarded_ctx = spy.run_calls[0]
+    assert argv == ["--target", "h1"]
+    assert forwarded_ctx is ctx
+
+
+# --------------------------------------------------------------------------- #
+# Subparser fan-out runtime behaviour                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_config_set_invocation_prepends_subcommand(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """``config_set`` dispatches ``['set', attribute, value]`` via the provider.
+
+    Registration alone cannot catch a dropped ``argv_prefix`` or a
+    ``None`` provider — only invoking the wrapper does.
+    """
+    out = asyncio.run(_tool(mcp, "config_set").fn(attribute="session_user", value="x"))
+
+    assert out == "SPY-RESULT"
+    cls, argv, _ = spy.run_calls[0]
+    assert cls is Command.registry["config"]
+    assert argv == ["set", "session_user", "x"]
+
+
+def test_config_show_invocation_prepends_subcommand(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """``config_show`` dispatches ``['show', *attributes]``."""
+    asyncio.run(_tool(mcp, "config_show").fn(attributes=["session_user"]))
+
+    cls, argv, _ = spy.run_calls[0]
+    assert cls is Command.registry["config"]
+    assert argv == ["show", "session_user"]
+
+
+# --------------------------------------------------------------------------- #
+# Tool descriptions                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_tool_description_is_stripped_command_docstring(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """Ordinary tools advertise the command class docstring, stripped."""
+    for name in ("run", "update", "whoami"):
+        expected = (Command.registry[name].__doc__ or "").strip()
+        assert expected, f"command {name!r} lost its docstring"
+        assert _tool(mcp, name).description == expected
+
+
+def test_fanned_out_tool_description_names_the_subcommand(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """``config_show``/``config_set`` descriptions come from the subparser.
+
+    A dropped description would silently fall back to the parent
+    ``config`` docstring, misleading clients about which tool does what.
+    """
+    assert _tool(mcp, "config_show").description.startswith("usage: config show")
+    assert _tool(mcp, "config_set").description.startswith("usage: config set")
+
+
+# --------------------------------------------------------------------------- #
+# background flag semantics                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_slow_tool_runs_foreground_by_default(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """Omitting ``background`` runs the command inline, not as a job."""
+    out = asyncio.run(_tool(mcp, "run").fn(command=["ls"], hosts=[]))
+
+    assert out == "SPY-RESULT"
+    assert spy.job_calls == []
+    assert len(spy.run_calls) == 1
+
+
+def test_slow_tool_background_multi_job_message_lists_every_job(
+    mcp: FastMCP, spy: SpySession, registered_names: list[str]
+) -> None:
+    """Fanning out to several templates reports every job id.
+
+    ``start_jobs`` mints one job per loaded template; the multi-job
+    branch of the wrapper (untested before) must name the command, the
+    job count, and each id so the client can poll them all.
+    """
+    spy.job_ids = ["run-1", "run-2"]
+    ctx = _fake_ctx()
+
+    out = asyncio.run(
+        _tool(mcp, "run").fn(command=["ls"], hosts=[], background=True, ctx=ctx)
+    )
+
+    assert spy.run_calls == []
+    cls, argv, forwarded_ctx = spy.job_calls[0]
+    assert cls is Command.registry["run"]
+    assert argv == ["ls"]
+    assert forwarded_ctx is ctx
+    assert "started 2 jobs" in out
+    assert "`run`" in out
+    assert "'run-1'" in out
+    assert "'run-2'" in out
+    assert "job_status" in out
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic "exactly one required" runtime guard                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_synthetic_required_error_reports_supplied_names(
+    mcp: FastMCP, registered_names: list[str]
+) -> None:
+    """The violation message carries the real count and kwarg names."""
+    with pytest.raises(McpCommandError) as both:
+        asyncio.run(
+            _tool(mcp, "load_template").fn(
+                auto_review_id="SUSE:Maintenance:1:1",
+                kernel_review_id="SUSE:Maintenance:2:2",
+            )
+        )
+    assert both.value.exit_code == 2
+    assert "--auto-review-id, --kernel-review-id" in both.value.stderr
+    assert "got 2 (auto_review_id, kernel_review_id)" in both.value.stderr
+
+    with pytest.raises(McpCommandError) as neither:
+        asyncio.run(
+            _tool(mcp, "load_template").fn(auto_review_id=None, kernel_review_id=None)
+        )
+    assert "got 0 (none)" in neither.value.stderr
+
+
+def test_non_required_synthetic_group_is_not_enforced(spy: SpySession) -> None:
+    """Only a *required* mutex group triggers the exactly-one guard.
+
+    A parser with a non-required shared-dest StoreAction group plus an
+    unrelated required group must accept a call supplying neither
+    synthetic kwarg: the guard has to key off the synthetic group's own
+    ``required`` flag (intersection, not union, with the group members).
+    """
+
+    class ProbeCommand:
+        """Probe command for wrapper synthesis."""
+
+        command = "probe_pin"
+
+    parser = argparse.ArgumentParser(prog="probe_pin")
+    optional_group = parser.add_mutually_exclusive_group()
+    optional_group.add_argument("--alpha-id", dest="ident")
+    optional_group.add_argument("--beta-id", dest="ident")
+    required_group = parser.add_mutually_exclusive_group(required=True)
+    required_group.add_argument("--on", action="store_true")
+    required_group.add_argument("--off", action="store_true")
+
+    wrapper = _make_wrapper(cast("type[Command]", ProbeCommand), parser, spy)
+
+    out = asyncio.run(wrapper(on=True))
+
+    assert out == "SPY-RESULT"
+    assert len(spy.run_calls) == 1
+    _, argv, _ = spy.run_calls[0]
+    assert argv == ["--on"]
+
+    # The synthetic kwargs still route when supplied.
+    asyncio.run(wrapper(alpha_id="X"))
+    assert spy.run_calls[1][1] == ["--alpha-id", "X"]


### PR DESCRIPTION
## What
36 pinning tests (3 new files) for the MCP request plumbing (~89 survivors): `kwargs_to_argv` round-trips (store_const mutex groups incl. the pre-scan skip semantics, nargs shapes, negative numbers, remainder), `_schema.action_to_parameter` typing/required rules, and tool wiring in `_make_wrapper`/`_fan_out_subparser`.

The adversarial review caught a golden-value coincidence in the const pre-scan test (the mutant emitted the same flag the assertion expected); the case now uses a const that differs from the group's first member, so the `continue`→`break` mutant fails loudly.

Part of the mutation-testing campaign (config and methodology in #298): these clusters were `covered-but-unasserted` — the suite executed the code but pinned nothing, so mutants survived. Every new test was **mutation-verified**: a representative mutant was hand-applied to the production code and the test shown to fail, then the tree restored byte-identical. Adversarially reviewed (pin-quality + hermeticity lenses, refute-by-default verification) before opening. Tests-only; all tests live in new files, so no conflicts with the open fix PRs.
