### PR TITLE
test(hosts): share one fixture host key across in-process SSH servers

### DIFF
--- a/crates/mtui-hosts/tests/ssh_integration.rs
+++ b/crates/mtui-hosts/tests/ssh_integration.rs
@@ -467,12 +467,21 @@ impl russh_sftp::server::Handler for SftpHandler {
 // Harness: start the server on an ephemeral port and connect a client.
 // ----------------------------------------------------------------------------
 
+/// Process-wide host key shared by every fixture server.
+///
+/// One key, not one per server: all tests append to the same `known_hosts`
+/// file, and the kernel recycles ephemeral loopback ports within a single
+/// run. A recycled port whose new server presented a *different* key would
+/// read as a changed key — rejected under every policy (`Unknown server
+/// key`), failing whichever test drew the reused port.
+static HOST_KEY: LazyLock<PrivateKey> =
+    LazyLock::new(|| PrivateKey::random(&mut rand::rng(), Algorithm::Ed25519).expect("host key"));
+
 /// Starts the in-process server, returning its bound port and the shared FS.
 async fn start_server(fs: SharedFs) -> u16 {
-    let key = PrivateKey::random(&mut rand::rng(), Algorithm::Ed25519).expect("host key");
     let config = Arc::new(russh::server::Config {
         auth_rejection_time: Duration::from_millis(1),
-        keys: vec![key],
+        keys: vec![HOST_KEY.clone()],
         ..Default::default()
     });
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("bind");


### PR DESCRIPTION
## What

Give every in-process SSH fixture server the same process-wide Ed25519 host key instead of generating a fresh one per server.

## Why

The SSH integration tests are flaky, and the flake bit twice on 2026-07-20 alone:

- `main` push run [29771576358](https://github.com/openSUSE/mtui/actions/runs/29771576358): `ssh_integration::lock_reaps_stale_foreign_lock_over_sftp`
- PR #339 run [29772475079](https://github.com/openSUSE/mtui/actions/runs/29772475079): `ssh_integration::sftp_append_creates_then_extends_at_eof_and_read_back`

Both panic at the same place with `connect: Connect { host: "127.0.0.1", reason: "Unknown server key" }` — a different victim test each time.

**Root cause:** every `start_server` generated its own random host key, while all tests in the binary append to one shared per-process `known_hosts` file. The kernel recycles ephemeral loopback ports within a run, so a later test can bind a port an earlier test already recorded — presenting a *different* key. The client correctly treats that as a changed host key and rejects it under every policy (including `AutoAdd`, which never auto-adds over a changed key), so whichever test drew the reused port fails.

With one shared key the recycled port always matches the recorded entry, and the changed-key rejection logic in `mtui-hosts` stays untouched — this is purely a test-fixture fix. No test relied on servers having distinct keys.

## Testing

- `cargo test -p mtui-hosts --test it` — 57/57 pass
- `cargo fmt --check`, `cargo clippy --tests` — clean
