### PR TITLE
feat(teregen): sync the client with the current report API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- The TeReGen client is synced with the current report API. `assign` now also
+  surfaces who already holds (or has decided) each review group, sourced from
+  the report's live per-group assignment map — context only, never a gate,
+  since an empty map can also mean the upstream lookup failed. New client
+  calls expose the parsed-report endpoints (`parsed`, `bugs` — with `bsc#`
+  ids percent-encoded — and `completeness`) for consumers without a local
+  checkout. The `updates` listing no longer crashes on a malformed deadline
+  value, and the `--review-group` help clarifies the bare group-name form.
+
 - `mtui-mcp` starts faster and ships a leaner tool manifest. The headless
   server no longer imports `prompt_toolkit` (~115 modules, ~170ms) at startup —
   it is loaded lazily only when the interactive REPL actually reads a line — and

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -1294,7 +1294,11 @@ assign
 
 Assigns the current update to you. When no group is given, mtui infers the
 single open QA group you belong to; specify ``-g`` to disambiguate. Mirrors
-the `osc qam assign`_ workflow.
+the `osc qam assign`_ workflow. After the assignment, mtui prints best-effort
+context from the TeReGen report API: the update's live priority and deadline,
+and — when the report already carries assignment state — who currently holds
+or has decided each review group. The context is informational only and never
+blocks the action (its absence can also mean the lookup failed).
 
 .. _osc qam assign: http://qam.suse.de/projects/oscqam/latest/workflows/tester.html#assigning-updates
 

--- a/mtui/commands/apicall.py
+++ b/mtui/commands/apicall.py
@@ -79,13 +79,34 @@ class BaseApiCall(Command, ABC):
         Sourced from the TeReGen report API. Best-effort context for the tester
         picking up an update: silent when TeReGen has nothing for this request.
         """
-        priority, deadline = TeReGen(self.config).priority_deadline(self.metadata.rrid)
-        if priority is None and deadline is None:
+        info = TeReGen(self.config).info(self.metadata.rrid)
+        if not info:
             return
-        self.println(
-            f"TeReGen: priority {priority if priority is not None else '?'}, "
-            f"deadline {deadline or '?'}"
-        )
+        priority, deadline = info.get("priority"), info.get("deadline")
+        if priority is not None or deadline is not None:
+            self.println(
+                f"TeReGen: priority {priority if priority is not None else '?'}, "
+                f"deadline {deadline or '?'}"
+            )
+        # Best-effort assignment context: warn when someone already holds (or
+        # has decided) a review group. An empty map is NOT authoritative — it
+        # is also what an upstream lookup failure yields, and the server caches
+        # this endpoint for up to ~300s — so absence prints nothing and nothing
+        # here ever gates the action.
+        assignees = info.get("assignees")
+        if isinstance(assignees, dict):
+            for group, entries in sorted(assignees.items()):
+                if not isinstance(entries, list):
+                    continue
+                holders = ", ".join(
+                    f"{e.get('user') or '?'} ({e.get('state') or '?'})"
+                    for e in entries
+                    if isinstance(e, dict)
+                )
+                if holders:
+                    self.println(
+                        f"TeReGen: {group} assignment state (may lag ~5 min): {holders}"
+                    )
 
     def _pi_autolock(self) -> None:
         """Locks/unlocks reference hosts around PI testing.

