### PR TITLE
refactor(dashboard): drop write-only QEM attributes and unused kwarg

### DIFF
--- a/mtui/data_sources/qem_dashboard/client.py
+++ b/mtui/data_sources/qem_dashboard/client.py
@@ -39,11 +39,10 @@ class QEMDashboardClient:
         # so every request honors the global ssl_verify config.
         self._session = build_session(verify)
 
-    def _get(self, path: str, **params) -> Any | None:
+    def _get(self, path: str) -> Any | None:
         try:
             response = self._session.get(
                 f"{self.apiurl}/{path.lstrip('/')}",
-                params=params or None,
                 headers={"Accept": "application/json"},
                 timeout=HTTP_TIMEOUT,
             )

--- a/mtui/data_sources/qem_dashboard/incident.py
+++ b/mtui/data_sources/qem_dashboard/incident.py
@@ -23,7 +23,6 @@ class QEMIncident:
                 Defaults to ``True``.
 
         """
-        self.rrid = rrid
         self.incident_number = self._incident_number(rrid)
         self.client = QEMDashboardClient(apiurl, verify)
         self.data: dict[str, Any] | None = self.client.incident(self.incident_number)


### PR DESCRIPTION
## What
- **`QEMDashboardClient._get(**params)`** — none of the five callers ever pass params, so `params=params or None` always resolved to `None`. Removed the `**params` kwarg and the `params=` argument.
- **`QEMIncident.rrid`** — assigned in `__init__` but never read (`DashboardAutoOpenQA` keeps its own independent copy from its own constructor arg). Removed the write-only attribute.

Part of the mutation-testing campaign (Wave C) — these were flagged as structurally-unkillable *dead-code* survivors: mutants survive because the mutated code is unreachable or its result is never read. Removal (not a test) is the fix. Verified by grepping the whole tree for readers/callers and confirming the full suite still passes; **adversarially reviewed** (over-deletion + blast-radius lenses, refute-by-default) with zero confirmed findings. Internal refactor — no CHANGELOG.
