### PR TITLE
chore(github): refresh PR and bug-report templates for the Rust tree

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,15 +46,8 @@ body:
       description: Output of `mtui -V`.
     validations:
       required: true
-  - type: input
-    id: python
-    attributes:
-      label: Python version
-      description: Output of `python3 --version`.
-    validations:
-      required: true
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: OS / distribution, install method (zypper / uv / pip from source), relevant config snippets (with secrets redacted).
+      description: OS / distribution, install method (zypper package / built from source), relevant config snippets (with secrets redacted).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,13 +15,17 @@ checklist below. See CONTRIBUTING.md for the full workflow.
 
 ## Checklist
 
+<!-- CI runs the same gates; see CONTRIBUTING.md "Quality gates". -->
+
 - [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
-- [ ] `uv run ruff format --check .` is clean.
-- [ ] `uv run ruff check .` is clean.
-- [ ] `uv run ty check` is clean.
-- [ ] `uv run pytest` passes.
-- [ ] User-visible changes are recorded under `[Unreleased]` in `CHANGELOG.md`.
-- [ ] Documentation under `Documentation/` updated where relevant.
+- [ ] `cargo fmt --all --check` is clean.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` is clean.
+- [ ] `cargo test --workspace` passes.
+- [ ] `cargo test -p mtui-mcp -F mcp` passes (when touching commands, `Session`, the registry, or entrypoints).
+- [ ] The compile-only feature matrix builds: `cargo build --workspace --no-default-features` and `--all-features`.
+- [ ] New/changed code is covered (>= 80% patch coverage).
+- [ ] User-visible changes are recorded in `CHANGELOG.md`.
+- [ ] Documentation under `docs/src/` updated where relevant; generated pages re-run with `cargo xtask gen-docs`.
 
 ## Related issues
 


### PR DESCRIPTION
## Summary

The Rust rewrite (#337) replaced the Python toolchain but left the GitHub templates behind, so they ask contributors for things that no longer exist. `CONTRIBUTING.md` was updated at the time; `.github/` was missed.

## Changes

- **`PULL_REQUEST_TEMPLATE.md`** — the checklist asked for `uv run ruff format --check`, `uv run ruff check`, `uv run ty check` and `uv run pytest`. None are runnable in this repo and none are what CI runs, so the checklist could only be filled in dishonestly. Replaced with the real gates — `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, and the compile-only feature matrix — matching `CONTRIBUTING.md`'s "Quality gates" section and `.github/workflows/ci.yml`. Also adds the >= 80% patch-coverage line from `AGENTS.md`, and points docs at `docs/src/` (with `cargo xtask gen-docs` for generated pages) instead of the removed `Documentation/` tree.
- **`ISSUE_TEMPLATE/bug_report.yml`** — dropped the **required** "Python version / output of `python3 --version`" field. mtui ships as a static binary with no Python runtime, so that answer cannot inform a diagnosis, and making it required puts reporters in the position of inventing one. Corrected the install methods listed in Environment (`zypper / uv / pip from source` -> `zypper package / built from source`).

No code or workflow changes; `mtui -V` is untouched and still required.

## Related issues

Follow-up to #337.
