### PR TITLE
fix(obs): don't reject a usable sshkey over credentials_mgr_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `credentials_mgr_class` when a usable `sshkey` is also configured. `approve`
   and `reject` failed outright with "supports only SSH-signature auth" for the
   common oscrc that sets both an `sshkey` and a password manager (e.g.
-  `TransientCredentialsManager`), even though the key was perfectly usable —
-  and that is exactly what `osc` itself does, ordering SSH-signature auth ahead
-  of the password path. The key is now resolved first and the credentials
+  `TransientCredentialsManager`), even though the key was perfectly usable.
+  `osc` disables its own password path outright for that manager, so the same
+  oscrc authenticates by SSH signature under `osc` too. The key is now
+  resolved first and the credentials
   manager is only consulted when no usable key exists, where a
   keyring/transient manager still fails closed (its secret is not in the file
   and mtui never prompts). `credentials_mgr_class` is also no longer inherited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- The native OBS backend no longer refuses an oscrc that names a
+  `credentials_mgr_class` when a usable `sshkey` is also configured. `approve`
+  and `reject` failed outright with "supports only SSH-signature auth" for the
+  common oscrc that sets both an `sshkey` and a password manager (e.g.
+  `TransientCredentialsManager`), even though the key was perfectly usable —
+  and that is exactly what `osc` itself does, ordering SSH-signature auth ahead
+  of the password path. The key is now resolved first and the credentials
+  manager is only consulted when no usable key exists, where a
+  keyring/transient manager still fails closed (its secret is not in the file
+  and mtui never prompts). `credentials_mgr_class` is also no longer inherited
+  from `[general]`, matching osc.
+
 ### Changed
 
 - `mtui-mcp` starts faster and ships a leaner tool manifest. The headless

--- a/mtui/data_sources/obs/oscrc.py
+++ b/mtui/data_sources/obs/oscrc.py
@@ -34,6 +34,29 @@ logger = getLogger("mtui.data_sources.obs.oscrc")
 # resolves it through the agent at signing time.
 _FINGERPRINT_RE = re.compile(r"^[A-Z0-9]+:")
 
+#: Characters an oscrc ``sshkey`` / ``credentials_mgr_class`` value can legally
+#: contain. Anything else means the value is not what we think it is.
+_SAFE_VALUE = re.compile(r"[\w.:/~@+-]+")
+
+
+def _for_display(value: str) -> str:
+    """Render an oscrc value for an error message without leaking a secret.
+
+    configparser folds an indented continuation line into the *previous*
+    option's value, so a stanza like::
+
+        sshkey = id_rsa
+         pass = hunter2
+
+    yields ``sshkey == "id_rsa\\npass = hunter2"``. Interpolating that raw into
+    an error would echo the password into the log and the mtui-mcp transcript.
+    Only values matching :data:`_SAFE_VALUE` are shown verbatim; anything else
+    (a fold, whitespace, quotes) is replaced wholesale rather than truncated,
+    because a truncation length is a guess and an empty first line defeats it.
+    """
+    return repr(value) if _SAFE_VALUE.fullmatch(value) else "<malformed>"
+
+
 # credentials_mgr_class values whose secret lives outside the oscrc (a system
 # keyring, or a transient prompt), so the native backend can never read it and
 # will not prompt. Only consulted when no usable 'sshkey' is configured: a
@@ -188,11 +211,13 @@ def read_credentials(apiurl: str) -> ObsCredentials:
         raise ObsConfigError(f"oscrc [{apiurl}] has no 'user'")
 
     # Resolve the ssh key FIRST, and ignore ``credentials_mgr_class`` entirely
