### PR TITLE
feat(obs): support all SSH key types and harden the native OBS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   behaviour notes: OBS TLS is now governed by `[mtui] ssl_verify` rather than
   oscrc's own TLS knobs (`sslcertck`/`cafile`/`capath`/`no_verify`); and the
   new `[obs] request_timeout` (default 180s) is a coarse between-call budget
-  layered over the per-call HTTP timeout, not a hard mid-call kill. The review
-  key must be an Ed25519 private key on disk; ssh-agent, encrypted, and
-  RSA/ECDSA keys are not yet supported. A new `[obs]` config section
-  (`api_url`, `conffile`, `request_timeout`) is introduced.
+  layered over the per-call HTTP timeout, not a hard mid-call kill. All OpenSSH
+  key types are supported — Ed25519, ECDSA and RSA (signed with `rsa-sha2-512`)
+  private-key files, as well as keys held by a running ssh-agent (selected by
+  the oscrc `sshkey` fingerprint, or as the passphrase-protected counterpart of
+  a key file). Under headless `mtui-mcp` the backend never prompts for a
+  passphrase: an encrypted key is used only via the agent, and anything
+  unresolvable fails closed. A new `[obs]` config section (`api_url`,
+  `conffile`, `request_timeout`) is introduced.
 
 - `mtui-mcp` is now much more token-efficient. Tool schemas are automatically
   slimmed of redundant pydantic boilerplate (the per-field `title` keys and the

--- a/Documentation/developer.rst
+++ b/Documentation/developer.rst
@@ -39,7 +39,8 @@ Project layout
         refhost/           #   reference-host schema (models, resolvers, store)
       data_sources/        # external HTTP services
         gitea.py           #   Gitea API client
-        oscqam.py          #   osc-qam wrapper
+        oscqam.py          #   native OBS/IBS QAM review backend
+        obs/               #   native OBS API client (auth, models, ops)
         openqa/            #   openQA clients (standard, kernel)
         qem_dashboard/     #   QEM dashboard client (split)
         oqa_search/        #   openQA build/version search (split)

--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -114,11 +114,14 @@ System-package requirements
 mtui invokes a small number of external CLI tools as subprocesses; these
 must be installed separately from the Python dependencies.
 
-``osc``
-    The OBS / IBS command-line client. mtui shells out to ``osc`` for
-    every action against ``SUSE:Maintenance`` requests; the connector
-    does not import ``osc`` as a library. On openSUSE this is the ``osc``
-    package; on other distributions install it from the
+``osc`` (optional)
+    The OBS / IBS command-line client. mtui no longer invokes ``osc`` — it
+    talks to the OBS API natively for every ``SUSE:Maintenance`` review
+    action — but it still reads the credentials (user and ``sshkey``) from
+    the ``~/.oscrc`` that ``osc`` creates, so ``osc`` remains the convenient
+    way to bootstrap that file (``osc -A https://api.suse.de whoami``). On
+    openSUSE this is the ``osc`` package; on other distributions install it
+    from the
     `openSUSE:Tools <https://build.opensuse.org/project/show/openSUSE:Tools>`_
     project or via ``pipx install osc``.
 

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -1277,8 +1277,13 @@ whoami
 Displays current user name and session PID.
 
 
-OSC-wrapper Commands
-*********************
+OBS Review Commands
+*******************
+
+These commands act on the loaded ``SUSE:Maintenance`` review request. mtui
+performs each action natively against the OBS/IBS API (it no longer shells out
+to the ``osc qam`` plugin), reading the acting user and SSH key from
+``~/.oscrc``. The linked pages document the equivalent tester workflow.
 
 assign
 ++++++
@@ -1287,8 +1292,9 @@ assign
 
     assign [-h] [-g [GROUP]]
 
-Wrapper around the `osc qam assign`_ command; assigns current update.
-QA groups for assignment can be specified.
+Assigns the current update to you. When no group is given, mtui infers the
+single open QA group you belong to; specify ``-g`` to disambiguate. Mirrors
+the `osc qam assign`_ workflow.
 
 .. _osc qam assign: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#assigning-updates
 
@@ -1306,8 +1312,9 @@ unassign
 
     unassign [-h] [-g [GROUP]]
 
-Wrapper around the `osc qam unassign`_ command; unassigns current update.
-QA groups for unassignment can be specified.
+Unassigns the current update. When no group is given, mtui reverts the
+assignment(s) you currently hold; specify ``-g`` to revert a particular group.
+Mirrors the `osc qam unassign`_ workflow.
 
 .. _osc qam unassign: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#unassigning-updates
 
@@ -1325,8 +1332,9 @@ approve
 
     approve [-h] [-g [GROUP]] [-r REVIEWER]
 
-Wrapper around the `osc qam approve`_ command; approves current update. It is
-possible to specify more QA groups for approval.
+Approves the current update for the review assigned to you. Group approval
+(``-g``) is not supported by the native backend and is refused, so approve the
+review assigned to you without ``-g``. Mirrors the `osc qam approve`_ workflow.
 
 When ``-r REVIEWER`` is given, the reviewer is recorded in the testreport (the
 ``Test Plan Reviewer:`` line), the testreport is committed to SVN, and only
@@ -1354,8 +1362,9 @@ reject
 
     reject [-h] [-g [GROUP]] -r REASON [-m ...]
 
-Wrapper around the `osc qam reject`_ command; rejects current update. The ``-r``
-option is required.
+Rejects the current update (always as a ``by_user`` decline). The ``-r``
+option is required; ``-g`` is accepted for compatibility but ignored. Mirrors
+the `osc qam reject`_ workflow.
 
 .. _osc qam reject: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#reject
 
@@ -1383,8 +1392,8 @@ comment
 
     comment
 
-Adds a comment to the currently loaded review request via OSC. The
-command takes no arguments; it prompts interactively for the comment
+Adds a comment to the currently loaded review request via the native OBS
+backend. The command takes no arguments; it prompts interactively for the comment
 text on stdin (``Comment:``). The comment is posted against the RRID
 of the loaded test report template.
 

--- a/mtui/data_sources/obs/auth.py
+++ b/mtui/data_sources/obs/auth.py
@@ -5,13 +5,19 @@ subprocess): the first request goes out unauthenticated (the session may
 already hold a cookie); on a 401 the ``WWW-Authenticate: Signature`` realm
 is read, an SSHSIG over ``(created): <epoch>`` is built with paramiko, and
 the request is resent exactly once with the ``Authorization: Signature``
-header. Day-one scope is an Ed25519 key from an explicit file; encrypted,
-agent, and non-Ed25519 keys fail closed with a typed :class:`ObsConfigError`.
-The Authorization header and its signature are never logged.
+header. The Authorization header and its signature are never logged.
+
+Any OpenSSH key type works — Ed25519, ECDSA, and RSA private-key files, plus
+keys held by a running ssh-agent (selected by ``SHA256:…`` fingerprint or as
+the passphrase-protected counterpart of a file on disk). Under headless
+``mtui-mcp`` we must never block on a passphrase prompt, so an encrypted key
+is only usable via the agent; every unresolvable case fails closed with a
+typed :class:`ObsConfigError`.
 """
 
 from __future__ import annotations
 
+import base64
 import time
 from logging import getLogger
 from pathlib import Path
@@ -61,35 +67,109 @@ def _challenge_params(response: requests.Response) -> dict[str, dict[str, str]]:
     return schemes
 
 
+def _pubkey_blob(path: Path) -> bytes | None:
+    """Return the public-key blob from ``<path>.pub``, or ``None`` if absent.
+
+    Used to identify a passphrase-protected private key's counterpart among
+    the ssh-agent's loaded keys by comparing raw public-key blobs.
+    """
+    try:
+        text = Path(f"{path}.pub").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    parts = text.split()
+    if len(parts) < 2:
+        return None
+    try:
+        return base64.b64decode(parts[1])
+    except ValueError:  # includes binascii.Error
+        return None
+
+
 class ObsSignatureAuth(requests.auth.AuthBase):
     """A ``requests`` auth handler for OBS SSH-signature authentication."""
 
-    def __init__(self, user: str, sshkey_path: Path) -> None:
-        """Initialise with the acting user and its Ed25519 private-key path."""
+    def __init__(
+        self,
+        user: str,
+        sshkey_path: Path | None = None,
+        sshkey_fingerprint: str | None = None,
+    ) -> None:
+        """Initialise with the acting user and its key locator.
+
+        Exactly one of ``sshkey_path`` (a private-key file) or
+        ``sshkey_fingerprint`` (an ssh-agent key's ``SHA256:…`` fingerprint)
+        identifies the signing key.
+        """
         self.user = user
         self.sshkey_path = sshkey_path
+        self.sshkey_fingerprint = sshkey_fingerprint
         self._retried = False
 
-    def _load_key(self) -> paramiko.Ed25519Key:
-        """Load the Ed25519 key, failing closed (never prompting)."""
+    @staticmethod
+    def _agent_keys() -> list[Any]:
+        """The keys currently held by the ssh-agent (fails closed on error)."""
         try:
-            return paramiko.Ed25519Key.from_private_key_file(str(self.sshkey_path))
-        except paramiko.PasswordRequiredException as e:
-            raise ObsConfigError(
-                f"ssh key {self.sshkey_path} is passphrase-protected; the native "
-                "OBS backend needs an unencrypted key or an ssh-agent (agent "
-                "support is not yet available)"
-            ) from e
+            return list(paramiko.Agent().get_keys())
         except paramiko.SSHException as e:
+            raise ObsConfigError(f"could not query the ssh-agent: {e}") from e
+
+    def _agent_key_by_fingerprint(self, fingerprint: str) -> Any:
+        """Select the ssh-agent key matching ``fingerprint`` (``SHA256:…``)."""
+        want = fingerprint.strip()
+        for key in self._agent_keys():
+            key_fp = key.fingerprint
+            if key_fp == want or key_fp.split(":", 1)[-1] == want:
+                return key
+        raise ObsConfigError(
+            f"ssh-agent has no key matching fingerprint {want!r}; load it with "
+            "'ssh-add' (the native OBS backend never prompts for a passphrase)"
+        )
+
+    def _agent_key_for_file(self, path: Path) -> Any:
+        """Find the ssh-agent key that is ``path``'s decrypted counterpart."""
+        blob = _pubkey_blob(path)
+        if blob is not None:
+            for key in self._agent_keys():
+                if key.asbytes() == blob:
+                    return key
+        hint = "" if blob is not None else f" (no {path}.pub found to identify it)"
+        raise ObsConfigError(
+            f"ssh key {path} is passphrase-protected and no matching key is "
+            f"loaded in the ssh-agent{hint}; run 'ssh-add {path}' first — the "
+            "native OBS backend never prompts for a passphrase"
+        )
+
+    def _load_key_file(self, path: Path) -> Any:
+        """Load any private-key type from ``path``, failing closed.
+
+        ``PKey.from_path`` auto-detects Ed25519/ECDSA/RSA. A missing
+        passphrase surfaces as ``PasswordRequiredException`` or (from the
+        cryptography backend) a bare ``TypeError``; either way we must never
+        prompt under headless mtui-mcp, so we fall back to an ssh-agent that
+        holds the decrypted key. A missing file may still be an agent key
+        identified by its ``.pub`` on disk.
+        """
+        try:
+            return paramiko.PKey.from_path(str(path))
+        except (paramiko.PasswordRequiredException, TypeError):
+            return self._agent_key_for_file(path)
+        except FileNotFoundError:
+            return self._agent_key_for_file(path)
+        except (paramiko.SSHException, ValueError) as e:
             raise ObsConfigError(
-                f"ssh key {self.sshkey_path} is not a usable Ed25519 key "
-                f"({e}); only Ed25519 keys are supported by the native OBS "
-                "backend today"
+                f"ssh key {path} is not a usable private key ({e})"
             ) from e
         except OSError as e:
-            raise ObsConfigError(
-                f"ssh key {self.sshkey_path} could not be read: {e}"
-            ) from e
+            raise ObsConfigError(f"ssh key {path} could not be read: {e}") from e
+
+    def _load_key(self) -> Any:
+        """Resolve the configured key locator to a loaded signing key."""
+        if self.sshkey_fingerprint is not None:
+            return self._agent_key_by_fingerprint(self.sshkey_fingerprint)
+        if self.sshkey_path is None:  # pragma: no cover - oscrc sets one
+            raise ObsConfigError("no ssh key configured for OBS signature auth")
+        return self._load_key_file(self.sshkey_path)
 
     def _authorization(self, realm: str) -> str:
         """Build the ``Authorization: Signature …`` header value for ``realm``."""

--- a/mtui/data_sources/obs/client.py
+++ b/mtui/data_sources/obs/client.py
@@ -38,6 +38,10 @@ logger = getLogger("mtui.data_sources.obs.client")
 
 def _error_summary(text: str) -> str:
     """Extract ``<status><summary>`` from an OBS error body (best effort)."""
+    if "<!DOCTYPE" in text or "<!ENTITY" in text:
+        # OBS never sends a DTD; skip parsing so an entity-expansion body
+        # cannot turn error handling into a DoS.
+        return ""
     try:
         root = ET.fromstring(text)
     except ET.ParseError:
@@ -61,7 +65,11 @@ class ObsClient:
         self._api_url = config.obs_api_url.rstrip("/")
         verify = resolve_verify(True, config.ssl_verify)
         self._session = build_session(verify)
-        self._auth = ObsSignatureAuth(credentials.user, credentials.sshkey_path)
+        self._auth = ObsSignatureAuth(
+            credentials.user,
+            sshkey_path=credentials.sshkey_path,
+            sshkey_fingerprint=credentials.sshkey_fingerprint,
+        )
         # Coarse between-calls budget: a whole operation makes a few calls;
         # the deadline is checked before each one.
         self._deadline = time.monotonic() + float(config.obs_request_timeout)

--- a/mtui/data_sources/obs/models.py
+++ b/mtui/data_sources/obs/models.py
@@ -13,8 +13,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from xml.etree import ElementTree as ET
 
+from .errors import ObsError
+
 # IBS ignores automation groups when deciding what counts as a QAM group.
 _IGNORED_QAM_GROUPS = frozenset({"qam-auto", "qam-openqa"})
+
+
+def _fromstring(xml: str) -> ET.Element:
+    """Parse OBS XML, refusing any DTD.
+
+    OBS never sends a ``<!DOCTYPE>``/``<!ENTITY>``, so rejecting one before
+    parsing neutralises entity-expansion DoS (billion-laughs / quadratic
+    blowup) from a compromised or MITM'd (``ssl_verify=false``) response,
+    without pulling in a third-party XML parser.
+    """
+    if "<!DOCTYPE" in xml or "<!ENTITY" in xml:
+        raise ObsError("refusing to parse an OBS document that carries a DTD")
+    return ET.fromstring(xml)
+
 
 # The MAINT:RejectReason attribute coordinates.
 REJECT_REASON_NAMESPACE = "MAINT"
@@ -85,18 +101,18 @@ def _parse_request_element(root: ET.Element) -> Request:
 
 def parse_request(xml: str) -> Request:
     """Parse a ``request?withfullhistory=1`` document."""
-    return _parse_request_element(ET.fromstring(xml))
+    return _parse_request_element(_fromstring(xml))
 
 
 def parse_request_collection(xml: str) -> list[Request]:
     """Parse a ``<collection>`` of requests (the previous-reject search)."""
-    root = ET.fromstring(xml)
+    root = _fromstring(xml)
     return [_parse_request_element(r) for r in root.findall("request")]
 
 
 def parse_group_directory(xml: str) -> list[str]:
     """Parse a ``group?login=<user>`` directory into its group names."""
-    root = ET.fromstring(xml)
+    root = _fromstring(xml)
     return [name for e in root.findall("entry") if (name := e.get("name"))]
 
 
@@ -106,7 +122,7 @@ def parse_reject_reason_values(xml: str) -> list[str]:
     Tolerates the empty ``<attributes/>`` OBS returns when the attribute is
     unset (returns ``[]``).
     """
-    root = ET.fromstring(xml)
+    root = _fromstring(xml)
     return [v.text.strip() for v in root.iter("value") if v.text and v.text.strip()]
 
 

--- a/mtui/data_sources/obs/oscrc.py
+++ b/mtui/data_sources/obs/oscrc.py
@@ -24,8 +24,8 @@ from ...support.exceptions import ObsConfigError
 logger = getLogger("mtui.data_sources.obs.oscrc")
 
 # An ``sshkey`` value like ``SHA256:abc...`` names a key held by the ssh
-# agent by fingerprint rather than a file on disk. Agent auth is not yet
-# supported by the native backend (deferred), so such values fail closed.
+# agent by fingerprint rather than a file on disk; the native backend
+# resolves it through the agent at signing time.
 _FINGERPRINT_RE = re.compile(r"^[A-Z0-9]+:")
 
 # credentials_mgr_class values that route credentials through a mechanism
@@ -37,15 +37,18 @@ _UNSUPPORTED_MGR = ("keyring", "transient")
 class ObsCredentials:
     """Resolved OBS Signature-auth credentials for one apiurl.
 
-    Carries no password by construction: the native backend uses SSH
-    signature auth against api.suse.de, so ``pass``/``passx`` are never
-    read for that target.
+    Exactly one of ``sshkey_path`` (a private-key file on disk) or
+    ``sshkey_fingerprint`` (an ssh-agent key's ``SHA256:…`` fingerprint)
+    identifies the signing key. Carries no password by construction: the
+    native backend uses SSH signature auth against api.suse.de, so
+    ``pass``/``passx`` are never read for that target.
     """
 
     apiurl: str
     user: str
-    sshkey_path: Path
     source: str
+    sshkey_path: Path | None = None
+    sshkey_fingerprint: str | None = None
 
 
 def _default_conffile() -> Path:
@@ -53,29 +56,27 @@ def _default_conffile() -> Path:
     return Path("~/.oscrc").expanduser()
 
 
-def _resolve_sshkey(raw: str) -> Path:
-    """Resolve an oscrc ``sshkey`` value to a private-key file path.
+def _resolve_sshkey(raw: str) -> tuple[Path | None, str | None]:
+    """Resolve an oscrc ``sshkey`` value to ``(path, fingerprint)``.
 
-    A bare name (``id_ed25519``) resolves under ``~/.ssh/``; a value
-    containing ``/`` is treated as a literal (``~``-expanded) path.
+    A ``SHA256:…`` (or other ``ALG:…``) value names an ssh-agent key by
+    fingerprint and yields ``(None, fingerprint)``. Otherwise it is a
+    private-key file: a bare name (``id_ed25519``) resolves under
+    ``~/.ssh/``; a value containing ``/`` is a literal (``~``-expanded) path,
+    yielding ``(path, None)``.
 
     Raises:
-        ObsConfigError: If the value is empty, or is an agent fingerprint
-            (``SHA256:…``) — ssh-agent auth is deferred and fails closed.
+        ObsConfigError: If the value is empty.
 
     """
     value = raw.strip()
     if not value:
         raise ObsConfigError("oscrc 'sshkey' is empty")
     if _FINGERPRINT_RE.match(value):
-        raise ObsConfigError(
-            f"oscrc sshkey {value!r} is an ssh-agent fingerprint; the native "
-            "OBS backend does not yet support ssh-agent auth — set 'sshkey' to "
-            "a private-key file name or path instead"
-        )
+        return None, value
     if "/" in value:
-        return Path(value).expanduser()
-    return Path("~/.ssh").expanduser() / value
+        return Path(value).expanduser(), None
+    return Path("~/.ssh").expanduser() / value, None
 
 
 def read_credentials(apiurl: str, conffile: str = "") -> ObsCredentials:
@@ -165,12 +166,25 @@ def read_credentials(apiurl: str, conffile: str = "") -> ObsCredentials:
     # NB: 'pass'/'passx' are intentionally never read for this Signature-only
     # target — see the module docstring.
 
-    key_path = _resolve_sshkey(sshkey)
-    if not key_path.is_file():
+    key_path, fingerprint = _resolve_sshkey(sshkey)
+    if key_path is not None and not _key_available(key_path):
         raise ObsConfigError(
             f"ssh key {key_path} (from oscrc sshkey={sshkey!r}) does not exist"
         )
 
     return ObsCredentials(
-        apiurl=apiurl, user=user, sshkey_path=key_path, source=str(path)
+        apiurl=apiurl,
+        user=user,
+        source=str(path),
+        sshkey_path=key_path,
+        sshkey_fingerprint=fingerprint,
     )
+
+
+def _key_available(key_path: Path) -> bool:
+    """A key is usable if its private file or its ``.pub`` (agent) exists.
+
+    A ``.pub``-only key on disk is signed via an ssh-agent that holds the
+    private half (matched by public blob at auth time).
+    """
+    return key_path.is_file() or Path(f"{key_path}.pub").is_file()

--- a/mtui/data_sources/obs/preconditions.py
+++ b/mtui/data_sources/obs/preconditions.py
@@ -23,7 +23,10 @@ if TYPE_CHECKING:
 
 logger = getLogger("mtui.data_sources.obs.preconditions")
 
-_SUMMARY_RE = re.compile(r"^SUMMARY:\s*(\S+)", re.MULTILINE)
+# Capture the whole trimmed value, not just the first token, so a trailing
+# qualifier ("PASSED with notes") reads as UNKNOWN — matching the plugin's
+# whole-value compare rather than approving/rejecting on the first word.
+_SUMMARY_RE = re.compile(r"^SUMMARY:\s*(.+?)\s*$", re.MULTILINE)
 _COMMENT_RE = re.compile(r"^comment:\s*(.*)$", re.MULTILINE)
 
 

--- a/mtui/data_sources/obs/qam.py
+++ b/mtui/data_sources/obs/qam.py
@@ -136,7 +136,9 @@ def assign(
 ) -> None:
     """Assign the review to ``user`` for the resolved group(s)."""
     request = _get_request(client, rrid)
-    if request.state != "review":
+    # Mirror the plugin's Request.OPEN_STATES = ("new", "review"); OBS reports
+    # "new" while a request still has an open review it has not moved on from.
+    if request.state not in ("new", "review"):
         raise ObsError(
             f"request {request.reqid} is not open for review "
             f"(state={request.state!r}); refusing to assign"

--- a/mtui/data_sources/obs/sshsig.py
+++ b/mtui/data_sources/obs/sshsig.py
@@ -1,15 +1,22 @@
 """OpenSSH SSHSIG wire-format signer for OBS "Signature" auth.
 
-Reproduces ``ssh-keygen -Y sign`` byte-for-byte for an Ed25519 key using
-paramiko, so mtui authenticates to the OBS API in-process — no ``osc``
+Reproduces ``ssh-keygen -Y sign`` for any key type (Ed25519, ECDSA, RSA)
+using paramiko, so mtui authenticates to the OBS API in-process — no ``osc``
 library and no signing subprocess. The format is OpenSSH's SSHSIG
 (``PROTOCOL.sshsig``): the message is hashed, wrapped with the namespace,
 signed, and the signature plus public key are packed into the outer SSHSIG
 blob, returned base64-encoded WITHOUT the PEM armor (that raw base64 is what
 the OBS ``Authorization: Signature`` header carries).
 
+RSA keys are signed with ``rsa-sha2-512`` rather than paramiko's default
+legacy ``ssh-rsa`` (SHA-1), which modern OpenSSH/OBS reject. Ed25519 and
+ECDSA have a single signature algorithm, so no override is needed. The
+message-hash algorithm in the SSHSIG blob (``sha512``) is independent of the
+signature algorithm and stays fixed, matching ``ssh-keygen -Y sign``.
+
 paramiko ships no ``py.typed``, so ``ty`` cannot check the calls below; the
-committed golden-vector test (byte-for-byte vs ssh-keygen) is the real guard.
+committed golden vector (Ed25519, byte-for-byte vs ssh-keygen) plus the
+RSA/ECDSA verify-round-trip tests are the real guard.
 """
 
 from __future__ import annotations
@@ -23,13 +30,20 @@ _MAGIC = b"SSHSIG"
 _SIG_VERSION = 1
 _HASH_ALG = b"sha512"
 
+# paramiko's default RSA signature algorithm is legacy ``ssh-rsa`` (SHA-1),
+# which modern OpenSSH and OBS reject; sign RSA keys with SHA-512 instead.
+_RSA_KEY_NAME = "ssh-rsa"
+_RSA_SIG_ALGORITHM = "rsa-sha2-512"
+
 
 class _SshKey(Protocol):
     """The narrow paramiko key surface used here (keeps the boundary typed)."""
 
     def asbytes(self) -> bytes: ...
 
-    def sign_ssh_data(self, data: bytes) -> object: ...
+    def get_name(self) -> str: ...
+
+    def sign_ssh_data(self, data: bytes, algorithm: str | None = ...) -> object: ...
 
 
 def _wstr(data: bytes) -> bytes:
@@ -37,11 +51,30 @@ def _wstr(data: bytes) -> bytes:
     return pack(">I", len(data)) + data
 
 
+def _sig_algorithm(key: _SshKey) -> str | None:
+    """The signature algorithm to request; only RSA needs a non-default one."""
+    return _RSA_SIG_ALGORITHM if key.get_name() == _RSA_KEY_NAME else None
+
+
+def _sig_bytes(signed: object) -> bytes:
+    """Normalise ``sign_ssh_data``'s return to the raw SSH signature blob.
+
+    A file-backed paramiko key returns a ``Message`` (unwrapped with
+    ``.asbytes()``), but an ``AgentKey`` returns the signature ``bytes``
+    directly — both are the identical ``string(algo) + string(sig)`` wire
+    blob. Handling only ``.asbytes()`` would crash every ssh-agent key.
+    """
+    if isinstance(signed, bytes):
+        return signed
+    return signed.asbytes()  # ty: ignore[unresolved-attribute]
+
+
 def sign_created(key: _SshKey, namespace: str, created: int) -> str:
     """Build the base64 SSHSIG over the OBS ``(created): <epoch>`` payload.
 
     Args:
-        key: A loaded Ed25519 private key (paramiko ``Ed25519Key``).
+        key: A loaded private key (paramiko ``Ed25519Key``/``ECDSAKey``/
+            ``RSAKey`` or an ``AgentKey``).
         namespace: The SSHSIG namespace — the challenge ``realm`` (the live
             api.suse.de value is ``Use your developer account``).
         created: The signed Unix timestamp, also sent as the Authorization
@@ -61,7 +94,7 @@ def sign_created(key: _SshKey, namespace: str, created: int) -> str:
     to_sign = (
         _MAGIC + _wstr(namespace_bytes) + _wstr(b"") + _wstr(_HASH_ALG) + _wstr(hashed)
     )
-    signature: bytes = key.sign_ssh_data(to_sign).asbytes()  # ty: ignore[unresolved-attribute]
+    signature = _sig_bytes(key.sign_ssh_data(to_sign, _sig_algorithm(key)))
 
     # The outer SSHSIG blob: MAGIC | version | publickey | namespace |
     # reserved | hash_alg | signature.

--- a/mtui/data_sources/oscqam.py
+++ b/mtui/data_sources/oscqam.py
@@ -6,15 +6,10 @@ credentials from the user's ``~/.oscrc``. It replaces the historical
 shell-out to the external ``osc qam`` plugin.
 """
 
-import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from logging import getLogger
 
-import paramiko
-import requests
-
 from ..support.config import Config
-from ..support.exceptions import ObsError
 from ..types.rrid import RequestReviewID
 from .obs import qam as obs_qam
 from .obs.client import ObsClient
@@ -43,7 +38,14 @@ class OSC:
         Everything — reading oscrc, loading the key, building the session,
         the authenticated calls, XML parsing — happens here inside one
         try/except, because callers (apicall.py / approve.py) invoke the
-        seam methods bare with no guard of their own.
+        seam methods bare with no guard of their own. The catch is
+        deliberately broad (``Exception``, not a narrow tuple): besides the
+        expected ObsError / requests / paramiko / ElementTree failures, edge
+        inputs raise plain ``ValueError`` (a non-PEM key, a lone surrogate in
+        the body) or ``RuntimeError`` (``Path.expanduser`` with no home), and
+        the never-raise contract must hold for those too. ``BaseException``
+        is intentionally NOT caught, so KeyboardInterrupt/SystemExit
+        propagate.
         """
         try:
             credentials = read_credentials(
@@ -51,12 +53,7 @@ class OSC:
             )
             client = ObsClient(self.config, credentials)
             op(client, credentials.user)
-        except (
-            ObsError,
-            requests.RequestException,
-            paramiko.SSHException,
-            ET.ParseError,
-        ) as e:
+        except Exception as e:  # noqa: BLE001 - documented never-raise seam
             logger.error("OBS operation on %s failed: %s", self.rrid, e)
             return False
         return True

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -259,7 +259,7 @@ class Config:
     lock_wait: int
     lock_wait_poll: int
 
-    # -- OBS/IBS native QAM review backend (mtui/data_sources/osc/) --
+    # -- OBS/IBS native QAM review backend (mtui/data_sources/obs/) --
     obs_api_url: str
     obs_conffile: str
     obs_request_timeout: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def mock_config():
     config.openqa_install_logs = "install-logs.tar"
     config.install_logs = "install_logs"
     config.reports_url = "https://reports.example.com"
-    # Native OBS backend defaults (mtui/data_sources/osc/); see [obs].
+    # Native OBS backend defaults (mtui/data_sources/obs/); see [obs].
     config.obs_api_url = "https://api.suse.de"
     config.obs_conffile = ""
     config.obs_request_timeout = 180

--- a/tests/test_obs_auth.py
+++ b/tests/test_obs_auth.py
@@ -129,27 +129,198 @@ def test_non_401_passes_through(key_path):
     assert len(responses.calls) == 1
 
 
-def test_passphrase_key_fails_closed(tmp_path):
-    """An encrypted key raises ObsConfigError (never prompts)."""
-    priv = Ed25519PrivateKey.from_private_bytes(SEED)
-    pem = priv.private_bytes(
+def _encrypted_ed25519(path):
+    """Write a passphrase-protected Ed25519 key (no usable passphrase)."""
+    pem = Ed25519PrivateKey.from_private_bytes(SEED).private_bytes(
         serialization.Encoding.PEM,
         serialization.PrivateFormat.OpenSSH,
         serialization.BestAvailableEncryption(b"hunter2"),
     )
-    path = tmp_path / "enc"
     path.write_bytes(pem)
-    auth = ObsSignatureAuth("qamuser", path)
+
+
+def _fake_agent(monkeypatch, *keys):
+    """Point paramiko.Agent at a fixed key set (no real agent required)."""
+    monkeypatch.setattr(
+        paramiko, "Agent", lambda: SimpleNamespace(get_keys=lambda: tuple(keys))
+    )
+
+
+def _real_agent_key(signer):
+    """A genuine paramiko ``AgentKey`` backed by an in-process ``signer``.
+
+    Real ssh-agent keys return raw *bytes* from ``sign_ssh_data`` (via the
+    agent wire protocol), unlike file keys which return a ``Message``. This
+    fixture reproduces that so the agent signing path is exercised for real —
+    an in-process ``PKey`` stand-in would mask the bytes/Message mismatch.
+    """
+    from paramiko.agent import SSH2_AGENT_SIGN_RESPONSE
+
+    flag_to_algo = {0: None, 2: "rsa-sha2-256", 4: "rsa-sha2-512"}
+
+    class _Conn:
+        def _send_message(self, msg):
+            m = paramiko.Message(msg.asbytes())
+            m.get_byte()  # SSH2_AGENTC_SIGN_REQUEST opcode
+            m.get_string()  # key blob
+            data = m.get_string()  # the data to sign
+            algo = flag_to_algo[m.get_int()]
+            resp = paramiko.Message()
+            resp.add_string(signer.sign_ssh_data(data, algo).asbytes())
+            resp.rewind()
+            return SSH2_AGENT_SIGN_RESPONSE, resp
+
+    # _Conn duck-types the Agent surface AgentKey.sign_ssh_data actually uses.
+    return paramiko.AgentKey(agent=_Conn(), blob=signer.asbytes())  # ty: ignore[invalid-argument-type]
+
+
+def _assert_authz_verifies(signer, authz):
+    """The Authorization header's SSHSIG verifies against ``signer``'s key."""
+    import hashlib
+    from struct import pack
+
+    from paramiko.message import Message
+
+    b64 = authz.split('signature="')[1].split('"')[0]
+    created = int(authz.split("created=")[1].split(",")[0])
+    raw = base64.b64decode(b64)
+    off = 10  # 6 magic + 4 version
+
+    def rd(o):
+        n = int.from_bytes(raw[o : o + 4], "big")
+        return raw[o + 4 : o + 4 + n], o + 4 + n
+
+    pub, off = rd(off)
+    _ns, off = rd(off)
+    _reserved, off = rd(off)
+    halg, off = rd(off)
+    sig, off = rd(off)
+    assert pub == signer.asbytes()
+    assert halg == b"sha512"
+    hashed = hashlib.sha512(f"(created): {created}".encode()).digest()
+
+    def w(b):
+        return pack(">I", len(b)) + b
+
+    to_sign = b"SSHSIG" + w(REALM.encode()) + w(b"") + w(b"sha512") + w(hashed)
+    assert signer.verify_ssh_sig(to_sign, Message(sig))
+
+
+def test_rsa_key_signs(tmp_path):
+    """An RSA private-key file now signs successfully (all key types)."""
+    path = tmp_path / "id_rsa"
+    paramiko.RSAKey.generate(2048).write_private_key_file(str(path))
+    authz = ObsSignatureAuth("qamuser", sshkey_path=path)._authorization(REALM)
+    assert 'signature="' in authz
+
+
+def test_ecdsa_key_signs(tmp_path):
+    """An ECDSA private-key file signs successfully."""
+    path = tmp_path / "id_ecdsa"
+    paramiko.ECDSAKey.generate().write_private_key_file(str(path))
+    authz = ObsSignatureAuth("qamuser", sshkey_path=path)._authorization(REALM)
+    assert 'signature="' in authz
+
+
+@pytest.mark.parametrize(
+    "signer",
+    [paramiko.ECDSAKey.generate(), paramiko.RSAKey.generate(2048)],
+    ids=["ecdsa", "rsa"],
+)
+def test_agent_fingerprint_signs(monkeypatch, signer):
+    """A key selected by SHA256 fingerprint is signed via a real AgentKey.
+
+    Uses a genuine paramiko AgentKey (bytes-returning sign_ssh_data), so a
+    regression to the file-key .asbytes() path would crash here. The RSA case
+    also pins the rsa-sha2-512 agent flag round-trip.
+    """
+    agent_key = _real_agent_key(signer)
+    _fake_agent(monkeypatch, agent_key)
+    auth = ObsSignatureAuth("qamuser", sshkey_fingerprint=agent_key.fingerprint)
+    authz = auth._authorization(REALM)
+    assert 'signature="' in authz
+    _assert_authz_verifies(signer, authz)
+
+
+def test_agent_fingerprint_without_prefix_matches(monkeypatch):
+    """A fingerprint given without the SHA256: prefix still matches."""
+    signer = paramiko.ECDSAKey.generate()
+    agent_key = _real_agent_key(signer)
+    _fake_agent(monkeypatch, agent_key)
+    bare = agent_key.fingerprint.split(":", 1)[-1]
+    auth = ObsSignatureAuth("qamuser", sshkey_fingerprint=bare)
+    _assert_authz_verifies(signer, auth._authorization(REALM))
+
+
+def test_agent_fingerprint_not_found_fails_closed(monkeypatch):
+    """A fingerprint absent from the agent fails closed (never prompts)."""
+    _fake_agent(monkeypatch, paramiko.ECDSAKey.generate())
+    auth = ObsSignatureAuth("qamuser", sshkey_fingerprint="SHA256:missing")
+    with pytest.raises(ObsConfigError, match="no key matching fingerprint"):
+        auth._authorization(REALM)
+
+
+def test_agent_query_error_fails_closed(monkeypatch):
+    """An ssh-agent protocol error fails closed."""
+
+    def boom():
+        raise paramiko.SSHException("no agent socket")
+
+    monkeypatch.setattr(paramiko, "Agent", lambda: SimpleNamespace(get_keys=boom))
+    auth = ObsSignatureAuth("qamuser", sshkey_fingerprint="SHA256:x")
+    with pytest.raises(ObsConfigError, match="ssh-agent"):
+        auth._authorization(REALM)
+
+
+def test_encrypted_key_falls_back_to_agent(tmp_path, monkeypatch):
+    """An encrypted key is signed via the agent that holds its decrypted half."""
+    signer = paramiko.RSAKey.generate(2048)
+    agent_key = _real_agent_key(signer)
+    priv = tmp_path / "id_rsa"
+    _encrypted_ed25519(priv)
+    # The .pub on disk identifies the agent key by public-blob equality.
+    (tmp_path / "id_rsa.pub").write_text(f"ssh-rsa {signer.get_base64()} me\n")
+    _fake_agent(monkeypatch, agent_key)
+    auth = ObsSignatureAuth("qamuser", sshkey_path=priv)
+    _assert_authz_verifies(signer, auth._authorization(REALM))
+
+
+def test_pub_only_file_uses_agent(tmp_path, monkeypatch):
+    """A key present only as <name>.pub is signed via the agent's private half."""
+    signer = paramiko.RSAKey.generate(2048)
+    agent_key = _real_agent_key(signer)
+    priv = tmp_path / "id_rsa"  # the private file does not exist on disk
+    (tmp_path / "id_rsa.pub").write_text(f"ssh-rsa {signer.get_base64()} me\n")
+    _fake_agent(monkeypatch, agent_key)
+    auth = ObsSignatureAuth("qamuser", sshkey_path=priv)
+    _assert_authz_verifies(signer, auth._authorization(REALM))
+
+
+def test_missing_file_no_pub_fails_closed(tmp_path):
+    """A missing key file with no .pub cannot resolve to an agent key."""
+    auth = ObsSignatureAuth("qamuser", sshkey_path=tmp_path / "absent")
     with pytest.raises(ObsConfigError, match="passphrase-protected"):
         auth._authorization(REALM)
 
 
-def test_non_ed25519_key_fails_closed(tmp_path):
-    """A non-Ed25519 key raises ObsConfigError (only Ed25519 supported)."""
-    path = tmp_path / "rsa"
-    paramiko.RSAKey.generate(2048).write_private_key_file(str(path))
-    auth = ObsSignatureAuth("qamuser", path)
-    with pytest.raises(ObsConfigError, match="Ed25519"):
+def test_encrypted_key_no_pub_fails_closed(tmp_path):
+    """An encrypted key with no .pub cannot be matched to an agent key."""
+    priv = tmp_path / "enc"
+    _encrypted_ed25519(priv)
+    auth = ObsSignatureAuth("qamuser", sshkey_path=priv)
+    with pytest.raises(ObsConfigError, match="passphrase-protected"):
+        auth._authorization(REALM)
+
+
+def test_encrypted_key_pub_not_in_agent_fails_closed(tmp_path, monkeypatch):
+    """An encrypted key whose .pub is not loaded in the agent fails closed."""
+    priv = tmp_path / "id_rsa"
+    _encrypted_ed25519(priv)
+    wanted = paramiko.RSAKey.generate(2048)
+    (tmp_path / "id_rsa.pub").write_text(f"ssh-rsa {wanted.get_base64()} me\n")
+    _fake_agent(monkeypatch, paramiko.ECDSAKey.generate())  # a different key
+    auth = ObsSignatureAuth("qamuser", sshkey_path=priv)
+    with pytest.raises(ObsConfigError, match="passphrase-protected"):
         auth._authorization(REALM)
 
 
@@ -157,9 +328,34 @@ def test_unreadable_key_fails_closed(tmp_path):
     """A key path that cannot be read (here a directory) fails closed."""
     keydir = tmp_path / "keydir"
     keydir.mkdir()
-    auth = ObsSignatureAuth("qamuser", keydir)
+    auth = ObsSignatureAuth("qamuser", sshkey_path=keydir)
     with pytest.raises(ObsConfigError):
         auth._authorization(REALM)
+
+
+def test_binary_key_fails_closed(tmp_path):
+    """A binary/non-PEM key file raises ObsConfigError, not a bare ValueError.
+
+    paramiko's loader raises a plain ValueError on such input; without the
+    ValueError catch it would escape the never-raise facade as a traceback.
+    """
+    path = tmp_path / "id_bin"
+    path.write_bytes(bytes(range(256)) * 8)
+    auth = ObsSignatureAuth("qamuser", sshkey_path=path)
+    with pytest.raises(ObsConfigError, match="not a usable private key"):
+        auth._authorization(REALM)
+
+
+def test_pubkey_blob_missing_and_malformed(tmp_path):
+    """_pubkey_blob returns None for absent, short, or non-base64 .pub files."""
+    from mtui.data_sources.obs.auth import _pubkey_blob
+
+    assert _pubkey_blob(tmp_path / "absent") is None
+    base = tmp_path / "k"
+    (tmp_path / "k.pub").write_text("only-one-field\n")
+    assert _pubkey_blob(base) is None
+    (tmp_path / "k.pub").write_text("ssh-rsa @@@not-base64@@@ comment\n")
+    assert _pubkey_blob(base) is None
 
 
 def test_authorization_header_never_logged(key_path, caplog):

--- a/tests/test_obs_client.py
+++ b/tests/test_obs_client.py
@@ -109,6 +109,11 @@ def test_between_calls_budget_aborts(client):
         ("<status><summary> boom </summary></status>", "boom"),
         ("<status/>", ""),
         ("not xml", ""),
+        # A DTD-bearing error body is skipped (no entity-expansion parsing).
+        (
+            '<!DOCTYPE x [<!ENTITY e "boom">]><status><summary>&e;</summary></status>',
+            "",
+        ),
     ],
 )
 def test_error_summary(body, expected):

--- a/tests/test_obs_models.py
+++ b/tests/test_obs_models.py
@@ -1,6 +1,9 @@
 """Tests for the OBS XML parsers (mtui.data_sources.obs.models)."""
 
+import pytest
+
 from mtui.data_sources.obs import models
+from mtui.data_sources.obs.errors import ObsError
 
 REQUEST_XML = """
 <request id="42">
@@ -85,3 +88,24 @@ def test_is_qam_group():
     assert not models.is_qam_group("qam-auto")
     assert not models.is_qam_group("qam-openqa")
     assert not models.is_qam_group("legal-auto")
+
+
+@pytest.mark.parametrize(
+    "parser",
+    [
+        models.parse_request,
+        models.parse_request_collection,
+        models.parse_group_directory,
+        models.parse_reject_reason_values,
+    ],
+)
+def test_parsers_refuse_dtd(parser):
+    """A DTD (billion-laughs vector) is refused before parsing."""
+    billion_laughs = (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE lolz [<!ENTITY lol "lol">'
+        '<!ENTITY lol2 "&lol;&lol;&lol;">]>'
+        '<request><state name="&lol2;"/></request>'
+    )
+    with pytest.raises(ObsError, match="DTD"):
+        parser(billion_laughs)

--- a/tests/test_obs_oscrc.py
+++ b/tests/test_obs_oscrc.py
@@ -85,10 +85,23 @@ def test_unsupported_credentials_manager_raises(tmp_path):
         oscrc.read_credentials(API, conffile=str(conf))
 
 
-def test_agent_fingerprint_sshkey_fails_closed(tmp_path):
+def test_agent_fingerprint_sshkey_is_accepted(tmp_path):
+    """A SHA256: fingerprint yields an agent-key credential (no file)."""
     conf = _write(tmp_path, f"[{API}]\nuser = bob\nsshkey = SHA256:abc123\n")
-    with pytest.raises(ObsConfigError, match="ssh-agent fingerprint"):
-        oscrc.read_credentials(API, conffile=str(conf))
+    creds = oscrc.read_credentials(API, conffile=str(conf))
+    assert creds.sshkey_fingerprint == "SHA256:abc123"
+    assert creds.sshkey_path is None
+    assert creds.user == "bob"
+
+
+def test_pub_only_key_on_disk_is_accepted(tmp_path):
+    """A key present only as <name>.pub is accepted (agent holds the private)."""
+    priv = tmp_path / "id_ed25519"
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA comment\n")
+    conf = _write(tmp_path, f"[{API}]\nuser = bob\nsshkey = {priv}\n")
+    creds = oscrc.read_credentials(API, conffile=str(conf))
+    assert creds.sshkey_path == priv
+    assert creds.sshkey_fingerprint is None
 
 
 def test_missing_key_file_raises(tmp_path):
@@ -165,7 +178,11 @@ def test_loose_permissions_warn(tmp_path, caplog):
     ],
 )
 def test_resolve_sshkey_paths(value, expected):
-    assert oscrc._resolve_sshkey(value) == expected
+    assert oscrc._resolve_sshkey(value) == (expected, None)
+
+
+def test_resolve_sshkey_fingerprint():
+    assert oscrc._resolve_sshkey("SHA256:abc123") == (None, "SHA256:abc123")
 
 
 def test_resolve_sshkey_empty_raises():

--- a/tests/test_obs_qam.py
+++ b/tests/test_obs_qam.py
@@ -68,6 +68,15 @@ def _body(index=-1):
     return body.decode() if isinstance(body, bytes) else str(body)
 
 
+def _query_of(method, path):
+    """Parsed query of the (first) recorded call matching method + URL path."""
+    for call in responses.calls:
+        parsed = urlparse(str(call.request.url))
+        if call.request.method == method and parsed.path == path:
+            return parse_qs(parsed.query)
+    raise AssertionError(f"no {method} call to {path} was recorded")
+
+
 # --------------------------------------------------------------------------- #
 # comment                                                                      #
 # --------------------------------------------------------------------------- #
@@ -146,6 +155,17 @@ def test_assign_refused_when_not_open():
 
 
 @responses.activate
+def test_assign_accepts_state_new():
+    """state='new' is an open state (parity with the plugin's OPEN_STATES)."""
+    responses.add(responses.GET, f"{API}/request/56789", body=_request_xml(state="new"))
+    responses.add(responses.GET, LOG_URL, body="SUMMARY: PASSED\n")
+    responses.add(responses.GET, f"{API}/request", body="<collection/>")
+    responses.add(responses.POST, f"{API}/request/56789", body="<ok/>")
+    qam.assign(_client(), _config(), RRID, USER, ["qam-sle"])  # no raise
+    assert _last_query()["by_group"] == ["qam-sle"]
+
+
+@responses.activate
 def test_assign_refused_when_no_testreport():
     responses.add(responses.GET, f"{API}/request/56789", body=_request_xml())
     responses.add(responses.GET, LOG_URL, status=404)
@@ -196,6 +216,47 @@ def test_assign_previous_reject_proceeds_when_none_declined():
 
 
 @responses.activate
+def test_assign_pins_get_queries():
+    """The request GET carries withfullhistory=1 and the group GET login=user.
+
+    Both are load-bearing against real OBS (the nested review history feeds the
+    inference machine; login= scopes the group directory to the acting user).
+    """
+    reviews = "<review state='new' by_group='qam-sle'/>"
+    responses.add(
+        responses.GET, f"{API}/request/56789", body=_request_xml(reviews=reviews)
+    )
+    responses.add(responses.GET, LOG_URL, body="SUMMARY: PASSED\n")
+    responses.add(
+        responses.GET,
+        f"{API}/group",
+        body='<directory><entry name="qam-sle"/></directory>',
+    )
+    responses.add(responses.GET, f"{API}/request", body="<collection/>")
+    responses.add(responses.POST, f"{API}/request/56789", body="<ok/>")
+    qam.assign(_client(), _config(), RRID, USER, [])  # auto-infer -> hits group GET
+    assert _query_of("GET", "/request/56789")["withfullhistory"] == ["1"]
+    assert _query_of("GET", "/group")["login"] == [USER]
+
+
+@responses.activate
+def test_assign_previous_reject_ignores_non_qam_declined():
+    """A declined request with no qam-group review is excluded by the prefilter."""
+    responses.add(responses.GET, f"{API}/request/56789", body=_request_xml())
+    responses.add(responses.GET, LOG_URL, body="SUMMARY: PASSED\n")
+    # Declined, but its only review is a non-qam group -> prefilter drops it,
+    # so assign must still proceed (not blocked by an unrelated decline).
+    non_qam = (
+        "<collection><request id='9'><state name='declined'/>"
+        "<review state='declined' by_group='maintenance-team'/></request></collection>"
+    )
+    responses.add(responses.GET, f"{API}/request", body=non_qam)
+    responses.add(responses.POST, f"{API}/request/56789", body="<ok/>")
+    qam.assign(_client(), _config(), RRID, USER, ["qam-sle"])  # no raise
+    assert _last_query()["by_group"] == ["qam-sle"]
+
+
+@responses.activate
 def test_assign_skips_preconditions_for_pi():
     responses.add(responses.GET, f"{API}/request/70000", body=_request_xml())
     responses.add(responses.POST, f"{API}/request/70000", body="<ok/>")
@@ -220,6 +281,24 @@ def test_unassign_reverts_inferred_group():
     q = _last_query()
     assert q["revert"] == ["1"]
     assert q["by_group"] == ["qam-sle"]
+
+
+@responses.activate
+def test_unassign_reverts_explicit_group_over_inferred():
+    """With -G given, the revert targets the explicit group, not the inferred."""
+    # The user holds an assignment on qam-sle (the inferred group) ...
+    reviews = _group_review(
+        "qam-sle", "accepted", (USER, "2020-01-01T00:00:00", ACCEPT)
+    )
+    responses.add(
+        responses.GET, f"{API}/request/56789", body=_request_xml(reviews=reviews)
+    )
+    responses.add(responses.POST, f"{API}/request/56789", body="<ok/>")
+    # ... but the caller explicitly asks to revert a different group.
+    qam.unassign(_client(), _config(), RRID, USER, ["qam-cloud"])
+    q = _last_query()
+    assert q["revert"] == ["1"]
+    assert q["by_group"] == ["qam-cloud"]
 
 
 @responses.activate
@@ -302,6 +381,34 @@ def test_reject_writes_reason_and_declines():
 
 
 @responses.activate
+def test_reject_appends_to_existing_reject_reason():
+    """The MAINT:RejectReason RMW preserves other incidents' recorded reasons."""
+    responses.add(responses.GET, f"{API}/request/56789", body=_request_xml())
+    responses.add(responses.GET, LOG_URL, body="SUMMARY: FAILED\ncomment: broken\n")
+    attr = f"{API}/source/SUSE:Maintenance:1/_attribute/MAINT:RejectReason"
+    # A pre-existing reason for a different incident must survive the write.
+    responses.add(
+        responses.GET,
+        attr,
+        body=(
+            '<attributes><attribute name="RejectReason" namespace="MAINT">'
+            "<value>100:regression</value></attribute></attributes>"
+        ),
+    )
+    responses.add(responses.POST, attr, body="<ok/>")
+    responses.add(responses.POST, f"{API}/request/56789", body="<ok/>")
+    qam.reject(_client(), _config(), RRID, USER, [], "not_fixed", "msg")
+    attr_post = next(
+        c
+        for c in responses.calls
+        if c.request.url == attr and c.request.method == "POST"
+    )
+    posted = str(attr_post.request.body)
+    assert "100:regression" in posted  # pre-existing value preserved
+    assert "56789:not_fixed" in posted  # new value appended
+
+
+@responses.activate
 def test_reject_refused_when_not_failed():
     responses.add(responses.GET, f"{API}/request/56789", body=_request_xml())
     responses.add(responses.GET, LOG_URL, body="SUMMARY: PASSED\n")
@@ -338,6 +445,32 @@ def test_reject_ignores_group_with_log(caplog):
 # --------------------------------------------------------------------------- #
 # preconditions error paths                                                    #
 # --------------------------------------------------------------------------- #
+def test_summary_captures_whole_value_not_first_token():
+    """A trailing qualifier yields the whole value (-> UNKNOWN), matching the plugin.
+
+    Pins the `(.+?)` regex: under the old `(\\S+)` this would read 'PASSED' and
+    wrongly allow approve.
+    """
+    from mtui.data_sources.obs import preconditions
+
+    assert preconditions.summary("SUMMARY: PASSED\n") == "PASSED"
+    assert preconditions.summary("SUMMARY: PASSED with notes\n") == "PASSED WITH NOTES"
+
+
+@responses.activate
+def test_approve_refused_when_summary_has_trailing_qualifier():
+    """'SUMMARY: PASSED with notes' is not exactly PASSED -> approve refused."""
+    reviews = _group_review(
+        "qam-sle", "accepted", (USER, "2020-01-01T00:00:00", ACCEPT)
+    )
+    responses.add(
+        responses.GET, f"{API}/request/56789", body=_request_xml(reviews=reviews)
+    )
+    responses.add(responses.GET, LOG_URL, body="SUMMARY: PASSED with notes\n")
+    with pytest.raises(ObsError, match="not PASSED"):
+        qam.approve(_client(), _config(), RRID, USER, [])
+
+
 @responses.activate
 def test_fetch_testreport_log_none_on_server_error():
     from mtui.data_sources.obs import preconditions

--- a/tests/test_obs_sshsig.py
+++ b/tests/test_obs_sshsig.py
@@ -9,17 +9,67 @@ deterministic), and ``GOLDEN`` below was cross-checked once against
 """
 
 import base64
+import hashlib
+from struct import pack
 
 import paramiko
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from paramiko.message import Message
 
 from mtui.data_sources.obs import sshsig
 
 SEED = base64.b64decode("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=")
 NAMESPACE = "Use your developer account"
 CREATED = 1700000000
+
+
+def _read_str(raw: bytes, off: int) -> tuple[bytes, int]:
+    n = int.from_bytes(raw[off : off + 4], "big")
+    off += 4
+    return raw[off : off + n], off + n
+
+
+def _decode_sshsig(blob_b64: str) -> dict[str, bytes]:
+    """Unpack the outer SSHSIG blob into its fields (for verification)."""
+    raw = base64.b64decode(blob_b64)
+    assert raw[:6] == b"SSHSIG"
+    off = 10  # 6 magic + 4 version
+    pub, off = _read_str(raw, off)
+    namespace, off = _read_str(raw, off)
+    _reserved, off = _read_str(raw, off)
+    hashalg, off = _read_str(raw, off)
+    signature, off = _read_str(raw, off)
+    return {
+        "pub": pub,
+        "namespace": namespace,
+        "hashalg": hashalg,
+        "signature": signature,
+    }
+
+
+def _to_sign(namespace: str, created: int) -> bytes:
+    hashed = hashlib.sha512(f"(created): {created}".encode()).digest()
+
+    def w(b: bytes) -> bytes:
+        return pack(">I", len(b)) + b
+
+    return b"SSHSIG" + w(namespace.encode()) + w(b"") + w(b"sha512") + w(hashed)
+
+
+def _assert_verifies(key, blob_b64: str) -> dict[str, bytes]:
+    """The SSHSIG blob carries the key's pubkey and a valid signature."""
+    fields = _decode_sshsig(blob_b64)
+    assert fields["pub"] == key.asbytes()
+    assert fields["namespace"] == NAMESPACE.encode()
+    assert fields["hashalg"] == b"sha512"
+    assert key.verify_ssh_sig(
+        _to_sign(NAMESPACE, CREATED), Message(fields["signature"])
+    )
+    return fields
+
+
 GOLDEN = (
     "U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgA6EHv/POEL4dcN0Y50vAmWfk1jCb"
     "pQ1fHdyGZBJVMbgAAAAaVXNlIHlvdXIgZGV2ZWxvcGVyIGFjY291bnQAAAAAAAAABnNoYTUx"
@@ -77,3 +127,24 @@ def test_blob_is_valid_sshsig_base64(key):
 def test_wstr_encodes_ssh_string():
     assert sshsig._wstr(b"") == b"\x00\x00\x00\x00"
     assert sshsig._wstr(b"abc") == b"\x00\x00\x00\x03abc"
+
+
+def test_rsa_key_signs_with_rsa_sha2_512():
+    """RSA is signed with rsa-sha2-512 (not paramiko's legacy ssh-rsa/SHA-1)."""
+    key = paramiko.RSAKey.generate(2048)
+    fields = _assert_verifies(key, sshsig.sign_created(key, NAMESPACE, CREATED))
+    # The inner signature's algorithm field must be rsa-sha2-512.
+    assert Message(fields["signature"]).get_text() == "rsa-sha2-512"
+
+
+def test_ecdsa_key_signs_and_verifies():
+    """An ECDSA key produces a valid (randomised) SSHSIG signature."""
+    key = paramiko.ECDSAKey.generate()
+    fields = _assert_verifies(key, sshsig.sign_created(key, NAMESPACE, CREATED))
+    assert Message(fields["signature"]).get_text() == "ecdsa-sha2-nistp256"
+
+
+def test_sig_algorithm_only_overrides_rsa():
+    """Only RSA keys request an explicit signature algorithm."""
+    assert sshsig._sig_algorithm(paramiko.RSAKey.generate(2048)) == "rsa-sha2-512"
+    assert sshsig._sig_algorithm(paramiko.ECDSAKey.generate()) is None

--- a/tests/test_oscqam_native.py
+++ b/tests/test_oscqam_native.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 import requests
+import responses
 
 from mtui.data_sources import oscqam
 from mtui.data_sources.obs.oscrc import ObsCredentials
@@ -62,6 +63,13 @@ def test_native_group_none_normalised_to_empty_list(wired):
     assert calls["assign"][-1] == []
 
 
+def test_native_unassign_dispatches(wired):
+    calls, client = wired
+    assert OSC(_config(), RRID).unassign(["qam-sle"]) is True
+    c, _cfg, rrid, user, groups = calls["unassign"]
+    assert (c, rrid, user, groups) == (client, RRID, "qamuser", ["qam-sle"])
+
+
 def test_native_comment_and_reject_signatures(wired):
     calls, client = wired
     OSC(_config(), RRID).comment("hi")
@@ -78,6 +86,12 @@ def test_native_comment_and_reject_signatures(wired):
         ObsConfigError("no oscrc"),
         requests.exceptions.ConnectionError("down"),
         ET.ParseError("bad xml"),
+        # Non-obvious escapes the narrow tuple used to miss: a non-PEM key
+        # (ValueError), Path.expanduser() with no home (RuntimeError), and a
+        # lone surrogate in the body (UnicodeEncodeError, a ValueError).
+        ValueError("Unable to load PEM file"),
+        RuntimeError("Could not determine home directory"),
+        UnicodeEncodeError("utf-8", "\udce9", 0, 1, "surrogates not allowed"),
     ],
 )
 def test_native_never_raises_returns_false(monkeypatch, exc):
@@ -89,6 +103,34 @@ def test_native_never_raises_returns_false(monkeypatch, exc):
 
     monkeypatch.setattr(oscqam.obs_qam, "comment", boom)
     assert OSC(_config(), RRID).comment("x") is False
+
+
+def test_native_surrogate_body_returns_false(monkeypatch):
+    """A lone surrogate in the body (reachable via MCP JSON) yields False.
+
+    End-to-end through the real ObsClient: body.encode('utf-8') raises
+    UnicodeEncodeError before any network call, and the facade must catch it.
+    """
+    monkeypatch.setattr(oscqam, "read_credentials", lambda *a, **k: CREDS)
+    assert OSC(_config(), RRID).comment("bad \udce9 surrogate") is False
+
+
+@responses.activate
+def test_native_binary_key_returns_false(tmp_path, monkeypatch):
+    """A binary/non-PEM key loaded during the 401 handshake yields False."""
+    key = tmp_path / "id_bin"
+    key.write_bytes(bytes(range(256)) * 8)
+    creds = ObsCredentials(
+        apiurl="https://api.suse.de", user="qamuser", source="s", sshkey_path=key
+    )
+    monkeypatch.setattr(oscqam, "read_credentials", lambda *a, **k: creds)
+    responses.add(
+        responses.POST,
+        "https://api.suse.de/comments/request/56789",
+        status=401,
+        headers={"WWW-Authenticate": 'Signature realm="r"'},
+    )
+    assert OSC(_config(), RRID).comment("hello") is False
 
 
 def test_native_credential_error_returns_false(monkeypatch):


### PR DESCRIPTION
Follow-up to #322 (the native direct-OBS-API backend that replaced the `osc qam` plugin). This completes the one loose end the migration deliberately deferred — **support for all SSH key types** — and fixes two defects a post-merge adversarial review found in what #322 shipped.

## What changed

### 1. All OpenSSH key types (`feat`)
The signature auth previously accepted only an unencrypted Ed25519 key file. Now:
- **Any private-key file** — Ed25519, ECDSA, RSA — loaded via `paramiko.PKey.from_path`.
- **RSA is signed with `rsa-sha2-512`** (not paramiko's legacy `ssh-rsa`/SHA-1, which modern OpenSSH/OBS reject).
- **ssh-agent keys** — selected by the oscrc `sshkey` `SHA256:` fingerprint, as the passphrase-protected counterpart of a key file (matched by public-key blob), or as a `.pub`-only key on disk. `AgentKey.sign_ssh_data` returns raw bytes rather than a `Message`, which the signer now normalises.
- **Headless-safe**: `mtui-mcp` never prompts for a passphrase — an encrypted key is usable only via the agent, and every unresolvable case fails closed with a typed `ObsConfigError`.

### 2. Never-raise seam fix (`fix`) — a live regression in `main`
`OSC._native` caught only a narrow exception tuple, but its bare callers (`apicall.py`/`approve.py`) rely on it never raising. Three plausible inputs escaped as uncaught tracebacks: a non-PEM key file (`ValueError`), `Path.expanduser()` with no `$HOME` (`RuntimeError`, the headless-container case), and a lone surrogate in the body from MCP JSON (`UnicodeEncodeError`). The catch is broadened to `except Exception` (BaseException still propagates), matching the documented "convert any failure into False" contract.

### 3. Parity + hardening + docs (`refactor`)
- `assign` accepts request state `new` as well as `review` (plugin `Request.OPEN_STATES` parity).
- The `SUMMARY:` precondition compares the whole trimmed value, so `PASSED with notes` reads as UNKNOWN rather than PASSED.
- OBS XML carrying a DTD (`<!DOCTYPE`/`<!ENTITY`) is rejected before parsing, neutralising entity-expansion DoS on a compromised/MITM'd body.
- Docs/comments now describe the native OBS backend instead of an `osc` shell-out (`installation.rst`, `iui.rst`, `developer.rst`).

## Review
Built and reviewed by two rounds of adversarial fan-out (5 lenses + triage each, refute-by-default). The first round caught the never-raise blocker; the second caught that ssh-agent signing crashed on the real `AgentKey` bytes return (the agent tests had used in-process key stand-ins that hid it) — both fixed here, with a genuine `AgentKey` regression fixture and an end-to-end SSHSIG-verifies assertion.

## Testing
- `ruff format --check` + `ruff check` + `ty check` clean.
- Full suite: **2402 passing**. The `obs/` package and `oscqam.py` are at 100% line/branch coverage.
- New guards: RSA/ECDSA SSHSIG verify round-trips, real-`AgentKey` agent path, encrypted→agent and `.pub`-only fallbacks, binary-key fail-closed, facade never-raise for `ValueError`/`RuntimeError`/`UnicodeEncodeError`, GET query-param pins (`withfullhistory`/`login`), the `MAINT:RejectReason` append, the unassign explicit-group path, and the DTD guard.