--- a/mtui/commands/updates.py
+++ b/mtui/commands/updates.py
@@ -40,7 +40,8 @@ class Updates(Command):
         parser.add_argument(
             "--review-group",
             default=None,
-            help="filter by review group, e.g. qam-sle",
+            help="filter by review group as the bare group name, e.g. qam-sle "
+            "(not the '<group>-review' login form, which classic rows lack)",
         )
         parser.add_argument(
             "--status",
@@ -115,7 +116,9 @@ class Updates(Command):
                 self.println(f"  {u}")
                 continue
             # deadline is an ISO timestamp; the date alone is enough for a row.
-            deadline = (u.get("deadline") or "")[:10] or "-"
+            # str() guards against shape drift (a non-string would crash the
+            # whole listing over one row).
+            deadline = str(u.get("deadline") or "")[:10] or "-"
             row = (
                 f"  prio={u.get('priority', '?')!s:<5} "
                 f"{u.get('status', '?')!s:<10} "

--- a/mtui/data_sources/teregen.py
+++ b/mtui/data_sources/teregen.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from logging import getLogger
 from typing import Any
+from urllib.parse import quote
 
 import requests
 
@@ -76,8 +77,10 @@ class TeReGen:
             return None
 
     def info(self, rrid: object) -> dict[str, Any] | None:
-        """The main report endpoint (``GET /reports/{id}``): id, file list, and
-        the live ``priority``/``deadline`` (refreshed from SMELT for SLFO)."""
+        """The main report endpoint (``GET /reports/{id}``): id, file list, the
+        live ``priority``/``deadline`` (refreshed from SMELT — v2 for SLFO,
+        GraphQL for classic Maintenance), and the live per-group ``assignees``
+        map (``{group: [{user, state}]}``, cached server-side up to ~300s)."""
         d = self._get(f"reports/{rrid}")
         return d if isinstance(d, dict) else None
 
@@ -91,17 +94,52 @@ class TeReGen:
         d = self._get(f"reports/{rrid}/status")
         return d if isinstance(d, dict) else None
 
-    def priority_deadline(self, rrid: object) -> tuple[int | None, str | None]:
-        """``(priority, deadline)`` from the main report endpoint, best-effort."""
-        info = self.info(rrid)
-        if not info:
-            return None, None
-        return info.get("priority"), info.get("deadline")
-
     def checkers(self, rrid: object) -> list[Any] | None:
         """Live checker (build-check) result runs for a report, or ``None``."""
         d = self._get(f"reports/{rrid}/checkers")
         return d.get("checkers") if isinstance(d, dict) else None
+
+    def parsed(self, rrid: object, section: str | None = None) -> dict[str, Any] | None:
+        """The parsed report (``GET /reports/{id}/parsed[/{section}]``).
+
+        Without ``section``: the full normalized parse (keys ``sections``,
+        ``summary``, ``metadata``, ``packages``, ``products``, ``bugs``,
+        ``new_bugs``, ``testers``, ``completeness``). With ``section``: an
+        ``{id, section, data}`` envelope with the slice under ``data``. New
+        metadata consumers should prefer the ``metadata`` section (the
+        canonical, snake_case superset) over the frozen raw ``/metadata``
+        endpoint.
+        """
+        path = f"reports/{rrid}/parsed"
+        if section:
+            path += f"/{quote(section, safe='')}"
+        d = self._get(path)
+        return d if isinstance(d, dict) else None
+
+    def bugs(self, rrid: object, bug_id: str | None = None) -> dict[str, Any] | None:
+        """Parsed bug index or one bug (``GET /reports/{id}/bugs[/{bug_id}]``).
+
+        The index carries rows of ``{id, description, status, is_new}``; a
+        single bug comes back as an ``{id, bug_id, bug}`` envelope. A
+        ``bug_id`` like ``bsc#1196693`` is percent-encoded (``#`` → ``%23``)
+        so it survives the URL path.
+        """
+        path = f"reports/{rrid}/bugs"
+        if bug_id:
+            path += f"/{quote(bug_id, safe='')}"
+        d = self._get(path)
+        return d if isinstance(d, dict) else None
+
+    def completeness(self, rrid: object) -> dict[str, Any] | None:
+        """Report fill state (``GET /reports/{id}/completeness``).
+
+        The canonical, flat shape: ``{id, complete, unfilled: [{field,
+        value}]}``. (The parsed hash also happens to carry a ``completeness``
+        key, but ``/parsed/completeness`` is unspecified section behaviour the
+        server may close — this hits the dedicated endpoint.)
+        """
+        d = self._get(f"reports/{rrid}/completeness")
+        return d if isinstance(d, dict) else None
 
     def updates(
         self,

--- a/tests/test_cmd_apicall.py
+++ b/tests/test_cmd_apicall.py
@@ -219,10 +219,10 @@ def test_assign_prefers_teregen_priority_deadline(mock_config):
         patch("mtui.commands.apicall.TeReGen") as teregen_cls,
     ):
         teregen = teregen_cls.return_value
-        teregen.priority_deadline.return_value = (700, "2026-07-09")
+        teregen.info.return_value = {"priority": 700, "deadline": "2026-07-09"}
         Assign(args, mock_config, sysmock, prompt)()
 
-    teregen.priority_deadline.assert_called_once()
+    teregen.info.assert_called_once()
     out = sysmock.stdout.getvalue()
     assert "TeReGen: priority 700" in out
     assert "2026-07-09" in out
@@ -237,11 +237,66 @@ def test_assign_silent_when_teregen_has_nothing(mock_config):
         patch("mtui.commands.apicall.OSC"),
         patch("mtui.commands.apicall.TeReGen") as teregen_cls,
     ):
-        teregen_cls.return_value.priority_deadline.return_value = (None, None)
+        teregen_cls.return_value.info.return_value = None
         Assign(args, mock_config, sysmock, prompt)()
 
     out = sysmock.stdout.getvalue()
     assert "TeReGen" not in out
+
+
+def test_assign_shows_existing_assignment_holders(mock_config):
+    """Current holders (and past decisions) are surfaced; a group may carry
+    both a decision entry and a live assignment (decider != tester)."""
+    prompt = _prompt()
+    prompt.metadata.giteapr = None
+    args = Namespace(group=["qam-sle"], user="", force=False)
+    sysmock = _sysmock()
+
+    with (
+        patch("mtui.commands.apicall.OSC"),
+        patch("mtui.commands.apicall.TeReGen") as teregen_cls,
+    ):
+        teregen_cls.return_value.info.return_value = {
+            "priority": 700,
+            "deadline": "2026-07-09",
+            "assignees": {
+                "qam-sle": [
+                    {"user": "pluskalm", "state": "accepted"},
+                    {"user": "mpluskal", "state": "assigned"},
+                ]
+            },
+        }
+        Assign(args, mock_config, sysmock, prompt)()
+
+    out = sysmock.stdout.getvalue()
+    assert (
+        "qam-sle assignment state (may lag ~5 min): "
+        "pluskalm (accepted), mpluskal (assigned)"
+    ) in out
+
+
+def test_assign_empty_assignees_map_prints_nothing(mock_config):
+    """An empty map is not authoritative (it is also what an upstream lookup
+    failure yields), so it must stay silent and never gate the action."""
+    prompt = _prompt()
+    prompt.metadata.giteapr = None
+    args = Namespace(group=["qam-sle"], user="", force=False)
+    sysmock = _sysmock()
+
+    with (
+        patch("mtui.commands.apicall.OSC"),
+        patch("mtui.commands.apicall.TeReGen") as teregen_cls,
+    ):
+        teregen_cls.return_value.info.return_value = {
+            "priority": 700,
+            "deadline": "2026-07-09",
+            "assignees": {},
+        }
+        Assign(args, mock_config, sysmock, prompt)()
+
+    out = sysmock.stdout.getvalue()
+    assert "assignment state" not in out
+    assert "TeReGen: priority 700" in out
 
 
 def test_unassign_does_not_show_priority_deadline(mock_config):
@@ -256,4 +311,37 @@ def test_unassign_does_not_show_priority_deadline(mock_config):
     ):
         Unassign(args, mock_config, sysmock, prompt)()
 
