### PR TITLE
perf(export): download AUTO-workflow install logs concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   The wait itself is kept (it guards against reconnecting to a
   still-shutting-down sshd); only the serialization is removed. Most visible on
   transactional (SL Micro) updates, which reboot every host.
+- Exporting an AUTO-workflow testreport is faster. The openQA install logs are
+  now downloaded concurrently instead of one after another; results are written
+  in the original order, so the exported report is unchanged.
 
 ## 19.0.1 - 2026-07-17
 

--- a/mtui/update_workflow/export/auto.py
+++ b/mtui/update_workflow/export/auto.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import requests
 
+from ...support.concurrency import ContextExecutor
 from ...support.http import HTTP_TIMEOUT, build_session, resolve_verify
 from ...types import FileList
 from .base import BaseExport
@@ -112,10 +113,14 @@ class AutoExport(BaseExport):
         # paths may not have pre-created it, and writing a log into a missing
         # directory raises FileNotFoundError.
         filepath.mkdir(parents=True, exist_ok=True)
-        ilogs = zip_longest(
-            auto.results,
-            map(self._openqa_installog_to_template, auto.results),
-        )
+        # Download the install logs concurrently -- each is an independent
+        # HTTP GET (and builds its own requests session, so nothing is
+        # shared across workers). executor.map preserves input order, so the
+        # results still line up with auto.results. The file writes below stay
+        # serial (they touch the filesystem and may prompt on overwrite).
+        with ContextExecutor() as executor:
+            logs = list(executor.map(self._openqa_installog_to_template, auto.results))
+        ilogs = zip_longest(auto.results, logs)
         filenames = []
         for i, y in ilogs:
             fn = f"{i.distri.lower()}_{i.version}_{i.arch}.log"

--- a/tests/test_export_auto_download.py
+++ b/tests/test_export_auto_download.py
@@ -6,6 +6,7 @@ when it migrated from raw ``urllib`` to ``mtui.support.http``.
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import requests
@@ -157,3 +158,119 @@ def test_get_logs_creates_install_logs_dir(mock_config, tmp_path):
     assert len(filenames) == 1
     written = target_dir / "sle_15-SP7_x86_64.log"
     assert written.is_file()
