### PR TITLE
perf(mcp): explicit, configurable command thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   still-shutting-down sshd); only the serialization is removed. Most visible on
   transactional (SL Micro) updates, which reboot every host.
 
+### Added
+
+- New `[mcp] command_pool_size` option sizes the thread pool that runs blocking
+  command bodies under `mtui-mcp` (installed as the asyncio loop's default
+  executor). It defaults to `min(32, cpu+4)` — asyncio's own default — so stdio
+  and modest http deployments are unchanged. An http deployment that raises
+  `[mcp] session_cap` for a large agent fleet should raise this too; otherwise
+  command concurrency stays pinned near 32 regardless of how many sessions
+  connect.
+
 ## 19.0.1 - 2026-07-17
 
 ### Added

--- a/Documentation/cfg.rst
+++ b/Documentation/cfg.rst
@@ -310,6 +310,23 @@ integer; set to ``0`` to disable reaping. Ignored under the ``stdio``
 transport. See :doc:`mcp`.
 
 
+``mcp.command_pool_size``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  | **type**
+  |     int
+  | **default**
+  |     ``min(32, cpu + 4)``
+
+Size of the thread pool that runs blocking command bodies under ``mtui-mcp``
+(installed as the asyncio event loop's default executor, which
+``asyncio.to_thread`` uses). The default matches asyncio's own default pool
+size, so ``stdio`` and modest ``http`` deployments are unchanged. When you
+raise ``session_cap`` to admit a large agent fleet on the ``http`` transport,
+raise this too -- otherwise the number of command bodies executing at once
+stays pinned near 32 regardless of how many sessions connect, and calls queue.
+Must be a positive integer. See :doc:`mcp`.
+
+
 ``mcp.tool_profile``
 ~~~~~~~~~~~~~~~~~~~~
   | **type**
@@ -599,6 +616,7 @@ Example
   [mcp]
   session_cap = 32
   session_idle_timeout = 1800
+  command_pool_size = 36
   tool_profile = full
   max_output_bytes = 100000
   

--- a/mtui/mcp/main.py
+++ b/mtui/mcp/main.py
@@ -25,6 +25,8 @@ import asyncio
 import copy
 import logging
 import sys
+import weakref
+from contextlib import asynccontextmanager
 from logging import Logger
 from typing import TYPE_CHECKING
 
@@ -56,6 +58,12 @@ _SHUTDOWN_LEAVES: tuple[type[BaseException], ...] = (
     SystemExit,
     asyncio.CancelledError,
 )
+
+#: Event loops on which the mtui-mcp command pool has already been installed as
+#: the default executor. Under http the lifespan runs once per session on one
+#: shared loop, so this guards against reinstalling (and leaking) a pool per
+#: session; a WeakSet lets ephemeral test loops drop out on GC.
+_command_pool_loops: weakref.WeakSet[asyncio.AbstractEventLoop] = weakref.WeakSet()
 
 
 def _is_clean_shutdown_group(exc: BaseException) -> bool:
@@ -182,10 +190,47 @@ def main() -> int:
     else:
         provider = build_session(cfg, logger)
 
+    # Install a process-wide thread pool as the event loop's default executor,
+    # so ``asyncio.to_thread`` (which every blocking command body funnels
+    # through, session.py::_run_sync) uses an explicitly-sized, configurable
+    # pool instead of asyncio's implicit default. At the default size this is
+    # behaviourally equivalent to asyncio's own default; it lets an http
+    # deployment with a raised ``[mcp] session_cap`` also raise command
+    # concurrency past the ~32-thread default that would otherwise cap it
+    # regardless of session count. It is a :class:`ContextExecutor` so the
+    # per-call log-capture contextvars still propagate into the worker threads.
+    #
+    # Under the http transport FastMCP enters this lifespan once PER SESSION,
+    # all on the single shared event loop. Install the pool exactly once per
+    # loop (first session) and never tear it down per session -- shutting it
+    # down when one session ends would poison the shared default executor for
+    # every still-live peer (their next ``to_thread`` would raise "cannot
+    # schedule new futures after shutdown"). asyncio never shut down its own
+    # implicit default either; ``concurrent.futures``' atexit join reclaims the
+    # pool at interpreter exit.
+    @asynccontextmanager
+    async def _command_pool_lifespan(_server):
+        from ..support.concurrency import ContextExecutor
+
+        loop = asyncio.get_running_loop()
+        if loop not in _command_pool_loops:
+            pool = ContextExecutor(max_workers=cfg.mcp_command_pool_size)
+            loop.set_default_executor(pool)
+            _command_pool_loops.add(loop)
+            logger.info(
+                "mtui-mcp: command thread pool size=%d", cfg.mcp_command_pool_size
+            )
+        yield {}
+
     # ``host``/``port`` are constructor-time settings in the SDK and
     # only consulted under the ``streamable-http`` transport; passing
     # them under stdio is a harmless no-op.
