### PR TITLE
docs: mtui is REPL-only, not a single-command CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ maintenance ecosystem (see "Contracts" below).
 ## Two driving surfaces (keep both working)
 Like upstream, there are **two entrypoints**, and command/entrypoint changes must
 keep both green:
-- `mtui` — the interactive REPL (`reedline`) + non-interactive single-command mode.
+- `mtui` — the interactive REPL (`reedline`).
 - `mtui-mcp` — the MCP server, which **synthesises its tools from the command
   registry**. Adding/renaming/removing a command affects MCP tools automatically.
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ ecosystem.
 
 ## Two surfaces
 
-- `mtui` — interactive REPL (line editing, tab completion, history) **and**
-  non-interactive single-command mode.
+- `mtui` — interactive REPL (line editing, tab completion, history).
 - `mtui-mcp` — a Model Context Protocol server whose tools are **synthesised from
   the command registry**, so the CLI and the MCP surface never drift.
 


### PR DESCRIPTION
## What

README and AGENTS both described the `mtui` binary as having a
"non-interactive single-command mode". It has no such mode — and the rest of the
tree already says so.

## Why it's wrong

`mtui` is **REPL-only**:

- `crates/mtui-cli/src/main.rs` parses the top-level `Args`, seeds the session
  from `-a`/`-k`/`--sut`, and enters the reedline REPL. It never parses a
  positional command and never calls `run_once`.
- The headless single-command driver `mtui_core::run_once`
  (`crates/mtui-core/src/entrypoint.rs`) is explicitly documented as the
  `mtui-mcp`/embedding primitive — *"not a CLI mode … neither surface takes a
  positional command."*
- `docs/src/invocation.md` (generated from the clap parsers) already states:
  *"`mtui` is REPL-only. There is no positional single-command mode."*

So the two claims in README and AGENTS were the only spots out of step with the
code and the generated docs.

## Change

Drop the inaccurate clause in both files, leaving the two surfaces described
consistently everywhere: `mtui` (interactive REPL) and `mtui-mcp` (headless MCP
server). Docs-only; no code or behavior change.
