### PR TITLE
chore(ci): add CodeQL, dependency-review and Scorecard; harden release build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+---
+name: codeql
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly published query still finds old code that no PR touches.
+    - cron: '31 5 * * 3'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Rust is source-extracted, so no build orchestration is needed;
+          # the workflows themselves are scanned as `actions`.
+          - language: rust
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Analyze
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+---
+name: dependency-review
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  # Write only so the action can post its summary comment on the PR.
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dependency-review:
+    # Block PRs that add a vulnerable dependency before merge. Complements
+    # Dependabot, which only alerts once the code is already on main.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          # No `deny-licenses` here, deliberately. mtui is GPL-2.0-only while
+          # russh, rmcp and ring are Apache-2.0-*only*, which is generally read
+          # as GPLv2-incompatible. That question predates this workflow and
+          # needs a real decision (relicense to -or-later, or replace those
+          # stacks); gating every PR on it would just paint CI red without
+          # moving it forward.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,12 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The release is published with `gh release create` using
+          # ${{ github.token }}; no git push happens, so the checkout does not
+          # need a credential left behind in .git/config.
+          persist-credentials: false
 
       - name: Verify tag matches workspace version
         run: |
@@ -42,10 +47,13 @@ jobs:
       - name: Install musl tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      # `--locked` so a release is built from the dependency versions committed
+      # in Cargo.lock. Without it a newly published (or yanked-and-replaced)
+      # transitive crate could differ from anything CI ever tested.
       - name: Build release binaries
         run: |
-          cargo build --release --target "$TARGET" -p mtui-cli
-          cargo build --release --target "$TARGET" -p mtui-mcp --features mcp
+          cargo build --release --locked --target "$TARGET" -p mtui-cli
+          cargo build --release --locked --target "$TARGET" -p mtui-mcp --features mcp
 
       - name: Package release tarball
         run: cargo xtask package --version "$GITHUB_REF_NAME" --target "$TARGET"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+---
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "42 3 * * 1"
+  push:
+    branches:
+      - main
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF REST API so consumers can see the score and
+          # the repository can carry a Scorecard badge.
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,18 @@ _The entries below document the final Python releases, retained for history._
   gate is turned off by configuration (`slack_enabled = false`), which is
   explicit and auditable. `reject` is never gated. With Slack disabled (the
   default) `approve` behaves exactly as before.
+### Security
+
+- Release binaries are now built with `cargo build --locked`, so a published
+  release is compiled from exactly the dependency versions recorded in
+  `Cargo.lock` rather than whatever resolved at tag time.
+- Pull requests are now gated by `dependency-review`, which blocks a change that
+  introduces a dependency with a known high-severity advisory. The code and the
+  workflows are additionally scanned by CodeQL and OpenSSF Scorecard, and
+  Dependabot now opens security updates for known-vulnerable crates.
+- `SECURITY.md` has been rewritten for the Rust tool; it previously asked
+  reporters for their Python and paramiko versions and scoped out dependencies
+  the project no longer has.
 
 ## 19.0.1 - 2026-07-17
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,9 @@ maintained release branches.
 
 ## Reporting a vulnerability
 
