### PR TITLE
perf(reboot): reconnect hosts concurrently after a reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   updates. `refhosts.yml` is now parsed once per report and shared across every
   testplatform (and with the product-drift check) instead of being re-parsed
   (~1s each) for every testplatform during autoconnect / `add_host`.
+- Rebooting a host group is faster. After the reboot is dispatched, the hosts
+  are now reconnected concurrently instead of one at a time, so the fixed
+  per-host reconnect wait (~10s) overlaps across hosts rather than stacking.
+  The wait itself is kept (it guards against reconnecting to a
+  still-shutting-down sshd); only the serialization is removed. Most visible on
+  transactional (SL Micro) updates, which reboot every host.
 
 ## 19.0.1 - 2026-07-17
 

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -214,9 +214,7 @@ class HostsGroup(UserDict[str, Target]):
             # host with retries + backoff while it comes back up.
             for hn, command in reboot.items():
                 self.data[hn].reboot(command)
-            for hn in sorted(reboot):
-                self.data[hn].reconnect(retry=10, backoff=True)
-                logger.info("%s is back up", hn)
+            self._reconnect_all(sorted(reboot))
 
     def reboot(
         self, command: str = "systemctl reboot", relock_comment: str = ""
@@ -245,9 +243,7 @@ class HostsGroup(UserDict[str, Target]):
         boot_ids = {hn: t.boot_id() for hn, t in self.data.items()}
         for t in self.data.values():
             t.reboot(command)
-        for hn in sorted(self.data):
-            self.data[hn].reconnect(retry=10, backoff=True)
-            logger.info("%s is back up", hn)
+        self._reconnect_all(sorted(self.data))
 
         for hn, t in self.data.items():
             self._verify_reboot(t, boot_ids[hn])
@@ -281,6 +277,29 @@ class HostsGroup(UserDict[str, Target]):
                 target.hostname,
                 new_boot_id,
             )
+
+    def _reconnect_all(self, hostnames: list[str]) -> None:
+        """Reconnect the given hosts concurrently after a reboot.
+
+        Each ``Connection.reconnect`` begins with a fixed pre-sleep (~10s on
+        the first attempt) before probing the host. Fanning the reconnects
+        out overlaps those waits instead of stacking them (N hosts would
+        otherwise pay ~N*10s even though they all rebooted at once); the
+        per-host sleep is kept -- it guards against reconnecting to a
+        still-shutting-down sshd -- and only its accumulation is removed.
+        Reconnects are independent: each :class:`Target` owns its own
+        connection. The first failure surfaces to the caller, as a serial
+        loop would.
+        """
+
+        def _reconnect(hn: str) -> None:
+            self.data[hn].reconnect(retry=10, backoff=True)
+            logger.info("%s is back up", hn)
+
+        run_parallel(
+            [(_reconnect, (hn,)) for hn in hostnames],
+            desc="reconnect" if self.interactive else None,
+        )
 
     def update_lock(self) -> None:
         """Locks all hosts in the group for an update."""

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -548,6 +548,33 @@ def test_reboot_all_logs_clean_host_list_and_back_up(caplog):
     assert not any("['" in m for m in msgs)
 
 
+def test_reboot_reconnects_hosts_concurrently():
+    """Post-reboot reconnects run in parallel, not one host at a time.
+
+    Each host's reconnect blocks on a Barrier of width N; it trips only if
+    every host's reconnect is in flight at once. A revert to the serial loop
+    makes the first reconnect block alone until the Barrier times out, and
+    run_parallel re-raises the resulting BrokenBarrierError -- so this test
+    fails on that revert. It also pins the keyword call convention.
+    """
+    import threading
+
+    hosts = ["h1", "h2", "h3"]
+    barrier = threading.Barrier(len(hosts))
+    targets = []
+    for hn in hosts:
+        t = _stub_target(hn, transactional=True)
+        t.reconnect.side_effect = lambda retry, backoff: barrier.wait(timeout=10)
+        targets.append(t)
+
+    hg = HostsGroup(targets)
+    hg._reboot(dict.fromkeys(hosts, "systemctl reboot"))
+
+    for t in targets:
+        t.reboot.assert_called_once_with("systemctl reboot")
+        t.reconnect.assert_called_once_with(retry=10, backoff=True)
+
+
 # ---------------------------------------------------------------------------
 # update_lock — comment-logging branch
 # ---------------------------------------------------------------------------
@@ -1025,6 +1052,28 @@ def test_hostgroup_interactive_passes_desc_label_to_run_parallel():
         hg._fanout_set_repo("add", MagicMock())  # noqa: SLF001
 
     assert mock_rp.call_args.kwargs["desc"] == "set_repo add"
+
+
+def test_hostgroup_non_interactive_reconnect_passes_desc_none():
+    """``_reconnect_all`` on a headless group (mtui-mcp) must pass ``desc=None``."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1], interactive=False)
+
+    with patch("mtui.hosts.target.hostgroup.run_parallel") as mock_rp:
+        hg._reconnect_all(["h1"])  # noqa: SLF001
+
+    assert mock_rp.call_args.kwargs["desc"] is None
+
+
+def test_hostgroup_interactive_reconnect_passes_desc_label():
+    """The REPL path keeps the ``reconnect`` spinner label."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])  # interactive=True by default
+
+    with patch("mtui.hosts.target.hostgroup.run_parallel") as mock_rp:
+        hg._reconnect_all(["h1"])  # noqa: SLF001
+
+    assert mock_rp.call_args.kwargs["desc"] == "reconnect"
 
 
 def test_hostgroup_non_interactive_run_passes_through_to_runcommand():


### PR DESCRIPTION
`reboot()` / `_reboot()` dispatched the reboot command fire-and-forget to every
host, then reconnected the hosts **one at a time**. `Connection.reconnect`
begins with a fixed pre-sleep (~10s on the first attempt) before it probes the
host, so the serial loop *stacked* that wait: N hosts paid ~N×10s even though
they all rebooted at once.

This extracts a `_reconnect_all` helper that fans the reconnects out via the
file's own `run_parallel` idiom (the same one `_fanout_set_repo` uses), so the
per-host waits overlap instead of accumulating. For a typical 2–4 host
transactional fleet that's ~10–30s saved per reboot, doubled on the newpackage
update path (which reboots twice).

### What's preserved
- **The ~10s pre-sleep is kept** — it's the only guard against reconnecting to a
  still-shutting-down sshd. Only its *accumulation* is removed.
- The reconnect call is unchanged (`retry=10, backoff=True`, once per host).
- Reconnects are independent (each `Target` owns its `Connection`).
- First failure still surfaces to the caller (`run_parallel` re-raises the first
  worker exception).
- `reboot()` still captures boot ids before and runs `_verify_reboot` serially
  after all reconnects complete, and re-applies the lock.
- Most visible on transactional (SL Micro) updates, which reboot every host.

### Testing
- A **Barrier-based** concurrency proof (verified to fail with
  `BrokenBarrierError` on a serial revert) that also pins the keyword call
  convention.
- Interactive / non-interactive `desc` parity tests mirroring the existing
  `_fanout_set_repo` ones (covers the headless `mtui-mcp` spinner-suppression
  path).
- `ruff` / `ty` / full `pytest` (2422) green locally.

Adversarial pre-PR review (4 dimensions × 3 lenses): **no must-fixes**; folded
in the two nits (the desc-parity tests and a stale docstring clause).

Part of a performance series: #327 (mtui-mcp startup), #328 (openqa_overview),
#329 (refhosts memoization).
