### PR TITLE
feat(ci): configure 7-day cooldown for Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       actions-minor-and-patch:


### PR DESCRIPTION
Motivation:
Reduce CI pipeline load and review fatigue by pacing automated updates.

Design Choices:
Configure cooldown with default-days set to 7 in the github-actions section
of .github/dependabot.yml.

Benefits:
Paces automated pull requests to match the established openQA and qem-dashboard
update patterns.

Related issue: https://progress.opensuse.org/issues/203049