### PR TITLE
refactor(cli): remove dead REPL/history utilities

### DIFF
--- a/mtui/cli/_history.py
+++ b/mtui/cli/_history.py
@@ -12,29 +12,14 @@ Public surface:
 * :func:`default_history_path` — the canonical ``~/.mtui_history`` location.
 * :func:`get_history` — memoised :class:`FileHistory` accessor keyed on the
   resolved absolute path.
-* :func:`pop_last_entry` — drop the most recent entry from both the
-  in-memory cache and the on-disk file. A standalone utility with no
-  current caller: :func:`mtui.cli.term.prompt_user` used to call it to
-  scrub a yes/no answer, but the answer is now read through an ephemeral
-  in-memory history and never reaches this shared file, so the pop was
-  removed.
 """
 
 from __future__ import annotations
 
-import logging
 import threading
 from pathlib import Path
 
 from prompt_toolkit.history import FileHistory
-
-logger = logging.getLogger(__name__)
-
-# Record separator written by ``FileHistory.store_string``: every entry is
-# prefixed with ``\n# <timestamp>\n`` followed by one or more ``+<line>``
-# lines. Finding the LAST occurrence of this separator tells us where the
-# tail entry starts, so we can truncate in place without re-parsing.
-_RECORD_SEP = b"\n# "
 
 _cache: dict[Path, FileHistory] = {}
 _cache_lock = threading.Lock()
@@ -71,75 +56,3 @@ def get_history(path: Path) -> FileHistory:
             hist = FileHistory(str(key))
             _cache[key] = hist
         return hist
-
-
-def pop_last_entry(path: Path) -> str | None:
-    """Remove and return the most recent history entry at ``path``.
-
-    Mirrors the legacy ``readline.remove_history_item`` behaviour. It once
-    scrubbed a yes/no answer typed at :func:`mtui.cli.term.prompt_user`, but
-    that caller now reads through an ephemeral in-memory history and no longer
-    needs (or calls) this; it is retained as a standalone utility.
-
-    Both the on-disk file and any in-memory deque held by a cached
-    :class:`FileHistory` for the same path are updated, so the next prompt
-    does not resurrect the dropped entry.
-
-    Args:
-        path: history file location.
-
-    Returns:
-        The popped entry's string, or ``None`` when there was nothing to
-        pop (missing file, empty file, or no parseable record).
-
-    """
-    key = Path(path).expanduser().resolve(strict=False)
-
-    # Evict from the in-memory deque of any cached instance first, so a
-    # concurrent reader cannot see a state where the file was truncated
-    # but the deque still holds the dropped entry.
-    popped_in_memory: str | None = None
-    with _cache_lock:
-        hist = _cache.get(key)
-    if hist is not None and hist._loaded_strings:  # noqa: SLF001
-        popped_in_memory = hist._loaded_strings.pop(0)  # noqa: SLF001
-
-    if not key.exists():
-        return popped_in_memory
-
-    try:
-        data = key.read_bytes()
-    except OSError as e:
-        logger.debug("failed to read history file %s: %s", key, e)
-        return popped_in_memory
-
-    if not data:
-        return popped_in_memory
-
-    # Find the last record header. Every entry produced by
-    # ``FileHistory.store_string`` starts with ``\n# `` (the leading
-    # newline guarantees the marker is unambiguous even when the file is
-    # opened in append mode and the prior write ended without one).
-    sep_idx = data.rfind(_RECORD_SEP)
-    if sep_idx < 0:
-        # File exists but contains no recognisable record (e.g. a file
-        # written by the old `readline` backend, or hand-edited). Do not
-        # touch it.
-        logger.debug("no FileHistory record marker in %s; leaving file untouched", key)
-        return popped_in_memory
-
-    tail = data[sep_idx:].decode("utf-8", errors="replace")
-    # Reconstruct the popped string the same way ``load_history_strings``
-    # does: collect every ``+``-prefixed line, strip the leading ``+``, and
-    # drop the final ``\n``.
-    parts: list[str] = [line[1:] for line in tail.splitlines() if line.startswith("+")]
-    popped_on_disk = "\n".join(parts) if parts else None
-
-    try:
-        with key.open("wb") as f:
-            f.write(data[:sep_idx])
-    except OSError as e:
-        logger.debug("failed to rewrite history file %s: %s", key, e)
-        return popped_in_memory or popped_on_disk
-
-    return popped_on_disk or popped_in_memory

--- a/mtui/cli/colors/formatter.py
+++ b/mtui/cli/colors/formatter.py
@@ -114,7 +114,6 @@ class ColorFormatter(logging.Formatter):
             The formatted log record as a string.
 
         """
-        record.message = record.getMessage()
         if self._fmt and self._fmt.find("%(levelname)") >= 0:
             # Substitute the colorized levelname only for the duration of
             # this handler's formatting: the record object is shared with

