### PR TITLE
perf: trim mtui-mcp startup cost and tool manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- `mtui-mcp` starts faster and ships a leaner tool manifest. The headless
+  server no longer imports `prompt_toolkit` (~115 modules, ~170ms) at startup —
+  it is loaded lazily only when the interactive REPL actually reads a line — and
+  the text-returning tools no longer advertise a redundant `{"result": string}`
+  `outputSchema` nor echo their output back as `structuredContent`. That trims
+  ~9KB (~2.4k tokens) from the `list_tools` manifest the client re-reads each
+  session; MCP clients should read tool output from the text content block (as
+  before) rather than `structuredContent`. Large single-command `run` output is
+  also accumulated without the previous quadratic buffer growth.
+
 ## 19.0.1 - 2026-07-17
 
 ### Added

--- a/mtui/cli/term.py
+++ b/mtui/cli/term.py
@@ -14,9 +14,6 @@ import struct
 import termios
 from collections.abc import Callable, Collection
 
-from prompt_toolkit import PromptSession
-from prompt_toolkit.history import InMemoryHistory
-
 
 def termsize() -> tuple[int, int]:
     """Gets the size of the terminal.
@@ -76,7 +73,15 @@ def _read_line(text: str) -> str:
     (yes/no confirmations, free-form comments) never reach
     ``~/.mtui_history``. The shared on-disk file is still owned by
     :mod:`mtui.cli._history`.
+
+    ``prompt_toolkit`` is imported here rather than at module scope so
+    the headless ``mtui-mcp`` server -- which imports this module only
+    for :func:`termsize`/:func:`page` and never reads a line -- does not
+    pay prompt_toolkit's import cost (~115 submodules) at startup.
     """
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import InMemoryHistory
+
     return PromptSession(history=InMemoryHistory()).prompt(text)
 
 

--- a/mtui/hosts/connection/connection.py
+++ b/mtui/hosts/connection/connection.py
@@ -388,8 +388,13 @@ class Connection:
         self.stdin = command
         self.stdout = ""
         self.stderr = ""
-        stdout = b""
-        stderr = b""
+        # Accumulate recv() chunks in lists and join once at the end.
+        # A ``bytes += buffer`` accumulator recopies the whole grown
+        # buffer on every 1 KiB read -- O(n^2) in the total output size,
+        # which bites multi-MB single commands (journalctl, cat of a big
+        # log). ``b"".join`` of the chunk list is byte-identical and O(n).
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
 
         session = self.__run_command(command)
         counter = 0
@@ -460,17 +465,22 @@ class Connection:
                     # print the received data
                     if session.recv_ready():
                         buffer = session.recv(1024)
-                        stdout += buffer
-                        for line in buffer.decode("utf-8", "ignore").split("\n"):
-                            if line:
-                                logger.debug(line)
+                        stdout_chunks.append(buffer)
+                        # Skip the per-line decode/split entirely unless DEBUG
+                        # is on -- otherwise every chunk is decoded and split
+                        # only to be discarded by a silenced logger.
+                        if logger.isEnabledFor(logging.DEBUG):
+                            for line in buffer.decode("utf-8", "ignore").split("\n"):
+                                if line:
+                                    logger.debug(line)
 
                     if session.recv_stderr_ready():
                         buffer = session.recv_stderr(1024)
-                        stderr += buffer
-                        for line in buffer.decode("utf-8", "ignore").split("\n"):
-                            if line:
-                                logger.debug(line)
+                        stderr_chunks.append(buffer)
+                        if logger.isEnabledFor(logging.DEBUG):
+                            for line in buffer.decode("utf-8", "ignore").split("\n"):
+                                if line:
+                                    logger.debug(line)
 
                     if not buffer:
                         break
@@ -497,8 +507,8 @@ class Connection:
         # dumps, non-UTF-8 locales, odd rpm metadata). A strict decode would
         # raise here and turn a successful command into a phantom failure
         # with its output lost -- mirror the tolerant per-line decode above.
-        self.stdout = stdout.decode("utf-8", "replace")
-        self.stderr = stderr.decode("utf-8", "replace")
+        self.stdout = b"".join(stdout_chunks).decode("utf-8", "replace")
+        self.stderr = b"".join(stderr_chunks).decode("utf-8", "replace")
         return exitcode
 
     def __invoke_shell(self, width: int, height: int) -> Channel | None:

