### PR TITLE
feat(commands): add request_review Slack review command and gate approve on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ _The entries below document the final Python releases, retained for history._
   still-shutting-down sshd); only the serialization is removed. Most visible on
   transactional (SL Micro) updates, which reboot every host.
 
+### Added
+
+- New `request_review` command: posts a review request for the loaded update to
+  a Slack channel and records the resulting message in the testreport template,
+  so a request is traceable back to the update it belongs to. With `--watch` it
+  then polls the message for reviewer reactions (👍 approves, 👎 rejects, skin
+  tone ignored) until a verdict or timeout, and Ctrl-C stops watching without
+  killing mtui. The integration is **off by default** and configured under
+  `[slack]`: set `enabled = true` plus a `token` and `channel` to opt in. The
+  token is masked as `<set>` in `config` output and never logged. Over
+  `mtui-mcp` the command is exposed with `background=true`, which is how a
+  `--watch` run should be started there.
+
 ## 19.0.1 - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ _The entries below document the final Python releases, retained for history._
 
 - New `request_review` command: posts a review request for the loaded update to
   a Slack channel and records the resulting message in the testreport template,
-  so a request is traceable back to the update it belongs to. With `--watch` it
+  committing it so the request is visible from any checkout. With `--watch` it
   then polls the message for reviewer reactions (👍 approves, 👎 rejects, skin
   tone ignored) until a verdict or timeout, and Ctrl-C stops watching without
   killing mtui. The integration is **off by default** and configured under
@@ -68,6 +68,14 @@ _The entries below document the final Python releases, retained for history._
   token is masked as `<set>` in `config` output and never logged. Over
   `mtui-mcp` the command is exposed with `background=true`, which is how a
   `--watch` run should be started there.
+- Enabling the Slack integration also gates `approve`: an update can only be
+  approved once its review request has been acknowledged in Slack by someone
+  other than the bot, and only if the recorded message still names that RRID
+  (so a marker copied between templates cannot launder an approval). If Slack
+  cannot be read, `approve` fails closed. There is no per-command bypass — the
+  gate is turned off by configuration (`slack_enabled = false`), which is
+  explicit and auditable. `reject` is never gated. With Slack disabled (the
+  default) `approve` behaves exactly as before.
 
 ## 19.0.1 - 2026-07-17
 

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -223,6 +223,36 @@ pub(crate) fn default_gitea_url() -> String {
 pub(crate) fn default_openqa_install_distri() -> String {
     "sle".to_owned()
 }
+/// The Slack integration is **opt-in**: off unless a site turns it on.
+///
+/// Posting to a chat workspace is an outward-facing side effect, so it should
+/// never happen because a default said so. Most mtui users have no Slack
+/// integration at all, and for them the feature staying dark — and saying why
+/// when invoked — is the correct behaviour. Turning it on is one explicit
+/// `enabled = true` alongside the token and channel it needs anyway.
+pub(crate) fn default_slack_enabled() -> bool {
+    false
+}
+/// Trusted Slack API origin the [`slack_token`](Config::slack_token) may be
+/// sent to, mirroring the `gitea_url` reasoning: the token is only ever
+/// attached to requests against this base, so pointing it elsewhere is an
+/// explicit, auditable act rather than something a checked-out template can
+/// influence. Overridable mainly so tests can aim at a local mock server.
+pub(crate) fn default_slack_api_url() -> String {
+    "https://slack.com/api".to_owned()
+}
+/// Seconds between reaction polls while watching a review request. Slack's
+/// Web API tier-3 methods allow ~50 requests/minute; two minutes per poll keeps
+/// a multi-template watch far inside that even before jitter.
+pub(crate) fn default_slack_poll_interval() -> u64 {
+    120
+}
+/// Seconds a `request_review` watch runs before giving up, defaulting to one
+/// hour: long enough for a reviewer to notice, short enough that a forgotten
+/// foreground watch does not pin a terminal indefinitely.
+pub(crate) fn default_slack_watch_timeout() -> u64 {
+    3600
+}
 pub(crate) fn default_refhosts_resolvers() -> String {
     "https,path".to_owned()
 }
@@ -407,6 +437,23 @@ pub(crate) struct GiteaSection {
     pub url: Option<String>,
 }
 
+/// `[slack]` table — the Slack review-request integration.
+///
+/// Off by default, and gated twice over: `enabled` must be `true`, and
+/// `token`/`channel` must both be set. An unconfigured mtui therefore never
+/// reaches Slack, and `request_review` refuses with the reason rather than
+/// failing somewhere inside the API.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub(crate) struct SlackSection {
+    pub enabled: Option<bool>,
+    pub token: Option<String>,
+    pub channel: Option<String>,
+    pub api_url: Option<String>,
+    pub poll_interval: Option<u64>,
+    pub watch_timeout: Option<u64>,
+}
+
 /// `[lock]` table — remote-lock behaviour on target hosts.
 ///
 /// Mirrors upstream `mtui/support/config.py`'s `lock_*` options (which live
