### PR TITLE
fix(config): enforce the positive-only connection/timeout invariant on config set and --connection-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ _The entries below document the final Python releases, retained for history._
   could store a `0` the file would reject, contradicting the command's own
   promise that it cannot store what the file refuses. `lock_stale_age` and
   `lock_wait` still accept `0`, as the file format does.
+- The `--connection-timeout` flag (on both `mtui` and `mtui-mcp`) now rejects
+  `0` at parse time, for the same reason: the config-file loader refuses a
+  non-positive `connection_timeout`, so the CLI must not be able to express one.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,13 @@ _The entries below document the final Python releases, retained for history._
   `mtui-mcp` wire. Its terse-rewrite rule had drifted from the actual help text
   and silently stopped matching, so every host-targeting tool advertised the
   long form; the manifest each client re-reads is now a little leaner again.
+- `config set` now rejects `0` for the positive-only integer keys
+  (`connection_timeout`, `max_parallel`, `refhosts_https_expiration`,
+  `slack_poll_interval`, `slack_watch_timeout`, `lock_wait_poll`), matching the
+  config-file loader's `validated_positive!` guard. Previously a runtime `set`
+  could store a `0` the file would reject, contradicting the command's own
+  promise that it cannot store what the file refuses. `lock_stale_age` and
+  `lock_wait` still accept `0`, as the file format does.
 
 ### Removed
 