--- a/mtui/mcp/tools.py
+++ b/mtui/mcp/tools.py
@@ -244,11 +244,18 @@ def _register_tool(
 
     wrapper = _make_wrapper(cls, parser, provider, argv_prefix=argv_prefix)
     desc = (description or cls.__doc__ or name).strip()
+    # structured_output=False: the wrapper returns a plain ``str``, so the
+    # SDK's default would advertise an information-free ``{"result": str}``
+    # outputSchema on every tool (bloating the list_tools manifest the
+    # client carries each session) and echo the whole text back as
+    # ``structuredContent`` on every call, duplicating the text block.
+    # Mirrors ``register_testreport_tools`` (testreport_tools.py).
     mcp.add_tool(
         wrapper,
         name=name,
         description=desc,
         annotations=ToolAnnotations(readOnlyHint=_is_read_only(name)),
+        structured_output=False,
     )
 
 
@@ -440,29 +447,36 @@ def register_job_tools(mcp: FastMCP, provider: SessionProvider) -> list[str]:
         "host (SSH/subprocess) may keep running on the host even after cancel."
     )
 
+    # structured_output=False on all four: they return plain ``str``; see
+    # the rationale in ``_register_tool``. Keeps the job tools consistent
+    # with every other ``-> str`` tool on the server.
     mcp.add_tool(
         job_list,
         name="job_list",
         description=list_desc,
         annotations=ToolAnnotations(readOnlyHint=True),
+        structured_output=False,
     )
     mcp.add_tool(
         job_status,
         name="job_status",
         description=status_desc,
         annotations=ToolAnnotations(readOnlyHint=True),
+        structured_output=False,
     )
     mcp.add_tool(
         job_result,
         name="job_result",
         description=result_desc,
         annotations=ToolAnnotations(readOnlyHint=True),
+        structured_output=False,
     )
     mcp.add_tool(
         job_cancel,
         name="job_cancel",
         description=cancel_desc,
         annotations=ToolAnnotations(readOnlyHint=False),
+        structured_output=False,
     )
     logger.info("registered 4 job tools: job_cancel, job_list, job_result, job_status")
     return ["job_cancel", "job_list", "job_result", "job_status"]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -162,6 +162,97 @@ def test_run_tolerates_non_utf8_output(mock_ssh_client, mock_ssh_config, mock_pa
     assert conn.stderr == "warn�\n"
 
 
+def test_run_joins_multiple_recv_chunks(mock_ssh_client, mock_ssh_config, mock_path):
+    """Output arriving over several recv() chunks is concatenated in order.
+
+    Guards the switch from a ``bytes += buffer`` accumulator (O(n^2) in
+    the total output size) to a list of chunks joined once with
+    ``b"".join`` at the end: the joined result must stay byte-identical
+    to a straight concatenation of every chunk, across both streams.
+    """
+    conn = Connection("test_host", 22, 300)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"chunk-one ", b"chunk-two ", b"chunk-three"]
+    mock_session.recv_ready.side_effect = [True, True, True, False]
+    mock_session.recv_stderr.side_effect = [b"err-a ", b"err-b"]
+    mock_session.recv_stderr_ready.side_effect = [True, True, False, False]
+
+    with patch("select.select", return_value=([mock_session], [], [])):
+        exit_code = conn.run("cat big.log")
+
+    assert exit_code == 0
+    assert conn.stdout == "chunk-one chunk-two chunk-three"
+    assert conn.stderr == "err-a err-b"
+
+
+@pytest.mark.parametrize("debug_enabled", [True, False])
+def test_run_debug_line_logging_is_gated(
+    debug_enabled, mock_ssh_client, mock_ssh_config, mock_path
+):
+    """The per-line decode/split/debug loop runs only when DEBUG is on.
+
+    Each recv() chunk is decoded, split on newlines and fed to
+    ``logger.debug`` one line at a time -- pointless work when the logger
+    is above DEBUG, so it is guarded by ``isEnabledFor``. Both streams are
+    driven so the stdout and stderr gates are pinned symmetrically, and
+    the captured output must be byte-identical either way.
+
+    The assertion spies the ``logger.debug`` *calls* rather than the
+    emitted records, and leaves ``isEnabledFor`` real. ``logger.debug``
+    self-gates on the effective level, so a records-only check stays green
+    even with the guard deleted; asserting the per-line calls never happen
+    when the logger is silenced is what actually fails on a reverted guard.
+    """
+    import logging
+
+    from mtui.hosts.connection import connection as conn_module
+
+    conn = Connection("test_host", 22, 300)
+
+    mock_session = MagicMock()
+    mock_ssh_client.get_transport.return_value.open_session.return_value = mock_session
+    mock_session.recv_exit_status.return_value = 0
+    mock_session.recv.side_effect = [b"out-line\n", b""]
+    mock_session.recv_stderr.side_effect = [b"err-line\n", b""]
+    mock_session.recv_ready.side_effect = [True, False]
+    mock_session.recv_stderr_ready.side_effect = [True, False]
+
+    logger = conn_module.logger
+    original_level = logger.level
+    logger.setLevel(logging.DEBUG if debug_enabled else logging.WARNING)
+    try:
+        with (
+            patch.object(logger, "debug") as dbg,
+            patch("select.select", return_value=([mock_session], [], [])),
+        ):
+            conn.run("echo hi")
+    finally:
+        logger.setLevel(original_level)
+
+    # The final join+decode is independent of the per-line loop, so the
+    # captured output is identical regardless of log level.
+    assert conn.stdout == "out-line\n"
+    assert conn.stderr == "err-line\n"
+
+    # The loop logs each split line with the bare line as the first arg;
+    # setup-path debug calls use format strings, so filter to our lines.
+    per_line = [
+        c.args[0] for c in dbg.call_args_list if c.args and isinstance(c.args[0], str)
+    ]
+    if debug_enabled:
+        assert "out-line" in per_line
+        assert "err-line" in per_line
+    else:
+        # Guard skipped both loops: the wasted decode/split and these
+        # per-line logger.debug calls never happen. Fails if the
+        # isEnabledFor guard is removed.
+        assert "out-line" not in per_line
+        assert "err-line" not in per_line
+
+
 def test_run_closes_stdin_after_exec(mock_ssh_client, mock_ssh_config, mock_path):
     """run() must close the channel's write half so the remote command's
     stdin gets EOF and can't block forever waiting for input."""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -34,6 +34,7 @@ from mtui.mcp._argv import kwargs_to_argv  # noqa: E402
 from mtui.mcp._schema import build_parameters  # noqa: E402
 from mtui.mcp.deny import REPL_ONLY  # noqa: E402
 from mtui.mcp.session import McpSession  # noqa: E402
