### PR TITLE
fix(mcp): release pool claims and disconnect hosts on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   gate is turned off by configuration (`slack_enabled = false`), which is
   explicit and auditable. `reject` is never gated. With Slack disabled (the
   default) `approve` behaves exactly as before.
+- New `[lock]` config keys `pool_reap_stale` (default `true`) and
+  `pool_stale_age` (default `86400` seconds) give the host-arbitration pool claim
+  the same stale-lock reaping the operation lock already had. A pool claim orphaned
+  by an uncatchable exit (`SIGKILL`, panic, power loss) is force-removed on the
+  next claim attempt once it is older than `pool_stale_age`, so pool arbitration
+  self-heals instead of blocking until a human runs `unlock -f -p`. Set
+  `pool_reap_stale = false` or `pool_stale_age = 0` to disable it. Both keys are
+  visible in `config show` and settable with `config set`.
 
 ### Security
 
@@ -59,6 +67,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `mtui-mcp` now releases remote pool claims and disconnects hosts when it shuts
+  down, on both transports. Over **stdio** the parent exiting (stdin EOF, e.g.
+  `/exit`) or a `SIGTERM` now runs the same teardown the REPL's `quit` does;
+  previously the process fell off the end of its serve loop and left the loaded
+  template's `/var/lock/mtui-pool.lock` claims held on the reference hosts. Over
+  **http** a clean Ctrl-C or `SIGTERM` now tears down **every** live client
+  session, not just idle ones; the idle sweeper only ever reclaimed quiet
+  sessions, so a busy server leaked active sessions' pool claims and SSH
+  connections on shutdown. (An uncatchable exit — `SIGKILL`, panic, power loss —
+  still cannot run teardown; the new pool-claim stale reaping below is the
+  recovery for those.)
 - Concurrent `refhosts.yml` HTTPS refreshes no longer stampede the server.
   When several sessions or commands hit a stale cache at once, one of them
   downloads while the rest wait and then read the freshly written cache —

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -300,6 +300,12 @@ pub(crate) fn default_lock_reap_stale() -> bool {
 pub(crate) fn default_lock_stale_age() -> u64 {
     86400
 }
+pub(crate) fn default_pool_reap_stale() -> bool {
+    true
+}
+pub(crate) fn default_pool_stale_age() -> u64 {
+    86400
+}
 pub(crate) fn default_lock_pi_autolock() -> bool {
     true
 }
@@ -464,6 +470,8 @@ pub(crate) struct SlackSection {
 pub(crate) struct LockSection {
     pub reap_stale: Option<bool>,
     pub stale_age: Option<u64>,
+    pub pool_reap_stale: Option<bool>,
+    pub pool_stale_age: Option<u64>,
     pub pi_autolock: Option<bool>,
     pub wait: Option<u64>,
     pub wait_poll: Option<u64>,
@@ -586,6 +594,8 @@ impl RawConfig {
         take!(slack, watch_timeout);
         take!(lock, reap_stale);
         take!(lock, stale_age);
+        take!(lock, pool_reap_stale);
+        take!(lock, pool_stale_age);
         take!(lock, pi_autolock);
         take!(lock, wait);
         take!(lock, wait_poll);
@@ -723,6 +733,16 @@ pub struct Config {
     /// Age (seconds) beyond which a remote lock is considered stale and reapable.
     /// A non-positive value disables reaping.
     pub lock_stale_age: u64,
+    /// On a pool claim attempt, force-remove a pre-existing pool-claim lock older
+    /// than [`pool_stale_age`](Self::pool_stale_age) seconds regardless of owner.
+    /// The pool-claim analogue of [`lock_reap_stale`](Self::lock_reap_stale) — the
+    /// only automatic recovery for a pool claim orphaned by an uncatchable exit
+    /// (SIGKILL / panic / power loss), which the RRID-based pool lock otherwise
+    /// leaves held until a manual `unlock -f -p`.
+    pub pool_reap_stale: bool,
+    /// Age (seconds) beyond which a pool-claim lock is considered stale and
+    /// reapable. A value of `0` disables pool-claim reaping.
+    pub pool_stale_age: u64,
     /// When testing a Product Increment (PI), auto-lock all reference hosts on
     /// `assign` and unlock them at end of testing.
     pub lock_pi_autolock: bool,
@@ -844,6 +864,8 @@ impl Default for Config {
             target_tempdir: default_target_tempdir(),
             lock_reap_stale: default_lock_reap_stale(),
             lock_stale_age: default_lock_stale_age(),
+            pool_reap_stale: default_pool_reap_stale(),
+            pool_stale_age: default_pool_stale_age(),
             lock_pi_autolock: default_lock_pi_autolock(),
             lock_wait: default_lock_wait(),
             lock_wait_poll: default_lock_wait_poll(),
@@ -1008,6 +1030,8 @@ impl Config {
                 .map_or(d.target_tempdir, |p| expanduser(&p)),
             lock_reap_stale: raw.lock.reap_stale.unwrap_or(d.lock_reap_stale),
             lock_stale_age: raw.lock.stale_age.unwrap_or(d.lock_stale_age),
+            pool_reap_stale: raw.lock.pool_reap_stale.unwrap_or(d.pool_reap_stale),
+            pool_stale_age: raw.lock.pool_stale_age.unwrap_or(d.pool_stale_age),
             lock_pi_autolock: raw.lock.pi_autolock.unwrap_or(d.lock_pi_autolock),
             lock_wait: raw.lock.wait.unwrap_or(d.lock_wait),
             lock_wait_poll: validated_positive!(
@@ -1085,6 +1109,9 @@ mod tests {
         // [lock] defaults mirror upstream config.py exactly.
         assert!(c.lock_reap_stale);
         assert_eq!(c.lock_stale_age, 86400);
+        // Pool-claim reaping defaults match the operation lock's.
+        assert!(c.pool_reap_stale);
+        assert_eq!(c.pool_stale_age, 86400);
         assert!(c.lock_pi_autolock);
         assert_eq!(c.lock_wait, 0);
         assert_eq!(c.lock_wait_poll, 15);
@@ -1270,12 +1297,14 @@ mod tests {
     #[test]
     fn lock_section_parses_and_overrides() {
         let raw: RawConfig = toml::from_str(
-            "[lock]\nreap_stale = false\nstale_age = 3600\npi_autolock = false\nwait = 30\nwait_poll = 5\n",
+            "[lock]\nreap_stale = false\nstale_age = 3600\npool_reap_stale = false\npool_stale_age = 7200\npi_autolock = false\nwait = 30\nwait_poll = 5\n",
         )
         .unwrap();
         let c = Config::from_raw(raw);
         assert!(!c.lock_reap_stale);
         assert_eq!(c.lock_stale_age, 3600);
+        assert!(!c.pool_reap_stale);
+        assert_eq!(c.pool_stale_age, 7200);
         assert!(!c.lock_pi_autolock);
         assert_eq!(c.lock_wait, 30);
         assert_eq!(c.lock_wait_poll, 5);
@@ -1289,6 +1318,8 @@ mod tests {
         assert_eq!(c.lock_wait, 45);
         assert!(c.lock_reap_stale);
         assert_eq!(c.lock_stale_age, 86400);
+        assert!(c.pool_reap_stale);
+        assert_eq!(c.pool_stale_age, 86400);
         assert_eq!(c.lock_wait_poll, 15);
     }
 

--- a/crates/mtui-config/tests/fixtures/config.toml
+++ b/crates/mtui-config/tests/fixtures/config.toml
@@ -32,8 +32,10 @@ path = "svn+ssh://svn@svn.example/testreports"
 [lock]
 reap_stale = false                # boolean value
 stale_age = 3600                  # integer value
+pool_stale_age = 7200             # integer value
 wait = 30
 # wait_poll omitted on purpose: it must keep its upstream default (15)
+# pool_reap_stale omitted on purpose: it must keep its upstream default (true)
 
 [slack]
 enabled = true                    # boolean value

--- a/crates/mtui-config/tests/load.rs
+++ b/crates/mtui-config/tests/load.rs
@@ -59,6 +59,8 @@ fn config_toml_fixture_parses_all_sections() {
     // [lock] section: explicit overrides land, an omitted key keeps its default.
     assert!(!cfg.lock_reap_stale);
     assert_eq!(cfg.lock_stale_age, 3600);
+    assert_eq!(cfg.pool_stale_age, 7200);
+    assert!(cfg.pool_reap_stale); // omitted -> upstream default (true)
     assert_eq!(cfg.lock_wait, 30);
     assert_eq!(cfg.lock_wait_poll, 15); // omitted -> upstream default
 

--- a/crates/mtui-core/src/commands/config.rs
+++ b/crates/mtui-core/src/commands/config.rs
@@ -65,6 +65,8 @@ fn attr_value(config: &Config, attr: &str) -> Option<String> {
         "target_tempdir" => config.target_tempdir.display().to_string(),
         "lock_reap_stale" => config.lock_reap_stale.to_string(),
         "lock_stale_age" => config.lock_stale_age.to_string(),
+        "pool_reap_stale" => config.pool_reap_stale.to_string(),
+        "pool_stale_age" => config.pool_stale_age.to_string(),
         "lock_pi_autolock" => config.lock_pi_autolock.to_string(),
         "lock_wait" => config.lock_wait.to_string(),
         "lock_wait_poll" => config.lock_wait_poll.to_string(),
@@ -97,7 +99,7 @@ fn ssl_verify_to_string(v: &SslVerify) -> String {
 }
 
 /// The attribute names `show` lists when given none, in a stable order.
-const ATTRS: [&str; 36] = [
+const ATTRS: [&str; 38] = [
     "template_dir",
     "local_tempdir",
     "session_user",
@@ -131,6 +133,8 @@ const ATTRS: [&str; 36] = [
     "target_tempdir",
     "lock_reap_stale",
     "lock_stale_age",
+    "pool_reap_stale",
+    "pool_stale_age",
     "lock_pi_autolock",
     "lock_wait",
     "lock_wait_poll",
@@ -188,11 +192,13 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         "ssl_verify" => config.ssl_verify = SslVerify::parse(raw),
         "chdir_to_template_dir" => config.chdir_to_template_dir = parse_bool(raw)?,
         "lock_reap_stale" => config.lock_reap_stale = parse_bool(raw)?,
+        "pool_reap_stale" => config.pool_reap_stale = parse_bool(raw)?,
         "lock_pi_autolock" => config.lock_pi_autolock = parse_bool(raw)?,
         "connection_timeout" => config.connection_timeout = parse_positive_u64(raw)?,
         "max_parallel" => config.max_parallel = parse_positive_u64(raw)?,
         "refhosts_https_expiration" => config.refhosts_https_expiration = parse_positive_u64(raw)?,
         "lock_stale_age" => config.lock_stale_age = parse_u64(raw)?,
+        "pool_stale_age" => config.pool_stale_age = parse_u64(raw)?,
         "lock_wait" => config.lock_wait = parse_u64(raw)?,
         "lock_wait_poll" => config.lock_wait_poll = parse_positive_u64(raw)?,
         other => return Err(format!("unknown or read-only attribute: {other}")),
@@ -556,6 +562,47 @@ mod tests {
         assert_eq!(
             attr_value(&session.config, "refhosts_https_expiration").as_deref(),
             Some("3600")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_pool_reap_keys_roundtrip() {
+        // The pool-claim reap knobs are settable: a boolean toggle and a u64 age
+        // (0 allowed, matching the loader's `unwrap_or`).
+        let (mut session, _buf) = empty_session();
+        ConfigCmd
+            .call(
+                &mut session,
+                &matches(&ConfigCmd, &["set", "pool_reap_stale", "false"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            attr_value(&session.config, "pool_reap_stale").as_deref(),
+            Some("false")
+        );
+        ConfigCmd
+            .call(
+                &mut session,
+                &matches(&ConfigCmd, &["set", "pool_stale_age", "3600"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            attr_value(&session.config, "pool_stale_age").as_deref(),
+            Some("3600")
+        );
+        // 0 disables reaping and must be accepted (loader takes it via unwrap_or).
+        ConfigCmd
+            .call(
+                &mut session,
+                &matches(&ConfigCmd, &["set", "pool_stale_age", "0"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            attr_value(&session.config, "pool_stale_age").as_deref(),
+            Some("0")
         );
     }
 

--- a/crates/mtui-hosts/src/target/locks.rs
+++ b/crates/mtui-hosts/src/target/locks.rs
@@ -738,6 +738,14 @@ where
 pub struct PoolLock<C: Clock = SystemClock> {
     inner: TargetLock<C>,
     i_am_rrid: String,
+    /// Force-reap a pool claim older than [`Self::pool_stale_age`] on claim
+    /// (`pool_reap_stale`). The pool-claim analogue of the operation lock's
+    /// `lock_reap_stale`, kept separate because the inner [`TargetLock`]'s
+    /// reap fields govern the *operation* lock's stale age, not the pool claim's.
+    pool_reap_stale: bool,
+    /// Age (seconds) beyond which a pool claim is reapable (`pool_stale_age`);
+    /// `0` disables pool-claim reaping.
+    pool_stale_age: u64,
 }
 
 impl PoolLock<SystemClock> {
@@ -765,6 +773,8 @@ impl<C: Clock> PoolLock<C> {
                 PathBuf::from(POOL_LOCK_PATH),
             ),
             i_am_rrid: rrid.into(),
+            pool_reap_stale: config.pool_reap_stale,
+            pool_stale_age: config.pool_stale_age,
         }
     }
 
@@ -897,16 +907,52 @@ impl<C: Clock> PoolLock<C> {
         self.inner.lock(comment).await
     }
 
+    /// Force-removes the pool claim if it is older than the configured pool
+    /// stale age.
+    ///
+    /// The pool-claim analogue of [`TargetLock::reap_if_stale`], gated by
+    /// `pool_reap_stale` (default on) and `pool_stale_age` (default 86400s; `0`
+    /// disables reaping). Pool ownership is RRID-based, so a foreign claim's PID
+    /// disappearing never frees it — an orphan left by an uncatchable exit
+    /// (SIGKILL / panic / power loss) would otherwise block arbitration until a
+    /// manual `unlock -f -p`. This reaps any pool claim older than the TTL,
+    /// regardless of owner, via a forced [`unlock`](Self::unlock).
+    ///
+    /// # Errors
+    /// Propagates an SFTP error from the load/unlock path.
+    pub async fn reap_if_stale(&mut self) -> Result<bool> {
+        if !self.pool_reap_stale || self.pool_stale_age == 0 {
+            return Ok(false);
+        }
+        let Some(age) = self.inner.age_seconds().await? else {
+            return Ok(false);
+        };
+        if age <= self.pool_stale_age {
+            return Ok(false);
+        }
+        tracing::warn!(
+            host = %self.inner.hostname(),
+            user = %self.inner.current().user,
+            hours = age / 3600,
+            "removing stale pool claim"
+        );
+        self.unlock(true).await?;
+        Ok(true)
+    }
+
     /// Claims the pool lock without raising when it is already claimed.
     ///
     /// The non-raising counterpart to [`lock`](Self::lock), used by host
     /// arbitration. Ownership is RRID-based: a claim recording *our* RRID (even
-    /// from another process) counts as ours.
+    /// from another process) counts as ours. A foreign claim older than
+    /// `pool_stale_age` is force-reaped first (see
+    /// [`reap_if_stale`](Self::reap_if_stale)), the only automatic recovery for a
+    /// claim orphaned by an uncatchable exit.
     ///
     /// # Errors
     /// Propagates an SFTP error from the underlying calls.
     pub async fn try_claim(&mut self, comment: &str) -> Result<bool> {
-        if self.is_locked().await? && !self.is_mine()? {
+        if self.is_locked().await? && !self.is_mine()? && !self.reap_if_stale().await? {
             return Ok(false);
         }
         match self.lock(comment).await {
@@ -1801,6 +1847,91 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    /// A pool claim built from `conn`+`rrid` with an explicit `[lock]` `config`
+    /// (so reaping knobs can be toggled per test).
+    fn pool_with_cfg(conn: MockConnection, rrid: &str, config: &Config) -> PoolLock<FakeClock> {
+        PoolLock::with_clock(Box::new(conn), config, rrid, FakeClock::new(now()))
+    }
+
+    #[tokio::test]
+    async fn pool_try_claim_reaps_stale_foreign_claim() {
+        // A foreign pool claim older than pool_stale_age is force-reaped, then
+        // re-claimed for us — the only automatic recovery for a claim orphaned by
+        // an uncatchable exit (RRID ownership means the dead PID never frees it).
+        let stale = now() - 200_000; // >> default pool_stale_age (86400)
+        let foreign =
+            format!("{stale}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
+        let conn = MockConnection::new("h1").with_file(POOL_LOCK_PATH, foreign);
+        let handle = conn.clone();
+        let mut p = pool(conn, "SUSE:Maintenance:1:2");
+        assert!(
+            p.try_claim("mtui pool SUSE:Maintenance:1:2 [alice]")
+                .await
+                .unwrap(),
+            "a stale foreign claim must be reaped and re-claimed"
+        );
+        // The reap removed the pool lockfile, and we then wrote our own claim.
+        let contents = String::from_utf8(handle.file_contents(POOL_LOCK_PATH).unwrap()).unwrap();
+        assert!(contents.contains("SUSE:Maintenance:1:2"));
+    }
+
+    #[tokio::test]
+    async fn pool_try_claim_does_not_reap_fresh_foreign_claim() {
+        // A foreign claim younger than pool_stale_age is left alone and refused.
+        let fresh = now() - 10; // well under the 86400 default
+        let foreign =
+            format!("{fresh}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
+        let conn = MockConnection::new("h1").with_file(POOL_LOCK_PATH, foreign);
+        let mut p = pool(conn, "SUSE:Maintenance:1:2");
+        assert!(
+            !p.try_claim("mtui pool SUSE:Maintenance:1:2 [alice]")
+                .await
+                .unwrap(),
+            "a fresh foreign claim must not be reaped"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_try_claim_respects_reaping_disabled() {
+        // With pool_reap_stale=false (or pool_stale_age=0) even an ancient foreign
+        // claim is left in place and the claim is refused.
+        let stale = now() - 200_000;
+        let foreign =
+            format!("{stale}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
+
+        let mut disabled = cfg();
+        disabled.pool_reap_stale = false;
+        let conn = MockConnection::new("h1").with_file(POOL_LOCK_PATH, foreign.clone());
+        let mut p = pool_with_cfg(conn, "SUSE:Maintenance:1:2", &disabled);
+        assert!(
+            !p.try_claim("mtui pool SUSE:Maintenance:1:2 [alice]")
+                .await
+                .unwrap(),
+            "pool_reap_stale=false must not reap"
+        );
+
+        let mut zero_age = cfg();
+        zero_age.pool_stale_age = 0;
+        let conn = MockConnection::new("h1").with_file(POOL_LOCK_PATH, foreign);
+        let mut p = pool_with_cfg(conn, "SUSE:Maintenance:1:2", &zero_age);
+        assert!(
+            !p.try_claim("mtui pool SUSE:Maintenance:1:2 [alice]")
+                .await
+                .unwrap(),
+            "pool_stale_age=0 must disable reaping"
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_reap_if_stale_returns_false_for_fresh_claim() {
+        let fresh = now() - 10;
+        let foreign =
+            format!("{fresh}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
+        let conn = MockConnection::new("h1").with_file(POOL_LOCK_PATH, foreign);
+        let mut p = pool(conn, "SUSE:Maintenance:1:2");
+        assert!(!p.reap_if_stale().await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -2629,7 +2629,15 @@ mod tests {
 
     #[tokio::test]
     async fn pool_claim_false_on_foreign_claim() {
-        let foreign = b"1700000000:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]".to_vec();
+        // A *fresh* foreign claim (not stale) must be refused. Timestamped ~now
+        // so the default pool-claim reaping does not treat it as abandoned (the
+        // stale-reap path is covered by `pool_claim_reaps_stale_foreign_claim`).
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let foreign =
+            format!("{now}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
         let conn = MockConnection::new("h1").with_file(crate::POOL_LOCK_PATH, foreign);
         let mut t = enabled_with(conn);
         t.set_rrid("SUSE:Maintenance:1:2");
@@ -2638,8 +2646,31 @@ mod tests {
             !t.pool_claim("mtui pool SUSE:Maintenance:1:2 [SUSE:Maintenance:1:2]")
                 .await
                 .unwrap(),
-            "a host claimed by another process must not be claimable"
+            "a fresh foreign claim must not be claimable"
         );
+    }
+
+    #[tokio::test]
+    async fn pool_claim_reaps_stale_foreign_claim() {
+        // A stale foreign pool claim (orphaned by an uncatchable exit) is reaped
+        // on the next claim attempt and the host becomes claimable — the recovery
+        // path arbitration relies on, reached transparently via `pool_claim`.
+        let stale = 1_700_000_000u64.saturating_sub(200_000); // >> pool_stale_age
+        let foreign =
+            format!("{stale}:otheruser:99:mtui pool SUSE:Maintenance:9:9 [bob]").into_bytes();
+        let conn = MockConnection::new("h1").with_file(crate::POOL_LOCK_PATH, foreign);
+        let handle = conn.clone();
+        let mut t = enabled_with(conn);
+        t.set_rrid("SUSE:Maintenance:1:2");
+        assert!(
+            t.pool_claim("mtui pool SUSE:Maintenance:1:2 [SUSE:Maintenance:1:2]")
+                .await
+                .unwrap(),
+            "a host holding a stale foreign claim must become claimable"
+        );
+        let contents =
+            String::from_utf8(handle.file_contents(crate::POOL_LOCK_PATH).unwrap()).unwrap();
+        assert!(contents.contains("SUSE:Maintenance:1:2"));
     }
 
     // --- add_history -------------------------------------------------------

--- a/crates/mtui-mcp/src/provider.rs
+++ b/crates/mtui-mcp/src/provider.rs
@@ -364,6 +364,59 @@ impl SessionRegistry {
     pub fn sweep_parallel(&self) -> usize {
         self.sweep_parallel
     }
+
+    /// Tear down **every** live session, for graceful process shutdown.
+    ///
+    /// The HTTP transport's counterpart to the stdio serve loop's
+    /// [`McpSession::close`]: cancelling the idle sweeper alone does **not**
+    /// release live sessions (its cancel branch just returns, and the registry
+    /// holds only [`Weak`] handles whose `Drop` cannot run the async pool-claim
+    /// release), so a clean Ctrl-C / SIGTERM of a busy server would otherwise
+    /// leak every active session's pool claims and SSH connections.
+    ///
+    /// Snapshots the live sessions, removes them from the live set, and closes
+    /// them concurrently under [`sweep_parallel`](Self::sweep_parallel) with a
+    /// single overall deadline (`DISCONNECT_TIMEOUT + 1s`) so one wedged host
+    /// close cannot hang process exit. Best-effort and idempotent: a second call
+    /// finds an empty set.
+    pub async fn close_all(&self) {
+        let sessions: Vec<Arc<McpSession>> = {
+            let mut set = match self.live.lock() {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            let sessions = set.values().filter_map(|t| t.session.upgrade()).collect();
+            set.clear();
+            sessions
+        };
+        close_sessions(sessions, self.sweep_parallel).await;
+    }
+}
+
+/// Close a batch of sessions concurrently under `parallel`, bounded by a single
+/// overall deadline (`DISCONNECT_TIMEOUT + 1s`).
+///
+/// Shared by the idle sweep ([`sweep_once`]) and graceful shutdown
+/// ([`SessionRegistry::close_all`]): one budget (not N×) guarantees the batch
+/// returns even if every close wedges, keeping teardown latency ~independent of
+/// session count.
+async fn close_sessions(sessions: Vec<Arc<McpSession>>, parallel: usize) {
+    use futures::stream::StreamExt as _;
+
+    if sessions.is_empty() {
+        return;
+    }
+    let batch =
+        futures::stream::iter(sessions).for_each_concurrent(parallel, |session| async move {
+            session.close().await;
+        });
+    let deadline = DISCONNECT_TIMEOUT + Duration::from_secs(1);
+    if tokio::time::timeout(deadline, batch).await.is_err() {
+        tracing::warn!(
+            ?deadline,
+            "session teardown timed out; abandoning remaining closes"
+        );
+    }
 }
 
 /// Collect the ids + strong handles of sessions idle for at least `timeout`.
@@ -405,8 +458,6 @@ async fn sweep_loop(live: LiveSet, timeout: Duration, parallel: usize, cancel: C
 /// One sweep cycle: confirm the stale set under the lock, then close it
 /// concurrently under `parallel` with a single overall deadline.
 async fn sweep_once(live: &LiveSet, timeout: Duration, parallel: usize) {
-    use futures::stream::StreamExt as _;
-
     let now = now_millis();
     let timeout_ms = timeout.as_millis() as u64;
 
@@ -439,22 +490,9 @@ async fn sweep_once(live: &LiveSet, timeout: Duration, parallel: usize) {
 
     // Phase 2 (concurrent, unlocked): tear the confirmed-stale sessions down
     // under a small bound so one wedged host close cannot serialize reclamation
-    // of the rest. `close()` self-bounds each teardown to `DISCONNECT_TIMEOUT`;
-    // an overall deadline (one budget, not N×) guarantees the sweep returns even
-    // if every close wedges, keeping sweep latency ~independent of stale count.
-    // Entries are already out of the live set, so abandoned closes are a
-    // best-effort no-op the OS reclaims at process exit.
-    let batch =
-        futures::stream::iter(to_close).for_each_concurrent(parallel, |session| async move {
-            session.close().await;
-        });
-    let deadline = DISCONNECT_TIMEOUT + Duration::from_secs(1);
-    if tokio::time::timeout(deadline, batch).await.is_err() {
-        tracing::warn!(
-            ?deadline,
-            "idle sweep teardown timed out; abandoning remaining closes"
-        );
-    }
+    // of the rest. Entries are already out of the live set, so abandoned closes
+    // are a best-effort no-op the OS reclaims at process exit.
+    close_sessions(to_close, parallel).await;
 }
 
 #[cfg(test)]
@@ -722,6 +760,66 @@ mod tests {
             serial > concurrent * 2,
             "serial (bound=1) sweep {serial:?} must be much slower than concurrent {concurrent:?}"
         );
+    }
+
+    /// `close_all` tears down **every** live session (regardless of idle state)
+    /// and empties the live set — the graceful-shutdown path the HTTP transport
+    /// runs after `axum::serve` returns.
+    #[tokio::test]
+    async fn close_all_closes_every_live_session() {
+        let reg = reg_with_idle(Duration::from_secs(3600)); // effectively no sweep
+        // Two freshly-touched (non-idle) sessions, each holding a mock host.
+        let s1 = slow_close_session(Duration::from_millis(10)).await;
+        let s2 = slow_close_session(Duration::from_millis(10)).await;
+        track(&reg, &s1, now_millis());
+        track(&reg, &s2, now_millis());
+        assert_eq!(reg.live_count(), 2);
+
+        reg.close_all().await;
+
+        assert_eq!(reg.live_count(), 0, "close_all must empty the live set");
+        // Idempotent: a second call over the now-empty set is a no-op.
+        reg.close_all().await;
+        assert_eq!(reg.live_count(), 0);
+    }
+
+    /// `close_all` disconnects a live session's hosts (not just idle ones) — the
+    /// concrete leak Part A-HTTP fixes: a busy session's SSH/pool state must be
+    /// reclaimed on process shutdown.
+    #[tokio::test]
+    async fn close_all_disconnects_live_session_hosts() {
+        use mtui_hosts::{HostsGroup, MockConnection, Target};
+        use mtui_testreport::{ObsReport, TestReport};
+        use mtui_types::RequestReviewID;
+        use mtui_types::enums::{ExecutionMode, TargetState};
+
+        let reg = reg_with_idle(Duration::from_secs(3600));
+        let conn = MockConnection::new("h1");
+        let handle = conn.clone();
+        let target = Target::with_connection(
+            "h1",
+            TargetState::Enabled,
+            ExecutionMode::Parallel,
+            Box::new(conn),
+        );
+        let session = reg.make_session();
+        {
+            let mut guard = session.session().lock().await;
+            let mut report = ObsReport::new(guard.config.clone());
+            report.base_mut().rrid = Some(RequestReviewID::parse("SUSE:Maintenance:1:1").unwrap());
+            report.base_mut().targets = HostsGroup::new(vec![target], false);
+            guard.templates.add(Box::new(report));
+            guard.templates.set_active("SUSE:Maintenance:1:1");
+        }
+        track(&reg, &session, now_millis());
+
+        assert!(!handle.is_closed(), "host starts connected");
+        reg.close_all().await;
+        assert!(
+            handle.is_closed(),
+            "close_all must disconnect a live session's hosts on shutdown"
+        );
+        assert_eq!(reg.live_count(), 0);
     }
 
     /// Cancelling the token mid-sweep preempts a wedged teardown batch: the

--- a/crates/mtui-mcp/src/runner.rs
+++ b/crates/mtui-mcp/src/runner.rs
@@ -27,6 +27,7 @@ use tracing_subscriber::EnvFilter;
 use crate::args::{McpArgs, Transport};
 use crate::provider::{SessionProvider, SessionRegistry, StdioProvider};
 use crate::server::McpServer;
+use crate::session::McpSession;
 
 /// Run the `mtui-mcp` server: the binary's entire body.
 ///
@@ -52,7 +53,7 @@ pub async fn run() -> anyhow::Result<()> {
 ///
 /// stdout is the JSON-RPC transport — logging goes to stderr only.
 async fn serve_stdio(args: &McpArgs) -> anyhow::Result<()> {
-    let server = build_stdio_server(args).await;
+    let (server, session) = build_stdio_server(args).await;
 
     tracing::info!("mtui-mcp: serving on stdio");
 
@@ -62,11 +63,50 @@ async fn serve_stdio(args: &McpArgs) -> anyhow::Result<()> {
         .serve((tokio::io::stdin(), tokio::io::stdout()))
         .await?;
 
-    // Block until the peer disconnects (or Ctrl-C ends the loop); a clean
-    // disconnect is a normal exit.
-    running.waiting().await?;
-    tracing::info!("mtui-mcp: shutting down");
+    // Block until the peer disconnects (stdin EOF — e.g. the MCP parent exits or
+    // `/exit`) or the process is signalled (Ctrl-C / SIGTERM), then run the
+    // teardown so the loaded template's remote pool claims are released and its
+    // hosts disconnected. Without this the `waiting()` future simply returns and
+    // the claims leak until a manual `unlock -f -p` (or the pool stale-reap).
+    tokio::select! {
+        r = running.waiting() => { r?; }
+        () = shutdown_signal() => {
+            tracing::info!("mtui-mcp: received shutdown signal");
+        }
+    }
+    tracing::info!("mtui-mcp: shutting down; releasing pool claims and disconnecting hosts");
+    session.close().await;
     Ok(())
+}
+
+/// Resolves when the process receives a termination signal (Ctrl-C or, on unix,
+/// SIGTERM).
+///
+/// The stdio serve loop races this against the transport's `waiting()` future so
+/// a `kill <pid>` (SIGTERM) or Ctrl-C triggers the same graceful teardown as a
+/// clean stdin EOF. SIGKILL cannot be caught in any language; the pool-claim
+/// stale-reap (`[lock] pool_stale_age`) is the recovery for that.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "cannot install SIGTERM handler; Ctrl-C only");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 /// Serve the tool surface over streamable HTTP (one process, many clients).
@@ -147,9 +187,7 @@ async fn serve_http(args: &McpArgs) -> anyhow::Result<()> {
     tracing::info!(%addr, "mtui-mcp: serving on http");
 
     axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            let _ = tokio::signal::ctrl_c().await;
-        })
+        .with_graceful_shutdown(shutdown_signal())
         .await?;
 
     // Stop the sweeper and wait for it to unwind before returning.
@@ -157,7 +195,13 @@ async fn serve_http(args: &McpArgs) -> anyhow::Result<()> {
     if let Some(handle) = sweeper {
         let _ = handle.await;
     }
-    tracing::info!("mtui-mcp: shutting down");
+    // Cancelling the sweeper does not release live sessions (its cancel branch is
+    // a bare return, and the registry holds only `Weak` handles whose `Drop`
+    // cannot run the async pool-claim release). Explicitly tear down every
+    // still-live session so a clean Ctrl-C / SIGTERM of a busy server releases
+    // its pool claims and disconnects hosts instead of leaking them.
+    tracing::info!("mtui-mcp: shutting down; releasing pool claims and disconnecting hosts");
+    sessions.close_all().await;
     Ok(())
 }
 
@@ -222,12 +266,15 @@ fn default_directives(debug: bool) -> String {
 /// [`StdioProvider`] (stdio = one process = one session) and wires it into an
 /// [`McpServer`]. Factored out of [`run`] so the wiring is testable without the
 /// blocking stdio serve loop.
-async fn build_stdio_server(args: &McpArgs) -> McpServer {
+///
+/// Returns the server **and** a handle to its session, so the serve loop can run
+/// [`McpSession::close`] (release pool claims + disconnect hosts) on shutdown.
+async fn build_stdio_server(args: &McpArgs) -> (McpServer, Arc<McpSession>) {
     let config = args.resolve_config();
     let registry = Arc::new(register_all());
     let provider = StdioProvider::new(config);
     let session = provider.get_or_create("<default>").await;
-    McpServer::new(registry, session)
+    (McpServer::new(registry, Arc::clone(&session)), session)
 }
 
 #[cfg(test)]
@@ -245,10 +292,57 @@ mod tests {
     #[tokio::test]
     async fn build_stdio_server_wires_the_synthesised_surface() {
         // A built server reports tools capability — proving the handler is wired.
-        let server = build_stdio_server(&args(&[])).await;
+        let (server, _session) = build_stdio_server(&args(&[])).await;
         assert!(
             server.get_info().capabilities.tools.is_some(),
             "server should advertise the tools capability"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_stdio_server_returns_a_closeable_session() {
+        // The serve loop needs the session handle to run teardown on shutdown;
+        // `close()` on a session with no loaded template is a harmless no-op.
+        let (_server, session) = build_stdio_server(&args(&[])).await;
+        session.close().await;
+    }
+
+    #[tokio::test]
+    async fn stdio_shutdown_close_disconnects_loaded_hosts() {
+        // The teardown the stdio serve loop runs on shutdown must disconnect a
+        // loaded template's hosts (and, in the real path, release its pool
+        // claims). Build a session holding one mock-connected target and assert
+        // `close()` closes it — the connection stdio shutdown would otherwise
+        // leak.
+        use mtui_config::Config;
+        use mtui_hosts::{HostsGroup, MockConnection, Target};
+        use mtui_testreport::{ObsReport, TestReport};
+        use mtui_types::RequestReviewID;
+        use mtui_types::enums::{ExecutionMode, TargetState};
+
+        let conn = MockConnection::new("h1");
+        let handle = conn.clone();
+        let target = Target::with_connection(
+            "h1",
+            TargetState::Enabled,
+            ExecutionMode::Parallel,
+            Box::new(conn),
+        );
+        let session = McpSession::new(Config::default());
+        {
+            let mut guard = session.session().lock().await;
+            let mut report = ObsReport::new(guard.config.clone());
+            report.base_mut().rrid = Some(RequestReviewID::parse("SUSE:Maintenance:1:1").unwrap());
+            report.base_mut().targets = HostsGroup::new(vec![target], false);
+            guard.templates.add(Box::new(report));
+            guard.templates.set_active("SUSE:Maintenance:1:1");
+        }
+
+        assert!(!handle.is_closed(), "target starts connected");
+        session.close().await;
+        assert!(
+            handle.is_closed(),
+            "shutdown teardown must disconnect the loaded template's hosts"
         );
     }
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -176,8 +176,10 @@ fleet).
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
-| `reap_stale` | bool | `true` | On connect, force-remove a pre-existing lock older than `stale_age`, regardless of owner. |
-| `stale_age` | seconds | `86400` | Age beyond which a lock is stale and reapable. `0` disables reaping. |
+| `reap_stale` | bool | `true` | On connect, force-remove a pre-existing operation lock older than `stale_age`, regardless of owner. |
+| `stale_age` | seconds | `86400` | Age beyond which an operation lock is stale and reapable. `0` disables reaping. |
+| `pool_reap_stale` | bool | `true` | On a pool claim attempt, force-remove a pre-existing pool claim older than `pool_stale_age`, regardless of owner. The only automatic recovery for a claim orphaned by an uncatchable exit (SIGKILL/panic/power loss). |
+| `pool_stale_age` | seconds | `86400` | Age beyond which a pool claim is stale and reapable. `0` disables pool-claim reaping. |
 | `pi_autolock` | bool | `true` | When testing a Product Increment (PI), auto-lock all refhosts on `assign` and unlock at end of testing. |
 | `wait` | seconds | `0` | Pool-claim queueing budget. `0` fails fast on a busy host. |
 | `wait_poll` | seconds (>0) | `15` | Poll interval while waiting for a busy pool lock to free. |


### PR DESCRIPTION
## Problem

`mtui-mcp` never ran host/pool teardown when the process exited:

- **stdio**: the serve loop returned as soon as `waiting()` resolved (stdin EOF / disconnect), never calling the existing `McpSession::close` teardown.
- **http**: the idle sweeper only ever closes *idle* sessions. Cancelling it on shutdown does not tear down still-live sessions, and `Drop` cannot release a claim (release needs async I/O), so a clean Ctrl-C/SIGTERM of a busy server leaked every active session's pool claims and SSH connections.

In both cases the loaded template's remote `/var/lock/mtui-pool.lock` claims were left held on the reference hosts. Because pool ownership is RRID-based (not PID-based like the operation lock), the dead process's PID disappearing never freed the claim — it stayed held until a human ran `unlock -f -p`.

## Fix

Two independent parts, since SIGKILL/panic/power-loss can never be caught in-process:

**Catchable exits** — both transports now run the existing `McpSession::close` teardown on shutdown:
- stdio races `waiting()` against a new SIGTERM/Ctrl-C signal future, then closes.
- http widens its graceful-shutdown trigger to SIGTERM and, after `axum::serve` returns, explicitly tears down *every* live session via a new `SessionRegistry::close_all` (the sweeper's per-close fan-out logic is now shared via `close_sessions`, bounded by the same disconnect timeout).

**Uncatchable exits** — the pool-claim lock gets its own stale-reap gate, mirroring the operation lock's existing `reap_stale`/`stale_age`:
- New `[lock] pool_reap_stale` (default `true`) / `pool_stale_age` (default `86400`s) config keys, exposed via `config show`/`config set`.
- `PoolLock::try_claim` force-removes a foreign claim older than the TTL before claiming — the only automatic recovery for a claim orphaned by a crash/kill/power-loss.

## Testing

- New unit tests: stdio shutdown teardown, HTTP `close_all` (both an empty-registry case and a live-session-with-mock-host case), `PoolLock` reap (stale reaped, fresh refused, disabled via either flag), config load/set round-trips, `Target`-level reap.
- Fixed a pre-existing test whose fixture used a fixed 2023 timestamp for a "foreign claim" fixture, which the new default reaping would now (correctly) treat as stale — retimed to "now" so it still asserts a *fresh* foreign claim is refused.
- Full DoD gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` (default + `--all-features`), `cargo test --workspace`, `cargo test -p mtui-mcp --features mcp` (186 lib + 48 integration), and the compile-only feature matrix (`--no-default-features` / `--all-features`).

## Changelog

Entries added under `[Unreleased]` (Fixed: shutdown teardown; Added: new config keys). `docs/src/configuration.md`'s `[lock]` table updated.