### PR TITLE
docs: fix drift between README/AGENTS.md/configuration.md and the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 [openSUSE/mtui](https://github.com/openSUSE/mtui)** (Maintenance Test Update
 Installer) — the SUSE QE tool for validating maintenance updates: load a request
 by RRID, install/test it on reference hosts over SSH, then approve/reject. It
-drives `osc`/`svn`/Gitea and openQA/QEM under the hood.
+drives OBS/IBS and Gitea review workflows, `svn`, and openQA/QEM under the hood.
 
 This is a **rewrite/redesign, not a 1:1 transpile.** Use MTUI as the behavioral
 reference and the source of domain truth, but build something better: memory-safe,
@@ -173,8 +173,9 @@ and treat them as golden.
   (`serial_test`), and tests must not assume per-binary isolation (e.g. no
   asserting on heap-address identity — a freed `Arc` address can be reused).
 - **Mock, don't hit the network/hosts:** HTTP via `wiremock`; SSH via a
-  `MockConnection` implementing the `Connection` trait; `svn`/`osc` via a
-  command-runner trait or a stub on `PATH`.
+  `MockConnection` implementing the `Connection` trait; `svn` via the
+  `SvnRunner` command-runner trait/stub; OBS/IBS and every other HTTP
+  datasource via `wiremock`.
 - **Snapshot text contracts** (`insta`): testreport/export rendering, metadata
   parsing, MCP schemas, lock-file format, display output. `insta` prefixes each
   `.snap` file with the **test-binary** name, which is now `it` for every crate —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   The `refhosts.yml` I/O error message no longer misreports a write failure as
   a read. `docs/src/configuration.md` now documents the real default
   (`~/.local/share/refdb/refhosts.yml`) instead of a stale path.