--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Callable
 from logging import DEBUG, getLogger
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from prompt_toolkit import PromptSession
@@ -123,7 +122,6 @@ class CommandPrompt:
             null_factory=lambda: NullTestReport(config, prompter=prompter),
         )
 
-        self.homedir = Path("~").expanduser()
         self.config = config
         self.log = log
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pytest
@@ -52,74 +51,3 @@ def test_append_string_round_trips_through_load(tmp_path: Path) -> None:
     _history._cache.clear()
     reloaded = _history.get_history(p)
     assert list(reloaded.load_history_strings()) == ["hello"]
-
-
-def test_pop_last_entry_drops_tail_from_disk(tmp_path: Path) -> None:
-    p = tmp_path / ".mtui_history"
-    hist = _history.get_history(p)
-    hist.append_string("first")
-    hist.append_string("second")
-
-    popped = _history.pop_last_entry(p)
-    assert popped == "second"
-
-    # New instance reads only "first" from the rewritten file.
-    _history._cache.clear()
-    reloaded = _history.get_history(p)
-    assert list(reloaded.load_history_strings()) == ["first"]
-
-
-def test_pop_last_entry_evicts_cached_in_memory_deque(tmp_path: Path) -> None:
-    p = tmp_path / ".mtui_history"
-    hist = _history.get_history(p)
-    hist.append_string("first")
-    hist.append_string("second")
-
-    _history.pop_last_entry(p)
-
-    # Same cached instance: its in-memory deque must have lost the tail.
-    assert hist.get_strings() == ["first"]
-
-
-def test_pop_last_entry_on_missing_file_returns_none(tmp_path: Path) -> None:
-    p = tmp_path / "does-not-exist"
-    assert _history.pop_last_entry(p) is None
-
-
-def test_pop_last_entry_on_empty_file_returns_none(tmp_path: Path) -> None:
-    p = tmp_path / ".mtui_history"
-    p.touch()
-    assert _history.pop_last_entry(p) is None
-
-
-def test_pop_last_entry_on_unrecognised_format_logs_and_keeps_file(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A file written by the old ``readline`` backend lacks ``\\n# `` markers.
-
-    The function must leave it untouched rather than truncating to zero.
-    """
-    p = tmp_path / ".mtui_history"
-    p.write_bytes(b"legacy-readline-line\nanother\n")
-
-    with caplog.at_level(logging.DEBUG, logger="mtui.cli._history"):
-        assert _history.pop_last_entry(p) is None
-
-    assert "no FileHistory record marker" in caplog.text
-    # File still on disk, untouched.
-    assert p.read_bytes() == b"legacy-readline-line\nanother\n"
-
-
-def test_pop_last_entry_multiline_record(tmp_path: Path) -> None:
-    """``FileHistory`` stores newlines inside an entry as multiple ``+`` lines."""
-    p = tmp_path / ".mtui_history"
-    hist = _history.get_history(p)
-    hist.append_string("plain")
-    hist.append_string("line1\nline2")
-
-    popped = _history.pop_last_entry(p)
-    assert popped == "line1\nline2"
-
-    _history._cache.clear()
-    reloaded = _history.get_history(p)
-    assert list(reloaded.load_history_strings()) == ["plain"]


### PR DESCRIPTION
## What
Three pieces of provably-dead code in the CLI layer, plus their orphaned support:

- **`_history.pop_last_entry`** — its module docstring already noted the only caller was removed when `prompt_user` switched to an ephemeral in-memory history. Zero callers anywhere in `mtui/`. Removed the function, its now-unused `_RECORD_SEP` constant, the now-orphaned `logger`/`import logging`, and its 7 dedicated tests.
- **`CommandPrompt.homedir`** — `Path("~").expanduser()` assigned in `__init__` and never read; removed (and the now-unused `Path` import).
- **`ColorFormatter.format`** — a redundant `record.message = record.getMessage()` pre-assignment; the stdlib `logging.Formatter.format` recomputes it as its first statement, so the line was a pure dead store.

Left the `commands` dict alone deliberately (its values are currently unread, but MCP tool introspection is a plausible future consumer — a `set`-vs-`dict` change would be a design decision, out of scope). The `completion.py` dead filter this campaign flagged was already eliminated by #302.

Part of the mutation-testing campaign (Wave C) — these were flagged as structurally-unkillable *dead-code* survivors: mutants survive because the mutated code is unreachable or its result is never read. Removal (not a test) is the fix. Verified by grepping the whole tree for readers/callers and confirming the full suite still passes; **adversarially reviewed** (over-deletion + blast-radius lenses, refute-by-default) with zero confirmed findings. Internal refactor — no CHANGELOG.
