### PR TITLE
chore(ci): loosen approval requirement and switch to rebase merge strategy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,13 +11,13 @@ pull_request_rules:
         - "#check-pending=0"
         - linear-history
       - and:
-        - "#approved-reviews-by>=2"
+        - "#approved-reviews-by>=1"
         - "#changes-requested-reviews-by=0"
         # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
         - "#review-requested=0"
     actions: &merge
       merge:
-        method: merge
+        method: rebase
   - name: automatic merge on special label
     conditions:
       - and: *base_checks


### PR DESCRIPTION
Reduces approval threshold from 2 to 1 reviews for faster iteration and switches to rebase merge strategy for cleaner project history.