+
+
+def _multi_results() -> list[URLs]:
+    """Three install-log URLs with distinct filenames (varying arch)."""
+    return [
+        URLs("sle", "x86_64", "15-SP7", "https://oqa/1"),
+        URLs("sle", "aarch64", "15-SP7", "https://oqa/2"),
+        URLs("sle", "s390x", "15-SP7", "https://oqa/3"),
+    ]
+
+
+def test_get_logs_preserves_order_across_parallel_downloads(mock_config, tmp_path):
+    """Parallel downloads still line up with ``auto.results``, in order.
+
+    ``executor.map`` preserves input order, so each log's content must be
+    written to the file derived from the *same* result -- proving the
+    concurrent downloads did not scramble the pairing -- and the ``_writer``
+    calls stay serial and in order.
+    """
+    mock_config.template_dir = tmp_path
+    rrid = "SUSE:Maintenance:1:1"
+    exporter = AutoExport(mock_config, MagicMock(), FileList([]), False, rrid, False)
+    exporter.openqa = MagicMock()
+    exporter.openqa.auto.results = _multi_results()
+
+    with (
+        patch.object(
+            exporter,
+            "_openqa_installog_to_template",
+            side_effect=lambda url: [f"content-{url.url}\n"],
+        ),
+        patch.object(exporter, "_writer") as writer,
+    ):
+        filenames = exporter.get_logs()
+
+    assert [str(p) for p in filenames] == [
+        "sle_15-SP7_x86_64.log",
+        "sle_15-SP7_aarch64.log",
+        "sle_15-SP7_s390x.log",
+    ]
+    written = [(c.args[0].name, c.args[1]) for c in writer.call_args_list]
+    assert written == [
+        ("sle_15-SP7_x86_64.log", ["content-https://oqa/1\n"]),
+        ("sle_15-SP7_aarch64.log", ["content-https://oqa/2\n"]),
+        ("sle_15-SP7_s390x.log", ["content-https://oqa/3\n"]),
+    ]
+
+
+def test_get_logs_downloads_run_concurrently(mock_config, tmp_path):
+    """The per-log downloads run in parallel, not one after another.
+
+    Each download blocks on a Barrier of width N; it trips only if every
+    download is in flight at once. A revert to the serial ``map`` makes the
+    first download block alone until the Barrier times out, and the raised
+    ``BrokenBarrierError`` propagates out of ``get_logs`` -- so this fails on
+    that revert.
+    """
+    mock_config.template_dir = tmp_path
+    exporter = AutoExport(
+        mock_config, MagicMock(), FileList([]), False, "SUSE:Maintenance:1:1", False
+    )
+    exporter.openqa = MagicMock()
+    results = _multi_results()
+    exporter.openqa.auto.results = results
+    barrier = threading.Barrier(len(results))
+
+    def _fake_download(url):
+        barrier.wait(timeout=10)
+        return [f"content-{url.url}\n"]
+
+    with (
+        patch.object(
+            exporter, "_openqa_installog_to_template", side_effect=_fake_download
+        ),
+        patch.object(exporter, "_writer"),
+    ):
+        filenames = exporter.get_logs()
+
+    assert len(filenames) == 3
+
+
+def test_get_logs_skips_failed_download_and_keeps_pairing(mock_config, tmp_path):
+    """A download that returns ``[]`` (failed) is skipped; pairing survives.
+
+    Proves the ``if y:`` skip still works after the concurrent fan-out: the
+    empty middle result is dropped, and the two written files pair with the
+    two *non-empty* results in order.
+    """
+    mock_config.template_dir = tmp_path
+    exporter = AutoExport(
+        mock_config, MagicMock(), FileList([]), False, "SUSE:Maintenance:1:1", False
+    )
+    exporter.openqa = MagicMock()
+    exporter.openqa.auto.results = _multi_results()  # x86_64, aarch64, s390x
+
+    def _fake_download(url):
+        # The aarch64 log "fails" and yields no lines.
+        return [] if url.url == "https://oqa/2" else [f"content-{url.url}\n"]
+
+    with (
+        patch.object(
+            exporter, "_openqa_installog_to_template", side_effect=_fake_download
+        ),
+        patch.object(exporter, "_writer") as writer,
+    ):
+        filenames = exporter.get_logs()
+
+    assert [str(p) for p in filenames] == [
+        "sle_15-SP7_x86_64.log",
+        "sle_15-SP7_s390x.log",
+    ]
+    written = [(c.args[0].name, c.args[1]) for c in writer.call_args_list]
+    assert written == [
+        ("sle_15-SP7_x86_64.log", ["content-https://oqa/1\n"]),
+        ("sle_15-SP7_s390x.log", ["content-https://oqa/3\n"]),
+    ]


### PR DESCRIPTION
`AutoExport.get_logs` pulled each openQA install log through a lazy `map` inside
`zip_longest`, so the N downloads ran strictly one after another (each also
building its own `requests` session). This fans them out with `ContextExecutor`:
`executor.map` preserves input order, so results still line up with
`auto.results`, and the file-writing loop stays serial (it touches the
filesystem and may prompt on overwrite).

- N is typically 2–6 install jobs; ~0.5–2s serialized becomes ~the single
  slowest log. One-time per report export.
- **No session is shared across workers** — each `_openqa_installog_to_template`
  builds its own, as before; failures are still caught per-log and yield an
  empty result (that log is skipped).

### Testing
- Order preservation (each log's content lands in its own, correctly-named
  file).
- A **Barrier-based** concurrency proof (verified to fail with
  `BrokenBarrierError` on a serial revert).
- A failed-download test (one log returns empty → skipped, pairing of the
  remaining two survives the concurrent fan-out).
- `ruff` / `ty` / full `pytest` (2421) green locally; 100% patch coverage on the
  changed lines.

Adversarial pre-PR review (3 dimensions × 3 lenses): **no must-fixes / no
should-fixes** — folded in the one useful nit (the failed-download regression
guard).

Completes the performance series: #327 (mtui-mcp startup), #328
(openqa_overview), #329 (refhosts memoization), #330 (reboot reconnect).