@@ -489,6 +536,7 @@ pub(crate) struct RawConfig {
     pub svn: SvnSection,
     pub target: TargetSection,
     pub gitea: GiteaSection,
+    pub slack: SlackSection,
     pub lock: LockSection,
     pub mcp: McpSection,
     pub obs: ObsSection,
@@ -530,6 +578,12 @@ impl RawConfig {
         take!(target, tempdir);
         take!(gitea, token);
         take!(gitea, url);
+        take!(slack, enabled);
+        take!(slack, token);
+        take!(slack, channel);
+        take!(slack, api_url);
+        take!(slack, poll_interval);
+        take!(slack, watch_timeout);
         take!(lock, reap_stale);
         take!(lock, stale_age);
         take!(lock, pi_autolock);
@@ -637,6 +691,26 @@ pub struct Config {
     /// (scheme/host/port) matches this; metadata-supplied PR URLs pointing
     /// anywhere else are refused. Defaults to `https://src.suse.de`.
     pub gitea_url: String,
+
+    // [slack]
+    /// Whether the Slack review-request integration is available at all.
+    /// `false` by default — the feature is opt-in, so an unconfigured mtui
+    /// never posts anywhere; `request_review` refuses and says why.
+    pub slack_enabled: bool,
+    /// Bot token for the Slack Web API (scopes: `chat:write`, `reactions:read`,
+    /// `channels:history`). Empty by default; `request_review` refuses without
+    /// it, so the integration stays inert until deliberately configured.
+    pub slack_token: String,
+    /// Channel the review request is posted to (an ID such as `C01234567` or a
+    /// `#name`). Empty by default; `request_review` refuses without it.
+    pub slack_channel: String,
+    /// Trusted Slack API origin the [`slack_token`](Self::slack_token) may be
+    /// sent to. Defaults to `https://slack.com/api`.
+    pub slack_api_url: String,
+    /// Seconds between reaction polls while watching a review request.
+    pub slack_poll_interval: u64,
+    /// Seconds a `request_review` watch runs before giving up.
+    pub slack_watch_timeout: u64,
 
     // [target]
     /// Remote scratch directory on target hosts.
@@ -761,6 +835,12 @@ impl Default for Config {
             svn_path: default_svn_path(),
             gitea_token: String::new(),
             gitea_url: default_gitea_url(),
+            slack_enabled: default_slack_enabled(),
+            slack_token: String::new(),
+            slack_channel: String::new(),
+            slack_api_url: default_slack_api_url(),
+            slack_poll_interval: default_slack_poll_interval(),
+            slack_watch_timeout: default_slack_watch_timeout(),
             target_tempdir: default_target_tempdir(),
             lock_reap_stale: default_lock_reap_stale(),
             lock_stale_age: default_lock_stale_age(),
@@ -907,6 +987,21 @@ impl Config {
             svn_path: raw.svn.path.unwrap_or(d.svn_path),
             gitea_token: raw.gitea.token.unwrap_or(d.gitea_token),
             gitea_url: validated_url!(raw.gitea.url, "gitea_url", d.gitea_url),
+
+            slack_enabled: raw.slack.enabled.unwrap_or(d.slack_enabled),
+            slack_token: raw.slack.token.unwrap_or(d.slack_token),
+            slack_channel: raw.slack.channel.unwrap_or(d.slack_channel),
+            slack_api_url: validated_url!(raw.slack.api_url, "slack_api_url", d.slack_api_url),
+            slack_poll_interval: validated_positive!(
+                raw.slack.poll_interval,
+                "slack_poll_interval",
+                d.slack_poll_interval
+            ),
+            slack_watch_timeout: validated_positive!(
+                raw.slack.watch_timeout,
+                "slack_watch_timeout",
+                d.slack_watch_timeout
+            ),
             target_tempdir: raw
                 .target
                 .tempdir
@@ -1087,6 +1182,89 @@ mod tests {
         // A malformed value falls back to the default (lenient loading).
         let bad: RawConfig = toml::from_str("[gitea]\nurl = \"not a url\"\n").unwrap();
         assert_eq!(Config::from_raw(bad).gitea_url, "https://src.suse.de");
+    }
+
+    #[test]
+    fn slack_is_off_until_explicitly_enabled() {
+        let d = Config::default();
+        // Opt-in by default: posting into a chat workspace is an outward-facing
+        // side effect that must never follow from an unconfigured install.
+        assert!(!d.slack_enabled);
+        assert_eq!(d.slack_token, "");
+        assert_eq!(d.slack_channel, "");
+        assert_eq!(d.slack_api_url, "https://slack.com/api");
+        assert_eq!(d.slack_poll_interval, 120);
+        assert_eq!(d.slack_watch_timeout, 3600);
+    }
+
+    #[test]
+    fn slack_section_parses_and_overrides() {
+        let raw: RawConfig = toml::from_str(
+            "[slack]\nenabled = true\ntoken = \"xoxb-abc\"\nchannel = \"#qam\"\n\
+             api_url = \"https://slack.example.com/api\"\npoll_interval = 45\n\
+             watch_timeout = 600\n",
+        )
+        .unwrap();
+        let c = Config::from_raw(raw);
+        assert!(c.slack_enabled);
+        assert_eq!(c.slack_token, "xoxb-abc");
+        assert_eq!(c.slack_channel, "#qam");
+        assert_eq!(c.slack_api_url, "https://slack.example.com/api");
+        assert_eq!(c.slack_poll_interval, 45);
+        assert_eq!(c.slack_watch_timeout, 600);
+    }
+
+    #[test]
+    fn slack_partial_keeps_defaults() {
+        // Enabling the integration must not disturb the other options, so a
+        // site can switch it on without restating the whole section.
+        let raw: RawConfig = toml::from_str("[slack]\nenabled = true\n").unwrap();
+        let c = Config::from_raw(raw);
+        assert!(c.slack_enabled);
+        assert_eq!(c.slack_api_url, "https://slack.com/api");
+        assert_eq!(c.slack_poll_interval, 120);
+    }
+
+    #[test]
+    fn slack_invalid_values_fall_back_to_defaults() {
+        // Lenient loading: a bad value is logged and defaulted, never fatal.
+        let bad_url: RawConfig = toml::from_str("[slack]\napi_url = \"not a url\"\n").unwrap();
+        assert_eq!(
+            Config::from_raw(bad_url).slack_api_url,
+            "https://slack.com/api"
+        );
+
+        // A zero poll interval would busy-loop against a rate-limited API.
+        let zero_poll: RawConfig = toml::from_str("[slack]\npoll_interval = 0\n").unwrap();
+        assert_eq!(Config::from_raw(zero_poll).slack_poll_interval, 120);
+
+        // A zero timeout would mean a watch that ends before it begins.
+        let zero_timeout: RawConfig = toml::from_str("[slack]\nwatch_timeout = 0\n").unwrap();
+        assert_eq!(Config::from_raw(zero_timeout).slack_watch_timeout, 3600);
+    }
+
+    #[test]
+    fn slack_options_survive_the_file_merge() {
+        // Every field needs its own `take!` line; a forgotten one silently
+        // drops that option when a per-user file overrides /etc.
+        let mut base: RawConfig = toml::from_str(
+            "[slack]\nenabled = true\ntoken = \"etc\"\nchannel = \"#etc\"\n\
+             api_url = \"https://etc.example.com\"\npoll_interval = 10\nwatch_timeout = 20\n",
+        )
+        .unwrap();
+        let user: RawConfig = toml::from_str(
+            "[slack]\nenabled = false\ntoken = \"user\"\nchannel = \"#user\"\n\
+             api_url = \"https://user.example.com\"\npoll_interval = 30\nwatch_timeout = 40\n",
+        )
+        .unwrap();
+        base.merge(user);
+        let c = Config::from_raw(base);
+        assert!(!c.slack_enabled);
+        assert_eq!(c.slack_token, "user");
+        assert_eq!(c.slack_channel, "#user");
+        assert_eq!(c.slack_api_url, "https://user.example.com");
+        assert_eq!(c.slack_poll_interval, 30);
+        assert_eq!(c.slack_watch_timeout, 40);
     }
 
     #[test]

--- a/crates/mtui-config/tests/fixtures/config.toml
+++ b/crates/mtui-config/tests/fixtures/config.toml
@@ -35,6 +35,13 @@ stale_age = 3600                  # integer value
 wait = 30
 # wait_poll omitted on purpose: it must keep its upstream default (15)
 
+[slack]
+enabled = true                    # boolean value
+token = "xoxb-fixture"
+channel = "#qam-review"
+poll_interval = 90                # integer value
+# watch_timeout omitted on purpose: it must keep its default (3600)
+
 [mcp]
 max_output_bytes = 65536          # integer value
 profile = "core"                  # tool-surface profile

--- a/crates/mtui-config/tests/load.rs
+++ b/crates/mtui-config/tests/load.rs
@@ -68,6 +68,13 @@ fn config_toml_fixture_parses_all_sections() {
     assert_eq!(cfg.mcp_tools_allow, vec!["whoami".to_owned()]);
     assert_eq!(cfg.mcp_tools_deny, vec!["run".to_owned()]);
 
+    // [slack] section: explicit overrides land, an omitted key keeps its default.
+    assert!(cfg.slack_enabled);
+    assert_eq!(cfg.slack_token, "xoxb-fixture");
+    assert_eq!(cfg.slack_channel, "#qam-review");
+    assert_eq!(cfg.slack_poll_interval, 90);
+    assert_eq!(cfg.slack_watch_timeout, 3600);
+
     // [obs] section: explicit overrides land, an omitted key keeps its default.
     assert_eq!(cfg.obs_api_url, "https://api.example.de");
     assert_eq!(cfg.obs_request_timeout, 90);

--- a/crates/mtui-core/src/commands/approve.rs
+++ b/crates/mtui-core/src/commands/approve.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, ArgMatches};
-use mtui_datasources::Osc;
+use mtui_datasources::{Osc, Slack, is_ack_reaction};
 use mtui_testreport::{HashCheck, TokioSvnRunner, svn_commit_testreport};
 
 use crate::command::{Command, Scope};
@@ -77,6 +77,11 @@ impl Command for Approve {
     async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
         let rrid = require_update(session)?;
 
+        // Slack gate: when the site has opted into Slack review, an approval
+        // requires an acknowledged review request. Runs before any state
+        // changes so a refused approval leaves nothing half-done.
+        slack_review_gate(session, &rrid).await?;
+
         // -r/--reviewer: record + commit before approving; abort on failure.
         if let Some(reviewer) = args.get_one::<String>("reviewer") {
             record_reviewer(session, reviewer).await?;
@@ -128,6 +133,86 @@ impl Command for Approve {
     }
 }
 
+/// Refuse the approval unless the update's Slack review request was acked.
+///
+/// Only engages when the site has opted into the integration
+/// (`[slack] enabled = true`); with Slack off this is a no-op and `approve`
+/// behaves exactly as it always has. Once on, the gate is deliberately strict,
+/// because a gate with a per-invocation bypass flag is not a gate: turning it
+/// off is a config change (`config set slack_enabled false`), which is
+/// explicit and auditable rather than a habit that creeps into muscle memory.
+///
+/// Three things must hold, and each rules out a distinct way of approving
+/// something nobody reviewed:
+///
+/// 1. A marker exists — otherwise no review was ever requested.
+/// 2. The marked message still names this RRID — otherwise a marker copied
+///    from another template (or a re-used message) would launder an approval
+///    for an update nobody looked at.
+/// 3. Someone other than the bot left an approving reaction.
+///
+/// Only `approve` is gated. `reject` is the conservative direction: blocking
+/// it would strand an update that a reviewer wants stopped.
+async fn slack_review_gate(
+    session: &mut Session,
+    rrid: &mtui_types::RequestReviewID,
+) -> Result<(), CommandError> {
+    if !session.config.slack_enabled {
+        return Ok(());
+    }
+
+    let Some(marker) = session.metadata().base().slack_review.clone() else {
+        return Err(CommandError::Other(format!(
+            "Slack review is enabled but no review was requested for {rrid}; \
+             run `request_review` first (or disable the gate with \
+             `config set slack_enabled false`)"
+        )));
+    };
+
+    let slack = Slack::new(&session.config)
+        .map_err(|e| CommandError::Other(format!("could not check the Slack review: {e}")))?;
+    let message = slack
+        .get_message(&marker.channel, &marker.ts)
+        .await
+        .map_err(|e| {
+            CommandError::Other(format!(
+                "could not read the Slack review request for {rrid}, not approving: {e}"
+            ))
+        })?;
+
+    // Bind the marker to this update: a message that does not name this RRID
+    // is not this update's review, whatever the template claims.
+    if !message.text.contains(&rrid.to_string()) {
+        return Err(CommandError::Other(format!(
+            "the recorded Slack message does not mention {rrid}, not approving; \
+             re-run `request_review`"
+        )));
+    }
+
+    let bot = slack.auth_test().await.ok();
+    let acked: Vec<String> = message
+        .reactions
+        .iter()
+        .filter(|r| is_ack_reaction(&r.name))
+        .flat_map(|r| r.users.clone())
+        // The bot acking its own request would approve nothing.
+        .filter(|u| bot.as_deref() != Some(u.as_str()))
+        .collect();
+
+    if acked.is_empty() {
+        return Err(CommandError::Other(format!(
+            "the Slack review request for {rrid} has not been acknowledged, not approving; \
+             ask a reviewer for a :+1: on the request"
+        )));
+    }
+
+    session.display.println(&format!(
+        "Slack review acknowledged by {}",
+        acked.join(", ")
+    ));
+    Ok(())
+}
+
 /// Records the reviewer and commits the testreport to SVN (upstream
 /// `_record_reviewer`). Returns `Err` when the record/commit fails so the
 /// approval is aborted and the failure is surfaced (not swallowed).
@@ -177,6 +262,166 @@ mod tests {
         let (session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
         let out = Approve.complete(&session, "-r", "");
         assert_eq!(out, vec!["-r"]);
+    }
+
+    /// Enable the Slack gate against a mock server, with a marker recorded.
+    fn gated_session(
+        server: &wiremock::MockServer,
+        rrid: &str,
+        marker: Option<(&str, &str)>,
+    ) -> (Session, crate::commands::testkit::Buffer) {
+        let (mut session, buf) = session_with_hosts(rrid, &["h1"], "ok");
+        session.config.slack_enabled = true;
+        session.config.slack_token = "xoxb-test".to_owned();
+        session.config.slack_channel = "C1".to_owned();
+        session.config.slack_api_url = server.uri();
+        if let Some((channel, ts)) = marker {
+            session.metadata_mut().base_mut().slack_review =
+                Some(mtui_testreport::SlackReviewMarker {
+                    channel: channel.to_owned(),
+                    ts: ts.to_owned(),
+                });
+        }
+        (session, buf)
+    }
+
+    async fn mount_message(
+        server: &wiremock::MockServer,
+        text: &str,
+        reactions: serde_json::Value,
+    ) {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, ResponseTemplate};
+        Mock::given(path("/reactions.get"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "message": { "text": text, "reactions": reactions }
+            })))
+            .mount(server)
+            .await;
+        Mock::given(path("/auth.test"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "user_id": "UBOT" })),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn slack_gate_is_inert_when_the_integration_is_off() {
+        // The default posture. Approve must behave exactly as it always has,
+        // so every pre-existing approve test stays meaningful.
+        let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        assert!(!session.config.slack_enabled);
+        let rrid = require_update(&session).unwrap();
+        slack_review_gate(&mut session, &rrid).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn slack_gate_refuses_when_no_review_was_requested() {
+        let server = wiremock::MockServer::start().await;
+        let (mut session, _buf) = gated_session(&server, "SUSE:Maintenance:1:1", None);
+        let rrid = require_update(&session).unwrap();
+
+        let err = slack_review_gate(&mut session, &rrid).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no review was requested"), "{msg}");
+        assert!(msg.contains("request_review"), "says what to do: {msg}");
+        // Nothing was asked of Slack: the marker check short-circuits.
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn slack_gate_refuses_a_marker_pointing_at_another_update() {
+        // The defence against a marker copied between templates: the message
+        // must actually name this RRID, or it is not this update's review.
+        let server = wiremock::MockServer::start().await;
+        mount_message(
+            &server,
+            "Please review SUSE:Maintenance:9:9",
+            serde_json::json!([{ "name": "+1", "users": ["U1"] }]),
+        )
+        .await;
+        let (mut session, _buf) =
+            gated_session(&server, "SUSE:Maintenance:1:1", Some(("C1", "1.0")));
+        let rrid = require_update(&session).unwrap();
+
+        let err = slack_review_gate(&mut session, &rrid).await.unwrap_err();
+        assert!(err.to_string().contains("does not mention"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn slack_gate_refuses_an_unacknowledged_request() {
+        let server = wiremock::MockServer::start().await;
+        mount_message(
+            &server,
+            "Please review SUSE:Maintenance:1:1",
+            serde_json::json!([{ "name": "eyes", "users": ["U1"] }]),
+        )
+        .await;
+        let (mut session, _buf) =
+            gated_session(&server, "SUSE:Maintenance:1:1", Some(("C1", "1.0")));
+        let rrid = require_update(&session).unwrap();
+
+        let err = slack_review_gate(&mut session, &rrid).await.unwrap_err();
+        assert!(err.to_string().contains("not been acknowledged"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn slack_gate_ignores_the_bots_own_acknowledgement() {
+        // A workspace that auto-reacts must not be able to self-approve.
+        let server = wiremock::MockServer::start().await;
+        mount_message(
+            &server,
+            "Please review SUSE:Maintenance:1:1",
+            serde_json::json!([{ "name": "+1", "users": ["UBOT"] }]),
+        )
+        .await;
+        let (mut session, _buf) =
+            gated_session(&server, "SUSE:Maintenance:1:1", Some(("C1", "1.0")));
+        let rrid = require_update(&session).unwrap();
+
+        let err = slack_review_gate(&mut session, &rrid).await.unwrap_err();
+        assert!(err.to_string().contains("not been acknowledged"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn slack_gate_passes_on_a_human_acknowledgement() {
+        let server = wiremock::MockServer::start().await;
+        mount_message(
+            &server,
+            "Please review SUSE:Maintenance:1:1 (recommended)",
+            serde_json::json!([{ "name": "+1::skin-tone-2", "users": ["U1", "UBOT"] }]),
+        )
+        .await;
+        let (mut session, buf) =
+            gated_session(&server, "SUSE:Maintenance:1:1", Some(("C1", "1.0")));
+        let rrid = require_update(&session).unwrap();
+
+        slack_review_gate(&mut session, &rrid).await.unwrap();
+        // The human is named; the bot that shares the reaction is not.
+        let out = buf.contents();
+        assert!(out.contains("acknowledged by U1"), "{out}");
+        assert!(!out.contains("UBOT"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn slack_gate_refuses_when_slack_is_unreachable() {
+        // Fail closed: an unreadable review request is not an approved one.
+        let server = wiremock::MockServer::start().await;
+        use wiremock::matchers::path;
+        use wiremock::{Mock, ResponseTemplate};
+        Mock::given(path("/reactions.get"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let (mut session, _buf) =
+            gated_session(&server, "SUSE:Maintenance:1:1", Some(("C1", "1.0")));
+        let rrid = require_update(&session).unwrap();
+
+        let err = slack_review_gate(&mut session, &rrid).await.unwrap_err();
+        assert!(err.to_string().contains("not approving"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/mtui-core/src/commands/config.rs
+++ b/crates/mtui-core/src/commands/config.rs
@@ -49,6 +49,19 @@ fn attr_value(config: &Config, attr: &str) -> Option<String> {
             }
         }
         "gitea_url" => config.gitea_url.clone(),
+        // Also a secret, masked on the same terms as the Gitea token.
+        "slack_token" => {
+            if config.slack_token.is_empty() {
+                String::new()
+            } else {
+                SECRET_MASK.to_owned()
+            }
+        }
+        "slack_enabled" => config.slack_enabled.to_string(),
+        "slack_channel" => config.slack_channel.clone(),
+        "slack_api_url" => config.slack_api_url.clone(),
+        "slack_poll_interval" => config.slack_poll_interval.to_string(),
+        "slack_watch_timeout" => config.slack_watch_timeout.to_string(),
         "target_tempdir" => config.target_tempdir.display().to_string(),
         "lock_reap_stale" => config.lock_reap_stale.to_string(),
         "lock_stale_age" => config.lock_stale_age.to_string(),
@@ -69,7 +82,7 @@ const SECRET_MASK: &str = "<set>";
 /// echoed. The single source of truth for `show`'s mask and `set`'s redacted
 /// acknowledgement; add a new secret field here to cover both paths at once.
 fn is_secret_attr(attr: &str) -> bool {
-    attr == "gitea_token"
+    matches!(attr, "gitea_token" | "slack_token")
 }
 
 /// Render an [`SslVerify`] back to the string form `config set`/the config file
@@ -84,7 +97,7 @@ fn ssl_verify_to_string(v: &SslVerify) -> String {
 }
 
 /// The attribute names `show` lists when given none, in a stable order.
-const ATTRS: [&str; 30] = [
+const ATTRS: [&str; 36] = [
     "template_dir",
     "local_tempdir",
     "session_user",
@@ -109,6 +122,12 @@ const ATTRS: [&str; 30] = [
     "openqa_install_distri",
     "gitea_token",
     "gitea_url",
+    "slack_enabled",
+    "slack_token",
+    "slack_channel",
+    "slack_api_url",
+    "slack_poll_interval",
+    "slack_watch_timeout",
     "target_tempdir",
     "lock_reap_stale",
     "lock_stale_age",
@@ -146,6 +165,12 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         "openqa_install_distri" => config.openqa_install_distri = raw.to_owned(),
         "gitea_token" => config.gitea_token = raw.to_owned(),
         "gitea_url" => config.gitea_url = raw.to_owned(),
+        "slack_token" => config.slack_token = raw.to_owned(),
+        "slack_channel" => config.slack_channel = raw.to_owned(),
+        "slack_api_url" => config.slack_api_url = raw.to_owned(),
+        "slack_enabled" => config.slack_enabled = parse_bool(raw)?,
+        "slack_poll_interval" => config.slack_poll_interval = parse_u64(raw)?,
+        "slack_watch_timeout" => config.slack_watch_timeout = parse_u64(raw)?,
         // Goes through the same coercion as config-file loading (a boolean
         // spelling toggles verification, anything else is a CA-bundle path), so
         // a runtime `set` cannot store a value the file would reject.

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -48,6 +48,7 @@ mod openqa_jobs;
 mod openqa_overview;
 mod regenerate;
 mod reload_openqa;
+mod request_review;
 mod simpleset;
 mod updates;
 
@@ -112,6 +113,7 @@ pub use openqa_jobs::OpenQAJobs;
 pub use openqa_overview::OpenQAOverview;
 pub use regenerate::Regenerate;
 pub use reload_openqa::ReloadOpenQA;
+pub use request_review::RequestReview;
 pub use simpleset::{SetLogLevel, SetWorkflow};
 pub use updates::Updates;
 
@@ -785,6 +787,10 @@ mod mcp_nonempty_success_guard {
         // change (build_incident/refresh_auto), so success needs the QEM
         // Dashboard + openQA backends its own tests mock per case.
         "set_workflow",
+        // why: posts to the Slack Web API; the success line is printed only
+        // after a live `auth.test` + `chat.postMessage` succeed, so driving it
+        // needs the wiremock backend its own tests stand up per case.
+        "request_review",
         // why: connects a brand-new host over SSH; success needs a reachable
         // reference host (its tests only exercise the connect-failure path).
         "add_host",

--- a/crates/mtui-core/src/commands/request_review.rs
+++ b/crates/mtui-core/src/commands/request_review.rs
@@ -1,0 +1,724 @@
+//! The `request_review` command — ask for review of the loaded update in Slack.
+//!
+//! Posts a review request naming the update's RRID into the configured channel,
+//! records the resulting message in the testreport template so the request is
+//! traceable afterwards, and optionally watches the message for reviewer
+//! reactions.
+//!
+//! Three design decisions are worth stating, because each departs from the
+//! obvious reading:
+//!
+//! * **The watch is opt-in (`--watch`), not the default.** A watch runs for up
+//!   to an hour, and the same command has to behave sanely over MCP, where a
+//!   blocking call that outlives the client's timeout is indistinguishable from
+//!   a hang. Posting is fast and total; watching is the long-running extra the
+//!   caller asks for, and over MCP it belongs in a background job.
+//! * **The marker is written but not committed.** Persisting it to SVN would
+//!   couple posting a chat message to a working checkout and a network commit.
+//!   mtui already has an explicit `commit`, and the marker rides along with it
+//!   like every other template edit.
+//! * **Rate limiting is not failure.** Slack throttles routinely; a `429`
+//!   leaves the watch running rather than counting against it, or a busy
+//!   channel would end the watch early and report "no reaction" when the truth
+//!   is "we were not allowed to look".
+
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use clap::{Arg, ArgAction, ArgMatches};
+use mtui_datasources::{PostedMessage, Slack, SlackError, is_ack_reaction, is_nack_reaction};
+use mtui_testreport::SlackReviewMarker;
+
+use crate::command::{Command, Scope};
+use crate::commands::support::{require_update, template_completion};
+use crate::error::{CommandError, CommandResult};
+use crate::session::Session;
+
+/// How long to wait after a rate-limit reply that carried no `Retry-After`.
+const DEFAULT_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Upper bound on any single back-off, so a hostile or mistaken `Retry-After`
+/// cannot park the watch for hours.
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Consecutive hard failures tolerated before the watch gives up.
+///
+/// Transient errors happen; a persistent one (the message was deleted, the
+/// token was revoked) should end the watch rather than spin until timeout.
+const MAX_CONSECUTIVE_FAILURES: u32 = 5;
+
+/// How a watch ended, so the summary can say something true.
+#[derive(Debug, PartialEq, Eq)]
+enum WatchOutcome {
+    /// A reviewer reacted with an approval emoji.
+    Approved(Vec<String>),
+    /// A reviewer reacted with a rejection emoji.
+    Rejected(Vec<String>),
+    /// The watch window elapsed with no verdict.
+    TimedOut,
+    /// The user pressed Ctrl-C.
+    Interrupted,
+    /// The watch stopped because Slack kept failing.
+    Failed(String),
+}
+
+/// Spread a poll interval by ±15% so several mtui instances watching the same
+/// channel do not converge on the same request times.
+///
+/// Uses the clock's sub-second noise rather than pulling in a random-number
+/// dependency: the goal is decorrelation between processes, not unpredictability.
+fn jittered(base: Duration) -> Duration {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::from(d.subsec_nanos()));
+    // Map the noise onto [0.85, 1.15] in integer arithmetic.
+    let factor = 85 + (nanos % 31);
+    Duration::from_millis(base.as_millis() as u64 * factor / 100)
+}
+
+/// The message posted to Slack.
+///
+/// The RRID appears verbatim so the request can be traced back to the update
+/// from Slack alone, and so any later verification can bind to this exact
+/// message rather than to "some review request".
+fn review_message(rrid: &str, category: &str, note: Option<&str>) -> String {
+    let mut msg = format!("Please review {rrid}");
+    if !category.is_empty() {
+        msg.push_str(&format!(" ({category})"));
+    }
+    if let Some(note) = note.filter(|n| !n.trim().is_empty()) {
+        msg.push('\n');
+        msg.push_str(note.trim());
+    }
+    msg
+}
+
+/// Build a Slack client from the session config, mapping the refusal reasons
+/// to command errors that say what to do about them.
+fn slack_client(session: &Session) -> Result<Slack, CommandError> {
+    Slack::new(&session.config).map_err(|e| match e {
+        // The common case for anyone not using the integration: say so plainly
+        // rather than making them read it as a failure.
+        SlackError::Disabled => CommandError::Other(
+            "Slack integration is disabled; enable it with `config set slack_enabled true` \
+             or the `[slack] enabled` config key"
+                .to_owned(),
+        ),
+        other => CommandError::Other(format!("could not build Slack client: {other}")),
+    })
+}
+
+/// Resolve the channel to post to: `--channel` wins over the configured one.
+fn resolve_channel(session: &Session, args: &ArgMatches) -> Result<String, CommandError> {
+    let channel = args
+        .get_one::<String>("channel")
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .unwrap_or_else(|| session.config.slack_channel.clone());
+    if channel.is_empty() {
+        return Err(CommandError::Other(format!(
+            "{}",
+            SlackError::MissingChannel
+        )));
+    }
+    Ok(channel)
+}
+
+/// Poll `posted` until a verdict, the deadline, or Ctrl-C.
+///
+/// Returns the outcome rather than printing it, so the caller owns all display
+/// and the loop stays testable.
+async fn watch(
+    slack: &Slack,
+    posted: &PostedMessage,
+    poll: Duration,
+    timeout: Duration,
+    bot_id: Option<&str>,
+) -> WatchOutcome {
+    let deadline = Instant::now() + timeout;
+    let mut failures: u32 = 0;
+
+    loop {
+        // Poll before sleeping, so an already-acked request is recognised
+        // immediately and an elapsed deadline still gets exactly one look.
+        match slack.reactions(&posted.channel, &posted.ts).await {
+            Ok(reactions) => {
+                failures = 0;
+                let voters = |names: &[String]| -> Vec<String> {
+                    let mut v: Vec<String> = names.to_vec();
+                    // The bot's own reactions are not review decisions.
+                    if let Some(bot) = bot_id {
+                        v.retain(|u| u != bot);
+                    }
+                    v.sort();
+                    v.dedup();
+                    v
+                };
+                let acked: Vec<String> = voters(
+                    &reactions
+                        .iter()
+                        .filter(|r| is_ack_reaction(&r.name))
+                        .flat_map(|r| r.users.clone())
+                        .collect::<Vec<_>>(),
+                );
+                let nacked: Vec<String> = voters(
+                    &reactions
+                        .iter()
+                        .filter(|r| is_nack_reaction(&r.name))
+                        .flat_map(|r| r.users.clone())
+                        .collect::<Vec<_>>(),
+                );
+                // A rejection is checked first: if a reviewer left both, the
+                // objection is the one that must not be silently outvoted.
+                if !nacked.is_empty() {
+                    return WatchOutcome::Rejected(nacked);
+                }
+                if !acked.is_empty() {
+                    return WatchOutcome::Approved(acked);
+                }
+            }
+            // Throttling is not a failure — it is Slack asking us to wait.
+            Err(SlackError::RateLimited { retry_after }) => {
+                let wait = retry_after
+                    .map_or(DEFAULT_BACKOFF, Duration::from_secs)
+                    .min(MAX_BACKOFF);
+                tracing::debug!(?wait, "rate limited; backing off");
+                if sleep_or_interrupt(jittered(wait), deadline).await {
+                    return WatchOutcome::Interrupted;
+                }
+                if Instant::now() >= deadline {
+                    return WatchOutcome::TimedOut;
+                }
+                continue;
+            }
+            Err(e) => {
+                failures += 1;
+                let msg = e.to_string();
+                tracing::warn!(failures, "Slack reaction poll failed: {msg}");
+                if failures >= MAX_CONSECUTIVE_FAILURES {
+                    return WatchOutcome::Failed(msg);
+                }
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return WatchOutcome::TimedOut;
+        }
+        if sleep_or_interrupt(jittered(poll), deadline).await {
+            return WatchOutcome::Interrupted;
+        }
+    }
+}
+
+/// Sleep for `dur` (never past `deadline`), returning `true` if Ctrl-C arrived.
+///
+/// Nothing in the CLI installs a SIGINT handler today, so without this a
+/// Ctrl-C during a watch kills the process outright and the user never learns
+/// that their review request was in fact posted.
+async fn sleep_or_interrupt(dur: Duration, deadline: Instant) -> bool {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let dur = dur.min(remaining);
+    tokio::select! {
+        () = tokio::time::sleep(dur) => false,
+        _ = tokio::signal::ctrl_c() => true,
+    }
+}
+
+/// Requests review of the loaded update in Slack.
+pub struct RequestReview;
+
+#[async_trait]
+impl Command for RequestReview {
+    fn name(&self) -> &'static str {
+        "request_review"
+    }
+
+    fn about(&self) -> Option<&'static str> {
+        Some("Requests review of the loaded update in Slack.")
+    }
+
+    fn scope(&self) -> Scope {
+        Scope::Fanout
+    }
+
+    fn configure(&self, cmd: clap::Command) -> clap::Command {
+        cmd.arg(
+            Arg::new("channel")
+                .short('c')
+                .long("channel")
+                .value_name("CHANNEL")
+                .help("Channel to post to, overriding the configured one"),
+        )
+        .arg(
+            Arg::new("message")
+                .short('m')
+                .long("message")
+                .value_name("TEXT")
+                .help("Extra context appended to the review request"),
+        )
+        .arg(
+            Arg::new("watch")
+                .short('w')
+                .long("watch")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "After posting, watch the message for reviewer reactions until a \
+                     verdict or timeout (Ctrl-C stops it). Over MCP, pair this with \
+                     background=true so the call does not outlive the client timeout",
+                ),
+        )
+    }
+
+    fn complete(&self, session: &Session, text: &str, _line: &str) -> Vec<String> {
+        let mut out: Vec<String> = ["-c", "--channel", "-m", "--message", "-w", "--watch"]
+            .iter()
+            .filter(|f| f.starts_with(text))
+            .map(|s| (*s).to_owned())
+            .collect();
+        out.extend(template_completion(session, text));
+        out
+    }
+
+    async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
+        let rrid = require_update(session)?;
+        let slack = slack_client(session)?;
+        let channel = resolve_channel(session, args)?;
+
+        // Validate the token before posting, so a bad one is reported as such
+        // rather than as a confusing failure on the post itself.
+        let bot_id = match slack.auth_test().await {
+            Ok(id) => Some(id),
+            Err(e) => {
+                return Err(CommandError::Other(format!(
+                    "Slack authentication failed: {e}"
+                )));
+            }
+        };
+
+        let category = session.metadata().base().category.clone();
+        let note = args.get_one::<String>("message").map(String::as_str);
+        let text = review_message(&rrid.to_string(), &category, note);
+
+        let posted = slack
+            .post_message(&channel, &text)
+            .await
+            .map_err(|e| CommandError::Other(format!("failed to post review request: {e}")))?;
+
+        // Record the message before anything else can fail: from here on the
+        // request exists in Slack, and the template should say so even if the
+        // watch below is interrupted.
+        let marker = SlackReviewMarker {
+            channel: posted.channel.clone(),
+            ts: posted.ts.clone(),
+        };
+        let recorded = match session.metadata_mut().set_slack_review(&marker) {
+            Ok(()) => true,
+            Err(e) => {
+                // The request is already posted; failing the whole command here
+                // would misreport a real, visible message as not sent.
+                let msg = session.display.yellow(&format!(
+                    "warning: review request posted, but recording it in the template failed: {e}"
+                ));
+                session.display.println(&msg);
+                false
+            }
+        };
+
+        session
+            .display
+            .println(&format!("requested review of {rrid} in {channel}"));
+        if recorded {
+            session
+                .display
+                .println("recorded the request in the template (commit to share it)");
+        }
+
+        if !args.get_flag("watch") {
+            return Ok(());
+        }
+
+        let poll = Duration::from_secs(session.config.slack_poll_interval);
+        let timeout = Duration::from_secs(session.config.slack_watch_timeout);
+        session.display.println(&format!(
+            "watching for reactions (up to {}s, Ctrl-C to stop)",
+            timeout.as_secs()
+        ));
+
+        let outcome = watch(&slack, &posted, poll, timeout, bot_id.as_deref()).await;
+        report(session, &rrid.to_string(), &outcome);
+
+        // A failed watch is a failed command: over MCP the caller needs a
+        // failed tool call, not a success whose text happens to say otherwise.
+        if let WatchOutcome::Failed(e) = outcome {
+            return Err(CommandError::Other(format!("Slack watch failed: {e}")));
+        }
+        Ok(())
+    }
+}
+
+/// Print the watch result.
+fn report(session: &mut Session, rrid: &str, outcome: &WatchOutcome) {
+    let line = match outcome {
+        WatchOutcome::Approved(users) => session.display.green(&format!(
+            "{rrid}: review approved in Slack by {}",
+            users.join(", ")
+        )),
+        WatchOutcome::Rejected(users) => session.display.red(&format!(
+            "{rrid}: review rejected in Slack by {}",
+            users.join(", ")
+        )),
+        WatchOutcome::TimedOut => session
+            .display
+            .yellow(&format!("{rrid}: no review reaction before the timeout")),
+        WatchOutcome::Interrupted => session.display.yellow(&format!(
+            "{rrid}: stopped watching; the request is still posted"
+        )),
+        WatchOutcome::Failed(e) => session.display.red(&format!(
+            "{rrid}: stopped watching after repeated errors: {e}"
+        )),
+    };
+    session.display.println(&line);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::testkit::{matches, session_with_hosts};
+    use mtui_datasources::{HttpClient, VerifyPolicy};
+    use serde_json::json;
+    use wiremock::matchers::path;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const CHANNEL: &str = "C0123456789";
+    const TS: &str = "1700000000.000100";
+
+    fn slack_for(server: &MockServer) -> Slack {
+        let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
+        Slack::with_client(http, "xoxb-test".to_owned(), &server.uri()).expect("builds")
+    }
+
+    async fn mount(server: &MockServer, api_method: &str, body: serde_json::Value) {
+        Mock::given(path(format!("/{api_method}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    /// Mount the auth + post endpoints a successful `call` needs.
+    async fn mount_post_path(server: &MockServer) {
+        mount(
+            server,
+            "auth.test",
+            json!({ "ok": true, "user_id": "UBOT" }),
+        )
+        .await;
+        mount(
+            server,
+            "chat.postMessage",
+            json!({ "ok": true, "channel": CHANNEL, "ts": TS }),
+        )
+        .await;
+    }
+
+    /// A session with Slack enabled and pointed at `server`.
+    fn slack_session(server: &MockServer) -> (Session, crate::commands::testkit::Buffer) {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:2", &["h1"], "ok");
+        session.config.slack_enabled = true;
+        session.config.slack_token = "xoxb-test".to_owned();
+        session.config.slack_channel = CHANNEL.to_owned();
+        session.config.slack_api_url = server.uri();
+        (session, buf)
+    }
+
+    #[test]
+    fn review_message_names_the_rrid_verbatim() {
+        // The RRID must survive into the message text: it is what ties a Slack
+        // thread back to an update.
+        let msg = review_message("SUSE:Maintenance:1:2", "recommended", None);
+        assert!(msg.contains("SUSE:Maintenance:1:2"), "{msg}");
+        assert!(msg.contains("recommended"), "{msg}");
+
+        // An extra note is appended, and an empty one adds no stray blank line.
+        let with_note = review_message("SUSE:Maintenance:1:2", "", Some("  urgent  "));
+        assert!(with_note.ends_with("urgent"), "{with_note}");
+        assert_eq!(review_message("R", "", Some("   ")), "Please review R");
+    }
+
+    #[test]
+    fn jitter_stays_within_fifteen_percent() {
+        let base = Duration::from_secs(100);
+        for _ in 0..50 {
+            let j = jittered(base);
+            assert!(
+                j >= Duration::from_secs(85) && j <= Duration::from_secs(115),
+                "jitter out of range: {j:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_slack_refuses_with_an_actionable_message() {
+        let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:2", &["h1"], "ok");
+        // The default state: the integration is off.
+        let args = matches(&RequestReview, &[]);
+        let err = RequestReview.call(&mut session, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("disabled"), "{msg}");
+        assert!(msg.contains("slack_enabled"), "says how to fix it: {msg}");
+    }
+
+    #[tokio::test]
+    async fn missing_channel_refuses_before_posting() {
+        let server = MockServer::start().await;
+        let (mut session, _buf) = slack_session(&server);
+        session.config.slack_channel = String::new();
+
+        let args = matches(&RequestReview, &[]);
+        let err = RequestReview.call(&mut session, &args).await.unwrap_err();
+        assert!(err.to_string().contains("channel"), "{err}");
+        // Nothing was sent: the guard runs before any request.
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn posts_and_records_the_marker() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        let (mut session, buf) = slack_session(&server);
+
+        // Give the report a template file so the marker can be written.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log");
+        std::fs::write(&path, "Test Plan Reviewer: bob\n").unwrap();
+        session.metadata_mut().base_mut().path = Some(path.clone());
+
+        let args = matches(&RequestReview, &[]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        assert!(
+            buf.contents().contains("requested review"),
+            "{}",
+            buf.contents()
+        );
+        // The canonical channel from the post response is what gets recorded,
+        // not the configured name.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            written.contains(&format!("Slack Review: {CHANNEL} {TS}")),
+            "{written}"
+        );
+        assert_eq!(
+            session.metadata().base().slack_review.as_ref().unwrap().ts,
+            TS
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_marker_write_warns_but_keeps_the_post_reported() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        let (mut session, buf) = slack_session(&server);
+        // No template path: the marker write fails.
+        session.metadata_mut().base_mut().path = None;
+
+        let args = matches(&RequestReview, &[]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        // The message really was posted; reporting failure would be a lie.
+        assert!(out.contains("requested review"), "{out}");
+        assert!(out.contains("warning"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn without_watch_no_reactions_are_polled() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        let (mut session, _buf) = slack_session(&server);
+
+        let args = matches(&RequestReview, &[]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let polled = server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|r| r.url.path().contains("reactions.get"));
+        assert!(!polled, "watch is opt-in; nothing should have been polled");
+    }
+
+    #[tokio::test]
+    async fn watch_reports_an_approval() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        mount(
+            &server,
+            "reactions.get",
+            json!({ "ok": true, "message": { "reactions": [
+                { "name": "+1::skin-tone-3", "users": ["U1"] }
+            ]}}),
+        )
+        .await;
+        let (mut session, buf) = slack_session(&server);
+        session.config.slack_watch_timeout = 5;
+
+        let args = matches(&RequestReview, &["--watch"]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(out.contains("approved"), "{out}");
+        assert!(out.contains("U1"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn a_rejection_outranks_a_simultaneous_approval() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        // Two reviewers disagree. The objection must not be outvoted silently.
+        mount(
+            &server,
+            "reactions.get",
+            json!({ "ok": true, "message": { "reactions": [
+                { "name": "+1", "users": ["U1"] },
+                { "name": "-1", "users": ["U2"] }
+            ]}}),
+        )
+        .await;
+        let (mut session, buf) = slack_session(&server);
+        session.config.slack_watch_timeout = 5;
+
+        let args = matches(&RequestReview, &["--watch"]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(out.contains("rejected"), "{out}");
+        assert!(out.contains("U2"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn the_bots_own_reaction_is_not_a_review() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        // Some workspaces auto-react; that must not self-approve.
+        mount(
+            &server,
+            "reactions.get",
+            json!({ "ok": true, "message": { "reactions": [
+                { "name": "+1", "users": ["UBOT"] }
+            ]}}),
+        )
+        .await;
+        let (mut session, buf) = slack_session(&server);
+        session.config.slack_watch_timeout = 1;
+        session.config.slack_poll_interval = 1;
+
+        let args = matches(&RequestReview, &["--watch"]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(out.contains("no review reaction"), "{out}");
+        assert!(!out.contains("approved"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn watch_gives_up_after_repeated_failures_and_fails_the_command() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        mount(
+            &server,
+            "reactions.get",
+            json!({ "ok": false, "error": "message_not_found" }),
+        )
+        .await;
+        let (mut session, buf) = slack_session(&server);
+        session.config.slack_watch_timeout = 60;
+        session.config.slack_poll_interval = 1;
+
+        let args = matches(&RequestReview, &["--watch"]);
+        let err = RequestReview.call(&mut session, &args).await.unwrap_err();
+
+        // A watch that could never see the message is a failed command, so an
+        // MCP caller gets a failed tool call rather than a hopeful summary.
+        assert!(err.to_string().contains("message_not_found"), "{err}");
+        assert!(
+            buf.contents().contains("repeated errors"),
+            "{}",
+            buf.contents()
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limiting_does_not_count_as_a_failure() {
+        let server = MockServer::start().await;
+        Mock::given(path("/reactions.get"))
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "1"))
+            .mount(&server)
+            .await;
+        let slack = slack_for(&server);
+        let posted = PostedMessage {
+            channel: CHANNEL.to_owned(),
+            ts: TS.to_owned(),
+        };
+
+        // Deadline well inside MAX_CONSECUTIVE_FAILURES worth of polls: if
+        // throttling counted as failure the outcome would be Failed.
+        let outcome = watch(
+            &slack,
+            &posted,
+            Duration::from_millis(10),
+            Duration::from_millis(1200),
+            None,
+        )
+        .await;
+
+        assert_eq!(outcome, WatchOutcome::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn watch_times_out_with_an_elapsed_deadline_after_one_poll() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            "reactions.get",
+            json!({ "ok": true, "message": { "reactions": [] }}),
+        )
+        .await;
+        let slack = slack_for(&server);
+        let posted = PostedMessage {
+            channel: CHANNEL.to_owned(),
+            ts: TS.to_owned(),
+        };
+
+        let outcome = watch(
+            &slack,
+            &posted,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+            None,
+        )
+        .await;
+
+        assert_eq!(outcome, WatchOutcome::TimedOut);
+        // Exactly one look, even though the deadline had effectively passed.
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn completion_offers_the_flags() {
+        let (session, _buf) = session_with_hosts("SUSE:Maintenance:1:2", &["h1"], "ok");
+        let out = RequestReview.complete(&session, "--w", "");
+        assert!(out.contains(&"--watch".to_owned()), "{out:?}");
+    }
+
+    #[test]
+    fn channel_flag_overrides_the_configured_channel() {
+        let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:2", &["h1"], "ok");
+        session.config.slack_channel = "#configured".to_owned();
+        let args = matches(&RequestReview, &["--channel", "#override"]);
+        assert_eq!(resolve_channel(&session, &args).unwrap(), "#override");
+
+        let args = matches(&RequestReview, &[]);
+        assert_eq!(resolve_channel(&session, &args).unwrap(), "#configured");
+    }
+}

--- a/crates/mtui-core/src/commands/request_review.rs
+++ b/crates/mtui-core/src/commands/request_review.rs
@@ -13,10 +13,10 @@
 //!   blocking call that outlives the client's timeout is indistinguishable from
 //!   a hang. Posting is fast and total; watching is the long-running extra the
 //!   caller asks for, and over MCP it belongs in a background job.
-//! * **The marker is written but not committed.** Persisting it to SVN would
-//!   couple posting a chat message to a working checkout and a network commit.
-//!   mtui already has an explicit `commit`, and the marker rides along with it
-//!   like every other template edit.
+//! * **The marker is committed, not just written.** `approve` gates on it, and
+//!   the reviewer who approves is often not the person who asked: the marker
+//!   has to be visible from another checkout, so it goes to SVN immediately
+//!   rather than waiting for a later `commit`.
 //! * **Rate limiting is not failure.** Slack throttles routinely; a `429`
 //!   leaves the watch running rather than counting against it, or a busy
 //!   channel would end the watch early and report "no reaction" when the truth
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, ArgMatches};
 use mtui_datasources::{PostedMessage, Slack, SlackError, is_ack_reaction, is_nack_reaction};
-use mtui_testreport::SlackReviewMarker;
+use mtui_testreport::{SlackReviewMarker, SvnRunner, TokioSvnRunner, svn_commit_testreport};
 
 use crate::command::{Command, Scope};
 use crate::commands::support::{require_update, template_completion};
@@ -224,6 +224,39 @@ async fn sleep_or_interrupt(dur: Duration, deadline: Instant) -> bool {
     }
 }
 
+/// Write the marker into the template and commit it to SVN.
+///
+/// The commit matters because the marker is what `approve` gates on: a
+/// reviewer approving from a different checkout needs to see that a review was
+/// actually requested. Mirrors `approve`'s `record_reviewer`, including its
+/// ordering — the in-memory field is only set once the write succeeded, so a
+/// caller that treats a failure as fatal cannot proceed believing otherwise.
+async fn record_marker(
+    session: &mut Session,
+    marker: &SlackReviewMarker,
+    rrid: &str,
+    runner: &dyn SvnRunner,
+) -> Result<(), CommandError> {
+    session
+        .metadata_mut()
+        .set_slack_review(marker)
+        .map_err(|e| CommandError::Other(format!("failed to record the marker: {e}")))?;
+
+    let checkout = session
+        .metadata()
+        .base()
+        .report_wd()
+        .map_err(|e| CommandError::Other(format!("no report loaded: {e}")))?;
+    let install_logs = session.config.install_logs.clone();
+    let msg = vec![
+        "-m".to_owned(),
+        format!("Add Slack review request for {rrid}"),
+    ];
+    svn_commit_testreport(runner, &checkout, &install_logs, &msg)
+        .await
+        .map_err(|e| CommandError::Other(format!("failed to commit the testreport: {e}")))
+}
+
 /// Requests review of the loaded update in Slack.
 pub struct RequestReview;
 
@@ -311,18 +344,22 @@ impl Command for RequestReview {
             channel: posted.channel.clone(),
             ts: posted.ts.clone(),
         };
-        let recorded = match session.metadata_mut().set_slack_review(&marker) {
-            Ok(()) => true,
-            Err(e) => {
-                // The request is already posted; failing the whole command here
-                // would misreport a real, visible message as not sent.
-                let msg = session.display.yellow(&format!(
-                    "warning: review request posted, but recording it in the template failed: {e}"
-                ));
-                session.display.println(&msg);
-                false
-            }
-        };
+        let recorded =
+            match record_marker(session, &marker, &rrid.to_string(), &TokioSvnRunner).await {
+                Ok(()) => true,
+                Err(e) => {
+                    // The request is already posted; failing the whole command here
+                    // would misreport a real, visible message as not sent. But the
+                    // approval gate reads this marker, so an un-recorded request
+                    // will later refuse the approval — say so now, loudly.
+                    let msg = session.display.yellow(&format!(
+                        "warning: review request posted, but recording it failed: {e}\n\
+                     approve will not see this request; re-run request_review once fixed"
+                    ));
+                    session.display.println(&msg);
+                    false
+                }
+            };
 
         session
             .display
@@ -330,7 +367,7 @@ impl Command for RequestReview {
         if recorded {
             session
                 .display
-                .println("recorded the request in the template (commit to share it)");
+                .println("recorded the request in the testreport and committed it");
         }
 
         if !args.get_flag("watch") {
@@ -480,26 +517,70 @@ mod tests {
         assert!(server.received_requests().await.unwrap().is_empty());
     }
 
-    #[tokio::test]
-    async fn posts_and_records_the_marker() {
-        let server = MockServer::start().await;
-        mount_post_path(&server).await;
-        let (mut session, buf) = slack_session(&server);
+    /// An `SvnRunner` that records argv and replays a fixed outcome, so the
+    /// commit step can be driven both ways without a real working copy.
+    #[derive(Debug)]
+    struct StubSvn {
+        succeed: bool,
+        calls: std::sync::Mutex<Vec<Vec<String>>>,
+    }
 
-        // Give the report a template file so the marker can be written.
-        let dir = tempfile::tempdir().unwrap();
+    impl StubSvn {
+        fn new(succeed: bool) -> Self {
+            Self {
+                succeed,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn argv(&self) -> Vec<Vec<String>> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl SvnRunner for StubSvn {
+        async fn run(
+            &self,
+            args: &[String],
+            _cwd: &std::path::Path,
+        ) -> std::io::Result<mtui_testreport::SvnOutcome> {
+            self.calls.lock().unwrap().push(args.to_vec());
+            Ok(mtui_testreport::SvnOutcome {
+                success: self.succeed,
+                stderr: if self.succeed {
+                    String::new()
+                } else {
+                    "E155007: not a working copy".to_owned()
+                },
+            })
+        }
+    }
+
+    /// A loaded report backed by a real template file, so the marker can be
+    /// written; returns the template path for assertions.
+    fn report_with_template(session: &mut Session, dir: &tempfile::TempDir) -> std::path::PathBuf {
         let path = dir.path().join("log");
         std::fs::write(&path, "Test Plan Reviewer: bob\n").unwrap();
         session.metadata_mut().base_mut().path = Some(path.clone());
+        path
+    }
 
-        let args = matches(&RequestReview, &[]);
-        RequestReview.call(&mut session, &args).await.unwrap();
+    #[tokio::test]
+    async fn record_marker_writes_the_template_and_commits_it() {
+        let server = MockServer::start().await;
+        let (mut session, _buf) = slack_session(&server);
+        let dir = tempfile::tempdir().unwrap();
+        let path = report_with_template(&mut session, &dir);
+        let svn = StubSvn::new(true);
 
-        assert!(
-            buf.contents().contains("requested review"),
-            "{}",
-            buf.contents()
-        );
+        let marker = SlackReviewMarker {
+            channel: CHANNEL.to_owned(),
+            ts: TS.to_owned(),
+        };
+        record_marker(&mut session, &marker, "SUSE:Maintenance:1:2", &svn)
+            .await
+            .unwrap();
+
         // The canonical channel from the post response is what gets recorded,
         // not the configured name.
         let written = std::fs::read_to_string(&path).unwrap();
@@ -511,6 +592,58 @@ mod tests {
             session.metadata().base().slack_review.as_ref().unwrap().ts,
             TS
         );
+        // The commit really happened, and its message names the update — this
+        // is what makes the marker visible from another reviewer's checkout.
+        let argv = svn.argv();
+        assert!(!argv.is_empty(), "svn was invoked");
+        let ci = argv.iter().find(|a| a.first().is_some_and(|s| s == "ci"));
+        let ci = ci.expect("an `svn ci` was issued");
+        assert!(
+            ci.iter().any(|a| a.contains("SUSE:Maintenance:1:2")),
+            "commit message names the update: {ci:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_commit_is_reported_as_a_failure_to_record() {
+        let server = MockServer::start().await;
+        let (mut session, _buf) = slack_session(&server);
+        let dir = tempfile::tempdir().unwrap();
+        report_with_template(&mut session, &dir);
+        let svn = StubSvn::new(false);
+
+        let marker = SlackReviewMarker {
+            channel: CHANNEL.to_owned(),
+            ts: TS.to_owned(),
+        };
+        let err = record_marker(&mut session, &marker, "SUSE:Maintenance:1:2", &svn)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("commit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn posts_and_reports_the_request() {
+        let server = MockServer::start().await;
+        mount_post_path(&server).await;
+        let (mut session, buf) = slack_session(&server);
+        let dir = tempfile::tempdir().unwrap();
+        let path = report_with_template(&mut session, &dir);
+
+        let args = matches(&RequestReview, &[]);
+        RequestReview.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(out.contains("requested review"), "{out}");
+        // The marker reaches the template even though the real `svn ci` cannot
+        // succeed here (the tempdir is not a working copy) — the write is what
+        // must not depend on the commit.
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            written.contains(&format!("Slack Review: {CHANNEL} {TS}")),
+            "{written}"
+        );
     }
 
     #[tokio::test]
@@ -518,7 +651,7 @@ mod tests {
         let server = MockServer::start().await;
         mount_post_path(&server).await;
         let (mut session, buf) = slack_session(&server);
-        // No template path: the marker write fails.
+        // No template path: the marker write fails before any commit.
         session.metadata_mut().base_mut().path = None;
 
         let args = matches(&RequestReview, &[]);
@@ -528,6 +661,10 @@ mod tests {
         // The message really was posted; reporting failure would be a lie.
         assert!(out.contains("requested review"), "{out}");
         assert!(out.contains("warning"), "{out}");
+        // And the user is told the consequence: approve will refuse.
+        assert!(out.contains("approve will not see"), "{out}");
+        // The success line must NOT appear when nothing was recorded.
+        assert!(!out.contains("committed it"), "{out}");
     }
 
     #[tokio::test]

--- a/crates/mtui-core/src/commands/request_review.rs
+++ b/crates/mtui-core/src/commands/request_review.rs
@@ -41,6 +41,14 @@ const DEFAULT_BACKOFF: Duration = Duration::from_secs(30);
 /// cannot park the watch for hours.
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
+/// Lower bound on any single back-off.
+///
+/// A `Retry-After: 0` — from a buggy proxy, or a server trying to make us
+/// misbehave — would otherwise mean a zero-length sleep, turning the back-off
+/// into a tight loop that hammers the very endpoint that just asked us to slow
+/// down. Backing off by less than a second is never what a 429 means.
+const MIN_BACKOFF: Duration = Duration::from_secs(1);
+
 /// Consecutive hard failures tolerated before the watch gives up.
 ///
 /// Transient errors happen; a persistent one (the message was deleted, the
@@ -181,7 +189,7 @@ async fn watch(
             Err(SlackError::RateLimited { retry_after }) => {
                 let wait = retry_after
                     .map_or(DEFAULT_BACKOFF, Duration::from_secs)
-                    .min(MAX_BACKOFF);
+                    .clamp(MIN_BACKOFF, MAX_BACKOFF);
                 tracing::debug!(?wait, "rate limited; backing off");
                 if sleep_or_interrupt(jittered(wait), deadline).await {
                     return WatchOutcome::Interrupted;
@@ -827,18 +835,60 @@ mod tests {
             ts: TS.to_owned(),
         };
 
+        // A zero timeout puts the deadline at the loop's own start, so it is
+        // already reached by the time the first poll returns — no matter how
+        // fast the machine. A small non-zero timeout would race: if the mock
+        // answers inside it, the loop sleeps ~0 and polls a second time.
         let outcome = watch(
             &slack,
             &posted,
             Duration::from_secs(60),
-            Duration::from_millis(1),
+            Duration::ZERO,
             None,
         )
         .await;
 
         assert_eq!(outcome, WatchOutcome::TimedOut);
-        // Exactly one look, even though the deadline had effectively passed.
+        // Exactly one look, even though the deadline had already passed: the
+        // loop polls before it sleeps, so an expired watch still reports what
+        // the message looks like rather than nothing at all.
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_zero_retry_after_does_not_become_a_tight_loop() {
+        let server = MockServer::start().await;
+        // A server that says "rate limited, retry after 0 seconds". Taken
+        // literally that is a zero-length back-off, and the watch would spin
+        // against the endpoint that just asked it to slow down.
+        Mock::given(path("/reactions.get"))
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+            .mount(&server)
+            .await;
+        let slack = slack_for(&server);
+        let posted = PostedMessage {
+            channel: CHANNEL.to_owned(),
+            ts: TS.to_owned(),
+        };
+
+        let outcome = watch(
+            &slack,
+            &posted,
+            Duration::from_millis(10),
+            Duration::from_millis(250),
+            None,
+        )
+        .await;
+
+        assert_eq!(outcome, WatchOutcome::TimedOut);
+        // The floor holds the second poll past the deadline, so the quarter
+        // second buys one request, not hundreds. Without MIN_BACKOFF this runs
+        // into the thousands.
+        let polls = server.received_requests().await.unwrap().len();
+        assert!(
+            polls <= 2,
+            "backed off instead of spinning, got {polls} polls"
+        );
     }
 
     #[test]

--- a/crates/mtui-core/src/registry.rs
+++ b/crates/mtui-core/src/registry.rs
@@ -209,6 +209,7 @@ pub fn register_all() -> Registry {
     registry.register(Arc::new(commands::Comment));
     registry.register(Arc::new(commands::Approve));
     registry.register(Arc::new(commands::Regenerate));
+    registry.register(Arc::new(commands::RequestReview));
     // Phase 5 follow-ups — deferred commands now unblocked.
     registry.register(Arc::new(commands::Export));
     registry.register(Arc::new(commands::ListRefhosts));
@@ -353,6 +354,7 @@ mod tests {
             "comment",
             "approve",
             "regenerate",
+            "request_review",
         ] {
             assert!(r.contains(name), "expected {name} to be registered");
         }
@@ -360,12 +362,12 @@ mod tests {
 
     #[test]
     fn register_all_command_count() {
-        // 10 Wave 1 + 14 Wave 2 + 17 Wave 3 + 11 Wave 4 + 4 P5 follow-ups
-        // (export, list_refhosts, load_template, list_locks) + 2 openQA-holder
-        // follow-ups (reload_openqa, set_workflow: mtui-rs-zs4/plt) + 3 Phase 6
-        // (help: mtui-rs-lhz.9; edit: mtui-rs-lhz.10; terms: mtui-rs-lhz.11)
-        // = 61 canonical commands.
-        assert_eq!(register_all().len(), 61);
+        // 10 Wave 1 + 14 Wave 2 + 17 Wave 3 + 12 Wave 4 (incl. request_review)
+        // + 4 P5 follow-ups (export, list_refhosts, load_template, list_locks)
+        // + 2 openQA-holder follow-ups (reload_openqa, set_workflow:
+        // mtui-rs-zs4/plt) + 3 Phase 6 (help: mtui-rs-lhz.9; edit:
+        // mtui-rs-lhz.10; terms: mtui-rs-lhz.11) = 62 canonical commands.
+        assert_eq!(register_all().len(), 62);
     }
 
     #[test]

--- a/crates/mtui-core/tests/snapshots/help_listing__help_listing.snap
+++ b/crates/mtui-core/tests/snapshots/help_listing__help_listing.snap
@@ -14,9 +14,9 @@ list_templates        list_timeout          list_update_commands  list_versions
 load_template         lock                  lrun                  openqa_jobs
 openqa_overview       prepare               put                   quit
 reboot                regenerate            reject                reload_openqa
-reload_products       remove_host           run                   set_host_state
-set_log_level         set_repo              set_timeout           set_workflow
-shell                 show_diff             show_log              show_update_repos
-switch                terms                 unassign              uninstall
-unload                unlock                update                updates
-whoami
+reload_products       remove_host           request_review        run
+set_host_state        set_log_level         set_repo              set_timeout
+set_workflow          shell                 show_diff             show_log
+show_update_repos     switch                terms                 unassign
+uninstall             unload                unlock                update
+updates               whoami

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -184,6 +184,72 @@ pub enum GiteaError {
     Http(#[from] HttpError),
 }
 
+/// Errors from the Slack review-request connector ([`crate::slack`]).
+///
+/// Slack's Web API is unusual in two ways this enum has to model explicitly.
+/// It reports application-level failures as **HTTP 200** with `{"ok": false,
+/// "error": "&lt;code&gt;"}`, so a successful status tells you nothing —
+/// [`Api`](Self::Api) carries that code. And it rate-limits with `429` plus a
+/// `Retry-After` header, which callers must treat as "back off and keep going"
+/// rather than as a failure — hence the dedicated
+/// [`RateLimited`](Self::RateLimited) variant, so a watch loop can distinguish
+/// throttling from a genuine error instead of counting it as one.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SlackError {
+    /// The Slack bot token is empty, so the client cannot authenticate.
+    #[error(
+        "Slack API token is empty; set it with `config set slack_token &lt;token&gt;` \
+         or the `[slack] token` config key"
+    )]
+    MissingToken,
+
+    /// No Slack channel is configured to post the review request to.
+    #[error(
+        "no Slack channel configured; set it with `config set slack_channel &lt;channel&gt;` \
+         or the `[slack] channel` config key"
+    )]
+    MissingChannel,
+
+    /// The Slack integration is switched off in the configuration.
+    #[error("Slack integration is disabled ([slack] enabled = false)")]
+    Disabled,
+
+    /// A call failed at the transport level or returned a non-2xx status. The
+    /// payload is the upstream-style `"{method} - {url}"` context, always
+    /// sanitized — never the token.
+    #[error("Slack API call failed: {0}")]
+    FailedCall(String),
+
+    /// The call reached Slack but was refused at the application level
+    /// (HTTP 200 with `ok: false`). The payload is Slack's own error code,
+    /// such as `channel_not_found`, `not_in_channel` or `invalid_auth`.
+    #[error("Slack API returned an error: {0}")]
+    Api(String),
+
+    /// Slack rate-limited the call (`429 Too Many Requests`). A watch loop
+    /// treats this as "still watching" and backs off; it is not a failure.
+    #[error("Slack API rate limited{}", retry_after_suffix(*retry_after))]
+    RateLimited {
+        /// The `Retry-After` header in seconds, when the server sent one.
+        retry_after: Option<u64>,
+    },
+
+    /// The configured API base is not the trusted Slack origin (or is not
+    /// `https`, or carries userinfo), so the token was **not** sent. The
+    /// payload is the sanitized URL — never the token.
+    #[error(
+        "refusing to send Slack token to untrusted URL {0}: it must be an https \
+         URL whose origin matches the configured Slack API base \
+         ([slack] api_url / `config set slack_api_url`)"
+    )]
+    UntrustedOrigin(String),
+
+    /// The underlying HTTP layer failed to build the request or client.
+    #[error(transparent)]
+    Http(#[from] HttpError),
+}
+
 /// Errors from the openQA / QAM Dashboard overview search ([`crate::oqa_search`]).
 ///
 /// Mirrors upstream's single `_HTTPError` (raised by `_get_json` /
@@ -251,6 +317,16 @@ pub enum TeReGenError {
     /// malformed JSON body. Carries a sanitized description (never the raw URL).
     #[error("TeReGen fetch failed: {0}")]
     Fetch(String),
+}
+
+/// Render the trailing `" (retry after Ns)"` clause of
+/// [`SlackError::RateLimited`], omitted entirely when Slack sent no
+/// `Retry-After` header.
+fn retry_after_suffix(retry_after: Option<u64>) -> String {
+    match retry_after {
+        Some(secs) => format!(" (retry after {secs}s)"),
+        None => String::new(),
+    }
 }
 
 /// Render the [`GiteaError::AssignInvalid`] message for an assignment state,

--- a/crates/mtui-datasources/src/lib.rs
+++ b/crates/mtui-datasources/src/lib.rs
@@ -14,11 +14,12 @@ pub mod openqa;
 pub mod oqa_search;
 pub mod qem_dashboard;
 pub mod refhost;
+pub mod slack;
 pub mod teregen;
 
 pub use error::{
     GiteaError, HttpError, OpenQAError, OqaSearchError, QemDashboardError, RefhostError, Result,
-    TeReGenError,
+    SlackError, TeReGenError,
 };
 pub use gitea::{Comment, DEFAULT_GROUP, Gitea, assign_marker, pr_api_url, unassign_marker};
 pub use http::{
@@ -38,4 +39,7 @@ pub use oqa_search::{
 };
 pub use qem_dashboard::{DashboardAutoOpenQA, QemDashboardClient, QemIncident};
 pub use refhost::{Attributes, ProductDiff, Refhosts};
+pub use slack::{
+    PostedMessage, Reaction, Reply, Slack, is_ack_reaction, is_nack_reaction, normalize_reaction,
+};
 pub use teregen::{RegenOutcome, TeReGen, UpdatesQuery};

--- a/crates/mtui-datasources/src/lib.rs
+++ b/crates/mtui-datasources/src/lib.rs
@@ -40,6 +40,7 @@ pub use oqa_search::{
 pub use qem_dashboard::{DashboardAutoOpenQA, QemDashboardClient, QemIncident};
 pub use refhost::{Attributes, ProductDiff, Refhosts};
 pub use slack::{
-    PostedMessage, Reaction, Reply, Slack, is_ack_reaction, is_nack_reaction, normalize_reaction,
+    Message, PostedMessage, Reaction, Reply, Slack, is_ack_reaction, is_nack_reaction,
+    normalize_reaction,
 };
 pub use teregen::{RegenOutcome, TeReGen, UpdatesQuery};

--- a/crates/mtui-datasources/src/slack.rs
+++ b/crates/mtui-datasources/src/slack.rs
@@ -71,6 +71,15 @@ pub struct Reaction {
     pub users: Vec<String>,
 }
 
+/// A message read back from Slack: its body and its reactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    /// The message body as posted.
+    pub text: String,
+    /// Reactions on the message, skin-tone-normalised.
+    pub reactions: Vec<Reaction>,
+}
+
 /// A threaded reply to a posted message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Reply {
@@ -380,6 +389,61 @@ impl Slack {
         })
     }
 
+    /// Read a message's body and reactions in one call.
+    ///
+    /// `reactions.get` returns the message itself alongside its reactions, so
+    /// a caller that must confirm *which* message it is looking at — an
+    /// approval gate verifying a stored marker still points at a review
+    /// request for the update in hand — gets both from a single request.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SlackError`]; [`SlackError::Api`] carries `message_not_found`
+    /// when the message was deleted.
+    pub async fn get_message(&self, channel: &str, ts: &str) -> Result<Message, SlackError> {
+        let data = self
+            .request(
+                Method::GET,
+                "reactions.get",
+                &[("channel", channel), ("timestamp", ts)],
+                None,
+            )
+            .await?;
+        let message = data.get("message");
+        let text = message
+            .and_then(|m| m.get("text"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let reactions = message
+            .and_then(|m| m.get("reactions"))
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|r| {
+                        let name = r.get("name").and_then(Value::as_str)?;
+                        let users = r
+                            .get("users")
+                            .and_then(Value::as_array)
+                            .map(|us| {
+                                us.iter()
+                                    .filter_map(Value::as_str)
+                                    .map(str::to_owned)
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        Some(Reaction {
+                            name: normalize_reaction(name).to_owned(),
+                            users,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(Message { text, reactions })
+    }
+
     /// Read the reactions currently on the message identified by `channel`/`ts`.
     ///
     /// Reaction names come back skin-tone-normalised. An absent `reactions`
@@ -391,41 +455,7 @@ impl Slack {
     /// Any [`SlackError`]; [`SlackError::Api`] carries `message_not_found`
     /// when the message was deleted underneath the watch.
     pub async fn reactions(&self, channel: &str, ts: &str) -> Result<Vec<Reaction>, SlackError> {
-        let data = self
-            .request(
-                Method::GET,
-                "reactions.get",
-                &[("channel", channel), ("timestamp", ts)],
-                None,
-            )
-            .await?;
-        let Some(items) = data
-            .get("message")
-            .and_then(|m| m.get("reactions"))
-            .and_then(Value::as_array)
-        else {
-            return Ok(Vec::new());
-        };
-        Ok(items
-            .iter()
-            .filter_map(|r| {
-                let name = r.get("name").and_then(Value::as_str)?;
-                let users = r
-                    .get("users")
-                    .and_then(Value::as_array)
-                    .map(|us| {
-                        us.iter()
-                            .filter_map(Value::as_str)
-                            .map(str::to_owned)
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                Some(Reaction {
-                    name: normalize_reaction(name).to_owned(),
-                    users,
-                })
-            })
-            .collect())
+        Ok(self.get_message(channel, ts).await?.reactions)
     }
 
     /// Read the threaded replies to the message identified by `channel`/`ts`.

--- a/crates/mtui-datasources/src/slack.rs
+++ b/crates/mtui-datasources/src/slack.rs
@@ -1,0 +1,617 @@
+//! Slack Web API connector for the `request_review` workflow.
+//!
+//! Posts a review request for a loaded update into a configured channel, then
+//! reads back the reactions and threaded replies reviewers leave on it. The
+//! surface is deliberately small — post, react, reply, identity — because the
+//! review *policy* (which reaction counts as an ack, which reviewer is allowed
+//! to ack) belongs to the command, not the transport.
+//!
+//! Two Slack-specific behaviours shape the code here and are worth stating
+//! up front, because neither matches the other connectors in this crate:
+//!
+//! * **Application errors arrive as HTTP 200.** A refused call still returns
+//!   `200 OK`, carrying `{"ok": false, "error": "channel_not_found"}`. Checking
+//!   the status is therefore *not* enough — [`Slack::request`] inspects the
+//!   `ok` field on every response and converts a false one into
+//!   [`SlackError::Api`].
+//! * **Rate limiting is routine, not exceptional.** Tier-3 methods allow
+//!   roughly 50 requests a minute, and a watch loop polling several templates
+//!   will meet a `429` eventually. That is modelled as its own
+//!   [`SlackError::RateLimited`] variant so a caller can back off and keep
+//!   watching instead of counting throttling as a failure.
+//!
+//! Like the other connectors, the constructor pair splits config-reading
+//! ([`Slack::new`]) from the injectable seam ([`Slack::with_client`]) so tests
+//! can aim the client at a `wiremock` server.
+
+use mtui_config::Config;
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::error::SlackError;
+use crate::http::{
+    HttpClient, MAX_API_BODY, VerifyPolicy, is_ssl_verification_error, read_body_capped,
+    resolve_verify, sanitize_url, ssl_verification_hint,
+};
+
+/// Maximum `conversations.replies` pages walked before giving up.
+///
+/// A review thread is a handful of messages; a cursor that keeps yielding
+/// pages past this many means either a pathological thread or a server-side
+/// loop, and either way the watch should not spin forever on one poll.
+const MAX_REPLY_PAGES: usize = 10;
+
+/// Reaction names that count as an approval ack, after skin-tone stripping.
+const ACK_REACTIONS: &[&str] = &["+1", "thumbsup", "white_check_mark", "heavy_check_mark"];
+
+/// Reaction names that count as a rejection, after skin-tone stripping.
+const NACK_REACTIONS: &[&str] = &["-1", "thumbsdown", "x", "no_entry"];
+
+/// A message this client posted, identified the way Slack wants it referenced.
+///
+/// The `channel` is Slack's **canonical** channel ID from the post response,
+/// not whatever was configured. Those differ whenever the config names a
+/// channel by `#name`, and every later `reactions.get` / `conversations.replies`
+/// call must use the canonical form, so it is what gets persisted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostedMessage {
+    /// The canonical channel ID Slack resolved the post to.
+    pub channel: String,
+    /// The message timestamp, which doubles as its ID within the channel.
+    pub ts: String,
+}
+
+/// A reaction on a message, as returned by `reactions.get`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reaction {
+    /// The emoji name, with any `::skin-tone-N` suffix already stripped.
+    pub name: String,
+    /// User IDs that added this reaction.
+    pub users: Vec<String>,
+}
+
+/// A threaded reply to a posted message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reply {
+    /// The user ID that wrote the reply.
+    pub user: String,
+    /// The message body.
+    pub text: String,
+    /// The reply's own timestamp, used to track which replies were seen.
+    pub ts: String,
+}
+
+/// Strip a trailing `::skin-tone-N` modifier from a Slack reaction name.
+///
+/// Slack reports `+1::skin-tone-4` as a distinct reaction from `+1`, so a
+/// literal comparison would silently ignore an ack from anyone who has set a
+/// default skin tone. Normalising at the transport edge means every consumer
+/// compares against the base name and cannot forget this.
+#[must_use]
+pub fn normalize_reaction(name: &str) -> &str {
+    match name.split_once("::skin-tone-") {
+        Some((base, _)) => base,
+        None => name,
+    }
+}
+
+/// Whether `name` is a reaction that acknowledges/approves a review request.
+#[must_use]
+pub fn is_ack_reaction(name: &str) -> bool {
+    ACK_REACTIONS.contains(&normalize_reaction(name))
+}
+
+/// Whether `name` is a reaction that rejects a review request.
+#[must_use]
+pub fn is_nack_reaction(name: &str) -> bool {
+    NACK_REACTIONS.contains(&normalize_reaction(name))
+}
+
+/// Whether `host` is a loopback address, so a plain-HTTP mock server is allowed
+/// to receive the token in tests.
+fn is_loopback(host: &str) -> bool {
+    host == "localhost"
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+        || host.starts_with("127.")
+}
+
+/// Whether `url` may carry the bearer token: `https`, or `http` to loopback.
+///
+/// Unlike the Gitea connector — whose PR URL comes from attacker-influenceable
+/// checked-out metadata and so needs a full origin comparison — the Slack base
+/// is only ever read from the user's own config. The remaining risk is a
+/// misconfiguration that would put the token on the wire in clear text, which
+/// this refuses outright.
+fn is_token_safe_url(url: &str) -> bool {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return false;
+    };
+    // Userinfo in the authority would mean credentials in the URL itself.
+    let end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..end];
+    if authority.contains('@') {
+        return false;
+    }
+    let host = authority
+        .rsplit_once(':')
+        .map_or(authority, |(h, _)| h)
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    match scheme {
+        "https" => true,
+        "http" => is_loopback(host),
+        _ => false,
+    }
+}
+
+/// Percent-encode `params` into a query string, without a leading `?`.
+///
+/// reqwest's `query` feature is disabled workspace-wide, so query strings are
+/// hand-rolled here exactly as the TeReGen connector does.
+fn build_query(params: &[(&str, &str)]) -> String {
+    params
+        .iter()
+        .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// The shared envelope every Slack Web API method returns.
+#[derive(Debug, Deserialize)]
+struct SlackEnvelope {
+    ok: bool,
+    error: Option<String>,
+}
+
+/// Slack Web API client for the review-request workflow.
+#[derive(Debug, Clone)]
+pub struct Slack {
+    http: HttpClient,
+    token: String,
+    /// API base such as `https://slack.com/api`, never with a trailing slash.
+    base: String,
+}
+
+impl Slack {
+    /// Build a client from the session configuration.
+    ///
+    /// The integration is opt-in, so the common case is that this refuses: an
+    /// mtui with no `[slack]` configuration gets [`SlackError::Disabled`], not
+    /// an authentication failure several calls later.
+    ///
+    /// # Errors
+    ///
+    /// [`SlackError::Disabled`] when `[slack] enabled` is unset or `false`,
+    /// [`SlackError::MissingToken`] when no token is configured, and
+    /// [`SlackError::UntrustedOrigin`] when the configured API base would put
+    /// the token on an unencrypted wire.
+    pub fn new(config: &Config) -> Result<Self, SlackError> {
+        if !config.slack_enabled {
+            return Err(SlackError::Disabled);
+        }
+        if config.slack_token.is_empty() {
+            return Err(SlackError::MissingToken);
+        }
+        let verify: VerifyPolicy = resolve_verify(
+            VerifyPolicy::Default(true),
+            Some(VerifyPolicy::from_config(&config.ssl_verify)),
+        );
+        let http = HttpClient::new(verify)?;
+        Self::with_client(http, config.slack_token.clone(), &config.slack_api_url)
+    }
+
+    /// Build a client over an existing [`HttpClient`] against `api_base`.
+    ///
+    /// The injectable seam the other connectors use: tests point `api_base` at
+    /// a `wiremock` server, which is permitted because it is loopback.
+    ///
+    /// # Errors
+    ///
+    /// [`SlackError::UntrustedOrigin`] when `api_base` is not `https` (or
+    /// `http` to loopback), or embeds userinfo.
+    pub fn with_client(
+        http: HttpClient,
+        token: String,
+        api_base: &str,
+    ) -> Result<Self, SlackError> {
+        let base = api_base.trim_end_matches('/').to_owned();
+        if !is_token_safe_url(&base) {
+            return Err(SlackError::UntrustedOrigin(sanitize_url(&base)));
+        }
+        Ok(Self { http, token, base })
+    }
+
+    /// The configured API base.
+    #[must_use]
+    pub fn base(&self) -> &str {
+        &self.base
+    }
+
+    /// Issue a Slack Web API call and return its decoded envelope.
+    ///
+    /// Folds the three failure shapes — transport, HTTP status, and the
+    /// `ok: false` application error that arrives as HTTP 200 — into typed
+    /// errors, and lifts `429` into [`SlackError::RateLimited`] before any of
+    /// them so a caller can back off rather than fail.
+    async fn request(
+        &self,
+        method: Method,
+        api_method: &str,
+        query: &[(&str, &str)],
+        body: Option<Value>,
+    ) -> Result<Value, SlackError> {
+        let mut url = format!("{}/{api_method}", self.base);
+        if !query.is_empty() {
+            url.push('?');
+            url.push_str(&build_query(query));
+        }
+
+        tracing::debug!("Requesting {method} on {}", sanitize_url(&url));
+        let mut builder = self
+            .http
+            .inner()
+            .request(method.clone(), &url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/json");
+        if let Some(json) = &body {
+            builder = builder.json(json);
+        }
+
+        let response = match builder.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                if is_ssl_verification_error(&e) {
+                    tracing::error!("{}", ssl_verification_hint(None));
+                    tracing::debug!("Slack TLS error detail: {e}");
+                } else {
+                    tracing::warn!("API call to Slack failed: {e}");
+                }
+                return Err(SlackError::FailedCall(format!(
+                    "{method} - {}",
+                    sanitize_url(&url)
+                )));
+            }
+        };
+
+        let status = response.status();
+        if status.as_u16() == 429 {
+            // Slack sends the backoff in seconds; a malformed or absent header
+            // leaves the decision to the caller's own default.
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.trim().parse::<u64>().ok());
+            tracing::debug!(retry_after, "Slack rate limited the request");
+            return Err(SlackError::RateLimited { retry_after });
+        }
+        if !status.is_success() {
+            tracing::warn!(
+                "API call to {} failed with status code: {status}",
+                sanitize_url(&url)
+            );
+            return Err(SlackError::FailedCall(format!(
+                "{method} - {} returned status {}",
+                sanitize_url(&url),
+                status.as_u16()
+            )));
+        }
+
+        let bytes = read_body_capped(response, MAX_API_BODY)
+            .await
+            .map_err(|e| {
+                SlackError::FailedCall(format!("{method} - {}: {e}", sanitize_url(&url)))
+            })?;
+        let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+            SlackError::FailedCall(format!("{method} - {}: {e}", sanitize_url(&url)))
+        })?;
+
+        // A 200 proves only that Slack answered; `ok` is what says it agreed.
+        let envelope: SlackEnvelope = serde_json::from_value(value.clone()).map_err(|e| {
+            SlackError::FailedCall(format!("{method} - {}: {e}", sanitize_url(&url)))
+        })?;
+        if !envelope.ok {
+            return Err(SlackError::Api(
+                envelope.error.unwrap_or_else(|| "unknown".to_owned()),
+            ));
+        }
+        Ok(value)
+    }
+
+    /// Verify the token and return the bot's own user ID.
+    ///
+    /// Called before posting so a bad token is reported as such, up front,
+    /// instead of surfacing as a confusing failure on the post itself. The
+    /// returned ID also lets the caller ignore the bot's own reactions.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SlackError`]; [`SlackError::Api`] carries codes such as
+    /// `invalid_auth` or `account_inactive`.
+    pub async fn auth_test(&self) -> Result<String, SlackError> {
+        let data = self.request(Method::POST, "auth.test", &[], None).await?;
+        data.get("user_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| SlackError::FailedCall("auth.test - missing user_id".to_owned()))
+    }
+
+    /// Post `text` to `channel` and return its canonical identifiers.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SlackError`]; [`SlackError::Api`] carries codes such as
+    /// `channel_not_found` or `not_in_channel`.
+    pub async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+    ) -> Result<PostedMessage, SlackError> {
+        tracing::info!("Posting a review request to Slack");
+        let data = self
+            .request(
+                Method::POST,
+                "chat.postMessage",
+                &[],
+                Some(json!({ "channel": channel, "text": text })),
+            )
+            .await?;
+        // Persist what Slack echoes back, not what was asked for: a `#name`
+        // channel resolves to an ID here, and only the ID works for the
+        // reaction/reply reads that follow.
+        let canonical = data
+            .get("channel")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                SlackError::FailedCall("chat.postMessage - missing channel".to_owned())
+            })?;
+        let ts = data
+            .get("ts")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| SlackError::FailedCall("chat.postMessage - missing ts".to_owned()))?;
+        Ok(PostedMessage {
+            channel: canonical,
+            ts,
+        })
+    }
+
+    /// Read the reactions currently on the message identified by `channel`/`ts`.
+    ///
+    /// Reaction names come back skin-tone-normalised. An absent `reactions`
+    /// field means nobody has reacted yet, which is an empty list rather than
+    /// an error.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SlackError`]; [`SlackError::Api`] carries `message_not_found`
+    /// when the message was deleted underneath the watch.
+    pub async fn reactions(&self, channel: &str, ts: &str) -> Result<Vec<Reaction>, SlackError> {
+        let data = self
+            .request(
+                Method::GET,
+                "reactions.get",
+                &[("channel", channel), ("timestamp", ts)],
+                None,
+            )
+            .await?;
+        let Some(items) = data
+            .get("message")
+            .and_then(|m| m.get("reactions"))
+            .and_then(Value::as_array)
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(items
+            .iter()
+            .filter_map(|r| {
+                let name = r.get("name").and_then(Value::as_str)?;
+                let users = r
+                    .get("users")
+                    .and_then(Value::as_array)
+                    .map(|us| {
+                        us.iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_owned)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Some(Reaction {
+                    name: normalize_reaction(name).to_owned(),
+                    users,
+                })
+            })
+            .collect())
+    }
+
+    /// Read the threaded replies to the message identified by `channel`/`ts`.
+    ///
+    /// Follows Slack's cursor pagination, bounded by [`MAX_REPLY_PAGES`]. The
+    /// parent message is excluded: Slack returns it as the first element of
+    /// the first page, and it is the request itself, not a reply to it.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SlackError`]; [`SlackError::Api`] carries `thread_not_found`.
+    pub async fn replies(&self, channel: &str, ts: &str) -> Result<Vec<Reply>, SlackError> {
+        let mut out: Vec<Reply> = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        for page in 0..MAX_REPLY_PAGES {
+            let mut query: Vec<(&str, &str)> = vec![("channel", channel), ("ts", ts)];
+            if let Some(c) = &cursor {
+                query.push(("cursor", c.as_str()));
+            }
+            let data = self
+                .request(Method::GET, "conversations.replies", &query, None)
+                .await?;
+
+            if let Some(messages) = data.get("messages").and_then(Value::as_array) {
+                for m in messages {
+                    let Some(mts) = m.get("ts").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    // The parent is the review request itself, not a reply.
+                    if mts == ts {
+                        continue;
+                    }
+                    out.push(Reply {
+                        user: m
+                            .get("user")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_owned(),
+                        text: m
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_owned(),
+                        ts: mts.to_owned(),
+                    });
+                }
+            }
+
+            cursor = data
+                .get("response_metadata")
+                .and_then(|m| m.get("next_cursor"))
+                .and_then(Value::as_str)
+                .filter(|c| !c.is_empty())
+                .map(str::to_owned);
+            if cursor.is_none() {
+                return Ok(out);
+            }
+            if page + 1 == MAX_REPLY_PAGES {
+                tracing::warn!(
+                    pages = MAX_REPLY_PAGES,
+                    "Slack thread has more replies than the page cap; ignoring the rest"
+                );
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(base: &str) -> Result<Slack, SlackError> {
+        let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
+        Slack::with_client(http, "xoxb-test".to_owned(), base)
+    }
+
+    #[test]
+    fn normalize_reaction_strips_skin_tone() {
+        assert_eq!(normalize_reaction("+1::skin-tone-4"), "+1");
+        assert_eq!(normalize_reaction("thumbsup::skin-tone-2"), "thumbsup");
+        // A bare name is returned untouched.
+        assert_eq!(normalize_reaction("+1"), "+1");
+    }
+
+    #[test]
+    fn ack_and_nack_recognise_skin_toned_variants() {
+        // The whole point of normalising: a toned thumbs-up still acks.
+        assert!(is_ack_reaction("+1::skin-tone-6"));
+        assert!(is_ack_reaction("white_check_mark"));
+        assert!(!is_ack_reaction("eyes"));
+
+        assert!(is_nack_reaction("-1::skin-tone-3"));
+        assert!(is_nack_reaction("x"));
+        assert!(!is_nack_reaction("+1"));
+
+        // Ack and nack sets must stay disjoint, or a message could be both.
+        for a in ACK_REACTIONS {
+            assert!(!is_nack_reaction(a), "{a} is in both sets");
+        }
+    }
+
+    #[test]
+    fn with_client_accepts_https_and_loopback_http() {
+        assert!(client("https://slack.com/api").is_ok());
+        // wiremock serves plain HTTP on loopback; tests depend on this.
+        assert!(client("http://127.0.0.1:8080/api").is_ok());
+        assert!(client("http://localhost:9999").is_ok());
+    }
+
+    #[test]
+    fn with_client_refuses_to_put_the_token_in_clear_text() {
+        // Plain HTTP to a non-loopback host would leak the bearer token.
+        let err = client("http://slack.example.com/api").unwrap_err();
+        assert!(matches!(err, SlackError::UntrustedOrigin(_)), "{err:?}");
+        // Userinfo means credentials in the URL itself.
+        assert!(matches!(
+            client("https://user:pw@slack.com/api").unwrap_err(),
+            SlackError::UntrustedOrigin(_)
+        ));
+        // A non-HTTP scheme is not a Slack API base.
+        assert!(matches!(
+            client("ftp://slack.com/api").unwrap_err(),
+            SlackError::UntrustedOrigin(_)
+        ));
+    }
+
+    #[test]
+    fn untrusted_origin_error_never_echoes_credentials() {
+        let err = client("https://user:hunter2@slack.com/api").unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("hunter2"), "leaked a credential: {msg}");
+    }
+
+    #[test]
+    fn with_client_trims_trailing_slash() {
+        let c = client("https://slack.com/api/").expect("builds");
+        assert_eq!(c.base(), "https://slack.com/api");
+    }
+
+    #[test]
+    fn new_refuses_when_disabled_or_tokenless() {
+        let mut config = Config::default();
+
+        // The out-of-the-box state: nothing configured, so nothing is posted.
+        assert!(matches!(
+            Slack::new(&config).unwrap_err(),
+            SlackError::Disabled
+        ));
+
+        // Disabled wins even with a token present, so the reason is
+        // unambiguous when a site has switched the feature off on purpose.
+        config.slack_token = "xoxb-test".to_owned();
+        assert!(matches!(
+            Slack::new(&config).unwrap_err(),
+            SlackError::Disabled
+        ));
+
+        // Enabled but tokenless is the out-of-the-box state.
+        config.slack_enabled = true;
+        config.slack_token = String::new();
+        assert!(matches!(
+            Slack::new(&config).unwrap_err(),
+            SlackError::MissingToken
+        ));
+    }
+
+    #[test]
+    fn build_query_percent_encodes() {
+        assert_eq!(build_query(&[("channel", "C1")]), "channel=C1");
+        // A `#name` channel and a `.`-bearing ts must survive encoding.
+        assert_eq!(
+            build_query(&[("channel", "#qam review"), ("ts", "1700000000.000100")]),
+            "channel=%23qam%20review&ts=1700000000.000100"
+        );
+    }
+
+    #[test]
+    fn rate_limited_message_reports_the_backoff() {
+        let with = SlackError::RateLimited {
+            retry_after: Some(30),
+        };
+        assert!(with.to_string().contains("retry after 30s"), "{with}");
+        // No header means no clause, rather than a misleading "0s".
+        let without = SlackError::RateLimited { retry_after: None };
+        assert!(!without.to_string().contains("retry after"), "{without}");
+    }
+}

--- a/crates/mtui-datasources/tests/it.rs
+++ b/crates/mtui-datasources/tests/it.rs
@@ -29,3 +29,5 @@ mod oqa_search;
 mod qem_dashboard;
 #[path = "refhost.rs"]
 mod refhost;
+#[path = "slack.rs"]
+mod slack;

--- a/crates/mtui-datasources/tests/slack.rs
+++ b/crates/mtui-datasources/tests/slack.rs
@@ -1,0 +1,365 @@
+//! Integration tests for the Slack review-request connector against a real
+//! HTTP transport (`wiremock`).
+//!
+//! The cases that matter here are the ones a unit test cannot reach: Slack's
+//! `ok: false`-inside-HTTP-200 error convention, `429` handling, and cursor
+//! pagination. wiremock matches by request shape rather than call order, so a
+//! sequence of differing responses to the same endpoint is expressed with
+//! `expect`-scoped mounts or by matching on the request body.
+
+use mtui_datasources::slack::Slack;
+use mtui_datasources::{HttpClient, SlackError, VerifyPolicy};
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const CHANNEL: &str = "C0123456789";
+const TS: &str = "1700000000.000100";
+
+/// Build a Slack client whose API base resolves to `server`.
+///
+/// Loopback plain HTTP is deliberately permitted by the token-safety guard so
+/// this is possible; see `is_token_safe_url`.
+fn slack_for(server: &MockServer) -> Slack {
+    let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
+    Slack::with_client(http, "xoxb-test".to_owned(), &server.uri()).expect("slack client builds")
+}
+
+/// Mount a JSON response for `api_method`.
+async fn mount(server: &MockServer, api_method: &str, body: serde_json::Value) {
+    Mock::given(path(format!("/{api_method}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn post_message_returns_canonical_channel_and_ts() {
+    let server = MockServer::start().await;
+    // The caller posted to `#qam-review`; Slack answers with the channel ID.
+    // Persisting the ID rather than the name is what makes the later
+    // reactions/replies reads work at all.
+    mount(
+        &server,
+        "chat.postMessage",
+        json!({ "ok": true, "channel": CHANNEL, "ts": TS }),
+    )
+    .await;
+
+    let posted = slack_for(&server)
+        .post_message("#qam-review", "Please review SUSE:Maintenance:1:2")
+        .await
+        .expect("post succeeds");
+
+    assert_eq!(posted.channel, CHANNEL);
+    assert_eq!(posted.ts, TS);
+}
+
+#[tokio::test]
+async fn post_message_sends_bearer_token_and_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat.postMessage"))
+        .and(body_string_contains("SUSE:Maintenance:1:2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true, "channel": CHANNEL, "ts": TS
+        })))
+        .mount(&server)
+        .await;
+
+    slack_for(&server)
+        .post_message(CHANNEL, "Please review SUSE:Maintenance:1:2")
+        .await
+        .expect("post succeeds");
+
+    let requests = server.received_requests().await.unwrap();
+    let auth = requests[0]
+        .headers
+        .get("authorization")
+        .expect("authorization header is sent")
+        .to_str()
+        .unwrap();
+    assert_eq!(auth, "Bearer xoxb-test");
+}
+
+#[tokio::test]
+async fn application_error_in_http_200_is_an_api_error() {
+    let server = MockServer::start().await;
+    // Slack's defining quirk: the call "succeeded" at the HTTP layer and still
+    // failed. Trusting the status here would report a silent non-delivery as a
+    // posted review request.
+    mount(
+        &server,
+        "chat.postMessage",
+        json!({ "ok": false, "error": "channel_not_found" }),
+    )
+    .await;
+
+    let err = slack_for(&server)
+        .post_message("#nope", "hi")
+        .await
+        .unwrap_err();
+
+    match err {
+        SlackError::Api(code) => assert_eq!(code, "channel_not_found"),
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn missing_error_field_still_reports_an_api_error() {
+    let server = MockServer::start().await;
+    // A malformed `ok: false` without an error code must not be read as success.
+    mount(&server, "chat.postMessage", json!({ "ok": false })).await;
+
+    match slack_for(&server).post_message(CHANNEL, "hi").await {
+        Err(SlackError::Api(code)) => assert_eq!(code, "unknown"),
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_is_typed_and_carries_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(path("/reactions.get"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "30"))
+        .mount(&server)
+        .await;
+
+    let err = slack_for(&server).reactions(CHANNEL, TS).await.unwrap_err();
+
+    match err {
+        SlackError::RateLimited { retry_after } => assert_eq!(retry_after, Some(30)),
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_without_a_header_is_still_typed() {
+    let server = MockServer::start().await;
+    // The variant must survive a missing or unparseable header, since the
+    // watch loop's back-off decision depends on the *type*, not the number.
+    Mock::given(path("/reactions.get"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "soon"))
+        .mount(&server)
+        .await;
+
+    match slack_for(&server).reactions(CHANNEL, TS).await {
+        Err(SlackError::RateLimited { retry_after }) => assert_eq!(retry_after, None),
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reactions_are_skin_tone_normalised() {
+    let server = MockServer::start().await;
+    mount(
+        &server,
+        "reactions.get",
+        json!({
+            "ok": true,
+            "message": { "reactions": [
+                { "name": "+1::skin-tone-5", "users": ["U1", "U2"] },
+                { "name": "eyes", "users": ["U3"] }
+            ]}
+        }),
+    )
+    .await;
+
+    let reactions = slack_for(&server)
+        .reactions(CHANNEL, TS)
+        .await
+        .expect("reactions read");
+
+    assert_eq!(reactions.len(), 2);
+    // The tone modifier is gone, so the command can compare against "+1".
+    assert_eq!(reactions[0].name, "+1");
+    assert_eq!(reactions[0].users, vec!["U1", "U2"]);
+    assert_eq!(reactions[1].name, "eyes");
+}
+
+#[tokio::test]
+async fn reactions_query_identifies_the_message() {
+    let server = MockServer::start().await;
+    Mock::given(path("/reactions.get"))
+        .and(query_param("channel", CHANNEL))
+        .and(query_param("timestamp", TS))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true, "message": { "reactions": [] }
+        })))
+        .mount(&server)
+        .await;
+
+    // Mounting on the exact query means a wrong parameter name would 404 here
+    // rather than silently watching the wrong message.
+    let reactions = slack_for(&server)
+        .reactions(CHANNEL, TS)
+        .await
+        .expect("reactions read");
+    assert!(reactions.is_empty());
+}
+
+#[tokio::test]
+async fn no_reactions_field_is_an_empty_list_not_an_error() {
+    let server = MockServer::start().await;
+    // Nobody has reacted yet — the overwhelmingly common case during a watch.
+    mount(
+        &server,
+        "reactions.get",
+        json!({ "ok": true, "message": { "text": "Please review" } }),
+    )
+    .await;
+
+    let reactions = slack_for(&server)
+        .reactions(CHANNEL, TS)
+        .await
+        .expect("absent reactions is not a failure");
+    assert!(reactions.is_empty());
+}
+
+#[tokio::test]
+async fn replies_excludes_the_parent_message() {
+    let server = MockServer::start().await;
+    mount(
+        &server,
+        "conversations.replies",
+        json!({
+            "ok": true,
+            "messages": [
+                { "ts": TS, "user": "UBOT", "text": "Please review SUSE:Maintenance:1:2" },
+                { "ts": "1700000001.000200", "user": "U1", "text": "looks good" }
+            ]
+        }),
+    )
+    .await;
+
+    let replies = slack_for(&server)
+        .replies(CHANNEL, TS)
+        .await
+        .expect("replies read");
+
+    // The parent is the request itself; counting it as a reply would make an
+    // unanswered request look answered.
+    assert_eq!(replies.len(), 1);
+    assert_eq!(replies[0].user, "U1");
+    assert_eq!(replies[0].text, "looks good");
+}
+
+#[tokio::test]
+async fn replies_follow_the_cursor() {
+    let server = MockServer::start().await;
+    // Page 2 is mounted first: wiremock matches most-recently-mounted first,
+    // so the cursor-bearing request is answered by this narrower mount and the
+    // cursorless one falls through to the page-1 mount below.
+    Mock::given(path("/conversations.replies"))
+        .and(query_param("cursor", "page2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "messages": [{ "ts": "1700000002.000300", "user": "U2", "text": "second" }]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "messages": [{ "ts": "1700000001.000200", "user": "U1", "text": "first" }],
+            "response_metadata": { "next_cursor": "page2" }
+        })))
+        .mount(&server)
+        .await;
+
+    let replies = slack_for(&server)
+        .replies(CHANNEL, TS)
+        .await
+        .expect("replies read");
+
+    assert_eq!(replies.len(), 2);
+    assert_eq!(replies[0].text, "first");
+    assert_eq!(replies[1].text, "second");
+}
+
+#[tokio::test]
+async fn replies_stop_at_the_page_cap() {
+    let server = MockServer::start().await;
+    // A cursor that never clears would otherwise spin forever inside a single
+    // poll of the watch loop.
+    Mock::given(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "messages": [{ "ts": "1700000001.000200", "user": "U1", "text": "loop" }],
+            "response_metadata": { "next_cursor": "always-more" }
+        })))
+        .mount(&server)
+        .await;
+
+    let replies = slack_for(&server)
+        .replies(CHANNEL, TS)
+        .await
+        .expect("capped read still succeeds");
+
+    // MAX_REPLY_PAGES pages, one reply each.
+    assert_eq!(replies.len(), 10);
+    assert_eq!(server.received_requests().await.unwrap().len(), 10);
+}
+
+#[tokio::test]
+async fn auth_test_returns_the_bot_user_id() {
+    let server = MockServer::start().await;
+    mount(
+        &server,
+        "auth.test",
+        json!({ "ok": true, "user_id": "UBOT123", "team": "T1" }),
+    )
+    .await;
+
+    let id = slack_for(&server).auth_test().await.expect("auth ok");
+    assert_eq!(id, "UBOT123");
+}
+
+#[tokio::test]
+async fn invalid_auth_surfaces_slacks_own_code() {
+    let server = MockServer::start().await;
+    mount(
+        &server,
+        "auth.test",
+        json!({ "ok": false, "error": "invalid_auth" }),
+    )
+    .await;
+
+    match slack_for(&server).auth_test().await {
+        Err(SlackError::Api(code)) => assert_eq!(code, "invalid_auth"),
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn server_error_status_is_a_failed_call() {
+    let server = MockServer::start().await;
+    Mock::given(path("/chat.postMessage"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    match slack_for(&server).post_message(CHANNEL, "hi").await {
+        Err(SlackError::FailedCall(msg)) => {
+            assert!(msg.contains("503"), "names the status: {msg}");
+            assert!(!msg.contains("xoxb"), "must not leak the token: {msg}");
+        }
+        other => panic!("expected FailedCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_json_body_is_a_failed_call_not_a_panic() {
+    let server = MockServer::start().await;
+    // A proxy or captive portal answering with HTML must not take mtui down.
+    Mock::given(path("/auth.test"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>nope</html>"))
+        .mount(&server)
+        .await;
+
+    assert!(matches!(
+        slack_for(&server).auth_test().await,
+        Err(SlackError::FailedCall(_))
+    ));
+}

--- a/crates/mtui-mcp/src/tools.rs
+++ b/crates/mtui-mcp/src/tools.rs
@@ -50,6 +50,11 @@ const SLOW_COMMANDS: &[&str] = &[
     "set_repo",
     "reboot",
     "regenerate",
+    // `--watch` polls Slack for up to `[slack] watch_timeout` (an hour by
+    // default), far past any MCP client timeout, so the caller needs the
+    // `background` escape hatch. Without `--watch` the command just posts and
+    // returns, which is fast enough to run in the foreground.
+    "request_review",
 ];
 
 /// The one command whose `clap` subcommands are fanned out into per-subcommand

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/mtui-mcp/tests/slim_profile.rs
-assertion_line: 40
 expression: pretty
 ---
 [
@@ -1205,6 +1204,43 @@ expression: pretty
       "type": "object"
     },
     "name": "remove_host",
+    "read_only": false
+  },
+  {
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "all_templates": {
+          "default": false,
+          "description": "Act on every loaded template",
+          "type": "boolean"
+        },
+        "background": {
+          "default": false,
+          "description": "Return a job id immediately instead of blocking; poll job_status/job_result.",
+          "type": "boolean"
+        },
+        "channel": {
+          "description": "Channel to post to, overriding the configured one",
+          "type": "string"
+        },
+        "message": {
+          "description": "Extra context appended to the review request",
+          "type": "string"
+        },
+        "template": {
+          "description": "RRID of a single loaded template to act on",
+          "type": "string"
+        },
+        "watch": {
+          "default": false,
+          "description": "After posting, watch the message for reviewer reactions until a verdict or timeout (Ctrl-C stops it). Over MCP, pair this with background=true so the call does not outlive the client timeout",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "name": "request_review",
     "read_only": false
   },
   {

--- a/crates/mtui-mcp/tests/snapshots/it__tools_synthesis__tool_surface_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__tools_synthesis__tool_surface_snapshot.snap
@@ -42,6 +42,7 @@ reject read_only=false
 reload_openqa read_only=false
 reload_products read_only=false
 remove_host read_only=false
+request_review read_only=false
 run read_only=false
 set_host_state read_only=false
 set_log_level read_only=false

--- a/crates/mtui-testreport/src/lib.rs
+++ b/crates/mtui-testreport/src/lib.rs
@@ -35,7 +35,8 @@ pub use reports::repoparse::{
 pub use reports::{NullReport, ObsReport, PiReport, SlReport};
 pub use support::{FileList, atomic_write_file, detect_system, system_info, timestamp};
 pub use testreport::{
-    HashCheck, ReadError, ReportOpenQA, ReviewerError, TestReport, TestReportBase,
+    HashCheck, ReadError, ReportOpenQA, ReviewerError, SlackReviewError, SlackReviewMarker,
+    TestReport, TestReportBase,
 };
 pub use update_workflow::{
     CheckProvider, Diagnostic, DoerProvider, Role, TemplateError, UpdateError, WorkflowKey,

--- a/crates/mtui-testreport/src/metadata_parsers.rs
+++ b/crates/mtui-testreport/src/metadata_parsers.rs
@@ -67,6 +67,18 @@ impl ReducedMetadataParser {
     /// Parses a single line and records any hostname / jira / bug it carries
     /// into `results`.
     pub fn parse(results: &mut TestReportBase, line: &str) {
+        // First-wins, like every other arm here: if a template somehow carries
+        // several markers, the first is authoritative and the writer collapses
+        // the rest, so read and write agree on which message the gate checks.
+        if line.starts_with("Slack Review:") {
+            if results.slack_review.is_none()
+                && let Some(marker) = crate::testreport::SlackReviewMarker::parse_line(line)
+            {
+                results.slack_review = Some(marker);
+            }
+            return;
+        }
+
         if let Some(caps) = HOSTNAMES_RE.captures(line) {
             let host = &caps[1];
             if !host.contains('?') {

--- a/crates/mtui-testreport/src/testreport.rs
+++ b/crates/mtui-testreport/src/testreport.rs
@@ -118,6 +118,12 @@ pub struct TestReportBase {
     pub packager: String,
     /// Reviewer.
     pub reviewer: String,
+    /// The Slack message this update's review was requested on, if any.
+    ///
+    /// Written by `request_review` and read back on load, so a later `approve`
+    /// can verify the ack against the exact message rather than trusting that
+    /// a review happened. `None` when no request was posted.
+    pub slack_review: Option<SlackReviewMarker>,
     /// Update repository string.
     pub repository: String,
     /// Update repository URLs (upstream `repositories`, a `frozenset[str]`).
@@ -185,6 +191,7 @@ impl TestReportBase {
             category: String::new(),
             packager: String::new(),
             reviewer: String::new(),
+            slack_review: None,
             repository: String::new(),
             repositories: HashSet::new(),
             packages: HashMap::new(),
@@ -564,6 +571,13 @@ pub trait TestReport {
             ("Category".to_owned(), base.category.clone()),
             ("Hosts".to_owned(), hosts),
             ("Reviewer".to_owned(), base.reviewer.clone()),
+            (
+                "Slack Review".to_owned(),
+                base.slack_review
+                    .as_ref()
+                    .map(|m| format!("{} {}", m.channel, m.ts))
+                    .unwrap_or_default(),
+            ),
             ("Packager".to_owned(), base.packager.clone()),
             (
                 "Bugs".to_owned(),
@@ -840,15 +854,164 @@ pub trait TestReport {
         self.base_mut().reviewer = name;
         Ok(())
     }
+
+    /// Records the Slack message a review was requested on, in the loaded
+    /// template on disk.
+    ///
+    /// Unlike [`set_reviewer`](TestReport::set_reviewer), the line being
+    /// written does **not** pre-exist in a server-generated template, so this
+    /// replaces an existing marker when there is one and otherwise *inserts*
+    /// immediately after the `Test Plan Reviewer:` line. Replacing-only would
+    /// fail on every first use.
+    ///
+    /// A pre-existing marker is overwritten rather than duplicated, so
+    /// re-running `request_review` re-points the gate at the newest message
+    /// instead of leaving two markers to disagree.
+    ///
+    /// The in-memory field is updated only after the write succeeds, matching
+    /// `set_reviewer`: a caller that treats the error as fatal then cannot
+    /// proceed believing a marker was persisted when it was not.
+    ///
+    /// # Errors
+    ///
+    /// * [`SlackReviewError::NoTemplate`] when no template is loaded.
+    /// * [`SlackReviewError::NoAnchor`] when the template has no
+    ///   `Test Plan Reviewer:` line to insert after.
+    /// * [`SlackReviewError::Io`] when reading or rewriting the file fails.
+    fn set_slack_review(&mut self, marker: &SlackReviewMarker) -> Result<(), SlackReviewError> {
+        let path = self
+            .base()
+            .path
+            .clone()
+            .ok_or(SlackReviewError::NoTemplate)?;
+
+        let text = std::fs::read_to_string(&path).map_err(SlackReviewError::Io)?;
+        let line = marker.to_line();
+        let existing = slack_review_line_re();
+
+        let new_text = if existing.is_match(&text) {
+            // `replace` (not `replace_all`) rewrites the first marker; the
+            // duplicate-collapsing below removes any others.
+            let replaced = existing.replace(&text, line.as_str()).into_owned();
+            collapse_extra_marker_lines(&replaced)
+        } else {
+            let anchor = reviewer_line_re();
+            let Some(m) = anchor.find(&text) else {
+                return Err(SlackReviewError::NoAnchor);
+            };
+            let mut out = String::with_capacity(text.len() + line.len() + 1);
+            out.push_str(&text[..m.end()]);
+            out.push('\n');
+            out.push_str(&line);
+            out.push_str(&text[m.end()..]);
+            out
+        };
+
+        crate::support::atomic_write_file(new_text.as_bytes(), &path)
+            .map_err(SlackReviewError::Io)?;
+        self.base_mut().slack_review = Some(marker.clone());
+        Ok(())
+    }
+}
+
+/// Drop every `Slack Review:` line after the first.
+///
+/// A template that somehow accumulated several markers (a merge, a hand edit)
+/// would otherwise leave the reader picking one arbitrarily; collapsing on
+/// write makes the file agree with the first-wins read.
+fn collapse_extra_marker_lines(text: &str) -> String {
+    let mut seen = false;
+    let mut out: Vec<&str> = Vec::new();
+    for line in text.lines() {
+        if line.starts_with("Slack Review:") {
+            if seen {
+                continue;
+            }
+            seen = true;
+        }
+        out.push(line);
+    }
+    let mut joined = out.join("\n");
+    // `lines()` drops a trailing newline; keep the file's original ending.
+    if text.ends_with('\n') {
+        joined.push('\n');
+    }
+    joined
 }
 
 /// Matches the `Test Plan Reviewer:` (or legacy `Suggested Test Plan
 /// Reviewer:`) metadata line, ported from upstream `_reviewer_line`.
 ///
-/// Compiled on demand; only [`TestReport::set_reviewer`] uses it.
+/// Compiled on demand; [`TestReport::set_reviewer`] replaces it, and
+/// [`TestReport::set_slack_review`] uses it as the anchor to insert after.
 fn reviewer_line_re() -> regex::Regex {
     regex::Regex::new(r"(?m)^(?:Suggested )?Test Plan Reviewer:.*$")
         .expect("static reviewer-line regex is valid")
+}
+
+/// Matches the `Slack Review:` marker line written by `request_review`.
+fn slack_review_line_re() -> regex::Regex {
+    regex::Regex::new(r"(?m)^Slack Review:.*$").expect("static slack-review regex is valid")
+}
+
+/// The Slack message a review request was posted to.
+///
+/// Both halves are Slack's own canonical identifiers as returned by
+/// `chat.postMessage` — never the configured channel *name*, which does not
+/// work for the reaction and reply reads that verify the ack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackReviewMarker {
+    /// Canonical channel ID, e.g. `C0123456789`.
+    pub channel: String,
+    /// Message timestamp, which is also its ID within the channel.
+    pub ts: String,
+}
+
+impl SlackReviewMarker {
+    /// Render the marker as it appears in the template.
+    #[must_use]
+    pub fn to_line(&self) -> String {
+        format!("Slack Review: {} {}", self.channel, self.ts)
+    }
+
+    /// Parse a `Slack Review: <channel> <ts>` line.
+    ///
+    /// Returns `None` for anything that is not exactly that shape, so a
+    /// hand-edited or truncated marker is treated as absent rather than
+    /// producing a marker that points at no real message.
+    #[must_use]
+    pub fn parse_line(line: &str) -> Option<Self> {
+        let rest = line.strip_prefix("Slack Review:")?;
+        let mut parts = rest.split_whitespace();
+        let channel = parts.next()?;
+        let ts = parts.next()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            channel: channel.to_owned(),
+            ts: ts.to_owned(),
+        })
+    }
+}
+
+/// Failures from [`TestReport::set_slack_review`].
+#[derive(Debug, thiserror::Error)]
+pub enum SlackReviewError {
+    /// No template is loaded, so there is nothing to write the marker into.
+    #[error("Called while missing path")]
+    NoTemplate,
+    /// The template has no `Test Plan Reviewer:` line to anchor the marker to.
+    ///
+    /// Unlike the reviewer line the marker never pre-exists, so it has to be
+    /// inserted somewhere deterministic rather than replaced; without the
+    /// anchor there is no such place, and guessing risks corrupting the
+    /// template.
+    #[error("no 'Test Plan Reviewer:' line found in template to anchor the Slack marker to")]
+    NoAnchor,
+    /// Reading or atomically rewriting the template file failed.
+    #[error("failed to write the Slack review marker to template: {0}")]
+    Io(#[source] std::io::Error),
 }
 
 /// The outcome of [`TestReport::check_hash`] (upstream's `check_hash` plus the
@@ -1159,6 +1322,141 @@ mod tests {
         assert_eq!(r.giteaprapi(), Some("https://gitea/api/pr/1"));
         assert_eq!(r.giteacohash(), Some("deadbeef"));
         assert_eq!(r.workflow(), Workflow::Kernel);
+    }
+
+    /// Build a report backed by a temp template containing `body`.
+    fn report_with_template(dir: &tempfile::TempDir, body: &str) -> (MetaReport, PathBuf) {
+        let path = dir.path().join("log");
+        std::fs::write(&path, body).unwrap();
+        let mut base = TestReportBase::new(config());
+        base.path = Some(path.clone());
+        (MetaReport { base }, path)
+    }
+
+    fn marker(channel: &str, ts: &str) -> SlackReviewMarker {
+        SlackReviewMarker {
+            channel: channel.to_owned(),
+            ts: ts.to_owned(),
+        }
+    }
+
+    #[test]
+    fn set_slack_review_inserts_when_the_marker_is_absent() {
+        // The load-bearing case: the marker line never pre-exists in a
+        // server-generated template, so a replace-only implementation (like
+        // set_reviewer's) would fail on every first use.
+        let dir = tempfile::tempdir().unwrap();
+        let (mut r, path) = report_with_template(
+            &dir,
+            "Category: recommended\nTest Plan Reviewer: bob\nEnd\n",
+        );
+
+        r.set_slack_review(&marker("C123", "1700000000.000100"))
+            .unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            written,
+            "Category: recommended\nTest Plan Reviewer: bob\nSlack Review: C123 1700000000.000100\nEnd\n"
+        );
+        assert_eq!(
+            r.base().slack_review,
+            Some(marker("C123", "1700000000.000100"))
+        );
+    }
+
+    #[test]
+    fn set_slack_review_replaces_an_existing_marker() {
+        // Re-running request_review must re-point the gate at the new message,
+        // not leave two markers for the reader to choose between.
+        let dir = tempfile::tempdir().unwrap();
+        let (mut r, path) = report_with_template(
+            &dir,
+            "Test Plan Reviewer: bob\nSlack Review: COLD 1.0\nEnd\n",
+        );
+
+        r.set_slack_review(&marker("CNEW", "2.0")).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("Slack Review: CNEW 2.0"), "{written}");
+        assert!(!written.contains("COLD"), "{written}");
+        assert_eq!(written.matches("Slack Review:").count(), 1, "{written}");
+    }
+
+    #[test]
+    fn set_slack_review_collapses_duplicate_markers() {
+        // A hand-edited or merged template can carry several markers; the
+        // writer must leave exactly the one the reader would have picked.
+        let dir = tempfile::tempdir().unwrap();
+        let (mut r, path) = report_with_template(
+            &dir,
+            "Test Plan Reviewer: bob\nSlack Review: C1 1.0\nmiddle\nSlack Review: C2 2.0\nEnd\n",
+        );
+
+        r.set_slack_review(&marker("CNEW", "3.0")).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written.matches("Slack Review:").count(), 1, "{written}");
+        assert!(written.contains("Slack Review: CNEW 3.0"), "{written}");
+        // Unrelated content between the markers survives.
+        assert!(written.contains("middle"), "{written}");
+        assert!(
+            written.ends_with('\n'),
+            "trailing newline kept: {written:?}"
+        );
+    }
+
+    #[test]
+    fn set_slack_review_needs_an_anchor_and_a_template() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // No reviewer line: refuse rather than guess where the marker goes.
+        let (mut r, _) = report_with_template(&dir, "Category: recommended\nEnd\n");
+        assert!(matches!(
+            r.set_slack_review(&marker("C1", "1.0")).unwrap_err(),
+            SlackReviewError::NoAnchor
+        ));
+
+        // No template loaded at all.
+        let mut unloaded = MetaReport {
+            base: TestReportBase::new(config()),
+        };
+        assert!(matches!(
+            unloaded.set_slack_review(&marker("C1", "1.0")).unwrap_err(),
+            SlackReviewError::NoTemplate
+        ));
+    }
+
+    #[test]
+    fn set_slack_review_leaves_memory_untouched_when_the_write_fails() {
+        // Mirrors set_reviewer's contract: a caller that aborts on the error
+        // must not be left believing a marker was persisted.
+        let dir = tempfile::tempdir().unwrap();
+        let mut base = TestReportBase::new(config());
+        base.path = Some(dir.path().join("does/not/exist/log"));
+        let mut r = MetaReport { base };
+
+        assert!(r.set_slack_review(&marker("C1", "1.0")).is_err());
+        assert_eq!(r.base().slack_review, None);
+    }
+
+    #[test]
+    fn slack_marker_round_trips_through_its_line() {
+        let m = marker("C0123456789", "1700000000.000100");
+        assert_eq!(SlackReviewMarker::parse_line(&m.to_line()), Some(m));
+    }
+
+    #[test]
+    fn slack_marker_rejects_malformed_lines() {
+        // A truncated or over-long marker points at no real message; treating
+        // it as absent is safer than acting on half of one.
+        assert_eq!(SlackReviewMarker::parse_line("Slack Review: C1"), None);
+        assert_eq!(SlackReviewMarker::parse_line("Slack Review:"), None);
+        assert_eq!(
+            SlackReviewMarker::parse_line("Slack Review: C1 1.0 extra"),
+            None
+        );
+        assert_eq!(SlackReviewMarker::parse_line("Reviewer: bob"), None);
     }
 
     #[test]

--- a/crates/mtui-testreport/tests/metadata_parsers.rs
+++ b/crates/mtui-testreport/tests/metadata_parsers.rs
@@ -39,6 +39,52 @@ fn reduced_metadata_parser_parses_hosts_jira_bugs() {
 }
 
 #[test]
+fn reduced_metadata_parser_reads_back_the_slack_review_marker() {
+    // The read-back half of the marker contract: `approve` gates on this, so
+    // if the parser stops wiring the line up, an approval that should be
+    // refused would sail through instead.
+    let mut report = empty_report();
+
+    ReducedMetadataParser::parse(&mut report, "Slack Review: C0123456789 1700000000.000100");
+
+    let marker = report.slack_review.expect("marker parsed");
+    assert_eq!(marker.channel, "C0123456789");
+    assert_eq!(marker.ts, "1700000000.000100");
+}
+
+#[test]
+fn reduced_metadata_parser_keeps_the_first_slack_marker() {
+    // First-wins, matching the writer's duplicate collapsing: read and write
+    // must agree on which message the gate checks.
+    let mut report = empty_report();
+
+    ReducedMetadataParser::parse(&mut report, "Slack Review: CFIRST 1.0");
+    ReducedMetadataParser::parse(&mut report, "Slack Review: CSECOND 2.0");
+
+    let marker = report.slack_review.expect("marker parsed");
+    assert_eq!(marker.channel, "CFIRST");
+}
+
+#[test]
+fn reduced_metadata_parser_ignores_a_malformed_slack_marker() {
+    // A truncated marker points at no real message. Treating it as absent
+    // makes `approve` refuse (safe); half-parsing it could make the gate check
+    // the wrong message.
+    let mut report = empty_report();
+
+    ReducedMetadataParser::parse(&mut report, "Slack Review: CONLYCHANNEL");
+    assert!(report.slack_review.is_none());
+
+    ReducedMetadataParser::parse(&mut report, "Slack Review: C1 1.0 extra");
+    assert!(report.slack_review.is_none());
+
+    // A marker line must not be mistaken for the other metadata kinds.
+    assert!(report.hostnames.is_empty());
+    assert!(report.jira.is_empty());
+    assert!(report.bugs.is_empty());
+}
+
+#[test]
 fn reduced_metadata_parser_skips_placeholder_host_and_ignores_other_lines() {
     // Upstream guards `"?" not in match.group(1)`; unmatched lines are no-ops.
     let mut report = empty_report();

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -986,6 +986,27 @@ Options:
           Print help
 ```
 
+## `request_review`
+
+Requests review of the loaded update in Slack.
+
+```text
+Usage: request_review [OPTIONS]
+
+Options:
+  -c, --channel <CHANNEL>
+          Channel to post to, overriding the configured one
+
+  -m, --message <TEXT>
+          Extra context appended to the review request
+
+  -w, --watch
+          After posting, watch the message for reviewer reactions until a verdict or timeout (Ctrl-C stops it). Over MCP, pair this with background=true so the call does not outlive the client timeout
+
+  -h, --help
+          Print help
+```
+
 ## `export`
 
 Exports the gathered update data to the testing template.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -125,6 +125,33 @@ Defaults below are the built-in (upstream-matching) values.
 | `token` | string (**secret**) | *(empty)* | API token for the Gitea PR review workflow. The Gitea connector refuses to build without it. Masked as `<set>` in `config` output; sent only in an `Authorization` header, never logged. |
 | `url` | URL | `https://src.suse.de` | Trusted Gitea origin the `token` may be sent to. A PR API URL comes from checked-out metadata (which is not fully trusted), so the token is attached **only** to requests whose origin (scheme/host/port) matches this value, over `https`, with no embedded userinfo. Point it at another instance (e.g. `https://src.opensuse.org`) to use that one. A metadata URL on any other origin is refused before the token is sent. |
 
+### `[slack]`
+
+The Slack review-request integration behind the `request_review` command.
+
+**Off by default.** Posting into a chat workspace is an outward-facing side
+effect, so it never happens implicitly: `enabled` must be `true` *and* both
+`token` and `channel` must be set. An mtui with no `[slack]` section never
+contacts Slack, and `request_review` refuses with the reason.
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `enabled` | bool | `false` | Whether the integration is available at all. Set `true` to opt in; leaving it unset (or `false`) makes `request_review` refuse up front, which is how a site that does not use Slack — or wants the feature switched off despite credentials being present — runs mtui. |
+| `token` | string (**secret**) | *(empty)* | Slack bot token. Required scopes: `chat:write`, `reactions:read`, `channels:history`. Masked as `<set>` in `config` output; sent only in an `Authorization` header, never logged. |
+| `channel` | string | *(empty)* | Channel review requests are posted to — an ID (`C0123456789`) or a `#name`. Overridable per call with `request_review --channel`. |
+| `api_url` | URL | `https://slack.com/api` | Slack API base the `token` may be sent to. Refused unless it is `https` (or `http` to loopback, which is what makes the test suite's mock server possible) and carries no userinfo. |
+| `poll_interval` | int (seconds) | `120` | How often `request_review --watch` polls for reactions. Jittered by ±15% so several mtui instances watching the same channel do not synchronise. Slack's tier-3 methods allow roughly 50 requests/minute. |
+| `watch_timeout` | int (seconds) | `3600` | How long `request_review --watch` runs before giving up. |
+
+Example:
+
+```toml
+[slack]
+enabled = true
+token = "xoxb-…"
+channel = "#qam-review"
+```
+
 ### `[lock]`
 
 Remote-lock behaviour on target hosts (interoperable with Python mtui on a shared

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -134,6 +134,23 @@ effect, so it never happens implicitly: `enabled` must be `true` *and* both
 `token` and `channel` must be set. An mtui with no `[slack]` section never
 contacts Slack, and `request_review` refuses with the reason.
 
+**Enabling it also gates `approve`.** Once `enabled = true`, an update can only
+be approved after its Slack review request has been acknowledged. `approve`
+refuses unless all three hold:
+
+1. `request_review` recorded a marker for the update (and committed it, so a
+   reviewer approving from a different checkout sees it);
+2. the marked Slack message still names that RRID — a marker copied between
+   templates cannot launder an approval;
+3. somebody other than the bot left an approving reaction (👍, ✅; skin tone
+   ignored).
+
+If Slack cannot be read, `approve` fails closed — an unreadable review request
+is not an approved one. There is deliberately **no per-command bypass flag**: a
+gate with one is not a gate. Turning it off is a config change
+(`config set slack_enabled false`), which is explicit and auditable. `reject` is
+never gated — blocking it would strand an update a reviewer wants stopped.
+
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
 | `enabled` | bool | `false` | Whether the integration is available at all. Set `true` to opt in; leaving it unset (or `false`) makes `request_review` refuse up front, which is how a site that does not use Slack — or wants the feature switched off despite credentials being present — runs mtui. |


### PR DESCRIPTION
## Summary

Adds `request_review`, which posts a review request for the loaded update to a Slack channel, records the resulting message in the testreport, and optionally watches it for reviewer reactions. Enabling the integration also gates `approve` on an acknowledged request, so a requested review becomes something the tool can verify rather than a message someone may or may not have read.

Supersedes #257 (the Python implementation, closed at the Rust cutover). GitHub refused to reopen that PR because the branch was rebuilt on the Rust tree, so this is a fresh PR for the same feature; the reviewed semantics from #257 carry over.

**The integration is off by default.** Posting into a chat workspace is an outward-facing side effect, so it never happens implicitly: `[slack] enabled` must be `true` *and* both `token` and `channel` must be set. An mtui with no `[slack]` section never contacts Slack, `request_review` refuses with the reason and the config key that fixes it, and `approve` is completely unchanged.

## Changes

- **`[slack]` config section** (`enabled`, `token`, `channel`, `api_url`, `poll_interval`, `watch_timeout`). The token is a secret: masked as `<set>` by both `config show` and `config set`, and never logged. The API base is refused unless it is `https` (or `http` to loopback, which is what makes the wiremock suite possible), so a misconfiguration cannot put the bearer token on the wire in clear text.
- **`mtui-datasources::slack`** — a Web API client. Two Slack-specific behaviours shape it: application errors arrive as **HTTP 200** with `{"ok": false}`, so the envelope is checked rather than the status; and `429` is a typed `SlackError::RateLimited` treated as "keep watching" rather than a failure, so throttling cannot end a watch early and report "no reaction" when the truth is "we were not allowed to look".
- **`request_review` command** — posts, records, and with `--watch` polls for reactions (👍 approves, 👎 rejects, skin tone normalised, the bot's own reaction ignored). A rejection outranks a simultaneous approval. Ctrl-C prints a summary instead of killing mtui.
- **`Slack Review:` testreport marker** — written into the template and committed, so the marker is visible from another reviewer's checkout. Inserts when absent (the line never pre-exists in a generated template), replaces when present, and collapses duplicates so read and write agree.
- **`approve` gate** — with Slack enabled, refuses unless a marker exists, the marked message still names that RRID (so a marker copied between templates cannot launder an approval), and someone other than the bot acknowledged it. Unreadable Slack fails closed. No per-command bypass — a gate with one is not a gate; it is turned off by configuration, which is explicit and auditable. `reject` is never gated, because blocking it would strand an update a reviewer wants stopped.
- **MCP** — `request_review` joins `SLOW_COMMANDS` so it gains `background`, which is how a `--watch` run should be started there; a foreground watch would outlive any client timeout. Tool-surface snapshots regenerated.
- Docs (`docs/src/configuration.md`, generated `cli.md`) and CHANGELOG.

## Notable design decisions

- **The watch is opt-in (`--watch`), not implicit as in the Python original.** Posting is fast and total; watching is the long-running extra the caller asks for. This also makes the command behave sanely over MCP without a special case.
- **The marker is committed immediately** rather than riding a later `commit`: the person who approves is often not the person who asked, and the gate has to see it.
- The SVN runner is injected into the record step, because otherwise the success-path test passed via the failure branch (a tempdir is never a working copy).

## Checklist

The repo's PR template still lists the Python gates (`uv run ruff`/`pytest`/`Documentation/`), which the Rust rewrite replaced — worth updating separately. The actual gates, all observed locally:

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `cargo fmt --all --check` is clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean.
- [x] `cargo test --workspace` passes.
- [x] `cargo test -p mtui-mcp --features mcp` passes.
- [x] Feature matrix builds (`--no-default-features`, `--all-features`).
- [x] User-visible changes recorded in `CHANGELOG.md`.
- [x] Docs under `docs/src/` updated; generated pages re-run via `cargo xtask gen-docs`.

52 tests added across the config, client, marker, command, and gate surfaces.

## Related issues

Supersedes #257.
