### PR TITLE
chore(release): bump version to 26.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ name: release
 on:
   push:
     tags:
-      # Version tags: v26.0.0, optionally with a pre-release suffix
-      # (v26.0.0-rc1). The Rust project tags with a "v" prefix.
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      # Version tags: 26.0.1, optionally with a pre-release suffix
+      # (26.0.1rc1). The project tags without a "v" prefix.
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
   contents: read
@@ -35,8 +35,7 @@ jobs:
       - name: Verify tag matches workspace version
         run: |
           pkg="$(sed -n 's/^version = "\(.*\)".*/\1/p' Cargo.toml | head -1)"
-          tag="${GITHUB_REF_NAME#v}"
-          if [ "$pkg" != "$tag" ]; then
+          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
             echo "::error::tag '$GITHUB_REF_NAME' != workspace version '$pkg'"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [26.0.1] - 2026-07-22
+
 ### Changed
 
 - **MTUI has been rewritten in Rust.** This release replaces the Python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-cli"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-config"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "directories",
  "mtui-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-core"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-datasources"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-hosts"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-mcp"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-testreport"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-types"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "insta",
  "sandogasa-rpmvercmp",
@@ -5318,7 +5318,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "26.0.0"
+version = "26.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "xtask"]
 
 [workspace.package]
-version = "26.0.0"
+version = "26.1.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-2.0-only"       # match upstream mtui

--- a/dist/man/mtui-mcp.1
+++ b/dist/man/mtui-mcp.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui-mcp 1  "mtui-mcp 26.0.0" 
+.TH mtui-mcp 1  "mtui-mcp 26.1.0" 
 .SH NAME
 mtui\-mcp \- MCP server for mtui (tools synthesised from the command registry)
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.0.0
+v26.1.0

--- a/dist/man/mtui.1
+++ b/dist/man/mtui.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui 1  "mtui 26.0.0" 
+.TH mtui 1  "mtui 26.1.0" 
 .SH NAME
 mtui \- Maintenance Test Update Installer
 .SH SYNOPSIS
@@ -57,4 +57,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.0.0
+v26.1.0

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -383,7 +383,7 @@ pub fn stage_package(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
 /// layout it archives is the offline-tested [`stage_package`].
 pub fn package_target(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
     // Materialise the staging tree on disk; `tar` archives it by name below.
-    stage_package(inputs)?;
+    let staging = stage_package(inputs)?;
     let stem = package_stem(inputs.version, inputs.target);
     let tarball = inputs.out_dir.join(format!("{stem}.tar.gz"));
 
@@ -398,6 +398,13 @@ pub fn package_target(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
     .with_context(|| format!("archiving {}", tarball.display()))?;
 
     write_sha256(&tarball)?;
+
+    // Remove the now-archived staging dir so `out_dir` holds only the tarball +
+    // checksum — release.yml uploads `dist/release/*` verbatim, and `gh release
+    // create` errors on a bare directory in that glob.
+    std::fs::remove_dir_all(&staging)
+        .with_context(|| format!("removing staging dir {}", staging.display()))?;
+
     Ok(tarball)
 }
 


### PR DESCRIPTION
Bumps the workspace dev version 26.0.0 -> 26.1.0, regenerates the checked-in
man pages (`cargo xtask gen`) to carry the new version string, and cuts
26.0.1's changelog entry.

## Commits
- ci(release): revert to bare version tags (no "v" prefix)
- chore(release): cut 26.0.1
- fix(xtask): remove staging dir after packaging a release tarball
- chore(release): bump version to 26.1.0

No CHANGELOG.md changes in the version-bump commit; no tag created.