### PR TITLE
ci: adopt typos spell-checker + repair the terse-description drift it surfaced

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,27 @@
+---
+name: typos
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let main runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  typos:
+    # Source spell-check (code, docs, comments). Config: typos.toml at the repo
+    # root (allowlist-only; auto-discovered by the action).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Spell check
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14  # v1.48.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ _The entries below document the final Python releases, retained for history._
   fails, the callers that waited on it fail over to the next resolver
   immediately instead of each repeating the doomed download, so a down
   server costs one transport timeout, not one per caller.
+- The `-t`/`--target` argument description is now correctly shortened on the
+  `mtui-mcp` wire. Its terse-rewrite rule had drifted from the actual help text
+  and silently stopped matching, so every host-targeting tool advertised the
+  long form; the manifest each client re-reads is now a little leaner again.
 
 ### Removed
 

--- a/crates/mtui-mcp/src/slim.rs
+++ b/crates/mtui-mcp/src/slim.rs
@@ -77,22 +77,21 @@ pub fn truncation_notice(dropped: usize, limit: usize) -> String {
 /// Long `clap`/argparse `help` strings shared across many synthesised tools,
 /// mapped to a terse equivalent. Rewriting only the MCP wire copy keeps the REPL
 /// `--help` output (sourced from the same `clap` args) verbose and unchanged.
-/// Keys are matched exactly against a field's `description`. Mirrors upstream
-/// `_slim._TERSE_DESCRIPTIONS`.
-const TERSE_DESCRIPTIONS: &[(&str, &str)] = &[
-    (
-        "RRID of a single loaded template to act on (default: all loaded templates)",
-        "RRID of one loaded template (default: all)",
-    ),
-    (
-        "Act on every loaded template (the default for this command)",
-        "Act on all loaded templates (default)",
-    ),
-    (
-        "Host to act on. Can be used multiple times. If is ommited all hosts are used",
-        "Host to act on (repeatable; default: all hosts)",
-    ),
-];
+/// Mirrors upstream `_slim._TERSE_DESCRIPTIONS`.
+///
+/// Keys are matched **exactly** against a field's `description`, so a key must
+/// stay byte-identical to the `help` its source arg builds: a drifted key
+/// silently stops firing and the verbose text then ships un-slimmed. The
+/// `terse_mappings_are_all_live` test guards against that. Only genuinely
+/// verbose shared help earns an entry — the `-T/--template` and `--all-templates`
+/// descriptions were trimmed at the source (see `commands::support` /
+/// `engine::base_subcommand`) and are already terse, so their former entries had
+/// drifted dead and are dropped rather than revived (reviving would only
+/// *lengthen* the wire copy).
+const TERSE_DESCRIPTIONS: &[(&str, &str)] = &[(
+    "Host to act on. Can be used multiple times. If omitted all hosts are used",
+    "Host to act on (repeatable; default: all hosts)",
+)];
 
 /// Schema keywords whose value is a mapping of *names* to sub-schemas. Under
 /// these, the map keys are parameter/definition names, not schema keywords, so
@@ -271,18 +270,57 @@ mod tests {
     }
 
     #[test]
-    fn slim_rewrites_known_verbose_description() {
+    fn slim_rewrites_a_known_verbose_description() {
+        // The `-t/--target` help is the one genuinely verbose shared description
+        // still in the table; slimming rewrites it to the terse form.
         let node = json!({
-            "type": "string",
-            "default": null,
+            "type": "array",
             "description":
-                "RRID of a single loaded template to act on (default: all loaded templates)",
+                "Host to act on. Can be used multiple times. If omitted all hosts are used",
         });
         let out = slim_tool_schema(&node);
         assert_eq!(
             out["description"],
-            json!("RRID of one loaded template (default: all)")
+            json!("Host to act on (repeatable; default: all hosts)")
         );
+    }
+
+    #[test]
+    fn terse_mappings_are_all_live() {
+        // Every TERSE_DESCRIPTIONS key must still match a real synthesised arg
+        // `description`, or the exact-match rewrite silently stops firing and the
+        // verbose text ships un-slimmed — the drift that had killed the
+        // `-t/--target` key and the (now removed) template keys. This builds the
+        // live tool surface from the registry and fails on any stale key, which a
+        // hardcoded per-string test cannot: both sides of such a test drift
+        // together, away from the real clap help, undetected.
+        use std::collections::BTreeSet;
+
+        fn collect(node: &Value, out: &mut BTreeSet<String>) {
+            match node {
+                Value::Object(map) => {
+                    if let Some(Value::String(desc)) = map.get("description") {
+                        out.insert(desc.clone());
+                    }
+                    for value in map.values() {
+                        collect(value, out);
+                    }
+                }
+                Value::Array(items) => items.iter().for_each(|v| collect(v, out)),
+                _ => {}
+            }
+        }
+
+        let mut live = BTreeSet::new();
+        for descriptor in crate::tools::build_tools(&mtui_core::register_all()) {
+            collect(&Value::Object(descriptor.input_schema), &mut live);
+        }
+        for (from, _) in TERSE_DESCRIPTIONS {
+            assert!(
+                live.contains(*from),
+                "stale terse-description key (matches no live arg help): {from:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -269,7 +269,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -304,7 +304,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -361,7 +361,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -431,7 +431,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -476,7 +476,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -526,7 +526,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -564,7 +564,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -655,7 +655,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -738,7 +738,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -806,7 +806,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -951,7 +951,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1018,7 +1018,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1165,7 +1165,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1191,7 +1191,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1266,7 +1266,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1292,7 +1292,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1374,7 +1374,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1405,7 +1405,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1488,7 +1488,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1569,7 +1569,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1637,7 +1637,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"
@@ -1673,7 +1673,7 @@ expression: pretty
         },
         "hosts": {
           "items": {
-            "description": "Host to act on. Can be used multiple times. If omitted all hosts are used",
+            "description": "Host to act on (repeatable; default: all hosts)",
             "type": "string"
           },
           "type": "array"

--- a/crates/mtui-types/src/shellquote.rs
+++ b/crates/mtui-types/src/shellquote.rs
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn nul_bearing_token_is_dropped_not_leaked() {
-        let out = quote_args(&["ok", "ba\0d"]);
+        let out = quote_args(&["ok", "x\0y"]);
         assert!(!out.contains('\0'), "NUL leaked: {out:?}");
         assert!(out.contains("ok"));
     }

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,48 @@
+# Configuration for crate-ci/typos (https://github.com/crate-ci/typos).
+# Allowlist ONLY: every entry below is a deliberate, load-bearing spelling, a
+# quoted historical/upstream string, or a captured data fixture — never a masked
+# real typo. A genuine typo is fixed in source, not silenced here.
+
+[files]
+extend-exclude = [
+  # SSH key + signature fixtures for the OBS backend tests: base64 key material,
+  # not prose to spell-check (e.g. "...NdOUL...", "...jkd9...").
+  "crates/mtui-datasources/tests/fixtures/obs/id_*",
+]
+
+[default.extend-words]
+# Accepted alternative spelling of "cannot be parsed", used consistently across
+# the datasources/testreport crates and their tests (error text, doc comments).
+unparseable = "unparseable"
+# Deliberate `sic`: upstream mtui literally prints "Referenece host"; the Rust
+# port preserves the byte-for-byte output for tool parity (see display.rs).
+referenece = "referenece"
+# SUSE product name: SLE-HAE (High Availability Extension), e.g. "SLE-HAE",
+# "sle-hae" in product-normalisation code and its tests.
+hae = "hae"
+# The Python `certifi` CA-bundle package, referenced by name in a doc comment
+# and in the retained Python-era CHANGELOG history.
+certifi = "certifi"
+# Quoted historical log strings, verbatim in the append-only CHANGELOG history
+# and (for "aviable") in a comment documenting the upstream typo that the Rust
+# port deliberately drops.
+aviable = "aviable"
+cannont = "cannont"
+errocode = "errocode"
+# The English prefix "mis-" (mis-decoded / mis-classifying / mis-encoded), split
+# on the hyphen by the tokenizer.
+mis = "mis"
+# Accepted alternative spelling in a doc comment ("non-clonable io::Error").
+clonable = "clonable"
+# Markdown bold-acronym artifact: "**I**nstaller" (expanding MTUI = Maintenance
+# Test Update Installer) renders the bolded initial separately, leaving
+# "nstaller" in the raw source.
+nstaller = "nstaller"
+# Deliberate misspellings in MCP tests/comments that exercise the
+# reject-unknown-kwargs path: a mistyped field name must be rejected, so the
+# wrong spelling is the point (see tools.rs).
+attribut = "attribut"
+mesage = "mesage"
+# A partial-read test slice: b"ome\n" is the tail of "welcome\n" read through a
+# 4-byte buffer in the SSH integration suite.
+ome = "ome"


### PR DESCRIPTION
## What

Adopt the [`typos`](https://github.com/crate-ci/typos) spell-checker as a CI
gate — mirroring the sibling **repose** project's setup — and fix the drifted MCP
terse-description mappings that reviewing the one flagged typo surfaced.

## `ci: add typos spell-checker`

- **`.github/workflows/typos.yml`** — runs `crate-ci/typos` on `push` to `main`
  and on `pull_request`. SHA-pinned action (`# v1.48.0`) and `actions/checkout`
  (`# v7.0.1`, the same SHA the security workflows already use), `contents: read`
  + `persist-credentials: false`, PR-only concurrency cancellation — matching the
  house style of the existing workflows.
- **`typos.toml`** — **allowlist-only**; every entry is justified inline and is a
  deliberate/load-bearing spelling, not a masked typo:
  - `referenece` — deliberate `sic`; upstream mtui literally prints
    "Referenece host" and the port keeps byte-for-byte output parity (there's a
    dedicated regression test for it).
  - `hae` — the SUSE product name **SLE-HAE**; `unparseable` — an accepted
    alt-spelling used consistently across the datasources/testreport crates;
    `certifi` — the Python CA package, referenced by name.
  - `aviable` / `cannont` / `errocode` — quoted historical log strings in the
    append-only CHANGELOG (and a comment documenting an upstream typo the port
    drops).
  - `mis` (the `mis-` prefix), `clonable`, `nstaller` (a Markdown bold-acronym
    artifact of "**I**nstaller"), `attribut` / `mesage` (deliberate test
    misspellings exercising the reject-unknown-kwargs path), `ome` (a partial
    read slice in the SSH tests).
  - `[files] extend-exclude` skips only the OBS SSH key/signature fixtures
    (base64 blobs, not prose).
  - The one arbitrary NUL-bearing test token (`"ba\0d"`) is renamed to a
    non-word token rather than allow-listed, to avoid a broad tree-wide silence.

## `fix(mcp): repair drifted terse-description mappings on the wire`

`slim.rs::TERSE_DESCRIPTIONS` rewrites a few verbose clap `help` strings to a
terse form for the slimmed MCP manifest, matched by **exact** string equality.
All three entries had silently gone stale — the keys no longer matched the help
their source args build, so the rewrite never fired and the verbose text shipped
un-slimmed:

- `-t/--target` — the key had drifted (an extra word plus a misspelled
  "omitted"); aligned byte-for-byte with `commands::support::add_hosts_arg`, so
  it slims again (72 → 47 chars across **22 tools**). *This was the one genuine
  typo `typos` flagged.*
- `-T/--template` / `--all-templates` — the help was trimmed at the source
  (`engine::base_subcommand`) and is already terse; the table entries were dead,
  and reviving them would only **lengthen** the wire copy for 54 tools each, so
  they're dropped instead (a no-op on the manifest).

The hardcoded per-string tests (which can drift together with a stale key,
undetected) are replaced by `terse_mappings_are_all_live`, which builds the real
tool surface and fails on any key that matches no live description — the guard
that would have caught this class of bug.

## Testing

- `typos` v1.48.0 clean on the tree (exit 0).
- Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace
  --all-targets -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp
  -F mcp`, and the compile-only feature matrix
  (`--no-default-features` / `--all-features`).
