### PR TITLE
fix(cli): stop doubling the "error: " prefix on clap usage errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,11 @@ see phase progress. Phase 0 (workspace bootstrap) is already complete (closed).
 - Keep **both surfaces** (`mtui`, `mtui-mcp`) building and passing when touching
   commands, `Session`, the registry, or entrypoints.
 - Preserve the **Contracts** below unless the task explicitly changes one.
+- **Changelog:** add an entry to the top-most unreleased section of
+  `CHANGELOG.md` for user-visible changes (new/changed/removed commands or
+  flags, behavior a user or MCP client would notice, config format changes).
+  Internal refactors, perf/implementation-only fixes, and chore/CI-only
+  changes do not need one (`CONTRIBUTING.md` § Changelog is authoritative).
 
 ## Architecture (non-obvious bits — mirror these from MTUI)
 - **Command registry.** Every command implements the `Command` trait and is

--- a/crates/mtui-cli/src/logfmt.rs
+++ b/crates/mtui-cli/src/logfmt.rs
@@ -31,6 +31,12 @@ use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 
+/// Marks an event whose message is already fully rendered (e.g. clap's own
+/// colored `error: ...` usage text for a genuine parse error) so
+/// [`CompactLevelFormat::format_event`] must not prepend a second level
+/// prefix. Set via `tracing::error!(target: CLAP_PREFIXED_TARGET, "{msg}")`.
+pub(crate) const CLAP_PREFIXED_TARGET: &str = "mtui::clap_prefixed";
+
 /// A [`FormatEvent`] that renders `"{level}: {message}"` with a lowercased,
 /// optionally colorized level token and no timestamp/target.
 ///
@@ -84,7 +90,9 @@ where
         event: &Event<'_>,
     ) -> fmt::Result {
         let meta = event.metadata();
-        write!(writer, "{}: ", self.level_token(meta.level()))?;
+        if meta.target() != CLAP_PREFIXED_TARGET {
+            write!(writer, "{}: ", self.level_token(meta.level()))?;
+        }
         // The field formatter writes the `message` field (and any structured
         // fields) exactly as the stock compact format does — but without the
         // level/timestamp/target prefix we deliberately omit.
@@ -201,5 +209,24 @@ mod tests {
         assert_ne!(info, error);
         // Parity with the display's `error` token (both via owo-colors red).
         assert_eq!(error, "error".red().to_string());
+    }
+
+    /// An event marked with [`CLAP_PREFIXED_TARGET`] renders its message
+    /// verbatim, with no `"{level}: "` prefix added on top — the mechanism
+    /// that lets a genuine clap usage error (which already carries its own
+    /// `"error: "` prefix) avoid being double-prefixed.
+    #[test]
+    fn clap_prefixed_target_suppresses_level_prefix() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .event_format(CompactLevelFormat::new(false))
+            .with_writer(BufMaker(Arc::clone(&buf)))
+            .finish();
+        with_default(subscriber, || {
+            tracing::error!(target: CLAP_PREFIXED_TARGET, "error: already prefixed");
+        });
+        let out = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert_eq!(out, "error: already prefixed\n");
     }
 }

--- a/crates/mtui-cli/src/repl.rs
+++ b/crates/mtui-cli/src/repl.rs
@@ -259,8 +259,25 @@ pub async fn step(registry: &Registry, session: &mut Session, line: &str) -> Con
 /// `error: <message>` text through its captured display buffer. The two present
 /// failures with identical *text*; each uses the channel appropriate to its
 /// surface (REPL → operator log on stderr; headless → captured display sink).
+///
+/// One exception: a genuine usage error (`Parse { help_or_version: false,
+/// .. }`) carries clap's *own* already-rendered `error: ` prefix (and
+/// whatever color clap itself applied). Emitting it through the normal path
+/// would double that prefix, so it's tagged with
+/// [`CLAP_PREFIXED_TARGET`](crate::logfmt::CLAP_PREFIXED_TARGET) instead,
+/// which `CompactLevelFormat` recognizes and renders without adding a second
+/// one. `--help`/`--version` output (`help_or_version: true`) keeps flowing
+/// through the normal path unchanged.
 fn render_error(err: &EngineError) {
-    tracing::error!("{err}");
+    match err {
+        EngineError::Parse {
+            help_or_version: false,
+            message,
+        } => {
+            tracing::error!(target: crate::logfmt::CLAP_PREFIXED_TARGET, "{message}");
+        }
+        _ => tracing::error!("{err}"),
+    }
 }
 
 #[cfg(test)]
