### PR TITLE
perf(openqa): parallelize openqa_overview HTTP fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   session; MCP clients should read tool output from the text content block (as
   before) rather than `structuredContent`. Large single-command `run` output is
   also accumulated without the previous quadratic buffer growth.
+- `openqa_overview` is substantially faster. Its independent openQA/OBS HTTP
+  round-trips -- the per-version single-incident queries, the per-group and
+  per-version aggregated day-walks, and the per-log `build_checks` downloads --
+  now run concurrently instead of one after another, while results are read back
+  in the original order so the rendered overview is unchanged. The openQA
+  job-group list is fetched once up front and shared across the fan-out.
 
 ## 19.0.1 - 2026-07-17
 

--- a/mtui/data_sources/oqa_search/search.py
+++ b/mtui/data_sources/oqa_search/search.py
@@ -17,6 +17,7 @@ from logging import getLogger
 from typing import Any, Final, override
 from urllib.parse import quote, unquote
 
+from ...support.concurrency import ContextExecutor
 from .heuristics import (
     AGGREGATED_EXCLUDED_VERSIONS,
     AGGREGATED_GROUPS_TERMS,
@@ -404,32 +405,51 @@ def log_matches_package(log: str, packages: list[str]) -> bool:
 # --- Public entry points used by the command layer ---
 
 
+def _prewarm_openqa_groups(url_openqa: str) -> None:
+    """Populate the ``_fetch_openqa_groups`` cache on the calling thread.
+
+    ``_get_group_id`` reads the ``lru_cache``d group list, but ``lru_cache``
+    does not dedupe *concurrent* misses: fanning out per-version workers on
+    a cold cache would make each worker issue the large
+    ``/api/v1/job_groups`` GET. Warming it once here means the workers all
+    hit the cache. Any error is left to propagate exactly as the first
+    sequential ``_get_group_id`` would have raised it.
+    """
+    _fetch_openqa_groups(url_openqa)
+
+
 def single_incidents(
     build: str, versions: list[str], url_openqa: str
 ) -> list[VersionResult]:
-    """Resolve openQA status for each SLE version of a single incident."""
-    results: list[VersionResult] = []
-    for version in versions:
+    """Resolve openQA status for each SLE version of a single incident.
+
+    The per-version resolutions are independent HTTP round-trips, so they
+    are fanned out; results are read back in ``versions`` order to match
+    the previous sequential output.
+    """
+    if not versions:
+        return []
+
+    def _resolve(version: str) -> VersionResult:
         try:
             group_id = _get_group_id(url_openqa, version)
         except ValueError as e:
             logger.warning("%s", e)
-            results.append(
-                VersionResult(version=version, url="", status="failed", note=str(e))
-            )
-            continue
+            return VersionResult(version=version, url="", status="failed", note=str(e))
         try:
-            results.append(_query_version_status(url_openqa, version, build, group_id))
+            return _query_version_status(url_openqa, version, build, group_id)
         except _HTTPError as e:
-            results.append(
-                VersionResult(
-                    version=version,
-                    url="",
-                    status="failed",
-                    note=f"openQA query failed: {e}",
-                )
+            return VersionResult(
+                version=version,
+                url="",
+                status="failed",
+                note=f"openQA query failed: {e}",
             )
-    return results
+
+    _prewarm_openqa_groups(url_openqa)
+    with ContextExecutor() as executor:
+        futures = [executor.submit(_resolve, version) for version in versions]
+        return [future.result() for future in futures]
 
 
 def aggregated_updates(
@@ -455,26 +475,51 @@ def aggregated_updates(
     except (TypeError, ValueError):
         incident_id_int = None
 
-    results: list[GroupResult] = []
+    # Resolve group ids first, serially: this loop's first _get_group_id
+    # warms the _fetch_openqa_groups cache single-threaded (no separate
+    # prewarm needed here -- unlike single_incidents, the fan-out below runs
+    # _scan_aggregated_for_version, which never reads the group list). Drop
+    # groups that don't resolve, preserving order.
+    valid_groups: list[tuple[str, int]] = []
     for group in aggregated_groups:
         try:
             group_id = _get_group_id(url_openqa, group)
         except ValueError as e:
             logger.warning("%s", e)
             continue
+        valid_groups.append((group, group_id))
 
-        group_result = GroupResult(group=group)
-        for version in filtered_versions:
-            group_result.versions.append(
-                _scan_aggregated_for_version(
-                    url_openqa,
-                    version,
-                    days,
-                    group_id,
-                    incident_id_int,
-                )
+    if not valid_groups:
+        return []
+
+    # Fan out the independent per-(group, version) day-walks. Each
+    # _scan_aggregated_for_version stays internally serial: its early
+    # return on the first matching build is an ordering dependency.
+    with ContextExecutor() as executor:
+        submitted = [
+            (
+                group,
+                [
+                    executor.submit(
+                        _scan_aggregated_for_version,
+                        url_openqa,
+                        version,
+                        days,
+                        group_id,
+                        incident_id_int,
+                    )
+                    for version in filtered_versions
+                ],
             )
-        results.append(group_result)
+            for group, group_id in valid_groups
+        ]
+
+        results: list[GroupResult] = []
+        for group, version_futures in submitted:
+            group_result = GroupResult(group=group)
+            for future in version_futures:
+                group_result.versions.append(future.result())
+            results.append(group_result)
     return results
 
 
@@ -572,23 +617,27 @@ def build_checks(
         logger.warning("No build check logs found for packages %r", packages)
         return []
 
-    out: list[BuildCheckResult] = []
-    for log in logfiles:
+    def _fetch_and_parse(log: str) -> BuildCheckResult:
         log_url = f"{base_url}/{quote(log)}"
         try:
             log_text = _fetch_url_content(log_url)
         except _HTTPError as e:
             logger.warning("build_check log %s unavailable: %s", log_url, e)
-            out.append(BuildCheckResult(url=log_url))
-            continue
+            return BuildCheckResult(url=log_url)
 
         matches = extract_test_results(log_text, test_pattern)
         summary = ""
         if len(matches) > 4:
             summary = summarize_test_results(matches)
             matches = [matches[0], matches[-1]]
-        out.append(BuildCheckResult(url=log_url, matches=matches, summary=summary))
-    return out
+        return BuildCheckResult(url=log_url, matches=matches, summary=summary)
+
+    # Independent per-log downloads; ``map`` preserves the input order so
+    # the rendered rows stay in build_checks-index order. The per-log
+    # ``_HTTPError`` is caught inside the worker so one unavailable log
+    # still yields its placeholder row instead of failing the batch.
+    with ContextExecutor() as executor:
+        return list(executor.map(_fetch_and_parse, logfiles))
 
 
 # --- Plain-text renderer (shared by the command and the export injector) ---

--- a/tests/test_oqa_search_connector.py
+++ b/tests/test_oqa_search_connector.py
@@ -12,6 +12,7 @@ reference implementation.
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -924,3 +925,187 @@ def test_incident_jobs_captures_job_state():
 def test_incident_jobs_empty_build_makes_no_request():
     """A falsy build short-circuits with no HTTP call."""
     assert oqa_search.incident_jobs("", OPENQA) == []
+
+
+# --- fan-out concurrency + order preservation ---
+#
+# These patch the per-item network functions with a Barrier-synchronised
+# stub: the Barrier only trips once *every* item's worker is in flight, so
+# a revert to a sequential loop makes the first worker block until the
+# Barrier times out and the call raises -- i.e. the tests fail on a revert.
+# Each also asserts the results keep input order.
+
+_BARRIER_TIMEOUT = 10.0
+
+
+def test_single_incidents_fans_out_and_preserves_order(monkeypatch):
+    """single_incidents resolves versions concurrently, results stay in order."""
+    versions = ["15-SP2", "15-SP3", "15-SP1", "12-SP5"]
+    barrier = threading.Barrier(len(versions))
+
+    monkeypatch.setattr(oqa_search.search, "_prewarm_openqa_groups", lambda url: None)
+    monkeypatch.setattr(oqa_search.search, "_get_group_id", lambda url, key: 1)
+
+    def _fake_status(url_openqa, version, build, group_id):
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        return oqa_search.VersionResult(
+            version=version, url=f"u/{version}", status="passed"
+        )
+
+    monkeypatch.setattr(oqa_search.search, "_query_version_status", _fake_status)
+
+    rows = oqa_search.single_incidents("build", versions, OPENQA)
+
+    assert [r.version for r in rows] == versions
+
+
+def test_aggregated_updates_fans_out_and_preserves_order(monkeypatch):
+    """Per-(group, version) day-walks run concurrently; nested order is kept."""
+    groups = ["core", "sap"]
+    versions = ["15-SP5", "15-SP4"]
+    barrier = threading.Barrier(len(groups) * len(versions))
+
+    monkeypatch.setattr(
+        oqa_search.search,
+        "_get_group_id",
+        lambda url, key: {"core": 1, "sap": 2}[key],
+    )
+
+    def _fake_scan(url_openqa, version, days, group_id, incident_id):
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        return oqa_search.VersionResult(
+            version=version, url=f"g{group_id}/{version}", status="passed"
+        )
+
+    monkeypatch.setattr(oqa_search.search, "_scan_aggregated_for_version", _fake_scan)
+
+    out = oqa_search.aggregated_updates(12358, versions, 5, groups, OPENQA)
+
+    assert [g.group for g in out] == groups
+    for group_result in out:
+        assert [v.version for v in group_result.versions] == versions
+
+
+def test_build_checks_fans_out_and_preserves_order(monkeypatch):
+    """Per-log downloads run concurrently; rows stay in build-index order."""
+    logs = ["bash.x86_64.log", "bash.aarch64.log", "bash.s390x.log"]
+    index_html = "".join(f'<a href="{name}">{name}</a>' for name in logs)
+    barrier = threading.Barrier(len(logs))
+
+    def _fake_fetch(url):
+        if url.endswith("/build_checks"):
+            return index_html
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        return f"content of {url}"
+
+    monkeypatch.setattr(oqa_search.search, "_fetch_url_content", _fake_fetch)
+
+    out = oqa_search.build_checks("Maintenance", 12358, 199773, ["bash"], QAM, None)
+
+    assert [r.url.rsplit("/", 1)[-1] for r in out] == logs
+
+
+def test_single_incidents_prewarms_job_groups_on_main_thread(monkeypatch):
+    """single_incidents warms the group cache once, on the calling thread.
+
+    Prewarming ``_fetch_openqa_groups`` before submitting the workers means
+    the fanned-out ``_get_group_id`` calls hit the ``lru_cache`` instead of
+    each issuing the large ``/api/v1/job_groups`` GET (which ``lru_cache``
+    would not dedupe under concurrent misses). Spying the network call
+    (``_get_json``, invoked only on a cache miss) and asserting the single
+    fetch happens on the *main* thread makes this revert-sensitive: drop
+    the prewarm and the lone fetch instead fires from a worker thread.
+    """
+    main_thread = threading.get_ident()
+    fetch_threads: list[int] = []
+
+    def _spy_get_json(url):
+        fetch_threads.append(threading.get_ident())
+        return [{"id": 490, "name": "SLE 15 SP5 Core Incidents", "template": "t"}]
+
+    # _fetch_openqa_groups stays real (and lru_cached); only its network call
+    # is spied, so worker cache hits do not record.
+    monkeypatch.setattr(oqa_search.search, "_get_json", _spy_get_json)
+    monkeypatch.setattr(
+        oqa_search.search,
+        "_query_version_status",
+        lambda url, version, build, group_id: oqa_search.VersionResult(
+            version=version, url="u", status="passed"
+        ),
+    )
+
+    oqa_search.single_incidents("build", ["15-SP5", "15-SP4", "15-SP3"], OPENQA)
+
+    assert fetch_threads == [main_thread]
+
+
+def test_single_incidents_empty_versions_returns_empty_without_http(monkeypatch):
+    """No versions -> empty result and not a single network call (no prewarm)."""
+    calls: list[str] = []
+    monkeypatch.setattr(oqa_search.search, "_get_json", lambda url: calls.append(url))
+
+    assert oqa_search.single_incidents("build", [], OPENQA) == []
+    assert calls == []
+
+
+def test_single_incidents_isolates_a_failed_version(monkeypatch):
+    """One version's _HTTPError yields a failed row; siblings still resolve.
+
+    Pins the batch-isolation catch inside the fanned-out worker: a single
+    query failure must not abort the whole overview, and order is kept.
+    """
+    versions = ["15-SP5", "15-SP4", "15-SP3"]
+    monkeypatch.setattr(oqa_search.search, "_prewarm_openqa_groups", lambda url: None)
+    monkeypatch.setattr(oqa_search.search, "_get_group_id", lambda url, key: 1)
+
+    def _status(url_openqa, version, build, group_id):
+        if version == "15-SP4":
+            raise oqa_search._HTTPError("boom")
+        return oqa_search.VersionResult(version=version, url="u", status="passed")
+
+    monkeypatch.setattr(oqa_search.search, "_query_version_status", _status)
+
+    rows = oqa_search.single_incidents("build", versions, OPENQA)
+
+    assert [r.version for r in rows] == versions
+    statuses = {r.version: r.status for r in rows}
+    assert statuses == {"15-SP5": "passed", "15-SP4": "failed", "15-SP3": "passed"}
+    failed = next(r for r in rows if r.version == "15-SP4")
+    assert failed.note.startswith("openQA query failed")
+
+
+@responses.activate
+def test_aggregated_updates_unresolved_group_returns_empty():
+    """Groups that don't resolve produce no GroupResult (prewarm still succeeds)."""
+    # job_groups is reachable (so prewarm/_get_group_id do not raise _HTTPError)
+    # but contains no matching group -> every _get_group_id raises ValueError.
+    _register_job_groups(_job_group(490, "SLE 15 SP5 Core Incidents"))
+
+    out = oqa_search.aggregated_updates(12358, ["15-SP5"], 5, ["nope"], OPENQA)
+    assert out == []
+
+
+def test_build_checks_isolates_an_unavailable_log(monkeypatch):
+    """One unavailable log yields a placeholder row; siblings parse, order kept.
+
+    Pins the batch-isolation catch inside the per-log worker.
+    """
+    logs = ["bash.x86_64.log", "bash.aarch64.log", "bash.s390x.log"]
+    index_html = "".join(f'<a href="{name}">{name}</a>' for name in logs)
+
+    def _fake_fetch(url):
+        if url.endswith("/build_checks"):
+            return index_html
+        if url.endswith("bash.aarch64.log"):
+            raise oqa_search._HTTPError("404")
+        return f"PASSED {url}"
+
+    monkeypatch.setattr(oqa_search.search, "_fetch_url_content", _fake_fetch)
+
+    out = oqa_search.build_checks("Maintenance", 12358, 199773, ["bash"], QAM, None)
+
+    assert [r.url.rsplit("/", 1)[-1] for r in out] == logs
+    placeholder = out[1]
+    assert placeholder.url.endswith("bash.aarch64.log")
+    assert placeholder.matches == []
+    assert placeholder.summary == ""


### PR DESCRIPTION
The `openqa_overview` data layer issued its independent openQA/OBS HTTP
round-trips strictly one after another — the audit modelled this as ~33
sequential GETs at defaults, a ~10s serial stall (tens of seconds with wider
`--days`/`--aggregated-groups`). This fans them out with `ContextExecutor` (the
in-tree, context-propagating pool already used by `qem_dashboard`), reading
results back in the original order so the **rendered overview is byte-identical**.

### What runs concurrently now
- **`single_incidents`** — the per-version resolutions (group-id lookup +
  status query, ~2 GETs each).
- **`aggregated_updates`** — the independent per-`(group, version)` day-walks.
  Group ids are still resolved serially first (that loop warms the group-list
  cache single-threaded), and each `_scan_aggregated_for_version` stays
  internally serial — its early return on the first matching build is an
  ordering dependency that must be preserved.
- **`build_checks`** — the per-log downloads, via order-preserving
  `executor.map`.

### Thundering-herd guard
`single_incidents` prewarms the `lru_cache`d job-group list once on the calling
thread before fanning out: `lru_cache` does not dedupe *concurrent* misses, so
each fanned-out `_get_group_id` would otherwise race to GET
`/api/v1/job_groups`. (`aggregated_updates` needs no prewarm — its serial
group-resolution loop already warms the cache, and the fan-out never reads the
group list.)

### Testing
- Three **Barrier-based** concurrency+order tests, one per fan-out — verified to
  fail with `BrokenBarrierError` when execution is forced serial.
- A prewarm test asserting the single group-list fetch happens on the **main
  thread** (fails deterministically if the prewarm is removed).
- **Batch-isolation** tests for the per-worker `_HTTPError` catches: one failed
  version / one unavailable log yields its placeholder row while siblings
  resolve, order preserved.
- Empty-input guards.
- `ruff` / `ty` (this tree is ty-strict) / full `pytest` (2413) all green
  locally.

Went through an adversarial pre-PR review (5 dimensions × 3 verification
lenses): **no must-fixes**; folded in the should-fixes (the two batch-isolation
tests) and nits (removed a redundant prewarm in `aggregated_updates`, made the
prewarm test revert-sensitive, added empty-input coverage).

All openQA/OBS timings in the audit were modelled (no network was available);
one real `openqa_overview` run would confirm the exact wall-clock win. Part of a
series of performance fixes; the first (`perf: trim mtui-mcp startup cost`) is
#327.