-    # whenever a usable key exists. osc itself orders Signature auth ahead of
-    # Basic and explicitly disables the password path for the transient
-    # manager, so an oscrc carrying both an 'sshkey' and a password manager
-    # authenticates by signature under osc too. Rejecting such an oscrc up
-    # front turned a perfectly working configuration into a hard failure.
+    # whenever one is configured. osc disables its password path outright for
+    # ``TransientCredentialsManager`` (an exact class match), so the reported
+    # oscrc -- sshkey + transient manager + pass -- authenticates by signature
+    # under osc too. For other managers osc actually *prefers* Basic once a
+    # password resolves; mtui has no Basic path at all, so a configured key is
+    # its only usable credential either way. Rejecting such an oscrc up front
+    # turned a perfectly working configuration into a hard failure.
     sshkey = _inherited("sshkey")
     if not sshkey:
         # Only now does the credentials manager matter. Unlike 'sshkey', osc
@@ -202,14 +227,15 @@ def read_credentials(apiurl: str) -> ObsCredentials:
         if mgr and any(bad in mgr.lower() for bad in _UNSUPPORTED_MGR):
             raise ObsConfigError(
                 f"oscrc [{apiurl}] has no 'sshkey' and uses "
-                f"credentials_mgr_class={mgr!r}, whose secret is not stored in "
-                "the file; the native OBS backend cannot read it and never "
-                "prompts. Add an 'sshkey' entry to authenticate by SSH signature."
+                f"credentials_mgr_class={_for_display(mgr)}, whose secret is not "
+                "stored in the file; the native OBS backend cannot read it and "
+                "never prompts. Add an 'sshkey' entry to authenticate by SSH "
+                "signature."
             )
         raise ObsConfigError(
             f"oscrc [{apiurl}] has no 'sshkey' (in the section or [general]); the "
-            "native OBS backend requires SSH-signature auth (plaintext-password "
-            "auth is not supported)"
+            "native OBS backend supports no password mechanism (plaintext, "
+            "obfuscated, keyring or transient) — add an 'sshkey' entry"
         )
     # NB: 'pass'/'passx' are intentionally never read for this Signature-only
     # target — see the module docstring.
