### PR TITLE
fix(downgrade): abort loudly instead of silently half-rolling back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   still-shutting-down sshd); only the serialization is removed. Most visible on
   transactional (SL Micro) updates, which reboot every host.
 
+### Fixed
+
+- `downgrade` can no longer end as a silent half-rollback. The version probe
+  now runs a single `zypper se -s` invocation for the whole package list
+  instead of one per package (the per-package loop, block-buffered behind the
+  pipeline, emitted no output until the end and blew the SSH no-output timeout
+  on slow hosts, e.g. ppc64le with many packages). When the probe or a
+  downgrade command dies (times out or fails to run) or hits a recognized
+  zypper failure, the flow now aborts with an explicit error instead of
+  "completing" with nothing rolled back — per host: a dead probe on one host
+  no longer cancels the rollback of the healthy ones. After a completed run,
+  the final check names, per host at ERROR level, every package still at or
+  above the update's shipped version — previously the only hint was a bare
+  "downgrade not completed" warning. Headless (MCP) callers now get a failed
+  command instead of a success-looking log. An empty package list no longer
+  probes the entire repository catalog.
+
 ## 19.0.1 - 2026-07-17
 
 ### Added

--- a/Documentation/iui.rst
+++ b/Documentation/iui.rst
@@ -764,6 +764,20 @@ downgrade
 Downgrades all related packages to the last released version (using
 the UPDATE channel).
 
+If the rollback cannot complete on a host — the version probe or a
+downgrade command dies (times out or fails to run) or hits a recognized
+zypper failure — the command aborts for that host with an error instead
+of finishing quietly (the remaining hosts still roll back). Treat any
+such error as "the host may be half rolled back": verify with ``rpm -q``
+and re-run ``downgrade``.
+
+After a completed run, every package still found at or above the
+update's version is listed per host as an error. New packages (which
+have no released version to go back to) and multiversion packages such
+as the kernel (where the update's version legitimately stays installed
+alongside older ones) always appear in this list; re-running
+``downgrade`` will not clear them.
+
 reboot
 ++++++
 

--- a/mtui/commands/downgrade.py
+++ b/mtui/commands/downgrade.py
@@ -5,8 +5,10 @@ from traceback import format_exc
 
 from ..cli.argparse import ArgumentParser
 from ..cli.completion import complete_choices, template_completion
+from ..support.exceptions import UpdateError
 from ..support.messages import NoRefhostsDefinedError
 from ..support.misc import requires_update
+from ..types.rpmver import RPMVersion
 from . import Command
 
 logger = getLogger("mtui.command.downgrade")
@@ -43,33 +45,68 @@ class Downgrade(Command):
         except KeyboardInterrupt:
             logger.info("downgrade process canceled")
             return
+        except UpdateError as e:
+            # The workflow aborted mid-rollback (the version probe or a
+            # downgrade command died): some or all packages are still at the
+            # update version. Say so explicitly -- a bare "failed" reads like
+            # nothing happened, when the dangerous outcome is a half-rollback.
+            logger.error("downgrade failed: %s", e)
+            logger.error(
+                "packages may still be at the update version; "
+                "verify with 'rpm -q' and re-run downgrade"
+            )
+            logger.error("downgrade not completed")
+            # Headless callers (mtui-mcp) read structured success, not logs:
+            # re-raise so the tool call fails. An Exception, never SystemExit,
+            # so the per-template fan-out handling stays intact.
+            if not getattr(self.prompt, "interactive", True):
+                raise
+            return
         except Exception:
             logger.critical("failed to downgrade target systems")
             logger.debug(format_exc())
             return
 
-        message = "done"
+        # Verify the rollback actually happened. A package still at (or above)
+        # the update's shipped version did not downgrade -- report it per host
+        # at ERROR, naming the packages, so a caller who doesn't re-verify with
+        # rpm -q can't mistake a half-rollback for success. (The comparison
+        # against ``required`` also stays quiet when the update was never
+        # installed: those packages sit below ``required`` already.)
+        not_downgraded: dict[str, list[str]] = {}
         for target in targets.values():
             target.query_versions()