-    teregen_cls.return_value.priority_deadline.assert_not_called()
+    teregen_cls.return_value.info.assert_not_called()
+
+
+def test_assign_malformed_assignees_never_breaks_the_flow(mock_config):
+    """Malformed assignment payloads are filtered, never raised.
+
+    The context prints after the assignment has already succeeded, so a
+    crash here would turn a successful action into an error. Non-list group
+    values are skipped, non-dict entries filtered, and an explicit null
+    user/state renders as '?'.
+    """
+    prompt = _prompt()
+    prompt.metadata.giteapr = None
+    args = Namespace(group=["qam-sle"], user="", force=False)
+    sysmock = _sysmock()
+
+    with (
+        patch("mtui.commands.apicall.OSC"),
+        patch("mtui.commands.apicall.TeReGen") as teregen_cls,
+    ):
+        teregen_cls.return_value.info.return_value = {
+            "assignees": {
+                "a": None,
+                "b": ["not-a-dict"],
+                "c": [{"user": None, "state": "assigned"}],
+                "d": [{"user": "bob", "state": "assigned"}],
+            }
+        }
+        Assign(args, mock_config, sysmock, prompt)()
+
+    out = sysmock.stdout.getvalue()
+    assert "c assignment state (may lag ~5 min): ? (assigned)" in out
+    assert "d assignment state (may lag ~5 min): bob (assigned)" in out
+    assert "not-a-dict" not in out