-Please report suspected security issues privately to
-**qa-maintenance@suse.de**.
+Please report suspected security issues privately, either via GitHub's
+[**Report a vulnerability**](https://github.com/openSUSE/mtui/security/advisories/new)
+(Security → Advisories) or by mail to **qa-maintenance@suse.de**.
 
 Do not open a public GitHub issue or pull request for a suspected
 vulnerability before it has been triaged.
@@ -17,8 +18,7 @@ When reporting, include as much of the following as you can:
 
 - A description of the issue and its potential impact.
 - Steps to reproduce or a proof of concept.
-- The mtui version (`mtui -V`) and the Python / paramiko / openqa-client
-  versions.
+- The mtui version (`mtui -V`).
 - Any relevant configuration (with secrets redacted).
 
 ## Response expectations
@@ -29,10 +29,35 @@ team; there is no committed response time or fix-time SLA.
 
 ## Scope
 
-In scope: defects in mtui itself (the CLI, the SSH connection layer,
-the configuration loader, the OBS / openQA / Gitea connectors).
+In scope: defects in mtui itself. The security-relevant areas are:
 
-Out of scope: vulnerabilities in upstream dependencies (`paramiko`,
-`openqa-client`, `requests`, `ruamel.yaml`, `pyxdg`, `osc`, …). Please
-report those directly to the respective upstream projects; we will
-update the dependency once an upstream fix is available.
+- **SSH.** Host-key verification against `~/.ssh/known_hosts` (including
+  hashed entries) and remote command construction (shell quoting). mtui is
+  **pubkey-only by design** — password authentication is deliberately
+  absent and should not be added.
+- **Credential handling.** Service credentials (Gitea token, `oscrc` for
+  OBS, openQA API secrets, and any chat integration token) must never reach
+  terminal output, logs, or MCP responses. Secret config fields are
+  classified by `is_secret_attr` and masked as `<set>` by both
+  `config show` and `config set`; a change adding a credential field must
+  add it there in the same commit.
+- **URLs in logs.** URLs may carry credentials in userinfo or query
+  parameters, so they are passed through `mtui_datasources::sanitize_url`
+  before being logged.
+- **The MCP server.** `mtui-mcp --transport http` binds loopback
+  (`127.0.0.1`) by default and relies on rmcp's DNS-rebinding guard. It
+  exposes mtui commands — including ones that mutate remote hosts — to
+  whatever can reach that port.
+- The configuration loader and the OBS / openQA / Gitea connectors.
+
+Out of scope: vulnerabilities in upstream crates (`russh`, `rmcp`,
+`reqwest`, `tokio`, …). Please report those to the respective upstream
+projects; we will bump the dependency once an upstream fix is available.
+
+## Dependency and code scanning
+
+Pull requests are checked by `dependency-review`, which blocks a change
+introducing a dependency with a known high-severity advisory. The code and
+the workflows themselves are scanned by CodeQL, the repository is assessed
+by OpenSSF Scorecard, and Dependabot keeps Cargo and Actions dependencies
+current and opens security updates for known-vulnerable crates.


### PR DESCRIPTION
## Summary

Brings mtui's security tooling up to the same level as
[`openSUSE/repose`](https://github.com/openSUSE/repose), and hardens the release
build. The repository-level settings have already been enabled to match repose;
this PR is the in-tree half.

No Rust code is touched — this is `.github/`, `CHANGELOG.md` and `SECURITY.md`
only.

## Changes

**New security workflows** (from repose, retargeted `master` → `main`)

- `codeql.yml` — CodeQL for `rust` and `actions`, plus a weekly schedule so a
  newly published query still reaches code that no PR happens to touch.
- `dependency-review.yml` — blocks a PR that introduces a high-severity
  advisory before merge, where Dependabot only alerts once the code is already
  on `main`.
- `scorecard.yml` — OpenSSF Scorecard, publishing results.

All three are SHA-pinned, and every pin was verified to resolve to the tag it
claims. (repose still floats `codeql-action@v4`; pinning is what Scorecard's
Pinned-Dependencies check actually wants.)

**Release hardening (`release.yml`)**

- `cargo build --locked` for both binaries, so a published release is compiled
  from exactly the versions in `Cargo.lock` rather than whatever resolves at tag
  time.
- `persist-credentials: false` on checkout — the release is published via
  `gh release create` with `github.token`, so no git credential needs to be left
  behind in `.git/config`.

**`SECURITY.md`** was stale from the Python era: it asked reporters for their
`paramiko` / `openqa-client` versions and scoped out `ruamel.yaml`, `pyxdg` and
`osc`. Rewritten for the Rust tool — SSH pubkey-only posture, credential masking
via `is_secret_attr`, `sanitize_url` for logged URLs, and the loopback-only MCP
HTTP transport. It now also offers GitHub private advisories alongside the
existing qa-maintenance@suse.de address.

## Repository settings (already applied, listed for the record)

| Setting | Before | Now |
| --- | --- | --- |
| Secret scanning | disabled | enabled |
| Secret scanning push protection | disabled | enabled |
| Dependabot vulnerability alerts | disabled | enabled |
| Dependabot security updates | disabled | enabled |
| Private vulnerability reporting | disabled | enabled |

Secret scanning found 0 alerts across history. Private vulnerability reporting
had to be enabled for the "Report a vulnerability" link in `SECURITY.md` to work
at all — worth noting that repose links to the same form while having it
disabled.

## Notes for the reviewer

- **`deny-licenses` is intentionally unset in `dependency-review`.** mtui is
  `GPL-2.0-only`, but `russh`, `rmcp` and `ring` are Apache-2.0-**only**, which
  is generally read as GPLv2-incompatible. That predates this PR and wants a
  real decision (relicense to `-or-later`, or replace those stacks); gating
  every PR on it would just paint CI red without moving it forward. Flagging it
  here rather than silently encoding a policy either way.
- **No required status checks were added to the ruleset**, and the existing
  admin/maintainer bypass was left alone — both change merge behaviour and are
  yours to choose. Note mtui's ruleset is already stricter than repose's here
  (1 required approval + thread resolution, vs 0), so nothing was copied down.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] `cargo fmt --all --check` is clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean.
- [x] `cargo test --workspace` passes.
- [x] `cargo test -p mtui-mcp -F mcp` passes.
- [x] Feature matrix — unaffected; no Rust or manifest changes in this PR.
- [x] Coverage — no Rust code paths added.
- [x] User-visible changes are recorded in `CHANGELOG.md`.
- [x] Documentation under `docs/src/` — not applicable.