-            if message == "done":
-                for package in target.packages:
-                    target.packages[package].before = target.packages[package].after
-                    target.packages[package].after = target.packages[package].current
-                    if (
-                        target.packages[package].after is not None
-                        and target.packages[package].before is not None
-                        and target.packages[package].before
-                        == target.packages[package].after
-                    ):
-                        message = "downgrade not completed"
-                        break
-            else:
-                break
+            for name, package in target.packages.items():
+                package.before = package.after
+                package.after = package.current
+                required, current = package.required, package.current
+                if (
+                    isinstance(required, RPMVersion)
+                    and isinstance(current, RPMVersion)
+                    and current >= required
+                ):
+                    not_downgraded.setdefault(target.hostname, []).append(
+                        f"{name} (at {current}, update ships {required})"
+                    )
 
-        if message == "done":
-            logger.info(message)
+        if not_downgraded:
+            for hostname, names in not_downgraded.items():
+                logger.error(
+                    "%s: still at or above the update's shipped version "
+                    "after downgrade: %s",
+                    hostname,
+                    ", ".join(names),
+                )
+            logger.error(
+                "downgrade not completed; verify with 'rpm -q'. New packages "
+                "(no released version to go back to) and multiversion "
+                "packages (e.g. the kernel) always appear here; re-running "
+                "downgrade will not clear them"
+            )
+            if not getattr(self.prompt, "interactive", True):
+                raise UpdateError("downgrade not completed")
         else:
-            logger.warning(message)
+            logger.info("done")
 
     @staticmethod
     def complete(state, text, line, begidx, endidx) -> list[str]:

--- a/mtui/hosts/target/hostgroup.py
+++ b/mtui/hosts/target/hostgroup.py
@@ -450,6 +450,14 @@ class HostsGroup(UserDict[str, Target]):
         ver_re = re.compile(r"(.*) = (.*)")
         versions: dict[str, dict[str, str]] = {}
 
+        # Nothing to downgrade: return before locking or touching repos. The
+        # guard also keeps the probe template from rendering with an empty
+        # package list -- ``zypper se`` without names would list the entire
+        # repository catalog.
+        if not packages:
+            logger.warning("no packages to downgrade")
+            return
+
         # Resolve the per-host doer commands *before* taking the lock: if a host
         # has no downgrader the early return below must not leave the group
         # locked (the finally that unlocks only guards the second try block).
@@ -481,7 +489,38 @@ class HostsGroup(UserDict[str, Target]):
 
             self.run(list_cmd)
 
+            # A dead probe must abort that host's downgrade, not degrade it.
+            # When the probe dies (an SSH no-output timeout records exit -1)
+            # its stdout is empty, the version map below stays empty, and the
+            # flow would "complete" having run zero downgrade commands --
+            # leaving every package at the update version behind a
+            # success-looking run. The pipeline's exit status is awk's, so a
+            # non-zero int here always means the probe itself broke, never
+            # "package not found". Handled per host: the healthy hosts still
+            # roll back (and transactional ones still reboot); the error for
+            # the dead ones is raised at the end.
+            dead_probes = sorted(
+                hn
+                for hn in list_cmd
+                if isinstance(self.data[hn].lastexit(), int)
+                and self.data[hn].lastexit() != 0
+            )
+            for hn in dead_probes:
+                logger.critical(
+                    "%s: package version probe failed (exit %s); "
+                    "skipping downgrade on this host",
+                    hn,
+                    self.data[hn].lastexit(),
+                )
+            if dead_probes and len(dead_probes) == len(list_cmd):
+                raise UpdateError(
+                    "package version probe failed", ", ".join(dead_probes)
+                )
+
             for hn, t in self.data.items():
+                # A dead probe's partial output must not feed the version map.
+                if hn in dead_probes:
+                    continue
                 lines: list[str] = t.lastout().split("\n")
                 release: dict[str, list[str]] = {}
 
@@ -512,15 +551,19 @@ class HostsGroup(UserDict[str, Target]):
                 if cmd:
                     self.run(cmd)
 
