### PR TITLE
perf(refhosts): parse refhosts.yml once per report, not per testplatform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   now run concurrently instead of one after another, while results are read back
   in the original order so the rendered overview is unchanged. The openQA
   job-group list is fetched once up front and shared across the fan-out.
+- Loading a template / connecting reference hosts is faster for multi-target
+  updates. `refhosts.yml` is now parsed once per report and shared across every
+  testplatform (and with the product-drift check) instead of being re-parsed
+  (~1s each) for every testplatform during autoconnect / `add_host`.
 
 ## 19.0.1 - 2026-07-17
 

--- a/mtui/test_reports/testreport.py
+++ b/mtui/test_reports/testreport.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from traceback import format_exc
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..hosts.refhost import Attributes, RefhostsFactory, RefhostsResolveFailedError
+from ..hosts.refhost import Attributes, RefhostsFactory
 from ..hosts.refhost import verify as product_verify
 from ..hosts.target import Target, TargetLockedError
 from ..hosts.target.hostgroup import HostsGroup
@@ -35,6 +35,7 @@ from .svn_io import (
 if TYPE_CHECKING:
     from ..cli.prompter import Prompter
     from ..hosts.host_arbiter import HostArbiter
+    from ..hosts.refhost import Refhosts
 
 logger = getLogger("mtui.template.testreport")
 
@@ -168,9 +169,11 @@ class TestReport(ABC):
         # (see _verify_target_products); commands print these so they
         # reach MCP clients, which only see command stdout (not logs).
         self.product_warnings: dict[str, list[str]] = {}
-        # Lazily-built, cached refhosts store for the product check, with
-        # a lock because connect_targets runs connect_target concurrently.
-        self._refhosts_store: Any = None
+        # Lazily-built, cached refhosts store shared by host resolution
+        # (refhosts_from_tp) and the product-drift check, with a lock
+        # because connect_targets runs connect_target concurrently. A
+        # failed build is cached and not retried for the report's lifetime.
+        self._refhosts_store: Refhosts | None = None
         self._refhosts_store_built = False
         self._refhosts_store_lock = threading.Lock()
 
@@ -449,12 +452,14 @@ class TestReport(ABC):
         with suppress(TargetLockedError):
             target.lock(self.lock_comment)
 
-    def _get_refhosts_store(self):
+    def _get_refhosts_store(self) -> "Refhosts | None":
         """Build (once, thread-safe) the refhosts store, or None on failure.
 
-        connect_targets fans connect_target out across threads, so the
-        first lookup may race; guard the one-time build with a lock and
-        cache the (possibly ``None``) result.
+        Shared by host resolution (:meth:`refhosts_from_tp`) and the
+        product-drift check. connect_targets fans connect_target out
+        across threads, so the first lookup may race; guard the one-time
+        build with a lock and cache the (possibly ``None``) result. A
+        failed build is cached and not retried for the report's lifetime.
         """
         if self._refhosts_store_built:
             return self._refhosts_store
@@ -463,10 +468,7 @@ class TestReport(ABC):
                 try:
                     self._refhosts_store = self.refhostsFactory(self.config)
                 except Exception:
-                    logger.debug(
-                        "refhosts store unavailable for product check:\n%s",
-                        format_exc(),
-                    )
+                    logger.debug("refhosts store unavailable:\n%s", format_exc())
                     self._refhosts_store = None
                 self._refhosts_store_built = True
         return self._refhosts_store
@@ -782,9 +784,22 @@ class TestReport(ABC):
             testplatform: The test platform to get reference hosts from.
 
         """
-        try:
-            refhosts = self.refhostsFactory(self.config)
-        except RefhostsResolveFailedError:
+        # Reuse the once-built, thread-safe store instead of re-parsing
+        # refhosts.yml (~1s) for every testplatform. autoconnect/add_host
+        # call this once per testplatform, so a K-testplatform template
+        # otherwise paid ~K seconds. The store is read-only after build, so
+        # sharing one instance across testplatforms (and with the product
+        # drift check) is safe. ``_get_refhosts_store`` returns None on any
+        # resolver failure (the factory funnels every resolver error into
+        # RefhostsResolveFailedError, which it swallows). Note the memo caches
+        # a failed build: unlike the previous per-call factory build, a
+        # transient resolver failure is not retried for the report's lifetime
+        # (reload the template to recover). This is acceptable -- resolver
+        # failures are effectively persistent (missing refhosts.yml + no
+        # network), and within one autoconnect loop caching is strictly better
+        # (one dead attempt instead of one per testplatform).
+        refhosts = self._get_refhosts_store()
+        if refhosts is None:
             return
 
         try:

--- a/tests/test_testreport.py
+++ b/tests/test_testreport.py
@@ -890,6 +890,76 @@ def test_refhosts_from_tp_failed_resolve_swallows(tmp_path: Path) -> None:
     r.refhosts_from_tp("tp")
 
 
+def test_refhosts_from_tp_parses_refhosts_once_across_testplatforms(
+    tmp_path: Path,
+) -> None:
+    """refhosts.yml is parsed once per report, not once per testplatform.
+
+    autoconnect/add_host resolve every testplatform through
+    ``refhosts_from_tp``; reusing the memoized ``_get_refhosts_store``
+    collapses the K parses of a K-testplatform template to one. A revert to
+    the per-call factory build makes ``call_count == K``.
+    """
+    r = _make(tmp_path)
+    r._arbiter = None
+    r._owner = None
+    r.refhostsFactory = MagicMock(
+        return_value=_FakeRefhosts([_ph("h1", ("sles", "15", "x86_64", ()))])
+    )
+
+    for minor in (5, 6, 7):
+        r.refhosts_from_tp(f"base=sles(major=15,minor={minor});arch=[x86_64]")
+
+    assert r.refhostsFactory.call_count == 1
+    assert r.hostnames == {"h1"}
+
+
+def test_refhosts_from_tp_reuses_prebuilt_store(tmp_path: Path) -> None:
+    """A store already built (e.g. by the product-drift check) is reused.
+
+    ``refhosts_from_tp`` reads the same ``_get_refhosts_store`` memo the
+    product-drift check populates, so once the store is built it never calls
+    the factory again.
+    """
+    r = _make(tmp_path)
+    r._arbiter = None
+    r._owner = None
+    # Simulate the memo already built (as the product-drift check would).
+    # _FakeRefhosts is a structural test double, not a Refhosts subclass.
+    r._refhosts_store = _FakeRefhosts(  # ty: ignore[invalid-assignment]
+        [_ph("h1", ("sles", "15", "x86_64", ()))]
+    )
+    r._refhosts_store_built = True
+    r.refhostsFactory = MagicMock()
+
+    r.refhosts_from_tp("base=sles(major=15,minor=5);arch=[x86_64]")
+
+    r.refhostsFactory.assert_not_called()
+    assert r.hostnames == {"h1"}
+
+
+def test_refhosts_from_tp_caches_failed_resolve(tmp_path: Path) -> None:
+    """A failed store build is cached, not retried, for the report's lifetime.
+
+    Unlike the previous per-call factory build, the shared memo caches the
+    failure: a second ``refhosts_from_tp`` does not re-invoke the factory
+    (recovery needs a template reload). Pins the deliberate sticky-None
+    behavior of the memoization.
+    """
+    from mtui.hosts.refhost import RefhostsResolveFailedError
+
+    r = _make(tmp_path)
+    r._arbiter = None
+    r._owner = None
+    r.refhostsFactory = MagicMock(side_effect=RefhostsResolveFailedError("bad"))
+
+    r.refhosts_from_tp("base=sles(major=15,minor=5);arch=[x86_64]")
+    r.refhosts_from_tp("base=sles(major=15,minor=6);arch=[x86_64]")
+
+    assert r.refhostsFactory.call_count == 1
+    assert r.hostnames == set()
+
+
 # ---------------------------------------------------------------------------
 # trivial pytest sanity for shutil-side metadata; never raises.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`refhosts_from_tp` built a fresh `Refhosts` store via the factory on **every
call** — each is a ~1s ruamel parse of `refhosts.yml` — and autoconnect /
`add_host` call it once per testplatform. So a K-testplatform template paid ~K
seconds at session start, the first latency a user feels.

This reuses the already-memoized, thread-safe store from `_get_refhosts_store`
(the same one the product-drift check uses), so the file is parsed **once per
report** and shared. The `Refhosts` store is read-only after construction
(`search` / `host_by_name` / `search_pool*` only iterate `self.data`), so
sharing one instance across testplatforms and the concurrent `connect_targets`
fan-out is safe.

### Behavior preservation
The factory funnels every resolver failure into `RefhostsResolveFailedError`,
which the memo swallows to `None` — matching the old
`except RefhostsResolveFailedError: return`. One **deliberate** difference: a
failed build is now cached and not retried for the report's lifetime (reload the
template to recover). This is acceptable — resolver failures are effectively
persistent (missing `refhosts.yml` + no network), and within one autoconnect
loop caching is strictly better (one dead attempt instead of one per
testplatform). The comment and a dedicated test document this.

Also restores static typing of the memoized store (`Refhosts | None`) so both
call sites are ty-checked again (previously `Any`).

### Testing
- Factory called **once** across multiple testplatforms; a pre-built store is
  reused; and the sticky-None (no-retry-after-failure) property — all
  revert-sensitive (verified to fail on the per-call revert).
- `ruff` / `ty` / full `pytest` (2408) green locally.

Adversarial pre-PR review (4 dimensions × 3 lenses): **no must-fixes**; folded
in the should-fixes (corrected an over-claiming comment about failure
semantics; de-scoped stale "product check" wording now that the store is shared)
and nits (restored typing, added the sticky-None test).

Part of a performance series: #327 (mtui-mcp startup) and #328 (openqa_overview
fan-out).