--- a/tests/test_cmd_updates.py
+++ b/tests/test_cmd_updates.py
@@ -201,3 +201,16 @@ def test_updates_all_assignees_with_assignee_errors():
 def test_updates_mine_and_all_assignees_are_mutually_exclusive():
     with pytest.raises(ArgsParseFailureError):
         _parser().parse_args(["--mine", "--all-assignees"])
+
+
+def test_updates_non_string_deadline_does_not_crash(mock_config):
+    """Shape drift on 'deadline' (a non-string) must not kill the listing."""
+    sysmock = _sysmock()
+    with patch("mtui.commands.updates.TeReGen") as teregen_cls:
+        teregen_cls.return_value.updates.return_value = [
+            {"id": "SUSE:Maintenance:1:2", "priority": 100, "deadline": 12345},
+        ]
+        Updates(_args(), mock_config, sysmock, MagicMock())()
+    out = sysmock.stdout.getvalue()
+    assert "SUSE:Maintenance:1:2" in out
+    assert "12345" in out

--- a/tests/test_teregen.py
+++ b/tests/test_teregen.py
@@ -3,7 +3,7 @@
 The command-level tests mock the ``TeReGen`` client wholesale, so the client's
 own request/parse/poll logic is exercised here directly against ``responses``-
 mocked HTTP. Every method is best-effort: a transport or decode failure must