-                    for h, t in self.data.items():
-                        if h not in transactional_hosts:
-                            t.check("downgrader")(
-                                t.hostname,
-                                t.lastout(),
-                                t.lastin(),
-                                t.lasterr(),
-                                t.lastexit(),
-                            )
+                    # Check only the hosts that actually ran this command: a
+                    # host outside ``cmd`` still carries its previous record
+                    # (a dead probe's -1 would trip the timeout check here and
+                    # cancel the healthy hosts' rollback mid-loop).
+                    for h in cmd:
+                        t = self.data[h]
+                        t.check("downgrader")(
+                            t.hostname,
+                            t.lastout(),
+                            t.lastin(),
+                            t.lasterr(),
+                            t.lastexit(),
+                        )
 
             # Transactional hosts: downgrade ALL packages in a SINGLE
             # transaction/snapshot. A per-package loop opens a snapshot per
@@ -551,7 +594,14 @@ class HostsGroup(UserDict[str, Target]):
                         t.lastexit(),
                     )
 
-            self._reboot(reboot)
+            # Reboot the healthy transactional hosts first (their staged
+            # snapshots must still activate), then surface the dead probes as
+            # the command's failure.
+            self._reboot({h: r for h, r in reboot.items() if h not in dead_probes})
+            if dead_probes:
+                raise UpdateError(
+                    "package version probe failed", ", ".join(dead_probes)
+                )
         except MissingDowngraderError:
             return
         finally:

--- a/mtui/update_workflow/actions/downgrade.py
+++ b/mtui/update_workflow/actions/downgrade.py
@@ -13,10 +13,14 @@ def zypper() -> dict[str, Template]:
         A dictionary of command templates.
 
     """
+    # ONE zypper invocation for the whole package list. A per-package ``for``
+    # loop loads the repo metadata once per package and, piped through a
+    # block-buffered awk (no PTY), emits nothing until the last iteration --
+    # on a slow host a long package list blows the SSH no-output timeout
+    # (``connection_timeout``, default 300s) and the probe dies with no
+    # versions resolved.
     list_command_template = r"""
-for p in $packages; do \
-zypper -n se -s --match-exact -t package $$p; \
-done \
+zypper -n se -s --match-exact -t package $packages \
 | grep -v "(System" \
 | grep ^[iv] \
 | sed "s, ,,g" \
@@ -38,10 +42,10 @@ def slmicro() -> dict[str, Template]:
         A dictionary of command templates.
 
     """
+    # One invocation for the whole list -- see ``zypper()`` above for why a
+    # per-package loop is a timeout trap on slow hosts.
     list_command_template = r"""
-for p in $packages; do \
-zypper -n se -s --match-exact -t package $$p; \
-done \
+zypper -n se -s --match-exact -t package $packages \
 | grep -v "(System" \
 | grep ^[iv] \
 | sed "s, ,,g" \

