### PR TITLE
perf(refhosts): cache the refhosts.yml parse process-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   updates. `refhosts.yml` is now parsed once per report and shared across every
   testplatform (and with the product-drift check) instead of being re-parsed
   (~1s each) for every testplatform during autoconnect / `add_host`.
+- `refhosts.yml` is now parsed at most once per file version for the whole
+  process, shared across all reports and sessions, instead of once per report.
+  This matters most under the `mtui-mcp` server, where many concurrent sessions
+  previously each spent ~1s of CPU re-parsing the same file; a single-flight
+  cache (keyed on the file's path, mtime and size) collapses that to one parse
+  and picks up an updated file on its next load.
 - Rebooting a host group is faster. After the reboot is dispatched, the hosts
   are now reconnected concurrently instead of one at a time, so the fixed
   per-host reconnect wait (~10s) overlaps across hosts rather than stacking.

--- a/mtui/hosts/refhost/resolvers.py
+++ b/mtui/hosts/refhost/resolvers.py
@@ -8,11 +8,12 @@ singleton tries them in the order named by ``config.refhosts_resolvers``.
 
 import errno
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from logging import getLogger
 from pathlib import Path
 
 from ...support.http import resolve_verify
-from .store import Refhosts
+from .store import Refhosts, load_refhosts
 
 logger = getLogger("mtui.refhost")
 
@@ -28,7 +29,9 @@ class Resolver(ABC):
 class PathResolver(Resolver):
     """Resolve refhosts from a local file at ``config.refhosts_path``."""
 
-    def __init__(self, refhosts_factory: type[Refhosts] = Refhosts) -> None:
+    def __init__(
+        self, refhosts_factory: Callable[[Path], Refhosts] = load_refhosts
+    ) -> None:
         self.refhosts_factory = refhosts_factory
 
     def resolve(self, config) -> Refhosts:
@@ -45,7 +48,7 @@ class HttpsResolver(Resolver):
         urlopener,
         file_writer,
         cache_path: Path,
-        refhosts_factory: type[Refhosts] = Refhosts,
+        refhosts_factory: Callable[[Path], Refhosts] = load_refhosts,
     ) -> None:
         """Initialize the resolver.
 

--- a/mtui/hosts/refhost/store.py
+++ b/mtui/hosts/refhost/store.py
@@ -9,6 +9,8 @@ the concrete resolvers without a circular import.
 """
 
 import fnmatch
+import os
+import threading
 from logging import getLogger
 from pathlib import Path
 from traceback import format_exc
@@ -327,6 +329,64 @@ class Refhosts:
 
 class RefhostsResolveFailedError(RuntimeError):
     """Raised when no resolver can produce a usable ``refhosts.yml`` source."""