--- a/crates/mtui-core/src/args.rs
+++ b/crates/mtui-core/src/args.rs
@@ -69,7 +69,15 @@ pub struct Args {
     pub sut: Vec<Sut>,
 
     /// Override config `mtui.connection_timeout` (seconds).
-    #[arg(short = 'w', long = "connection-timeout", value_name = "SECONDS")]
+    // Rejected at parse time if 0 via the value_parser range: the config-file
+    // loader guards this key with `validated_positive!`, so the CLI must not be
+    // able to express a 0 the file would refuse (keeps `apply_to`'s invariant).
+    #[arg(
+        short = 'w',
+        long = "connection-timeout",
+        value_name = "SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
     pub connection_timeout: Option<u64>,
 
     /// Enable debugging output.
@@ -277,6 +285,19 @@ mod tests {
         let mut full = vec!["mtui"];
         full.extend_from_slice(argv);
         Args::try_parse_from(full)
+    }
+
+    #[test]
+    fn connection_timeout_zero_is_rejected_at_parse() {
+        // The file loader's `validated_positive!` rejects 0, so the CLI flag must
+        // too — a usage error, not a silently stored 0 that bypasses the guard.
+        assert!(parse(&["--connection-timeout", "0"]).is_err());
+        assert_eq!(
+            parse(&["--connection-timeout", "1"])
+                .unwrap()
+                .connection_timeout,
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/mtui-core/src/commands/config.rs
+++ b/crates/mtui-core/src/commands/config.rs
@@ -148,6 +148,17 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         s.parse::<u64>()
             .map_err(|e| format!("invalid integer: {e}"))
     };
+    // Positive-only variant for the keys the config-file loader guards with
+    // `validated_positive!` (0 is rejected there, falling back to the default).
+    // Runtime `set` must reject 0 too, so it cannot store a value the file would
+    // refuse — the guarantee this command's doc comment makes. Keys the loader
+    // accepts 0 for (`lock_stale_age`, `lock_wait`, via `unwrap_or`) keep the
+    // plain `parse_u64`.
+    let parse_positive_u64 = |s: &str| match s.parse::<u64>() {
+        Ok(0) => Err("expected a positive integer greater than 0".to_owned()),
+        Ok(value) => Ok(value),
+        Err(e) => Err(format!("invalid integer: {e}")),
+    };
 
     match attr {
         "session_user" => config.session_user = raw.to_owned(),
@@ -169,8 +180,8 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         "slack_channel" => config.slack_channel = raw.to_owned(),
         "slack_api_url" => config.slack_api_url = raw.to_owned(),
         "slack_enabled" => config.slack_enabled = parse_bool(raw)?,
-        "slack_poll_interval" => config.slack_poll_interval = parse_u64(raw)?,
-        "slack_watch_timeout" => config.slack_watch_timeout = parse_u64(raw)?,
+        "slack_poll_interval" => config.slack_poll_interval = parse_positive_u64(raw)?,
+        "slack_watch_timeout" => config.slack_watch_timeout = parse_positive_u64(raw)?,
         // Goes through the same coercion as config-file loading (a boolean
         // spelling toggles verification, anything else is a CA-bundle path), so
         // a runtime `set` cannot store a value the file would reject.
@@ -178,12 +189,12 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         "chdir_to_template_dir" => config.chdir_to_template_dir = parse_bool(raw)?,
         "lock_reap_stale" => config.lock_reap_stale = parse_bool(raw)?,
         "lock_pi_autolock" => config.lock_pi_autolock = parse_bool(raw)?,
-        "connection_timeout" => config.connection_timeout = parse_u64(raw)?,
-        "max_parallel" => config.max_parallel = parse_u64(raw)?,
-        "refhosts_https_expiration" => config.refhosts_https_expiration = parse_u64(raw)?,
+        "connection_timeout" => config.connection_timeout = parse_positive_u64(raw)?,
+        "max_parallel" => config.max_parallel = parse_positive_u64(raw)?,
+        "refhosts_https_expiration" => config.refhosts_https_expiration = parse_positive_u64(raw)?,
         "lock_stale_age" => config.lock_stale_age = parse_u64(raw)?,
         "lock_wait" => config.lock_wait = parse_u64(raw)?,
-        "lock_wait_poll" => config.lock_wait_poll = parse_u64(raw)?,
+        "lock_wait_poll" => config.lock_wait_poll = parse_positive_u64(raw)?,
         other => return Err(format!("unknown or read-only attribute: {other}")),
     }
     Ok(())
@@ -193,9 +204,9 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
 ///
 /// Ports upstream `mtui.commands.config.Config` (the command). `config show
 /// [attr ...]` prints the current values (all when none named); `config set
-/// <attr> <value>` updates one, going through the same value parsing/fixup as
-/// config-file loading so a runtime `set` cannot store a value the file would
-/// reject. Self-describing, so it runs once ([`Scope::Single`]).
+/// <attr> <value>` updates one, going through value parsing/validation at least
+/// as strict as config-file loading, so a runtime `set` cannot store a value the
+/// file would reject. Self-describing, so it runs once ([`Scope::Single`]).
 pub struct ConfigCmd;
 
 #[async_trait]
@@ -485,5 +496,80 @@ mod tests {
         let args = matches(&ConfigCmd, &["set", "nope", "x"]);
         let err = ConfigCmd.call(&mut session, &args).await.unwrap_err();
         assert!(matches!(err, CommandError::Other(m) if m.contains("unknown or read-only")));
+    }
+
+    #[tokio::test]
+    async fn set_zero_rejected_for_positive_only_keys() {
+        // These keys are guarded by `validated_positive!` in the config-file
+        // loader, so runtime `set` must reject 0 too — otherwise it could store a
+        // value the file would refuse, breaking the command's own contract.
+        for attr in [
+            "connection_timeout",
+            "max_parallel",
+            "refhosts_https_expiration",
+            "slack_poll_interval",
+            "slack_watch_timeout",
+            "lock_wait_poll",
+        ] {
+            let (mut session, _buf) = empty_session();
+            let before = attr_value(&session.config, attr);
+            let args = matches(&ConfigCmd, &["set", attr, "0"]);
+            let err = ConfigCmd.call(&mut session, &args).await.unwrap_err();
+            assert!(
+                matches!(&err, CommandError::Other(m) if m.contains("positive integer greater than 0")),
+                "{attr}: expected a positive-integer rejection, got {err:?}"
+            );
+            assert_eq!(
+                attr_value(&session.config, attr),
+                before,
+                "{attr}: value must be unchanged after a rejected set"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn set_zero_allowed_for_keys_the_loader_also_accepts() {
+        // `lock_stale_age` / `lock_wait` are taken via `unwrap_or` in the loader
+        // (0 is a valid value there), so the positive-only guard must not
+        // over-reach to keys the file format permits. Set a non-zero value first,
+        // then 0, so the final assertion proves 0 was actually stored (lock_wait's
+        // default is already 0, which would otherwise mask a no-op).
+        for attr in ["lock_stale_age", "lock_wait"] {
+            let (mut session, _buf) = empty_session();
+            ConfigCmd
+                .call(&mut session, &matches(&ConfigCmd, &["set", attr, "9"]))
+                .await
+                .unwrap();
+            ConfigCmd
+                .call(&mut session, &matches(&ConfigCmd, &["set", attr, "0"]))
+                .await
+                .unwrap();
+            assert_eq!(attr_value(&session.config, attr).as_deref(), Some("0"));
+        }
+    }
+
+    #[tokio::test]
+    async fn set_positive_expiration_roundtrips() {
+        let (mut session, _buf) = empty_session();
+        let args = matches(&ConfigCmd, &["set", "refhosts_https_expiration", "3600"]);
+        ConfigCmd.call(&mut session, &args).await.unwrap();
+        assert_eq!(
+            attr_value(&session.config, "refhosts_https_expiration").as_deref(),
+            Some("3600")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_non_numeric_on_positive_key_is_invalid_integer_not_range_error() {
+        // A non-numeric value must surface the parse error, not the positive-only
+        // rejection — the two failure modes stay distinct.
+        let (mut session, _buf) = empty_session();
+        let args = matches(&ConfigCmd, &["set", "max_parallel", "abc"]);
+        let err = ConfigCmd.call(&mut session, &args).await.unwrap_err();
+        assert!(
+            matches!(&err, CommandError::Other(m)
+                if m.contains("invalid integer") && !m.contains("positive integer")),
+            "expected an invalid-integer error, got {err:?}"
+        );
     }
 }

--- a/crates/mtui-mcp/src/args.rs
+++ b/crates/mtui-mcp/src/args.rs
@@ -39,7 +39,15 @@ pub struct McpArgs {
     pub template_dir: Option<PathBuf>,
 
     /// Override config `mtui.connection_timeout` (seconds).
-    #[arg(short = 'w', long = "connection-timeout", value_name = "SECONDS")]
+    // Rejected at parse time if 0 via the value_parser range: the config-file
+    // loader guards this key with `validated_positive!`, so the CLI must not be
+    // able to express a 0 the file would refuse.
+    #[arg(
+        short = 'w',
+        long = "connection-timeout",
+        value_name = "SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
     pub connection_timeout: Option<u64>,
 
     /// Enable debugging output.
@@ -129,6 +137,18 @@ mod tests {
         let mut full = vec!["mtui-mcp"];
         full.extend_from_slice(argv);
         McpArgs::try_parse_from(full)
+    }
+
+    #[test]
+    fn connection_timeout_zero_is_rejected_at_parse() {
+        // Same positive-only guard as the config-file loader: 0 is a usage error.
+        assert!(parse(&["--connection-timeout", "0"]).is_err());
+        assert_eq!(
+            parse(&["--connection-timeout", "1"])
+                .unwrap()
+                .connection_timeout,
+            Some(1)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Enforce the positive-only `connection_timeout`/timeout invariant on **every**
entrypoint that can set it. The config-**file** loader guards eleven integer
keys with `validated_positive!` (rejects `0` → falls back to default), but two
other paths could store a `0` the file refuses — contradicting the code's own
documented promise.

## Two gaps, same invariant

**1. `config set <key> 0`** — `set_attr` parsed every integer key with a bare
`parse_u64` (accepts `0`), so `config set refhosts_https_expiration 0` stored a
value the file would reject.

**2. `--connection-timeout 0`** — the `-w/--connection-timeout` flag on both
`mtui` and `mtui-mcp` assigned the value straight into the config with no check,
even though `apply_to`'s doc comment promises *"the CLI cannot express a value
the file could not."*

## Fix

- **`config set`:** add `parse_positive_u64` (rejects `0`) and route the keys
  that are **both** `validated_positive!` **and** runtime-settable through it:
  `connection_timeout`, `max_parallel`, `refhosts_https_expiration`,
  `slack_poll_interval`, `slack_watch_timeout`, `lock_wait_poll`.
- **`--connection-timeout`:** add `value_parser = clap::value_parser!(u64).range(1..)`
  to both binaries, so clap rejects `0` as a usage error at parse time.

Deliberately **left accepting `0`:** `lock_stale_age` and `lock_wait` — the
loader takes these via `unwrap_or` (it genuinely accepts `0`), so rejecting `0`
at runtime would be a *new* inconsistency. Not touched (no runtime gap):
`max_oqa_parallel`, `mcp_session_cap`, `mcp_session_idle_timeout`,
`mcp_sweep_parallel`, `obs_request_timeout` are `validated_positive!` but not
settable via `config set` at all.

`config set` **rejects** rather than coerce-to-default (as the lenient file
loader does), matching how it already rejects invalid booleans and unknown keys;
an interactive/tool `set` should report bad input, not silently substitute.

## How it was scoped

The exact key-set was derived from the codebase knowledge graph (which pointed
straight at the loader and the runtime setter) and then confirmed by a full
cross-reference of `validated_positive!` sites vs `set_attr` arms. The
`--connection-timeout` bypass was surfaced by adversarial review of the first
fix — the same invariant, a different entrypoint.

## Testing

- New unit tests: all six positive-only keys reject `0` in `config set` (value
  unchanged); `lock_stale_age`/`lock_wait` still accept `0` (proven by setting
  non-zero then `0`); a non-numeric value still yields "invalid integer", not the
  positive error; a positive value roundtrips; `--connection-timeout 0` is a
  parse error on both binaries.
- Full gate green: `typos`, `cargo fmt --all --check`, `cargo clippy --workspace
  --all-targets -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp
  -F mcp`, and the compile-only feature matrix. `config_set` over MCP shares
  `set_attr`, so the rejection applies there too (no schema/snapshot change).