@@ -217,7 +243,8 @@ def read_credentials(apiurl: str) -> ObsCredentials:
     key_path, fingerprint = _resolve_sshkey(sshkey)
     if key_path is not None and not _key_available(key_path):
         raise ObsConfigError(
-            f"ssh key {key_path} (from oscrc sshkey={sshkey!r}) does not exist"
+            f"ssh key {_for_display(str(key_path))} (from oscrc "
+            f"sshkey={_for_display(sshkey)}) does not exist"
         )
 
     return ObsCredentials(

--- a/mtui/data_sources/obs/oscrc.py
+++ b/mtui/data_sources/obs/oscrc.py
@@ -34,8 +34,10 @@ logger = getLogger("mtui.data_sources.obs.oscrc")
 # resolves it through the agent at signing time.
 _FINGERPRINT_RE = re.compile(r"^[A-Z0-9]+:")
 
-# credentials_mgr_class values that route credentials through a mechanism
-# the native SSH-signature backend cannot use.
+# credentials_mgr_class values whose secret lives outside the oscrc (a system
+# keyring, or a transient prompt), so the native backend can never read it and
+# will not prompt. Only consulted when no usable 'sshkey' is configured: a
+# working key authenticates by signature regardless of the manager.
 _UNSUPPORTED_MGR = ("keyring", "transient")
 
 
@@ -181,20 +183,29 @@ def read_credentials(apiurl: str) -> ObsCredentials:
             value = parser["general"].get(key, "").strip()
         return value
 
-    mgr = _inherited("credentials_mgr_class")
-    if mgr and any(bad in mgr.lower() for bad in _UNSUPPORTED_MGR):
-        raise ObsConfigError(
-            f"oscrc [{apiurl}] uses credentials_mgr_class={mgr!r}; the native "
-            "OBS backend supports only SSH-signature auth (an 'sshkey' entry) — "
-            "keyring/transient-password managers are not supported"
-        )
-
     user = section.get("user", "").strip()
     if not user:
         raise ObsConfigError(f"oscrc [{apiurl}] has no 'user'")
 
+    # Resolve the ssh key FIRST, and ignore ``credentials_mgr_class`` entirely
+    # whenever a usable key exists. osc itself orders Signature auth ahead of
+    # Basic and explicitly disables the password path for the transient
+    # manager, so an oscrc carrying both an 'sshkey' and a password manager
+    # authenticates by signature under osc too. Rejecting such an oscrc up
+    # front turned a perfectly working configuration into a hard failure.
     sshkey = _inherited("sshkey")
     if not sshkey:
+        # Only now does the credentials manager matter. Unlike 'sshkey', osc
+        # does not inherit ``credentials_mgr_class`` from [general], so read it
+        # from the host section only.
+        mgr = section.get("credentials_mgr_class", "").strip()
+        if mgr and any(bad in mgr.lower() for bad in _UNSUPPORTED_MGR):
+            raise ObsConfigError(
+                f"oscrc [{apiurl}] has no 'sshkey' and uses "
+                f"credentials_mgr_class={mgr!r}, whose secret is not stored in "
+                "the file; the native OBS backend cannot read it and never "
+                "prompts. Add an 'sshkey' entry to authenticate by SSH signature."
+            )
         raise ObsConfigError(
             f"oscrc [{apiurl}] has no 'sshkey' (in the section or [general]); the "
             "native OBS backend requires SSH-signature auth (plaintext-password "

--- a/tests/test_obs_oscrc.py
+++ b/tests/test_obs_oscrc.py
@@ -222,13 +222,8 @@ def test_sshkey_inherited_from_general(tmp_path, monkeypatch):
     assert creds.user == "bob"
 
 
-def test_credentials_manager_not_inherited_from_general(tmp_path, monkeypatch):
-    """``credentials_mgr_class`` is host-section only, and never beats a key.
-
-    osc inherits 'sshkey' from [general] but not ``credentials_mgr_class``
-    (which has no parent default), so a global manager must not veto a usable
-    per-host key.
-    """
+def test_general_credentials_manager_does_not_veto_host_sshkey(tmp_path, monkeypatch):
+    """A [general] manager must not veto a per-host key."""
     key = tmp_path / "k"
     _write(
         tmp_path,
@@ -240,6 +235,44 @@ def test_credentials_manager_not_inherited_from_general(tmp_path, monkeypatch):
     creds = oscrc.read_credentials(API)
     assert creds.sshkey_path == key
     assert creds.user == "bob"
+
+
+def test_credentials_manager_not_inherited_from_general(tmp_path, monkeypatch):
+    """``credentials_mgr_class`` is host-section only (osc gives it no parent).
+
+    Discriminating case: with NO sshkey anywhere, a [general] manager must not
+    be picked up — the failure must be the plain "no 'sshkey'" one, never the
+    manager-specific message.
+    """
+    _write(
+        tmp_path,
+        f"[general]\ncredentials_mgr_class = osc.credentials.KeyringCredentialsManager\n"
+        f"\n[{API}]\nuser = bob\n",
+        monkeypatch=monkeypatch,
+    )
+    with pytest.raises(ObsConfigError) as excinfo:
+        oscrc.read_credentials(API)
+    assert "no 'sshkey'" in str(excinfo.value)
+    assert "credentials_mgr_class" not in str(excinfo.value)
+
+
+def test_folded_pass_continuation_is_not_echoed(tmp_path, monkeypatch):
+    """A password folded into 'sshkey' must never reach the error message.
+
+    configparser folds an indented continuation into the previous option's
+    value, so ``sshkey = missing`` followed by `` pass = hunter2`` yields a
+    value carrying the password. Interpolating it raw would echo the secret
+    into the log and the mtui-mcp transcript.
+    """
+    _write(
+        tmp_path,
+        f"[{API}]\nuser = bob\nsshkey = /nonexistent/key\n pass = hunter2\n",
+        monkeypatch=monkeypatch,
+    )
+    with pytest.raises(ObsConfigError) as excinfo:
+        oscrc.read_credentials(API)
+    assert "hunter2" not in str(excinfo.value)
+    assert "<malformed>" in str(excinfo.value)
 
 
 def test_trailing_slash_section_header_matches(tmp_path, monkeypatch):

--- a/tests/test_obs_oscrc.py
+++ b/tests/test_obs_oscrc.py
@@ -102,13 +102,58 @@ def test_missing_sshkey_raises(tmp_path, monkeypatch):
         oscrc.read_credentials(API)
 
 
-def test_unsupported_credentials_manager_raises(tmp_path, monkeypatch):
+def test_credentials_manager_ignored_when_sshkey_usable(tmp_path, monkeypatch):
+    """A usable 'sshkey' wins; ``credentials_mgr_class`` is not consulted.
+
+    osc orders Signature auth ahead of Basic and disables the password path for
+    the transient manager, so an oscrc carrying both authenticates by signature
+    there too. Rejecting it turned a working configuration into a hard failure.
+    """
     key = tmp_path / "k"
     _write(
         tmp_path,
         f"[{API}]\nuser = bob\nsshkey = {key}\n"
         "credentials_mgr_class = osc.credentials.KeyringCredentialsManager\n",
         keyfile=key,
+        monkeypatch=monkeypatch,
+    )
+    creds = oscrc.read_credentials(API)
+    assert creds.sshkey_path == key
+    assert creds.user == "bob"
+
+
+def test_reported_transient_manager_with_sshkey_and_pass(tmp_path, monkeypatch):
+    """Regression for the reported failure: sshkey + transient mgr + pass.
+
+    This exact oscrc shape made ``approve`` fail with "supports only
+    SSH-signature auth" even though the sshkey was perfectly usable. The
+    password must never be read, nor leak into the credentials' repr.
+    """
+    key = tmp_path / "id_rsa"
+    _write(
+        tmp_path,
+        f"[{API}]\nuser = simonlm\nsshkey = {key}\n"
+        "credentials_mgr_class = osc.credentials.TransientCredentialsManager\n"
+        "pass = s3cret-not-read\n",
+        keyfile=key,
+        monkeypatch=monkeypatch,
+    )
+    creds = oscrc.read_credentials(API)
+    assert creds.sshkey_path == key
+    assert creds.user == "simonlm"
+    assert "s3cret-not-read" not in repr(creds)
+
+
+def test_unsupported_credentials_manager_without_sshkey_raises(tmp_path, monkeypatch):
+    """With no usable key, a keyring/transient manager still fails closed.
+
+    Its secret is not in the file and mtui never prompts, so there is nothing
+    to authenticate with.
+    """
+    _write(
+        tmp_path,
+        f"[{API}]\nuser = bob\n"
+        "credentials_mgr_class = osc.credentials.KeyringCredentialsManager\n",
         monkeypatch=monkeypatch,
     )
     with pytest.raises(ObsConfigError, match="credentials_mgr_class"):
@@ -177,8 +222,13 @@ def test_sshkey_inherited_from_general(tmp_path, monkeypatch):
     assert creds.user == "bob"
 
 
-def test_credentials_manager_inherited_from_general(tmp_path, monkeypatch):
-    """A global keyring manager in [general] still fails closed."""
+def test_credentials_manager_not_inherited_from_general(tmp_path, monkeypatch):
+    """``credentials_mgr_class`` is host-section only, and never beats a key.
+
+    osc inherits 'sshkey' from [general] but not ``credentials_mgr_class``
+    (which has no parent default), so a global manager must not veto a usable
+    per-host key.
+    """
     key = tmp_path / "k"
     _write(
         tmp_path,
@@ -187,8 +237,9 @@ def test_credentials_manager_inherited_from_general(tmp_path, monkeypatch):
         keyfile=key,
         monkeypatch=monkeypatch,
     )
-    with pytest.raises(ObsConfigError, match="credentials_mgr_class"):
-        oscrc.read_credentials(API)
+    creds = oscrc.read_credentials(API)
+    assert creds.sshkey_path == key
+    assert creds.user == "bob"
 
 
 def test_trailing_slash_section_header_matches(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes a reported failure: `approve` (and `reject`) died outright for a common
oscrc shape.

```
error: OBS operation on SUSE:SLFO:1.1:416806 failed: oscrc [https://api.suse.de]
uses credentials_mgr_class='osc.credentials.TransientCredentialsManager'; the
native OBS backend supports only SSH-signature auth (an 'sshkey' entry) —
keyring/transient-password managers are not supported
```

...for an oscrc that **already had a perfectly usable `sshkey`**:

```ini
[https://api.suse.de]
user=simonlm
sshkey=id_rsa
credentials_mgr_class=osc.credentials.TransientCredentialsManager
pass=xxxxxxx
```

`read_credentials` checked `credentials_mgr_class` *before* resolving the key,
so the presence of a password manager vetoed an auth method that would have
worked.

### Why ignoring the manager is right

Verified against the installed `osc` (1.27.2): `osc` disables its password path
**outright** for `TransientCredentialsManager` — `connection.py:648`,
`if creds_mgr == "osc.credentials.TransientCredentialsManager":
self.basic_auth_password = False` — so that exact oscrc authenticates by SSH
signature under `osc` too, and never reads `pass`.

To be precise about the general case: `osc` does *not* universally prefer
signature auth. For other managers it prefers Basic once a password resolves
(`connection.py:793`). mtui has **no** Basic path at all, so a configured key is
its only usable credential either way — signature-or-fail is the only option we
have.

The manager is only consulted when **no** key is configured, where a
keyring/transient manager still **fails closed** — its secret isn't in the file
and mtui never prompts (which would hang headless `mtui-mcp`).

Also: `credentials_mgr_class` is no longer inherited from `[general]`. `osc`
gives it no parent default (`conf.py:278`) unlike `sshkey`'s `FromParent`
(`conf.py:299`), so a global manager must not veto a usable per-host key.

### Secret hygiene

`configparser` folds an indented continuation into the *previous* option's
value, so:

```ini
sshkey = id_rsa
 pass = hunter2
```

yields `sshkey == "id_rsa\npass = hunter2"`. Two error paths interpolated such a
value raw, echoing the password into the log **and** the `mtui-mcp` transcript.
Values now go through a display helper that prints only values matching a
conservative charset and replaces anything else wholesale with `<malformed>` (a
truncation length is a guess, and an empty first line defeats it).

The keyless error also no longer claims "plaintext-password auth is not
supported" — misleading for a keyring or obfuscated manager — and instead names
every unsupported mechanism.

### Scope

`pass`/`passx` are still never read. Password (HTTP Basic) auth for users with
**no** key at all is a separate, larger change (obfuscated-`passx` decoding, a
redaction-safe credential type, TLS-and-same-host guards on the Basic header, a
no-preemptive-send handler); a full plan exists and can follow. This PR is the
fix for the reported breakage.

### Testing
- Regression test using the **exact reported oscrc**: succeeds via the key, and
  the password never reaches the credentials' `repr`.
- A folded-continuation test asserting a password can't reach an error message.
- A discriminating `[general]`-inheritance test (the first attempt wasn't — it
  had a host `sshkey`, so the manager lookup was unreachable and it passed
  either way).
- A usable key beats a keyring manager; with no key, keyring/transient still
  fails closed.
- `ruff` / `ty` (ty-strict tree) / `sphinx -W` / full `pytest` (2429) green.

Went through an adversarial review (4 dimensions × 3 lenses): **no must-fixes**;
it independently verified the `osc` claims against the installed source and
**refuted** my original "osc orders Signature ahead of Basic" wording, which is
corrected above and in the code comment. The secret-echo path and the
non-discriminating test were its findings too.