--- a/mtui/update_workflow/checks/downgrade.py
+++ b/mtui/update_workflow/checks/downgrade.py
@@ -22,6 +22,19 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         UpdateError: If an error is found in the output.
 
     """
+    # -1 is what ``Target.run`` records when the command timed out (SSH
+    # no-output window exceeded) or failed to run at all. Continuing past it
+    # turns an interrupted rollback into a silent half-rollback: the remaining
+    # packages stay at the update version while the flow ends looking done.
+    if exitcode == -1:
+        logger.critical(
+            '%s: command "%s" timed out or failed to run:\nstdout:\n%s\nstderr:\n%s',
+            hostname,
+            stdin,
+            stdout,
+            stderr,
+        )
+        raise UpdateError("downgrade command timed out or failed to run", hostname)
     if "A ZYpp transaction is already in progress." in stderr:
         logger.critical(
             '%s: command "%s" failed:\nstdout:\n%s\nstderr:\n%s',
@@ -54,10 +67,37 @@ def zypper(hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int) -
         logger.warning("%s: zypper returned with errorcode 106:\n%s", hostname, stderr)
 
 
+def transactional_update(
+    hostname: str, stdout: str, stdin: str, stderr: str, exitcode: int
+) -> None:
+    """Checks a `transactional-update` downgrade command for a dead run.
+
+    Only the timed-out/unrunnable gate: transactional-update's own exit
+    codes and messages differ from zypper's, so the zypper-specific
+    branches (104, lock strings) must not be reused here. Without this
+    check the registry falls back to a no-op and a dead combined command
+    sails on to the reboot with no snapshot staged.
+
+    Raises:
+        UpdateError: If the command timed out or failed to run.
+
+    """
+    if exitcode == -1:
+        logger.critical(
+            '%s: command "%s" timed out or failed to run:\nstdout:\n%s\nstderr:\n%s',
+            hostname,
+            stdin,
+            stdout,
+            stderr,
+        )
+        raise UpdateError("downgrade command timed out or failed to run", hostname)
+
+
 #: A dictionary that maps system configurations to downgrade check functions.
 downgrade_checks: dict[tuple[str, bool], Callable[[str, str, str, str, int], None]] = {
     ("11", False): zypper,
     ("12", False): zypper,
     ("15", False): zypper,
     ("16", False): zypper,
+    ("slmicro", True): transactional_update,
 }

--- a/tests/test_actions_downgrade.py
+++ b/tests/test_actions_downgrade.py
@@ -14,6 +14,28 @@ def test_zypper_downgrade_uses_oldpackage() -> None:
     assert "bash=1.2-3" in sub
 
 
+def test_zypper_list_command_probes_all_packages_in_one_call() -> None:
+    """The version probe runs ONE zypper invocation for the whole list.
+
+    The old per-package ``for`` loop loaded repo metadata once per package
+    and, piped through a block-buffered awk, produced no output until the
+    last iteration -- on a slow host a long package list blew the SSH
+    no-output timeout and the downgrade rolled back nothing.
+    """
+    sub = zypper()["list_command"].safe_substitute(packages="pkg-a pkg-b pkg-c")
+    assert "for p in" not in sub
+    assert sub.count("zypper") == 1
+    assert "zypper -n se -s --match-exact -t package pkg-a pkg-b pkg-c" in sub
+
+
+def test_slmicro_list_command_probes_all_packages_in_one_call() -> None:
+    """The slmicro probe is the same single-invocation shape as zypper's."""
+    sub = slmicro()["list_command"].safe_substitute(packages="pkg-a pkg-b")
+    assert "for p in" not in sub
+    assert sub.count("zypper") == 1
+    assert "zypper -n se -s --match-exact -t package pkg-a pkg-b" in sub
+
+
 def test_slmicro_downgrade_uses_oldpackage() -> None:
     """The transactional-update downgrade command allows older versions and takes
     the full ``name=version`` spec list as ``$package`` so all packages downgrade

--- a/tests/test_checks_downgrade.py
+++ b/tests/test_checks_downgrade.py
@@ -7,7 +7,11 @@ import logging
 import pytest
 
 from mtui.support.exceptions import UpdateError
-from mtui.update_workflow.checks.downgrade import downgrade_checks, zypper
+from mtui.update_workflow.checks.downgrade import (
+    downgrade_checks,
+    transactional_update,
+    zypper,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +70,15 @@ def test_zypper_dep_conflict_raises() -> None:
         zypper("h", "(c): c", "in pkg", "", 0)
 
 
+def test_zypper_exitcode_minus_one_raises() -> None:
+    """Exit -1 (``Target.run``'s marker for a timed-out or unrunnable command)
+    raises instead of letting the flow continue past an interrupted rollback."""
+    with pytest.raises(UpdateError) as ei:
+        zypper("h", "", "in pkg", "", -1)
+    assert ei.value.reason == "downgrade command timed out or failed to run"
+    assert ei.value.host == "h"
+
+
 def test_zypper_exitcode_104_raises() -> None:
     """Exitcode 104 raises ``UpdateError("Unspecified Error", host)``."""
     with pytest.raises(UpdateError):
@@ -96,7 +109,24 @@ def test_zypper_failure_log_labels_stdout_as_stdout(caplog) -> None:
     assert any("stdout:\nOUT-PAYLOAD" in r.message for r in caplog.records)
 
 
+def test_transactional_update_exitcode_minus_one_raises() -> None:
+    """The slmicro check raises on a dead command (exit -1): without it the
+    registry falls back to a no-op and a dead transactional-update sails on
+    to the reboot with no snapshot staged."""
+    with pytest.raises(UpdateError) as ei:
+        transactional_update("h", "", "tu pkg in", "", -1)
+    assert ei.value.reason == "downgrade command timed out or failed to run"
+    assert ei.value.host == "h"
+
+
+def test_transactional_update_clean_run_returns_none() -> None:
+    """A clean transactional-update run passes the check."""
+    assert transactional_update("h", "", "tu pkg in", "", 0) is None
+
+
 def test_downgrade_checks_dispatch_keys() -> None:
-    """The ``downgrade_checks`` registry maps SLE keys to ``zypper``."""
+    """The ``downgrade_checks`` registry maps SLE keys to ``zypper`` and the
+    transactional slmicro key to its own check (NOT the no-op fallback)."""
     assert downgrade_checks[("15", False)] is zypper
     assert downgrade_checks[("12", False)] is zypper
+    assert downgrade_checks[("slmicro", True)] is transactional_update

--- a/tests/test_cmd_downgrade.py
+++ b/tests/test_cmd_downgrade.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from argparse import Namespace
 from unittest.mock import MagicMock
 
@@ -9,7 +10,10 @@ import pytest
 
 from mtui.commands.downgrade import Downgrade
 from mtui.hosts.target.hostgroup import HostsGroup
+from mtui.support.exceptions import UpdateError
 from mtui.support.messages import NoRefhostsDefinedError, TestReportNotLoadedError
+from mtui.types import Package
+from mtui.types.rpmver import RPMVersion
 
 
 def _target(hostname="h1", state="enabled"):
@@ -20,12 +24,21 @@ def _target(hostname="h1", state="enabled"):
     return t
 
 
+def _pkg(name: str, required: str, current: str | None, after: str | None = None):
+    p = Package(name)
+    p.required = required
+    p.current = current
+    p.after = after
+    return p
+
+
 def _prompt(targets) -> MagicMock:
     p = MagicMock()
     p.metadata = MagicMock()
     p.metadata.__bool__ = lambda self: True
     p.display = MagicMock()
     p.targets = targets
+    p.interactive = True
     return p
 
 
@@ -52,4 +65,128 @@ def test_downgrade_without_metadata_raises(mock_config):
     prompt = _prompt(HostsGroup([]))
     prompt.metadata.__bool__ = lambda self: False
     with pytest.raises(TestReportNotLoadedError):
+        Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()
+
+
+# ---------------------------------------------------------------------------
+# Post-flow verification: a half-rollback must be a named ERROR, not a bare
+# warning a headless caller scrolls past (the ppc64le trap: the probe timed
+# out, zero downgrade commands ran, and "downgrade not completed" was the
+# only hint that all 28 packages were still at the update version).
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_reports_packages_still_at_update_version(mock_config, caplog):
+    """Packages at (or above) the update's shipped version after the flow are
+    named per host, with versions, at ERROR level -- on EVERY host (no
+    short-circuit after the first hit), and the bookkeeping still advances for
+    the non-flagged packages."""
+    t1 = _target("h1")
+    pkg_b = _pkg("pkg-b", required="2.0-1", current="1.0-1", after="0.9-1")
+    t1.packages = {
+        "pkg-a": _pkg("pkg-a", required="1.5-1", current="1.5-1"),
+        "pkg-b": pkg_b,
+    }
+    t2 = _target("h2")
+    pkg_c = _pkg("pkg-c", required="3.0-1", current="3.0-1", after="3.0-1")
+    t2.packages = {"pkg-c": pkg_c}
+    prompt = _prompt(HostsGroup([t1, t2]))
+
+    with caplog.at_level(logging.INFO, logger="mtui.command.downgrade"):
+        Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()
+
+    own = {
+        r.getMessage(): r.levelno
+        for r in caplog.records
+        if r.name == "mtui.command.downgrade"
+    }
+    assert (
+        own.get(
+            "h1: still at or above the update's shipped version after "
+            "downgrade: pkg-a (at 1.5-1, update ships 1.5-1)"
+        )
+        == logging.ERROR
+    )
+    assert (
+        own.get(
+            "h2: still at or above the update's shipped version after "
+            "downgrade: pkg-c (at 3.0-1, update ships 3.0-1)"
+        )
+        == logging.ERROR
+    )
+    assert any("downgrade not completed" in m for m in own)
+    assert "done" not in own
+    # Bookkeeping advanced for the healthy package (no short-circuit).
+    assert pkg_b.before == RPMVersion("0.9-1")
+    assert pkg_b.after == RPMVersion("1.0-1")
+    assert pkg_c.after == RPMVersion("3.0-1")
+
+
+def test_downgrade_below_required_is_done_and_bookkeeps(mock_config, caplog):
+    """A completed rollback reports done; before/after bookkeeping advances."""
+    t1 = _target("h1")
+    pkg = _pkg("pkg-a", required="1.5-1", current="1.0-1", after="1.5-1")
+    t1.packages = {"pkg-a": pkg}
+    prompt = _prompt(HostsGroup([t1]))
+
+    with caplog.at_level(logging.INFO, logger="mtui.command.downgrade"):
+        Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert "done" in messages
+    assert not any("after downgrade:" in m for m in messages)
+    # before <- old after, after <- current
+    assert pkg.before == RPMVersion("1.5-1")
+    assert pkg.after == RPMVersion("1.0-1")
+
+
+def test_downgrade_updateerror_reports_half_rollback(mock_config, caplog):
+    """An UpdateError from the workflow (dead probe / dead downgrade command)
+    surfaces as an explicit half-rollback ERROR with a verification hint."""
+    t1 = _target("h1")
+    prompt = _prompt(HostsGroup([t1]))
+    prompt.metadata.perform_downgrade.side_effect = UpdateError(
+        "package version probe failed", "h1"
+    )
+
+    with caplog.at_level(logging.ERROR, logger="mtui.command.downgrade"):
+        Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert "downgrade failed: h1: package version probe failed" in messages
+    assert any("verify with 'rpm -q'" in m for m in messages)
+    # The historical sentinel stays greppable on the abort path too.
+    assert "downgrade not completed" in messages
+    # The flow aborted: no version query, no claim of done.
+    t1.query_versions.assert_not_called()
+
+
+def test_downgrade_updateerror_headless_reraises(mock_config, caplog):
+    """Headless (mtui-mcp) callers read structured success, not logs: an
+    aborted rollback must fail the command, not end as an ERROR-logged
+    return that the tool reports as success."""
+    t1 = _target("h1")
+    prompt = _prompt(HostsGroup([t1]))
+    prompt.interactive = False
+    prompt.metadata.perform_downgrade.side_effect = UpdateError(
+        "package version probe failed", "h1"
+    )
+
+    with (
+        caplog.at_level(logging.ERROR, logger="mtui.command.downgrade"),
+        pytest.raises(UpdateError),
+    ):
+        Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()
+
+    assert any("downgrade failed" in r.getMessage() for r in caplog.records)
+
+
+def test_downgrade_not_completed_headless_raises(mock_config):
+    """Packages left at the update version fail the command when headless."""
+    t1 = _target("h1")
+    t1.packages = {"pkg-a": _pkg("pkg-a", required="1.5-1", current="1.5-1")}
+    prompt = _prompt(HostsGroup([t1]))
+    prompt.interactive = False
+
+    with pytest.raises(UpdateError, match="downgrade not completed"):
         Downgrade(Namespace(hosts=None), mock_config, MagicMock(), prompt)()

--- a/tests/test_hostgroup.py
+++ b/tests/test_hostgroup.py
@@ -712,6 +712,9 @@ def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
     t1 = _stub_target("h1")
     # Pretend list_command output is parsed: ``pkg-a = 1.0`` and ``pkg-a = 1.5``.
     t1.lastout.return_value = "pkg-a = 1.0-1\npkg-a = 1.5-1\n"
+    # A real successful probe records exit 0 -- pins that the dead-probe gate
+    # lets the happy path through (not just non-int mock exits).
+    t1.lastexit.return_value = 0
     t1.doer.return_value = {
         **_doer_dict(reboot="", init_snapshot=""),
         "list_command": MagicMock(safe_substitute=MagicMock(return_value="rpm -qa")),
@@ -726,6 +729,113 @@ def test_perform_downgrade_picks_highest_version_then_runs(mock_run):
     cmd_tpl = t1.doer.return_value["command"]
     cmd_tpl.safe_substitute.assert_any_call(package="pkg-a", version="1.5-1")
     t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_dead_probe_aborts(mock_run):
+    """A dead version probe (SSH no-output timeout records exit -1) aborts the
+    downgrade instead of 'completing' it with zero downgrade commands run.
+
+    Without the abort, the empty probe output parses to an empty version map,
+    no downgrade command is built, and every package silently stays at the
+    update version behind a success-looking flow.
+    """
+    t1 = _stub_target("h1")
+    t1.lastout.return_value = ""
+    t1.lastexit.return_value = -1
+    t1.doer.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="probe")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="zypper in")),
+    }
+    hg = HostsGroup([t1])
+    with pytest.raises(UpdateError) as ei:
+        hg.perform_downgrade(["pkg-a"], MagicMock())
+    assert ei.value.host == "h1"
+    # No downgrade command may be built after a dead probe.
+    t1.doer.return_value["command"].safe_substitute.assert_not_called()
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_partial_dead_probe_continues_on_healthy_hosts(mock_run):
+    """One host's dead probe skips THAT host and still rolls back the rest.
+
+    The dead host is excluded from the version parse, the command build, and
+    the post-command checks (its stale -1 record must not trip the timeout
+    check mid-loop); the error naming it is raised only at the end.
+    """
+    t1 = _stub_target("h1")
+    t1.lastout.return_value = "pkg-a = 1.0-1\npkg-a = 1.5-1\n"
+    t1.lastexit.return_value = 0
+    t1.doer.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="probe")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="zypper in")),
+    }
+    t1.check.return_value = MagicMock()
+    t2 = _stub_target("h2")
+    t2.lastout.return_value = ""
+    t2.lastexit.return_value = -1
+    t2.doer.return_value = {
+        **_doer_dict(reboot="", init_snapshot=""),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="probe")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="zypper in")),
+    }
+    t2.check.return_value = MagicMock()
+    hg = HostsGroup([t1, t2])
+    with pytest.raises(UpdateError) as ei:
+        hg.perform_downgrade(["pkg-a"], MagicMock())
+    assert ei.value.host == "h2"
+    # The healthy host rolled back (highest released version picked) and was
+    # checked; the dead host built no command and was never checked.
+    t1.doer.return_value["command"].safe_substitute.assert_any_call(
+        package="pkg-a", version="1.5-1"
+    )
+    t1.check.return_value.assert_called()
+    t2.doer.return_value["command"].safe_substitute.assert_not_called()
+    t2.check.return_value.assert_not_called()
+    t1.unlock.assert_called()
+    t2.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_transactional_dead_command_aborts_before_reboot(mock_run):
+    """A dead combined transactional-update command (exit -1) aborts BEFORE the
+    reboot: rebooting with no snapshot staged would activate nothing while
+    looking like a completed rollback. Exercises the real ``("slmicro", True)``
+    check the registry dispatches to."""
+    from mtui.update_workflow.checks.downgrade import transactional_update
+
+    t1 = _stub_target("h1", transactional=True)
+    t1.lastout.return_value = "pkg-a = 1.0-1\n"
+    # Probe exits 0 (two gate reads), then the combined command records -1.
+    t1.lastexit.side_effect = [0, 0] + [-1] * 5
+    t1.doer.return_value = {
+        **_doer_dict(reboot="reboot"),
+        "list_command": MagicMock(safe_substitute=MagicMock(return_value="probe")),
+        "command": MagicMock(safe_substitute=MagicMock(return_value="tu pkg in")),
+    }
+    t1.check.return_value = transactional_update
+    hg = HostsGroup([t1])
+    with (
+        patch.object(HostsGroup, "_reboot") as reboot_mock,
+        pytest.raises(UpdateError),
+    ):
+        hg.perform_downgrade(["pkg-a"], MagicMock())
+    reboot_mock.assert_not_called()
+    t1.unlock.assert_called()
+
+
+@patch("mtui.hosts.target.hostgroup.RunCommand")
+def test_perform_downgrade_empty_package_list_is_a_noop(mock_run):
+    """An empty package list returns before locking or probing: the probe
+    template with zero names would ask zypper to list the entire catalog."""
+    t1 = _stub_target("h1")
+    hg = HostsGroup([t1])
+    hg.perform_downgrade([], MagicMock())
+    mock_run.assert_not_called()
+    t1.unlock.assert_not_called()
 
 
 @patch("mtui.hosts.target.hostgroup.RunCommand")
@@ -786,6 +896,8 @@ def test_perform_downgrade_transactional_combines_packages(mock_run):
     t1 = _stub_target("h1", transactional=True)
     # list_command output parsed into versions: pkg-a -> 1.5-1, pkg-b -> 2.0-1.
     t1.lastout.return_value = "pkg-a = 1.5-1\npkg-b = 2.0-1\n"
+    # A real successful probe records exit 0 (see the zypper-path test above).
+    t1.lastexit.return_value = 0
     command = MagicMock(safe_substitute=MagicMock(return_value="tu pkg in ..."))
     t1.doer.return_value = {
         **_doer_dict(reboot=""),


### PR DESCRIPTION
## The trap (field report)

On a slow ppc64le host, `downgrade` aborted twice with only a WARNING `downgrade not completed` — leaving **all 28 packages still at the TEST version**. An agent only caught it by re-verifying with `rpm -q` instead of trusting the tool.

Root cause chain:
1. The version probe ran `zypper -n se -s` **once per package** in a remote `for` loop, piped through `grep|grep|sed|awk`. Without a PTY, awk block-buffers — **zero bytes** reach the SSH channel until the whole loop ends. 28 sequential repo-metadata loads on slow hardware exceed the 300s no-output window (`connection_timeout`).
2. The headless session raised `CommandTimeoutError`; `Target.run` swallowed it as exit `-1` with empty stdout.
3. `perform_downgrade` never checked the probe's exit status: the empty output parsed to an empty version map, **zero downgrade commands ran**, and the flow "completed".
4. The final check (`before == after`) logged a bare WARNING and the command looked successful.

## The fix

- **One probe invocation.** `zypper -n se -s --match-exact -t package <all packages>` — one metadata load instead of N, finishing well inside the timeout. Empty package list returns early (zero names would list the entire catalog).
- **Dead probes abort, per host.** A host whose probe records a non-zero int exit is skipped entirely (no partial parse, no stale `-1` tripping later checks) and reported via `UpdateError` **after** the healthy hosts roll back and transactional ones reboot. All-probed-hosts-dead aborts immediately.
- **Exit `-1` is a hard failure in the downgrade checks** — and transactional hosts now have their own `("slmicro", True)` check: previously they fell back to the registry's silent no-op, so a dead `transactional-update` sailed on to a reboot with no snapshot staged.
- **Honest verdict.** The final verification compares each package's current version against the update's `required` version and names, per host at ERROR level with versions, everything still at/above the update's version. The old `before == after` warning fired spuriously on a double downgrade and stayed quiet in logs. New/multiversion packages are documented as expected residents of the list.
- **Headless callers get a real failure.** When non-interactive (mtui-mcp), `UpdateError` re-raises so the tool call fails instead of returning a success-looking log.

## Verification

- 14 new/extended tests across templates, checks, hostgroup, and command layers; the behavioral ones **proven to fail on revert** (mutation-checked: the `isinstance` gate and the no-short-circuit bookkeeping both have killing tests).
- Full gate set green: `ruff format --check`, `ruff check`, `ty check`, 2439 tests, strict docs build.
- Pre-open adversarial review (4 dimensions × 3 verification lenses): 2 must-fixes it found (the slmicro no-op check fallback, a CHANGELOG merge artifact) and the per-host abort semantics, MCP failure signaling, empty-list guard, and both mutation-verified test holes are all folded into this PR.