### PR TITLE
docs: remove stale beads/PLAN-*.md/Phase-N tracking references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,13 +49,8 @@ crates/
   mtui-cli/          reedline REPL + `mtui` binary
   mtui-mcp/          rmcp server + `mtui-mcp` binary
 ```
-The high-level roadmap (architecture, crate layout, phase overview) lives in
-`PLAN-highlevel.md`. The **per-phase task breakdown is tracked in beads** (`br`):
-each phase is an epic (`Phase N: …`) whose child tasks carry the confirmed
-upstream behavior, crate mapping, DoD, and test strategy migrated from the former
-`PLAN-phaseN.md` files. **Before working on a subsystem, run `br ready` for the
-next actionable task and `br show <id>` for its detail;** use `br epic status` to
-see phase progress. Phase 0 (workspace bootstrap) is already complete (closed).
+Task breakdown is tracked in the project's issue tracker; check it for the
+next actionable task before working on a subsystem.
 
 ## Setup & commands
 - Build everything: `cargo build --workspace`
@@ -131,7 +126,9 @@ see phase progress. Phase 0 (workspace bootstrap) is already complete (closed).
   `[refhosts]`, `[url]`, ...) map to typed options whose defaults match upstream
   mtui exactly. Loading is **lenient**: a missing/malformed file (or a bad value)
   is logged at ERROR and skipped, falling back to defaults; it never hard-fails.
-  CLI-arg merging (`merge_args`) lands with the `clap` args in Phase 6.
+  CLI-arg merging (mirroring upstream `Config.merge_args`) is implemented via
+  `Args::apply_to` (`crates/mtui-core/src/args.rs`), the highest-precedence
+  config layer, applied after `Config::load`.
 - **MCP is a thin adapter.** `mtui-mcp` builds one tool per non-denied command by
   converting the command's `clap` arg spec to a JSON schema, reconstructing argv
   from tool kwargs, and dispatching through the **same engine** as the REPL.
@@ -233,70 +230,3 @@ the native OBS backend and `[obs]` config), reading credentials from `oscrc`.
   interactive command reference) remain the deepest behavioral references while
   porting; they are preserved on the `archive/python-main` tag and the
   `16.0.x`..`19.0.x` maintenance branches.
-
-<!-- br-agent-instructions-v1 -->
-
----
-
-## Beads Workflow Integration
-
-This project uses [beads_rust](https://github.com/Dicklesworthstone/beads_rust) (`br`/`bd`) for issue tracking. Issues are stored in `.beads/` and tracked in git.
-
-### Essential Commands
-
-```bash
-# View ready issues (open, unblocked, not deferred)
-br ready              # or: bd ready
-
-# List and search
-br list --status=open # All open issues
-br show <id>          # Full issue details with dependencies
-br search "keyword"   # Full-text search
-
-# Create and update
-br create --title="..." --description="..." --type=task --priority=2
-br update <id> --status=in_progress
-br close <id> --reason="Completed"
-br close <id1> <id2>  # Close multiple issues at once
-
-# Sync with git
-br sync --flush-only  # Export DB to JSONL
-br sync --status      # Check sync status
-```
-
-### Workflow Pattern
-
-1. **Start**: Run `br ready` to find actionable work
-2. **Claim**: Use `br update <id> --status=in_progress`
-3. **Work**: Implement the task
-4. **Complete**: Use `br close <id>`
-5. **Sync**: Always run `br sync --flush-only` at session end
-
-### Key Concepts
-
-- **Dependencies**: Issues can block other issues. `br ready` shows only open, unblocked work.
-- **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers 0-4, not words)
-- **Types**: task, bug, feature, epic, chore, docs, question
-- **Blocking**: `br dep add <issue> <depends-on>` to add dependencies
-
-### Session Protocol
-
-**Before ending any session, run this checklist:**
-
-```bash
-git status              # Check what changed
-git add <files>         # Stage code changes
-br sync --flush-only    # Export beads changes to JSONL
-git commit -m "..."     # Commit everything
-git push                # Push to remote
-```
-
-### Best Practices
-
-- Check `br ready` at session start to find available work
-- Update status as you work (in_progress → closed)
-- Create new issues with `br create` when you discover tasks
-- Use descriptive titles and set appropriate priority/type
-- Always sync before ending session
-
-<!-- end-br-agent-instructions -->

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # mtui-rs
 
-> **Status: feature-complete, in packaging (Phase 8).** This is a ground-up Rust
+> **Status: feature-complete, in packaging.** This is a ground-up Rust
 > rewrite of [openSUSE/mtui](https://github.com/openSUSE/mtui). The core
 > maintenance workflow, parallel SSH host fan-out, the native OBS/IBS and Gitea
 > review backends, openQA/QEM integration, the testreport lifecycle, and the
 > `mtui-mcp` server have all landed and are CI-gated; work now focuses on
-> packaging and distribution (`PLAN-highlevel.md`; per-phase tasks tracked in
-> beads). See [`docs/`](docs) for the user guide and command reference.
+> packaging and distribution. See [`docs/`](docs) for the user guide and
+> command reference.
 
 An **improved, idiomatic Rust successor** to MTUI — the **M**aintenance **T**est
 **U**pdate **I**nstaller, SUSE QE's tool for validating maintenance updates: load
@@ -102,11 +102,6 @@ configured via the `[obs]` table (`api_url`, `request_timeout`).
 - [`docs/`](docs) — the user guide (mdBook): installation, configuration, the
   generated command reference, the MCP server, and an FAQ. Build with
   `mdbook build docs`, or read the Markdown under `docs/src/` directly.
-- [`PLAN-highlevel.md`](PLAN-highlevel.md) — architecture, crate layout,
-  dependency mapping, and the 8-phase roadmap.
-- Per-phase task breakdown is tracked in [beads](https://github.com/Dicklesworthstone/beads_rust)
-  (`br ready`, `br epic status`, `br show <id>`); the detailed per-phase plans were
-  migrated from the former `PLAN-phase0..8.md` files into beads epics + tasks.
 - [`AGENTS.md`](AGENTS.md) — contributor/agent guide: conventions, contracts, and
   the definition of done.
 

--- a/crates/mtui-core/src/commands/apicall.rs
+++ b/crates/mtui-core/src/commands/apicall.rs
@@ -435,7 +435,7 @@ impl Command for Comment {
                 .long("message")
                 .num_args(1..)
                 .action(ArgAction::Append)
-                .help("The comment body (required; interactive prompt lands in Phase 6)"),
+                .help("The comment body (required)"),
         )
     }
     fn complete(&self, session: &Session, text: &str, _line: &str) -> Vec<String> {

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -173,7 +173,7 @@ expression: pretty
         },
         "message": {
           "items": {
-            "description": "The comment body (required; interactive prompt lands in Phase 6)",
+            "description": "The comment body (required)",
             "type": "string"
           },
           "minItems": 1,

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -3,9 +3,8 @@
 This page is a map, not a deep dive: it sketches how mtui-rs is put together so
 the rest of the book (and the source) is easier to navigate. For the day-to-day
 contributor workflow — toolchain, quality gates, adding a command, testing — see
-the [Developer guide](developer.md). For the full roadmap see `PLAN-highlevel.md`;
-for the authoritative contributor spec and definition of done see `AGENTS.md`.
-Both live in the repository root.
+the [Developer guide](developer.md). For the authoritative contributor spec and
+definition of done see `AGENTS.md`, which lives in the repository root.
 
 ## Workspace layout
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -913,7 +913,7 @@ Usage: comment [OPTIONS]
 
 Options:
   -m, --message <message>...
-          The comment body (required; interactive prompt lands in Phase 6)
+          The comment body (required)
 
   -h, --help
           Print help

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -266,23 +266,9 @@ mdbook build docs
 
 ## Issue tracking and commits
 
-Work is tracked in **beads** (`br`), stored under `.beads/` and committed with the
-code. The essentials:
-
-```sh
-br ready                     # actionable, unblocked work
-br show <id>                 # full issue detail + dependencies
-br update <id> --status=in_progress
-br close <id> --reason="..."
-br sync --flush-only         # export the DB to JSONL before committing
-```
-
-For the phased roadmap, `br epic status` shows progress; each phase is an epic
-whose child tasks carry the upstream behaviour, crate mapping, and DoD.
+Work is tracked in the project's issue tracker.
 
 Commits follow **Conventional Commits** (`feat`/`fix`/`docs`/`refactor`/`test`/
 `chore`/…), explaining **why** rather than restating the diff. Reference SUSE
 Bugzilla as `bsc#NNNN` / `boo#NNNN` where applicable. Only commit when asked;