-degrade to ``None`` (or ``(None, None)``) rather than raise.
+degrade to ``None`` rather than raise.
 """
 
 from __future__ import annotations
@@ -59,22 +59,6 @@ def test_metadata_and_status(mock_config):
     c = _client(mock_config)
     assert c.metadata(RRID) == {"rating": "low"}
     assert c.status(RRID) == {"template": True, "minion_state": "finished"}
-
-
-@responses.activate
-def test_priority_deadline_from_info(mock_config):
-    responses.add(
-        responses.GET,
-        f"{API}/reports/{RRID}",
-        json={"priority": 700, "deadline": "2026-07-01"},
-    )
-    assert _client(mock_config).priority_deadline(RRID) == (700, "2026-07-01")
-
-
-@responses.activate
-def test_priority_deadline_when_unreachable(mock_config):
-    responses.add(responses.GET, f"{API}/reports/{RRID}", status=404)
-    assert _client(mock_config).priority_deadline(RRID) == (None, None)
 
 
 @responses.activate
@@ -360,3 +344,73 @@ def test_regenerate_and_wait_unfinished(mock_config):
     assert outcome == RegenOutcome(
         ok=False, state="failed", minion_error="kaboom", job=8
     )
+
+
+# --- granular parsed endpoints (teregen b22f755) ---
+
+
+@responses.activate
+def test_parsed_full_report(mock_config):
+    body = {"sections": [], "summary": {}, "completeness": {"complete": True}}
+    responses.add(responses.GET, f"{API}/reports/{RRID}/parsed", json=body, status=200)
+    assert _client(mock_config).parsed(RRID) == body
+
+
+@responses.activate
+def test_parsed_section_slice(mock_config):
+    body = {"id": RRID, "section": "metadata", "data": {"rating": "important"}}
+    responses.add(
+        responses.GET,
+        f"{API}/reports/{RRID}/parsed/metadata",
+        json=body,
+        status=200,
+    )
+    # The server wraps a section in an {id, section, data} envelope.
+    assert _client(mock_config).parsed(RRID, "metadata") == body
+
+
+@responses.activate
+def test_bugs_index(mock_config):
+    body = {"bugs": [{"id": "bsc#1", "status": "NEW", "is_new": True}]}
+    responses.add(responses.GET, f"{API}/reports/{RRID}/bugs", json=body, status=200)
+    assert _client(mock_config).bugs(RRID) == body
+
+
+@responses.activate
+def test_bugs_single_id_is_percent_encoded(mock_config):
+    """'bsc#1196693' must reach the server as bugs/bsc%231196693.
+
+    An unencoded '#' would be a fragment separator and truncate the path.
+    """
+    body = {"id": RRID, "bug_id": "bsc#1196693", "bug": {"status": "RESOLVED"}}
+    responses.add(
+        responses.GET,
+        f"{API}/reports/{RRID}/bugs/bsc%231196693",
+        json=body,
+        status=200,
+    )
+    out = _client(mock_config).bugs(RRID, "bsc#1196693")
+    assert out == body
+    assert (responses.calls[0].request.url or "").endswith("/bugs/bsc%231196693")
+
+
+@responses.activate
+def test_completeness(mock_config):
+    body = {
+        "id": RRID,
+        "complete": False,
+        "unfilled": [{"field": "put here", "value": ""}],
+    }
+    responses.add(
+        responses.GET,
+        f"{API}/reports/{RRID}/completeness",
+        json=body,
+        status=200,
+    )
+    assert _client(mock_config).completeness(RRID) == body
+
+
+@responses.activate
+def test_parsed_non_dict_payload_is_none(mock_config):
+    responses.add(responses.GET, f"{API}/reports/{RRID}/parsed", json=["x"], status=200)
+    assert _client(mock_config).parsed(RRID) is None


### PR DESCRIPTION
Syncs mtui's TeReGen client with the current `/api/v1` (teregen master moved 29
commits: live per-report assignment, granular parsed-report endpoints, live
priority/deadline for classic Maintenance, a `GET /updates` queue).

**Nothing was actually broken** — the one server-side shape break (dropping the
flat `assignee` scalar on `/updates`) was reverted in teregen itself
(`5f9b864`) — so this is additive:

### `assign` shows assignment state
After assigning, mtui prints who holds (or has decided) each review group, from
the report's live `assignees` map (`{group: [{user, state}]}`). Deliberate
contract, encoded in tests:
- **context only, never a gate** — an empty map stays silent because it's
  indistinguishable from an upstream lookup failure;
- the server caches the endpoint ~300s, so the output says *"may lag ~5 min"*
  (right after assigning it typically shows the pre-assign snapshot);
- a group may carry both a decision entry and a live assignment (decider ≠
  tester);
- malformed payloads are filtered, never raised — this prints *after* the
  assignment succeeded, and a crash here would dress success up as an error.

### New client calls (shapes verified against the teregen source)
- `parsed(rrid, section=None)` — full parse, or an `{id, section, data}`
  envelope per section;
- `bugs(rrid, bug_id=None)` — flat index rows, single bug as an
  `{id, bug_id, bug}` envelope; `bsc#…` ids percent-encoded (an unencoded `#`
  truncates the URL as a fragment);
- `completeness(rrid)` — against the **canonical** `GET /reports/{id}/completeness`,
  not `/parsed/completeness` (unspecified section behaviour the server may
  close).

### Cleanup
- `priority_deadline()` removed (its only caller now reads `info()` directly);
- `updates` listing survives a non-string deadline;
- stale docstring + `--review-group` help corrected; `iui.rst` documents the
  new assign output.

### Process
Adversarial pre-MR review (4 dims × 3 lenses, contract claims verified against
the teregen repo, not the plan): **it caught my `completeness()` hitting the
non-canonical path with a wrongly-documented shape** (must-fix, fixed), the
envelope shapes for `parsed`/`bugs` sections that my first tests mocked flat, a
duplicated CHANGELOG heading, and the misleading "already has" wording — all
folded in. `ruff` / `ty` (strict tree) / `sphinx -W` / full `pytest` (2433)
green locally.
