### PR TITLE
refactor: remove vestigial constructor param and unread attribute

### DIFF
--- a/mtui/cli/repl.py
+++ b/mtui/cli/repl.py
@@ -119,7 +119,6 @@ class CommandPrompt:
         self.interactive: bool = True
         self.display = display_factory(self.sys.stdout)
         self.templates = TemplateRegistry(
-            config,
             null_factory=lambda: NullTestReport(config, prompter=prompter),
         )
 

--- a/mtui/commands/help.py
+++ b/mtui/commands/help.py
@@ -26,7 +26,6 @@ class UnknownHelpTopicError(UserError):
     """Raised when ``help <name>`` is asked for an unregistered command."""
 
     def __init__(self, name: str) -> None:
-        self.name = name
         self.message = f"No help available: {name!r} is not a known command"
 
 

--- a/mtui/mcp/session.py
+++ b/mtui/mcp/session.py
@@ -369,7 +369,6 @@ class McpSession:
         self.prompter = None
 
         self.templates = TemplateRegistry(
-            config,
             null_factory=lambda: NullTestReport(config, prompter=self.prompter),
         )
         # Mirror ``self.interactive`` onto the HostsGroup so long-running

--- a/mtui/template_registry.py
+++ b/mtui/template_registry.py
@@ -23,7 +23,6 @@ from uuid import uuid4
 from .hosts.host_arbiter import get_arbiter
 
 if TYPE_CHECKING:
-    from .support.config import Config
     from .test_reports.testreport import TestReport
 
 
@@ -38,21 +37,17 @@ class TemplateRegistry:
 
     def __init__(
         self,
-        config: Config,
         *,
         null_factory: Callable[[], TestReport],
     ) -> None:
         """Initialise an empty registry.
 
         Args:
-            config: The application configuration (kept for parity with the
-                rest of the runtime and for future arbiter wiring).
             null_factory: Zero-argument callable returning a fresh
                 :class:`NullTestReport`; used as the active-pointer fallback
                 when no template is loaded.
 
         """
-        self.config = config
         #: Stable per-registry identity; the owner-key seed for host
         #: arbitration (RFC §5.7). One registry per REPL process, one per MCP
         #: session.

--- a/tests/test_cmd_switch.py
+++ b/tests/test_cmd_switch.py
@@ -27,7 +27,7 @@ def _null():
 
 
 def _registry(*reports):
-    reg = TemplateRegistry(MagicMock(), null_factory=_null)
+    reg = TemplateRegistry(null_factory=_null)
     for r in reports:
         reg.add(r)
     return reg

--- a/tests/test_cmd_templates.py
+++ b/tests/test_cmd_templates.py
@@ -27,7 +27,7 @@ def _null():
 
 
 def _registry(*reports):
-    reg = TemplateRegistry(MagicMock(), null_factory=_null)
+    reg = TemplateRegistry(null_factory=_null)
     for r in reports:
         reg.add(r)
     return reg

--- a/tests/test_cmd_unload.py
+++ b/tests/test_cmd_unload.py
@@ -35,7 +35,7 @@ def _null():
 
 
 def _registry(*reports):
-    reg = TemplateRegistry(MagicMock(), null_factory=_null)
+    reg = TemplateRegistry(null_factory=_null)
     for r in reports:
         reg.add(r)
     return reg

--- a/tests/test_template_completion.py
+++ b/tests/test_template_completion.py
@@ -36,7 +36,7 @@ def _null():
 
 
 def _registry(*rrids):
-    reg = TemplateRegistry(MagicMock(), null_factory=_null)
+    reg = TemplateRegistry(null_factory=_null)
     for rrid in rrids:
         reg.add(_report(rrid))
     return reg

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -39,7 +39,7 @@ def null_report():
 
 @pytest.fixture
 def registry(null_report):
-    return TemplateRegistry(MagicMock(), null_factory=lambda: null_report)
+    return TemplateRegistry(null_factory=lambda: null_report)
 
 
 def test_empty_registry_is_falsey_and_active_is_null(registry, null_report):


### PR DESCRIPTION
## What
- **`TemplateRegistry.__init__(config=...)`** — the stored `self.config` was never read (the docstring admitted it was "kept for future arbiter wiring"). Removed the parameter, the stored attribute, and the `TYPE_CHECKING` `Config` import; updated all construction sites.
- **`UnknownHelpTopicError.name`** — assigned but never read (the error message f-string embeds the name directly). Removed the assignment.

Left the `loadtemplate` `kind not in ("kernel","auto")` guard in place — it is defensive against direct/MCP construction paths, not provably unreachable.

Part of the mutation-testing campaign (Wave C) — these were flagged as structurally-unkillable *dead-code* survivors: mutants survive because the mutated code is unreachable or its result is never read. Removal (not a test) is the fix. Verified by grepping the whole tree for readers/callers and confirming the full suite still passes; **adversarially reviewed** (over-deletion + blast-radius lenses, refute-by-default) with zero confirmed findings. Internal refactor — no CHANGELOG.