+- `docs/src/configuration.md` documented the default `[mcp]
+  session_idle_timeout` as `1800` (upstream Python mtui's value); the actual
+  default is `14400`, chosen so an idle HTTP MCP session outlasts rmcp's own
+  streamable-HTTP keep-alive floor. The runtime behaviour was never wrong —
+  only the documented value was.
 
 ## [26.0.1] - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # mtui
 
-> **Status: feature-complete, in packaging.** This is a ground-up Rust
-> rewrite of [openSUSE/mtui](https://github.com/openSUSE/mtui). The core
-> maintenance workflow, parallel SSH host fan-out, the native OBS/IBS and Gitea
-> review backends, openQA/QEM integration, the testreport lifecycle, and the
-> `mtui-mcp` server have all landed and are CI-gated; work now focuses on
-> packaging and distribution. See [`docs/`](docs) for the user guide and
-> command reference.
-
 An **improved, idiomatic Rust successor** to MTUI — the **M**aintenance **T**est
 **U**pdate **I**nstaller, SUSE QE's tool for validating maintenance updates: load
 a request by RRID, install and test it on reference hosts over SSH in parallel,
-then approve or reject. It drives `osc`/`svn`/Gitea and openQA/QEM under the hood.
+then approve or reject. It drives OBS/IBS and Gitea review workflows, `svn`, and
+openQA/QEM under the hood.
 
 This is a **redesign, not a transpile**: MTUI is the behavioral reference and
 source of domain truth, but mtui aims to be memory-safe, async-native, and
@@ -54,8 +47,14 @@ authenticated boundary trusted to operate the remaining maintenance tools.
   `dryrun` states and `parallel`/`serial` modes. **Pubkey auth only.**
 - OBS/IBS and Gitea maintenance-request workflow (`assign`, `approve`, `reject`,
   `comment`, …) via the native OBS/IBS API (no `osc` subprocess).
+- Optional Slack review-request integration (`request_review`, off by default):
+  posts a review request to a channel, can watch for reviewer 👍/👎 reactions
+  until a verdict, and — once enabled — gates `approve` on an acknowledged
+  review.
 - openQA / QEM Dashboard integration, incl. an `openqa_overview` (port of
   `oqa-search`) with `--export` into the testreport.
+- TeReGen-backed maintenance-queue browsing (`updates`) and template
+  regeneration (`regenerate`).
 - Reference-host discovery via `refhosts.yml` (HTTPS- or filesystem-resolved,
   cached) and offline inventory search (`list_refhosts`).
 - Cooperative reference-host locking (`/var/lock/mtui.lock`), interoperable with
@@ -63,6 +62,8 @@ authenticated boundary trusted to operate the remaining maintenance tools.
 - Test-report lifecycle: `load_template`, `checkout`, `commit`, `edit`, `export`
   (SVN and Gitea backends).
 - File transfer (`put`/`get`) over SFTP.
+- Vim syntax highlighting for testreport files, packaged separately as
+  `vim-plugin`.
 
 ## Build
 

--- a/dist/mtui.toml.example
+++ b/dist/mtui.toml.example
@@ -83,12 +83,35 @@
 # `config show`/`config set`, never logged). Empty by default; the Gitea
 # connector refuses to build without it.
 # token = ""
+# Trusted Gitea origin the `token` may be sent to.
+# url = "https://src.suse.de"
+
+[slack]
+# Whether the Slack `request_review` integration is available at all. Off by
+# default; `enabled = true` plus `token` and `channel` are all required to opt in.
+# enabled = false
+# Slack bot token (secret: masked as <set> by `config show`/`config set`, never
+# logged). Required scopes: chat:write, reactions:read, channels:history.
+# token = ""
+# Channel review requests are posted to: an ID (C0123456789) or a #name.
+# channel = ""
+# Slack API base the `token` may be sent to.
+# api_url = "https://slack.com/api"
+# How often `request_review --watch` polls for reactions, in seconds.
+# poll_interval = 120
+# How long `request_review --watch` runs before giving up, in seconds.
+# watch_timeout = 3600
 
 [lock]
 # On connect, force-remove a pre-existing lock older than `stale_age`, regardless of owner.
 # reap_stale = true
 # Age (seconds) beyond which a lock is stale and reapable. 0 disables reaping.
 # stale_age = 86400
+# On a pool claim attempt, force-remove a pre-existing pool claim older than
+# `pool_stale_age`, regardless of owner.
+# pool_reap_stale = true
+# Age (seconds) beyond which a pool claim is stale and reapable. 0 disables pool-claim reaping.
+# pool_stale_age = 86400
 # When testing a Product Increment (PI), auto-lock all refhosts on `assign` and unlock at end of testing.
 # pi_autolock = true
 # Pool-claim queueing budget, in seconds. 0 fails fast on a busy host.
@@ -99,6 +122,9 @@
 [mcp]
 # Upper bound (bytes) on a single mtui-mcp tool result. 0 disables the cap.
 # max_output_bytes = 100000
+# Upper bound (bytes) on an inbound HTTP request body under --transport http.
+# 0 disables mtui's limit entirely, dropping even axum's implicit 2 MB floor.
+# max_request_bytes = 10000000
 # Ceiling on concurrent background jobs per session. 0 disables.
 # max_active_jobs = 16
 # Ceiling on retained terminal (done/failed/cancelled) job records per session. 0 disables.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -195,7 +195,7 @@ fleet).
 | `max_active_jobs` | int | `16` | Ceiling on concurrent background jobs per session. `0` disables. |
 | `max_completed_jobs` | int | `128` | Ceiling on retained terminal job records per session (FIFO eviction). `0` disables. |
 | `session_cap` | int (>0) | `32` | Ceiling on concurrent per-client sessions under `--transport http`. |
-| `session_idle_timeout` | seconds (>0) | `1800` | Inactivity before an idle http session is swept. |
+| `session_idle_timeout` | seconds (>0) | `14400` | Inactivity before an idle http session is swept. Deliberately higher than upstream's `1800` so it comfortably exceeds rmcp's own HTTP session keep-alive floor. |
 | `sweep_parallel` | int (>0) | `4` | Max stale sessions the idle sweeper tears down concurrently per cycle. |
 | `profile` | string | `full` | Tool-surface profile: `full` (every synthesised tool) or `core` (curated everyday subset). Unknown → `full` with a warning. |
 | `tools_allow` | array of strings | *(empty)* | Extra tool names to keep on top of the profile. |


### PR DESCRIPTION
## Summary

A drift audit against the source of truth (`crates/mtui-config/src/options.rs` and the native OBS/IBS review backend) found several places where docs and code had quietly diverged:

- `README.md`/`AGENTS.md` still described the review workflow as shelling out to `osc`, though it talks to the OBS/IBS API natively.
- `AGENTS.md`'s testing-conventions bullet claimed an `osc` command-runner stub that doesn't exist (OBS/IBS is tested via `wiremock`, like every other HTTP datasource; only `svn` has a command-runner trait, `SvnRunner`).
- `docs/src/configuration.md` documented `[mcp] session_idle_timeout`'s default as upstream Python mtui's `1800`, not this codebase's deliberately higher `14400` (already correctly shown in `dist/mtui.toml.example`).
- `dist/mtui.toml.example` was missing four keys that already exist in the code and in `configuration.md`'s own table: `[slack]` (entire section), `[lock] pool_reap_stale`/`pool_stale_age`, `[gitea] url`, `[mcp] max_request_bytes`.
- `README.md`'s Features list was missing three landed capabilities: Slack `request_review`, TeReGen `updates`/`regenerate`, and the `vim-plugin` package. The stale "in packaging" status banner is also dropped now that the tool is released.

None of this changes runtime behavior — it's a docs-only correction.

## Changes

- `README.md`: dropped the Status banner; reworded the `osc`/`svn`/Gitea summary line; added three Features bullets.
- `AGENTS.md`: same summary-line fix; corrected the testing-conventions mocking bullet.
- `docs/src/configuration.md`: `session_idle_timeout` default `1800` → `14400`, with a note on why it's intentionally higher than upstream.
- `CHANGELOG.md`: `Fixed` entry for the `session_idle_timeout` docs bug.
- `dist/mtui.toml.example`: added `[slack]`, `[lock] pool_reap_stale`/`pool_stale_age`, `[gitea] url`, `[mcp] max_request_bytes`.

## Verification

- `rg '`osc`/' README.md AGENTS.md` no longer matches the summary lines (the correct oscrc-credential explanations elsewhere are untouched).
- `cargo test -p xtask checked_in_generated_docs_are_up_to_date` passes.
- `git diff --stat` against `main` touches exactly the five files listed above.