@@ -488,5 +505,13 @@ mod tests {
         assert_eq!(flow, ControlFlow::Continue(()));
         assert_eq!(runs.load(Ordering::SeqCst), 0, "the body never ran");
         assert!(!out.is_empty(), "usage error is rendered");
+        // clap's own "error: " prefix must survive exactly once, not doubled
+        // with mtui's own level prefix.
+        assert_eq!(
+            out.matches("error: ").count(),
+            1,
+            "exactly one error prefix, got: {out:?}"
+        );
+        assert!(!out.contains("error: error:"), "no doubled prefix: {out:?}");
     }
 }

--- a/crates/mtui-core/src/entrypoint.rs
+++ b/crates/mtui-core/src/entrypoint.rs
@@ -141,9 +141,20 @@ pub async fn run_once(
 /// display buffer. The two present the same `error: <message>` *text*; each uses
 /// the channel appropriate to its surface. No `tracing` event is emitted here so
 /// the failure never surfaces twice.
+///
+/// One exception: a [`EngineError::Parse`] here is always a genuine usage
+/// error (the `--help`/`--version` case is filtered out in [`run_once`]
+/// before `render_error` is ever called with it) and its message already
+/// carries clap's own `error: ` prefix (and whatever color clap itself
+/// applied). It is printed verbatim rather than wrapped a second time.
 fn render_error(session: &mut Session, err: &EngineError) {
-    let level = session.display.red("error");
-    session.display.println(&format!("{level}: {err}"));
+    match err {
+        EngineError::Parse { message, .. } => session.display.println(message),
+        _ => {
+            let level = session.display.red("error");
+            session.display.println(&format!("{level}: {err}"));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -297,6 +308,14 @@ mod tests {
             1,
             "usage error must be rendered exactly once, got: {out:?}"
         );
+        // clap's own "error: " prefix must survive exactly once, not doubled
+        // with mtui's own level prefix.
+        assert_eq!(
+            out.matches("error: ").count(),
+            1,
+            "exactly one error prefix, got: {out:?}"
+        );
+        assert!(!out.contains("error: error:"), "no doubled prefix: {out:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

`EngineError::Parse` stores clap's own rendered error text verbatim so
callers can present it exactly as clap produced it. For a genuine usage
error, clap's text already starts with its own colored `error: ` tag —
but both renderers (the REPL's tracing-based `CompactLevelFormat` and the
headless entrypoint's session-display renderer) unconditionally
prepended their own `error: ` on top, producing `error: error: ...`.

## What changed

- `logfmt.rs`: add a `CLAP_PREFIXED_TARGET` tracing target sentinel;
  `CompactLevelFormat::format_event` skips the level prefix for events
  carrying it.
- `repl.rs`: `render_error` routes a genuine `Parse` usage error through
  the sentinel target instead of the generic `tracing::error!` path.
- `entrypoint.rs`: `render_error` prints a `Parse` error's message
  directly, skipping the red `error: ` wrapper it adds for other
  variants.
- Extended existing tests in all three files to assert exactly one
  `error: ` occurrence and no `error: error:` doubling.
- `AGENTS.md`: surface the (pre-existing, `CONTRIBUTING.md`-owned)
  changelog policy directly in the Definition of Done checklist.

Fixed at the render sites via type-based matching
(`EngineError::Parse { help_or_version: false, .. }`), not by mutating
clap's message or forcing its `ColorChoice`, so clap's own text and
coloring decision are preserved verbatim. `--help`/`--version` output is
unaffected.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (37/37 test binaries green)
- Manual check against the real command registry (`config --no-such-flag`
  via `run_once`): renders exactly one `error: ` prefix.

No CHANGELOG entry: internal display-formatting fix, not a user-visible
behavior/command/flag change.