-inspect `git status`/`git diff` first and stage only intended files. Before ending
-a session, run `br sync --flush-only` so the beads JSONL is committed alongside the
-code.
+inspect `git status`/`git diff` first and stage only intended files.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -42,6 +42,5 @@ wire format that lets a Rust and a Python mtui share a host fleet).
   trait, how to add a command, and testing conventions.
 - [FAQ](faq.md).
 
-For architecture and the phased implementation roadmap, see `PLAN-highlevel.md`;
-for contributor conventions and the definition of done, see `AGENTS.md`. Both
-live in the repository root.
+For contributor conventions and the definition of done, see `AGENTS.md`, which
+lives in the repository root.


### PR DESCRIPTION
## Why

The Rust rewrite's roadmap was tracked as beads epics and in
`PLAN-highlevel.md`/`PLAN-phaseN.md` working documents, with commands and
"Phase N" markers sprinkled through `README.md`/`AGENTS.md`/the mdBook. The
project is now feature-complete and in packaging; the `PLAN-*.md` files are
gone and beads is no longer part of this repo's workflow, so those mentions
pointed at dead files and an unused tool.

## What changed

- Reworded/removed beads and `PLAN-*.md` mentions in `README.md`,
  `AGENTS.md`, and `docs/src/{developer,architecture,introduction}.md`,
  falling back to generic "project's issue tracker" framing where the
  sentence still needed one.
- Deleted `AGENTS.md`'s auto-appended "Beads Workflow Integration" block.
- Dropped stale "Phase N" references from `README.md`/`AGENTS.md` prose.
- Fixed the `comment` command's stale `--help` string (it cited a "Phase 6"
  TODO for a feature that shipped as a deliberate design choice, not a
  deferral) and regenerated `docs/src/cli.md` via `cargo xtask gen-docs`.

## Verification

- `grep -rn` sweep for `beads`, `PLAN-highlevel`, `PLAN-phase`, and `Phase
  [0-9A-Z]` across `README.md`, `AGENTS.md`, `docs/src/*.md` — clean.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — all passing.
- `mdbook build docs` — succeeds.

Documentation-only change plus one CLI `--help` string fix; no changelog
entry per `CONTRIBUTING.md` (internal/doc-only, no user-visible behavior
change).