+from mtui.mcp.testreport_tools import register_testreport_tools  # noqa: E402
 from mtui.mcp.tools import (  # noqa: E402
     SLOW_COMMANDS,
     SUBPARSER_COMMANDS,
@@ -113,6 +114,32 @@ def test_build_tools_excludes_subparser_parent(
     """Subparser parents are fanned out; the bare parent must not be a tool."""
     for parent in SUBPARSER_COMMANDS:
         assert parent not in registered_names
+
+
+def test_registered_tools_advertise_no_output_schema(
+    mcp: FastMCP, session: McpSession
+) -> None:
+    """No registered tool may carry an auto-generated ``outputSchema``.
+
+    The command wrappers and job tools return a plain ``str``; left to the
+    SDK default each would advertise an information-free ``{"result": str}``
+    output schema -- inflating the manifest the client re-reads each
+    session -- and echo the whole text back as ``structuredContent`` on
+    every call. The testreport tools return dicts but likewise opt out, to
+    keep the wire uniform. Every one of the server's six ``add_tool`` sites
+    therefore passes ``structured_output=False``; registering all of them
+    here pins that contract so a new site that forgets the flag is caught.
+    """
+    build_tools(mcp, session)
+    register_job_tools(mcp, session)
+    register_testreport_tools(mcp, session)
+
+    offenders = [
+        name
+        for name, tool in mcp._tool_manager._tools.items()  # noqa: SLF001
+        if tool.output_schema is not None
+    ]
+    assert not offenders, f"tools advertising a boilerplate outputSchema: {offenders}"
 
 
 def test_build_tools_includes_expected_commands(

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -1,5 +1,7 @@
 """Tests for the helpers in :mod:`mtui.term`."""
 
+import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,11 +15,18 @@ from mtui.cli.term import ask_user, filter_ansi, page, prompt_user
 def _patch_prompt(response):
     """Stub the ``PromptSession`` used by :func:`prompt_user` / :func:`ask_user`.
 
-    Returns a context manager that swaps ``mtui.cli.term.PromptSession``
+    Returns a context manager that swaps ``prompt_toolkit.PromptSession``
     for a factory yielding a session whose ``prompt`` call returns
     ``response``. Passing an exception class (e.g. ``KeyboardInterrupt``,
     ``EOFError``) raises it instead, so the bail-out branches can be
     exercised the same way.
+
+    ``prompt_toolkit`` is imported lazily inside
+    :func:`mtui.cli.term._read_line`, so the patch targets the class on
+    its home module (``prompt_toolkit.PromptSession``) rather than a
+    re-export on ``mtui.cli.term``; the lazy ``from prompt_toolkit import
+    PromptSession`` then binds the stub. This keeps the real ``_read_line``
+    body (and its ``InMemoryHistory`` construction) exercised.
     """
     session = MagicMock()
     if isinstance(response, type) and issubclass(response, BaseException):
@@ -25,7 +34,7 @@ def _patch_prompt(response):
     else:
         session.prompt.return_value = response
     factory = MagicMock(return_value=session)
-    return patch("mtui.cli.term.PromptSession", factory)
+    return patch("prompt_toolkit.PromptSession", factory)
 
 
 def test_filter_ansi():
@@ -188,6 +197,44 @@ def test_page_non_interactive_writer_receives_each_line():
     captured: list[str] = []
     page(["alpha", "beta\n", "gamma\r\n"], interactive=False, writer=captured.append)
     assert captured == ["alpha", "beta", "gamma"]
+
+
+def test_importing_term_does_not_load_prompt_toolkit():
+    """Importing :mod:`mtui.cli.term` must not pull in ``prompt_toolkit``.
+
+    The headless ``mtui-mcp`` server imports this module only for
+    :func:`termsize`/:func:`page` and never reads a line, so
+    ``prompt_toolkit`` (~115 submodules, ~170ms) is imported lazily
+    inside :func:`_read_line` instead of at module scope. Run in a fresh
+    interpreter because the test session itself imports prompt_toolkit
+    elsewhere, which would poison an in-process ``sys.modules`` check.
+    """
+    code = (
+        "import sys; import mtui.cli.term; "
+        "loaded = [m for m in sys.modules if m.startswith('prompt_toolkit')]; "
+        "assert not loaded, loaded; print('ok')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_read_line_lazy_import_still_prompts():
+    """The lazy import inside :func:`_read_line` still reaches prompt_toolkit.
+
+    Patching ``prompt_toolkit.PromptSession`` (its home, not a re-export
+    on ``mtui.cli.term``) proves the deferred ``from prompt_toolkit
+    import PromptSession`` binds the current attribute at call time.
+    """
+    from mtui.cli.term import _read_line
+
+    with _patch_prompt("typed answer"):
+        assert _read_line("prompt> ") == "typed answer"
 
 
 def test_termsize_fallback_matches_normal_path_order(monkeypatch):


### PR DESCRIPTION
Three low-risk performance quick wins from an adversarial performance audit of
the `mtui-mcp` server. Each is small, follows an idiom already in the tree, and
ships with a focused regression test. Numbers below are measured on this
machine.

### 1. Lazy-import `prompt_toolkit` in the headless server (`cli/term.py`)
The MCP server imports `term.py` only for `termsize`/`page` and never reads a
line, yet it was loading prompt_toolkit's ~115 submodules at every startup.
Moving the import into `_read_line()` drops them from the headless graph.

- **~1080 ms → ~910 ms** cold start (`import mtui.mcp.main`), 115 → 0
  prompt_toolkit submodules. The REPL imports prompt_toolkit via `repl.py`
  regardless, so it is unaffected.
- Test seam retargeted from `mtui.cli.term.PromptSession` to
  `prompt_toolkit.PromptSession` (its home, not a re-export), keeping the real
  `_read_line` body covered. A subprocess guard fails if the eager import
  returns.

### 2. Drop the boilerplate `{"result": string}` output schema on 60 tools (`mcp/tools.py`)
Every `-> str` tool was auto-wrapped in an information-free output schema and
echoed its whole text back as `structuredContent`, duplicating the text block.
Passing `structured_output=False` at all five `add_tool` sites suppresses both,
mirroring what `testreport_tools.py` already does.

- `list_tools` manifest **62.1 KB → 52.6 KB** (~2.4k tokens/session); all 60
  boilerplate `outputSchema` blocks gone.
- **Wire change:** MCP clients should read tool output from the text content
  block (as they already do); the dropped `structuredContent` was redundant.
  Noted in the CHANGELOG.

### 3. Kill the O(n²) byte accumulator in `Connection.run` (`hosts/connection/connection.py`)
Output was read in 1 KiB chunks and appended with `stdout += buffer`, recopying
the growing accumulator each read, then decoded/split per line to feed a usually
silenced logger. Now: collect chunks and `b"".join()` once; skip the decode
unless `DEBUG` is on.

- Byte-identical output. Only bites the tail — multi-MB single commands
  (`journalctl`, `cat` of a big log): a 5 MB read drops from ~2090 ms to ~11 ms
  in a microbenchmark.

### Testing
- `ruff format --check .`, `ruff check .`, `ty check`, full `pytest` (2411
  passed), and `sphinx-build -W` all green locally.
- +6 regression tests: import-graph guard + lazy-binding check (term), a
  **revert-sensitive** debug-gating test and a multi-chunk join test
  (connection, both gates pinned), and a manifest schema-contract test covering
  all six `add_tool` sites.

Went through an adversarial pre-PR review (5 dimensions × 3 verification lenses);
findings folded in — most notably rewriting the debug-gating test, which was a
false-negative (`logger.debug` self-gates on level, so a caplog-only assertion
could not detect a removed guard).

Remaining audit findings (openQA fan-out, refhosts re-parse, reboot reconnect,
export logs) are higher-payoff but need their own PRs; not included here.
