### PR TITLE
refactor(types): drop unreachable RRID parse guard

### DIFF
--- a/mtui/types/rrid.py
+++ b/mtui/types/rrid.py
@@ -10,7 +10,6 @@ from .enums import RequestKind
 def apply_parser(f, x, cnt):
     from ..support.exceptions import (
         ComponentParseError,
-        InternalParseError,
         MissingComponentError,
     )
 
@@ -25,13 +24,9 @@ def apply_parser(f, x, cnt):
         The parsed value.
 
     Raises:
-        InternalParseError: If the parser or count is not valid.
         MissingComponentError: If the value is missing.
         ComponentParseError: If the value cannot be parsed.
     """
-    if not f or not cnt:
-        raise InternalParseError(f, cnt)
-
     if not x:
         raise MissingComponentError(cnt, f)
 


### PR DESCRIPTION
## What
`apply_parser`'s `if not f or not cnt: raise InternalParseError(...)` guard is unreachable from `RequestReviewID`: it is called only via `zip_longest(parsers, xs, range(1, len(parsers)+1))` where `parsers` is a fixed 4-element list of always-truthy parser objects and the range always yields 1–4, so `f`/`cnt` are never falsy. Removed the dead guard.

Reviewed with extra scrutiny as a defensive-net removal: no reachable input triggers it, and the invariant (parsers length in lockstep with the range) is structural.

Part of the mutation-testing campaign (Wave C) — these were flagged as structurally-unkillable *dead-code* survivors: mutants survive because the mutated code is unreachable or its result is never read. Removal (not a test) is the fix. Verified by grepping the whole tree for readers/callers and confirming the full suite still passes; **adversarially reviewed** (over-deletion + blast-radius lenses, refute-by-default) with zero confirmed findings. Internal refactor — no CHANGELOG.