-    mcp = FastMCP(name="mtui", host=args.host, port=args.port)
+    mcp = FastMCP(
+        name="mtui",
+        host=args.host,
+        port=args.port,
+        lifespan=_command_pool_lifespan,
+    )
     build_tools(mcp, provider)
     register_testreport_tools(mcp, provider)
     register_job_tools(mcp, provider)

--- a/mtui/support/config.py
+++ b/mtui/support/config.py
@@ -11,7 +11,7 @@ from argparse import Namespace
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from logging import getLogger
-from os import getenv
+from os import getenv, process_cpu_count
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -266,6 +266,7 @@ class Config:
     # -- mtui-mcp server (http transport) per-client session registry --
     mcp_session_cap: int
     mcp_session_idle_timeout: int
+    mcp_command_pool_size: int
 
     # -- mtui-mcp tool surface / output budget (both transports) --
     mcp_tool_profile: str
@@ -632,6 +633,26 @@ class Config:
                 "mcp_session_idle_timeout",
                 ("mcp", "session_idle_timeout"),
                 1800,
+                _parse_positive_int,
+                getint,
+            ),
+            # Size of the process-wide thread pool that runs blocking command
+            # bodies under ``mtui-mcp`` (installed as the asyncio loop's default
+            # executor, so ``asyncio.to_thread`` uses it). The default matches
+            # asyncio's own default pool size, ``min(32, cpu+4)``, so stdio and
+            # modest http deployments are unchanged. Operators running the http
+            # transport with a raised ``session_cap`` should raise this too --
+            # otherwise command concurrency stays pinned at ~32 regardless of
+            # how many sessions connect. Ignored effect under stdio (one client)
+            # but harmless to set.
+            ConfigOption(
+                "mcp_command_pool_size",
+                ("mcp", "command_pool_size"),
+                # Matches asyncio's own default executor size, which is
+                # affinity- and cgroup-aware via ``process_cpu_count`` rather
+                # than ``cpu_count``, so the default equals what asyncio's
+                # implicit ``to_thread`` pool used before this change.
+                min(32, (process_cpu_count() or 1) + 4),
                 _parse_positive_int,
                 getint,
             ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -394,6 +394,32 @@ def test_invalid_value_logs_one_error_and_falls_back(
     assert errors[0].exc_info is None  # one line, no traceback
 
 
+def test_mcp_command_pool_size_reads_and_defaults(tmp_path, monkeypatch):
+    """``[mcp] command_pool_size`` reads, defaults to min(32, cpu+4), rejects bad."""
+    from os import process_cpu_count
+
+    default = min(32, (process_cpu_count() or 1) + 4)
+
+    empty = tmp_path / "empty.cfg"
+    empty.write_text("")
+    assert config.Config(empty).mcp_command_pool_size == default
+
+    explicit = tmp_path / "set.cfg"
+    explicit.write_text("[mcp]\ncommand_pool_size = 128\n")
+    assert config.Config(explicit).mcp_command_pool_size == 128
+
+    bad = tmp_path / "bad.cfg"
+    bad.write_text("[mcp]\ncommand_pool_size = -1\n")
+    assert config.Config(bad).mcp_command_pool_size == default
+
+    # Host-independent shape pins (the build host's CPU count would otherwise
+    # mask the formula): below the cap the offset is +4; above it, capped at 32.
+    monkeypatch.setattr(config, "process_cpu_count", lambda: 4)
+    assert config.Config(empty).mcp_command_pool_size == 8
+    monkeypatch.setattr(config, "process_cpu_count", lambda: 64)
+    assert config.Config(empty).mcp_command_pool_size == 32
+
+
 @pytest.mark.parametrize(
     ("ini_section", "ini_key", "ini_value", "attr", "expected"),
     [

--- a/tests/test_mcp_args_pins.py
+++ b/tests/test_mcp_args_pins.py
@@ -332,8 +332,13 @@ def test_main_constructs_fastmcp_with_parsed_host_and_port_as_int(
     rc = mcp_main.main()
 
     assert rc == 0
-    fastmcp_cls.assert_called_once_with(name="mtui", host="0.0.0.0", port=9000)
+    fastmcp_cls.assert_called_once()
     call_kwargs: Mapping[str, Any] = fastmcp_cls.call_args.kwargs
+    assert (call_kwargs["name"], call_kwargs["host"], call_kwargs["port"]) == (
+        "mtui",
+        "0.0.0.0",
+        9000,
+    )
     assert isinstance(call_kwargs["port"], int)
     fastmcp_instance.run.assert_called_once_with(transport="streamable-http")
 
@@ -349,6 +354,12 @@ def test_main_constructs_fastmcp_with_default_host_and_port_under_stdio(
     rc = mcp_main.main()
 
     assert rc == 0
-    fastmcp_cls.assert_called_once_with(name="mtui", host="127.0.0.1", port=8000)
-    assert isinstance(fastmcp_cls.call_args.kwargs["port"], int)
+    fastmcp_cls.assert_called_once()
+    call_kwargs = fastmcp_cls.call_args.kwargs
+    assert (call_kwargs["name"], call_kwargs["host"], call_kwargs["port"]) == (
+        "mtui",
+        "127.0.0.1",
+        8000,
+    )
+    assert isinstance(call_kwargs["port"], int)
     fastmcp_instance.run.assert_called_once_with()

--- a/tests/test_mcp_main_wiring_pins.py
+++ b/tests/test_mcp_main_wiring_pins.py
@@ -136,6 +136,7 @@ def stub_environment(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     cfg = MagicMock(name="Config")
     cfg.mcp_session_cap = 7
     cfg.mcp_session_idle_timeout = 123.0
+    cfg.mcp_command_pool_size = 17
     cfg.mcp_tool_profile = "readonly"
     cfg.mcp_tools_allow = ("whoami",)
     cfg.mcp_tools_deny = ("edit",)
@@ -427,7 +428,15 @@ def test_main_constructs_fastmcp_with_name_and_default_host_port(
     monkeypatch.setattr("sys.argv", ["mtui-mcp"])
     rc = mcp_main.main()
     assert rc == 0
-    fastmcp_cls.assert_called_once_with(name="mtui", host="127.0.0.1", port=8000)
+    fastmcp_cls.assert_called_once()
+    kwargs = fastmcp_cls.call_args.kwargs
+    assert (kwargs["name"], kwargs["host"], kwargs["port"]) == (
+        "mtui",
+        "127.0.0.1",
+        8000,
+    )
+    # The command-pool lifespan is wired in (installs the loop's default pool).
+    assert callable(kwargs["lifespan"])
 
 
 def test_main_constructs_fastmcp_with_custom_host_and_port(
@@ -439,7 +448,84 @@ def test_main_constructs_fastmcp_with_custom_host_and_port(
     monkeypatch.setattr("sys.argv", ["mtui-mcp", "--host", "0.0.0.0", "--port", "9001"])
     rc = mcp_main.main()
     assert rc == 0
-    fastmcp_cls.assert_called_once_with(name="mtui", host="0.0.0.0", port=9001)
+    fastmcp_cls.assert_called_once()
+    kwargs = fastmcp_cls.call_args.kwargs
+    assert (kwargs["name"], kwargs["host"], kwargs["port"]) == ("mtui", "0.0.0.0", 9001)
+    assert callable(kwargs["lifespan"])
+
+
+def test_command_pool_lifespan_installs_sized_context_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_environment: dict[str, Any],
+) -> None:
+    """The lifespan installs a ContextExecutor of the configured size.
+
+    Entering the lifespan must set the event loop's default executor to a
+    ``ContextExecutor`` (so ``asyncio.to_thread`` for command bodies uses it
+    and per-call log-capture contextvars still propagate) sized to
+    ``[mcp] command_pool_size`` -- default ``min(32, cpu+4)``.
+    """
+    import asyncio
+
+    from mtui.support.concurrency import ContextExecutor
+
+    fastmcp_cls, _ = _install_fake_fastmcp(monkeypatch)
+    monkeypatch.setattr("sys.argv", ["mtui-mcp"])
+    assert mcp_main.main() == 0
+    lifespan = fastmcp_cls.call_args.kwargs["lifespan"]
+
+    installed: list[Any] = []
+
+    async def _drive() -> None:
+        loop = asyncio.get_running_loop()
+        real_set = loop.set_default_executor
+
+        def _spy(ex):
+            installed.append(ex)
+            return real_set(ex)
+
+        loop.set_default_executor = _spy  # ty: ignore[invalid-assignment]
+        async with lifespan(None):
+            pass
+
+    asyncio.run(_drive())
+
+    assert len(installed) == 1
+    pool = installed[0]
+    assert isinstance(pool, ContextExecutor)
+    # Sized from cfg.mcp_command_pool_size (17 in the stub), proving the
+    # lifespan reads the config knob rather than a hardcoded default.
+    assert pool._max_workers == 17
+
+
+def test_command_pool_lifespan_survives_per_session_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_environment: dict[str, Any],
+) -> None:
+    """A second session's lifespan exit must not poison the shared pool.
+
+    Under http FastMCP enters the lifespan once per session on one shared
+    loop. Installing/tearing the loop default executor down per session would
+    break every live peer -- their next ``to_thread`` would raise "cannot
+    schedule new futures after shutdown". Entering the lifespan twice on one
+    loop and exiting the inner one must leave ``to_thread`` working; this test
+    is RED against a per-session install/shutdown implementation.
+    """
+    import asyncio
+
+    fastmcp_cls, _ = _install_fake_fastmcp(monkeypatch)
+    monkeypatch.setattr("sys.argv", ["mtui-mcp"])
+    assert mcp_main.main() == 0
+    lifespan = fastmcp_cls.call_args.kwargs["lifespan"]
+
+    async def _drive() -> None:
+        async with lifespan(None):  # session A installs the pool
+            async with lifespan(None):  # session B on the same loop -- no-op
+                pass  # session B ends; must NOT shut the shared pool down
+            # peer A is still live: its next to_thread must still succeed
+            assert await asyncio.to_thread(lambda: "ok") == "ok"
+
+    asyncio.run(_drive())
 
     fastmcp_instance = fastmcp_cls.return_value
     # The same instance is what gets threaded into every registration call.


### PR DESCRIPTION
Every blocking command body under `mtui-mcp` runs via `asyncio.to_thread`, which
uses the event loop's **implicit** default `ThreadPoolExecutor`. Under the http
transport that pool is completely decoupled from `[mcp] session_cap`: an
operator can raise the cap to admit hundreds of sessions, but command
concurrency stays pinned near 32 and calls queue (scale-audit finding **A1**).

This installs a process-wide `ContextExecutor` as the loop's default executor
from a FastMCP lifespan hook, sized via a new **`[mcp] command_pool_size`**
(default `min(32, process_cpu_count()+4)` — matching asyncio's own
affinity/cgroup-aware default, so stdio and modest http are byte-identical). It
is a `ContextExecutor`, not a bare pool, so per-call log-capture contextvars
still propagate into the worker threads.

**The multi-session subtlety (caught in review):** under http, FastMCP enters
the lifespan **once per session** on one shared loop. So the pool is installed
exactly **once per loop** and **never torn down per session** — a per-session
`shutdown()` would poison the shared default executor for every live peer (their
next `to_thread` would raise *"cannot schedule new futures after shutdown"*).
`concurrent.futures`' atexit join reclaims it at interpreter exit.

Scoped out (deliberately, as a separately-reviewable follow-up): splitting into
separate read-only and slow-op pools so a burst of slow commands can't
head-of-line-block quick reads. This PR is the configurable-pool foundation.

### Testing
- Config read / default / reject, with **host-independent shape pins**
  (`process_cpu_count` monkeypatched to 4 → 8 and 64 → 32).
- A lifespan runtime test (installs a `ContextExecutor` sized from the knob).
- A **multi-session regression test** — a second session's lifespan exit must
  not break a live peer's `to_thread` — verified RED against a per-session
  install/shutdown implementation.
- `ruff` / `ty` / `sphinx -W` / full `pytest` (2428) green locally.

Adversarial pre-PR review (4 dims × 3 lenses): it caught a **must-fix** (the
per-session teardown bug above) and two should-fixes (affinity-aware default;
the regression test) — all folded in; the concept was confirmed sound and
honestly scoped.

Third of the scale-audit top-three fixes (with #332 refhosts memo; A3 Slack
watch follows on the Slack branch).