+
+
+# Process-wide single-flight cache of parsed refhosts stores. ``refhosts.yml``
+# is ~68KB and its ruamel parse is ~1s of GIL-held CPU; under the ``mtui-mcp``
+# http transport hundreds of concurrent sessions would otherwise each re-parse
+# it, serialising the interpreter on that one core. A parsed :class:`Refhosts`
+# is read-only, so one instance is safely shared across every caller.
+_refhosts_cache: "dict[tuple[str, int, int], Refhosts]" = {}
+_refhosts_cache_lock = threading.Lock()
+#: A handful of distinct sources at most (the local path + the HTTPS cache,
+#: plus room for tests); the bound just keeps a leak impossible.
+_REFHOSTS_CACHE_MAXSIZE = 8
+
+
+def load_refhosts(hostmap: Path) -> Refhosts:
+    """Return a process-wide cached :class:`Refhosts` for ``hostmap``.
+
+    Collapses the ~1s ruamel parse to once per file *version* across the whole
+    process, shared by every resolver and session. The cache key is
+    ``(resolved path, st_mtime_ns, st_size)`` so an edited file -- or the
+    periodic HTTPS cache refresh -- is picked up on its next load. (This
+    relies on the filesystem's ``st_mtime_ns`` resolution: a byte-identical-
+    size in-place edit landing in the same mtime bucket on a coarse-mtime
+    mount would be missed until the mtime advances or the process restarts.
+    The default ``https``-first resolver is immune -- it rewrites the cache
+    via atomic rename -- and the ``path`` fallback is an RPM-managed file on
+    a nanosecond-mtime root filesystem.) A single
+    lock held across the parse (not a bare ``functools.lru_cache``) makes
+    concurrent cold-cache callers wait for one parse instead of stampeding
+    into N simultaneous 1s parses. Cache *hits* are lock-free.
+
+    A source that cannot be ``stat``-ed is not cached: :class:`Refhosts` is
+    constructed directly so the real error surfaces exactly as before.
+    """
+    try:
+        st = hostmap.stat()
+        key = (os.fspath(hostmap.resolve()), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return Refhosts(hostmap)
+
+    cached = _refhosts_cache.get(key)
+    if cached is not None:
+        return cached
+    with _refhosts_cache_lock:
+        cached = _refhosts_cache.get(key)
+        if cached is None:
+            cached = Refhosts(hostmap)
+            if len(_refhosts_cache) >= _REFHOSTS_CACHE_MAXSIZE:
+                # FIFO-evict the oldest entry (dict preserves insertion order).
+                del _refhosts_cache[next(iter(_refhosts_cache))]
+            _refhosts_cache[key] = cached
+    return cached
+
+
+def _clear_refhosts_cache() -> None:
+    """Drop the process-wide refhosts parse cache (test hook)."""
+    with _refhosts_cache_lock:
+        _refhosts_cache.clear()
 
 
 class _RefhostsFactory:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,22 @@ from mtui.types.systems import System
 
 __root__: Path = Path(__file__).parent / "fixtures"
 
+
+@pytest.fixture(autouse=True)
+def _clear_refhosts_parse_cache():
+    """Isolate the process-wide refhosts parse memo between tests.
+
+    ``mtui.hosts.refhost.store.load_refhosts`` caches parsed stores keyed on
+    ``(path, mtime, size)`` for the process lifetime; clear it around every
+    test so a fixture path reused across tests never serves a stale store.
+    """
+    from mtui.hosts.refhost.store import _clear_refhosts_cache
+
+    _clear_refhosts_cache()
+    yield
+    _clear_refhosts_cache()
+
+
 # mutmut's stats run re-resolves the relative [tool.mutmut] source_paths
 # against the *current* working directory on every trampoline hit, so any
 # test that chdir()s away from the package root crashes stats collection

--- a/tests/test_refhost.py
+++ b/tests/test_refhost.py
@@ -1,7 +1,10 @@
 """Tests for the mtui refhost module."""
 
 import errno
+import os
 import re
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -715,3 +718,129 @@ class TestExtensionBaseMatching:
         rh = refhost.Refhosts(REFHOSTS_FIXTURE)
         attr = self._attr("base=SLES(major=15,minor=SP6);arch=[x86_64]")
         assert rh.is_candidate_match(self._host(), attr)
+
+
+# --- process-wide parse memo (load_refhosts) ---
+
+
+def test_load_refhosts_memoizes_same_instance():
+    """Repeated loads of one file return the same parsed store (one parse)."""
+    from mtui.hosts.refhost.store import load_refhosts
+
+    a = load_refhosts(REFHOSTS_FIXTURE)
+    b = load_refhosts(REFHOSTS_FIXTURE)
+    assert a is b
+
+
+def test_load_refhosts_reparses_when_file_changes(tmp_path):
+    """A changed file (new mtime/size) invalidates the memo entry."""
+    from mtui.hosts.refhost.store import load_refhosts
+
+    yml = tmp_path / "refhosts.yml"
+    yml.write_text("default: []\n")
+    a = load_refhosts(yml)
+    yml.write_text("default: []\nnuremberg: []\n")  # different size
+    b = load_refhosts(yml)
+    assert a is not b
+
+
+def test_load_refhosts_is_single_flight(monkeypatch, tmp_path):
+    """Concurrent cold-cache callers trigger exactly one parse, not N.
+
+    The single lock held across the parse is what prevents a thundering herd
+    of simultaneous ~1s parses under the mtui-mcp http transport; six threads
+    racing on a cold key must all receive the one shared instance.
+    """
+    from mtui.hosts.refhost import store
+
+    yml = tmp_path / "refhosts.yml"
+    yml.write_text("default: []\n")
+
+    n = 6
+    barrier = threading.Barrier(n)
+    real = store.Refhosts
+    parses: list[int] = []
+    parses_lock = threading.Lock()
+
+    def _counting(path):
+        with parses_lock:
+            parses.append(1)
+        # Hold the parse open past one GIL slice so, absent the single-flight
+        # lock, every waiting thread would already be inside its own miss and
+        # record a parse -- making this test fail on a no-lock revert.
+        time.sleep(0.02)
+        return real(path)
+
+    monkeypatch.setattr(store, "Refhosts", _counting)
+
+    results: list[object] = []
+    results_lock = threading.Lock()
+
+    def _work():
+        barrier.wait(timeout=10)  # all n threads race the cold key together
+        r = store.load_refhosts(yml)
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=_work) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert len(parses) == 1
+    assert len(results) == n
+    assert all(r is results[0] for r in results)
+
+
+def test_load_refhosts_reparses_on_same_size_mtime_change(tmp_path):
+    """An equal-size edit still invalidates via st_mtime_ns.
+
+    Pins the mtime half of the key: a ``(path, size)``-only regression would
+    silently reopen the same-size staleness hole.
+    """
+    from mtui.hosts.refhost.store import load_refhosts
+
+    yml = tmp_path / "refhosts.yml"
+    yml.write_text("default: []\n")
+    a = load_refhosts(yml)
+
+    yml.write_text("hamburg: []\n")  # same byte length, different content
+    assert yml.stat().st_size == len("default: []\n")
+    os.utime(yml, ns=(a_ns := yml.stat().st_mtime_ns + 10_000_000, a_ns))
+
+    b = load_refhosts(yml)
+    assert a is not b
+
+
+def test_load_refhosts_evicts_oldest_beyond_maxsize(tmp_path):
+    """The cache is FIFO-bounded at _REFHOSTS_CACHE_MAXSIZE distinct files."""
+    from mtui.hosts.refhost import store
+
+    files = []
+    for i in range(store._REFHOSTS_CACHE_MAXSIZE + 1):
+        yml = tmp_path / f"refhosts_{i}.yml"
+        yml.write_text("default: []\n")
+        store.load_refhosts(yml)
+        files.append(yml)
+
+    assert len(store._refhosts_cache) == store._REFHOSTS_CACHE_MAXSIZE
+    # The first-loaded file was evicted; the last remains.
+    keys = list(store._refhosts_cache)
+    first_key = (os.fspath(files[0].resolve()), *_stat_key(files[0]))
+    last_key = (os.fspath(files[-1].resolve()), *_stat_key(files[-1]))
+    assert first_key not in keys
+    assert last_key in keys
+
+
+def _stat_key(path):
+    st = path.stat()
+    return (st.st_mtime_ns, st.st_size)
+
+
+def test_load_refhosts_unstatable_path_surfaces_error():
+    """A missing file is not cached; the real parse error propagates."""
+    from mtui.hosts.refhost.store import load_refhosts
+
+    with pytest.raises(FileNotFoundError):
+        load_refhosts(Path("/nonexistent/does/not/exist/refhosts.yml"))


### PR DESCRIPTION
Second layer under #329. `refhosts_from_tp` / `list_refhosts` / `add_host` each
build a `Refhosts` store via the resolver, and each build is a **~1s GIL-held
ruamel parse** of the ~68KB `refhosts.yml`. #329 collapsed that to once per
report; under the `mtui-mcp` **http transport**, hundreds of concurrent sessions
still each re-parse the same file, serialising the interpreter on one core (the
scale audit's finding **A2**).

This adds a **process-wide single-flight memo** at the `Refhosts(path)`
construction boundary (`store.load_refhosts`), injected as the default resolver
factory. The parsed store is read-only, so one instance is safely shared across
all callers. The key is `(resolved path, st_mtime_ns, st_size)`, so an edited
file — or the periodic HTTPS cache refresh — is picked up on its next load. A
single lock held **across** the parse (not a bare `lru_cache`) makes concurrent
cold-cache callers wait for one parse instead of stampeding into N simultaneous
~1s parses; **cache hits are lock-free**. An un-statable path bypasses the cache
so the real error surfaces unchanged.

Composes with #329: the per-report memo sits above this process-wide one.

### Testing
- Memoization (same instance), mtime/size invalidation **and** an equal-size
  edit invalidated via `st_mtime_ns`, **single-flight under 6 concurrent
  threads** (verified to fail — 6 parses — on a no-lock revert), FIFO eviction
  at the size bound, and uncacheable-path passthrough.
- A conftest autouse fixture isolates the process-wide cache between tests.
- `ruff` / `ty` / full `pytest` (2431) green locally.

Adversarial pre-PR review (4 dims × 3 lenses): **no must-fixes**; folded in the
should-fix (FIFO eviction coverage) and nits (single-flight revert-sensitivity,
a same-size invalidation test, a docstring note that the memo relies on
filesystem `st_mtime_ns` resolution).

First of the scale-audit top-three fixes; A1 (command executor) and A3 (Slack
watch) follow on their own branches.
