### PR TITLE
fix(hosts): grow the post-reboot reconnect budget instead of a fixed burst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- New `[connection]` config keys `reboot_timeout` (default `10` seconds) and
+  `reboot_retries` (default `10`) control the reconnect budget `prepare`,
+  `reboot`, and `update` use after rebooting a host: `reboot_timeout` is the
+  backoff base and `reboot_retries` the number of attempts beyond the first,
+  giving a slow/high-latency host (e.g. aarch64, cross-site refhosts) up to
+  ~12.7 minutes by default to come back before it is marked failed. Both are
+  visible in `config show`, settable with `config set`, and overridable with
+  the new `--reboot-timeout`/`--reboot-retries` CLI flags.
+
 ### Fixed
 
+- `prepare`/`reboot`/`update` no longer falsely mark a slow-to-reboot host as
+  "reconnect after reboot failed" when it is still mid-boot: reconnect after a
+  reboot now retries with a growing backoff (`reboot_timeout`/`reboot_retries`,
+  ~12.7 minutes by default) instead of a fixed ~1.2s burst of 6 attempts.
+  Because fan-out aggregates per-host failures, one slow host previously failed
+  the whole batch. Non-reboot paths (a dead SSH link mid-`run`/`shell`, or the
+  `sftp` pre-op check) are unaffected: they still fail fast on the first probe.
 - The `https` refhosts resolver no longer aborts when it cannot write its
   on-disk mirror to a read-only `refhosts.path` (e.g. a package-managed
   `/usr/share/qam-metadata/refhosts.yml`): the freshly downloaded database is

--- a/crates/mtui-cli/src/startup.rs
+++ b/crates/mtui-cli/src/startup.rs
@@ -97,6 +97,8 @@ mod tests {
             template_dir: None,
             sut: Vec::new(),
             connection_timeout: None,
+            reboot_timeout: None,
+            reboot_retries: None,
             debug: false,
             config: None,
             color: ColorArg::Never,

--- a/crates/mtui-config/src/lib.rs
+++ b/crates/mtui-config/src/lib.rs
@@ -129,6 +129,24 @@ mod tests {
     }
 
     #[test]
+    fn reboot_backoff_options_default_to_upstream() {
+        let d = Config::default();
+        assert_eq!(d.reboot_timeout, 10);
+        assert_eq!(d.reboot_retries, 10);
+    }
+
+    #[test]
+    fn load_reads_reboot_backoff_options() {
+        let path = write_tmp(
+            "reboot.toml",
+            "[connection]\nreboot_timeout = 20\nreboot_retries = 5\n",
+        );
+        let cfg = Config::load(Some(path));
+        assert_eq!(cfg.reboot_timeout, 20);
+        assert_eq!(cfg.reboot_retries, 5);
+    }
+
+    #[test]
     fn mcp_max_output_bytes_defaults_to_100k() {
         assert_eq!(Config::default().mcp_max_output_bytes, 100_000);
     }

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -179,6 +179,12 @@ pub(crate) fn is_relative_dir_name(raw: &str) -> bool {
 pub(crate) fn default_connection_timeout() -> u64 {
     300
 }
+pub(crate) fn default_reboot_timeout() -> u64 {
+    10
+}
+pub(crate) fn default_reboot_retries() -> u64 {
+    10
+}
 pub(crate) fn default_max_parallel() -> u64 {
     50
 }
@@ -371,6 +377,8 @@ pub(crate) struct MtuiSection {
 #[serde(default)]
 pub(crate) struct ConnectionSection {
     pub connection_timeout: Option<u64>,
+    pub reboot_timeout: Option<u64>,
+    pub reboot_retries: Option<u64>,
     pub max_parallel: Option<u64>,
     pub max_oqa_parallel: Option<u64>,
     pub ssh_strict_host_key_checking: Option<String>,
@@ -567,6 +575,8 @@ impl RawConfig {
         take!(mtui, chdir_to_template_dir);
         take!(mtui, ssl_verify);
         take!(connection, connection_timeout);
+        take!(connection, reboot_timeout);
+        take!(connection, reboot_retries);
         take!(connection, max_parallel);
         take!(connection, max_oqa_parallel);
         take!(connection, ssh_strict_host_key_checking);
@@ -640,6 +650,13 @@ pub struct Config {
     // [connection]
     /// SSH connect + command timeout, in seconds.
     pub connection_timeout: u64,
+    /// Backoff base (seconds) for post-reboot reconnect retries. Sleeps grow
+    /// as `2*(reboot_timeout + 5*count)` after the first probe. Upstream
+    /// `reconnect(timeout=...)`.
+    pub reboot_timeout: u64,
+    /// Number of post-reboot reconnect attempts beyond the first probe.
+    /// Upstream `reconnect(retry=...)`.
+    pub reboot_retries: u64,
     /// Maximum number of hosts to fan out to concurrently (SSH command,
     /// SFTP, lock-probe, and connect batches). Caps peak sockets/tasks/RSS
     /// and remote load on large fleets; serial-host semantics are unaffected.
@@ -837,6 +854,8 @@ impl Default for Config {
             chdir_to_template_dir: false,
             ssl_verify: SslVerify::Enabled,
             connection_timeout: default_connection_timeout(),
+            reboot_timeout: default_reboot_timeout(),
+            reboot_retries: default_reboot_retries(),
             max_parallel: default_max_parallel(),
             max_oqa_parallel: default_max_oqa_parallel(),
             ssh_strict_host_key_checking: default_ssh_strict_host_key_checking(),
@@ -956,6 +975,16 @@ impl Config {
                 raw.connection.connection_timeout,
                 "connection_timeout",
                 d.connection_timeout
+            ),
+            reboot_timeout: validated_positive!(
+                raw.connection.reboot_timeout,
+                "reboot_timeout",
+                d.reboot_timeout
+            ),
+            reboot_retries: validated_positive!(
+                raw.connection.reboot_retries,
+                "reboot_retries",
+                d.reboot_retries
             ),
             max_parallel: validated_positive!(
                 raw.connection.max_parallel,
@@ -1083,6 +1112,8 @@ mod tests {
     fn default_matches_upstream_scalars() {
         let c = Config::default();
         assert_eq!(c.connection_timeout, 300);
+        assert_eq!(c.reboot_timeout, 10);
+        assert_eq!(c.reboot_retries, 10);
         assert_eq!(c.max_parallel, 50);
         assert_eq!(c.max_oqa_parallel, 8);
         assert_eq!(c.refhosts_https_expiration, 3600 * 12);
@@ -1376,6 +1407,8 @@ mod tests {
     fn from_raw_applies_values_and_defaults() {
         let mut raw = RawConfig::default();
         raw.connection.connection_timeout = Some(450);
+        raw.connection.reboot_timeout = Some(20);
+        raw.connection.reboot_retries = Some(5);
         raw.connection.max_parallel = Some(8);
         raw.connection.max_oqa_parallel = Some(3);
         raw.mtui.chdir_to_template_dir = Some(true);
@@ -1383,6 +1416,8 @@ mod tests {
         let c = Config::from_raw(raw);
         // Overridden.
         assert_eq!(c.connection_timeout, 450);
+        assert_eq!(c.reboot_timeout, 20);
+        assert_eq!(c.reboot_retries, 5);
         assert_eq!(c.max_parallel, 8);
         assert_eq!(c.max_oqa_parallel, 3);
         assert!(c.chdir_to_template_dir);
@@ -1395,11 +1430,14 @@ mod tests {
     fn merge_later_wins_on_shared_keys() {
         let mut base = RawConfig::default();
         base.connection.connection_timeout = Some(100);
+        base.connection.reboot_timeout = Some(10);
         base.url.bugzilla = Some("base".to_owned());
         let mut over = RawConfig::default();
         over.connection.connection_timeout = Some(999);
+        over.connection.reboot_timeout = Some(30);
         base.merge(over);
         assert_eq!(base.connection.connection_timeout, Some(999));
+        assert_eq!(base.connection.reboot_timeout, Some(30));
         // A key not set in `over` is preserved from base.
         assert_eq!(base.url.bugzilla.as_deref(), Some("base"));
     }
@@ -1494,6 +1532,8 @@ mod tests {
             r#"
             [connection]
             connection_timeout = 0
+            reboot_timeout = 0
+            reboot_retries = 0
             max_parallel = 0
             max_oqa_parallel = 0
             [refhosts]
@@ -1510,6 +1550,8 @@ mod tests {
         let c = Config::from_raw(raw);
         let d = Config::default();
         assert_eq!(c.connection_timeout, d.connection_timeout);
+        assert_eq!(c.reboot_timeout, d.reboot_timeout);
+        assert_eq!(c.reboot_retries, d.reboot_retries);
         assert_eq!(c.max_parallel, d.max_parallel);
         assert_eq!(c.max_oqa_parallel, d.max_oqa_parallel);
         assert_eq!(c.refhosts_https_expiration, d.refhosts_https_expiration);

--- a/crates/mtui-config/tests/fixtures/config.toml
+++ b/crates/mtui-config/tests/fixtures/config.toml
@@ -13,6 +13,7 @@ ssl_verify = "warn.example/ca.pem"
 
 [connection]
 connection_timeout = 450          # integer value
+reboot_timeout = 25               # integer value
 max_parallel = 8                  # integer value
 max_oqa_parallel = 4              # integer value
 ssh_strict_host_key_checking = "warn"

--- a/crates/mtui-config/tests/load.rs
+++ b/crates/mtui-config/tests/load.rs
@@ -34,6 +34,8 @@ fn config_toml_fixture_parses_all_sections() {
 
     // Integer-typed options.
     assert_eq!(cfg.connection_timeout, 450);
+    assert_eq!(cfg.reboot_timeout, 25);
+    assert_eq!(cfg.reboot_retries, 10); // omitted -> upstream default
     assert_eq!(cfg.max_parallel, 8);
     assert_eq!(cfg.max_oqa_parallel, 4);
     assert_eq!(cfg.refhosts_https_expiration, 3600);

--- a/crates/mtui-core/src/args.rs
+++ b/crates/mtui-core/src/args.rs
@@ -80,6 +80,28 @@ pub struct Args {
     )]
     pub connection_timeout: Option<u64>,
 
+    /// Override config `connection.reboot_timeout`: the backoff base
+    /// (seconds) for post-reboot reconnect retries.
+    // Rejected at parse time if 0, matching `validated_positive!` in the
+    // config-file loader.
+    #[arg(
+        long = "reboot-timeout",
+        value_name = "SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
+    pub reboot_timeout: Option<u64>,
+
+    /// Override config `connection.reboot_retries`: the number of post-reboot
+    /// reconnect attempts beyond the first probe.
+    // Rejected at parse time if 0, matching `validated_positive!` in the
+    // config-file loader.
+    #[arg(
+        long = "reboot-retries",
+        value_name = "COUNT",
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
+    pub reboot_retries: Option<u64>,
+
     /// Enable debugging output.
     #[arg(short = 'd', long = "debug")]
     pub debug: bool,
@@ -166,6 +188,12 @@ impl Args {
         }
         if let Some(timeout) = self.connection_timeout {
             config.connection_timeout = timeout;
+        }
+        if let Some(timeout) = self.reboot_timeout {
+            config.reboot_timeout = timeout;
+        }
+        if let Some(retries) = self.reboot_retries {
+            config.reboot_retries = retries;
         }
         if let Some(token) = &self.gitea_token {
             config.gitea_token = token.clone();
@@ -301,11 +329,22 @@ mod tests {
     }
 
     #[test]
+    fn reboot_backoff_zero_is_rejected_at_parse() {
+        assert!(parse(&["--reboot-timeout", "0"]).is_err());
+        assert!(parse(&["--reboot-retries", "0"]).is_err());
+        let a = parse(&["--reboot-timeout", "20", "--reboot-retries", "5"]).unwrap();
+        assert_eq!(a.reboot_timeout, Some(20));
+        assert_eq!(a.reboot_retries, Some(5));
+    }
+
+    #[test]
     fn no_args_leaves_everything_default() {
         let a = parse(&[]).unwrap();
         assert!(a.template_dir.is_none());
         assert!(a.sut.is_empty());
         assert!(a.connection_timeout.is_none());
+        assert!(a.reboot_timeout.is_none());
+        assert!(a.reboot_retries.is_none());
         assert!(!a.debug);
         assert!(a.config.is_none());
         assert_eq!(a.color, ColorArg::Auto);
@@ -471,6 +510,10 @@ mod tests {
         parse(&[
             "--connection-timeout",
             "42",
+            "--reboot-timeout",
+            "20",
+            "--reboot-retries",
+            "5",
             "--gitea-token",
             "tok",
             "--ssl-verify",
@@ -481,6 +524,8 @@ mod tests {
         .unwrap()
         .apply_to(&mut cfg);
         assert_eq!(cfg.connection_timeout, 42);
+        assert_eq!(cfg.reboot_timeout, 20);
+        assert_eq!(cfg.reboot_retries, 5);
         assert_eq!(cfg.gitea_token, "tok");
         assert_eq!(cfg.ssl_verify, SslVerify::Disabled);
         assert_eq!(cfg.template_dir, std::path::PathBuf::from("/tmp/tpl"));

--- a/crates/mtui-core/src/commands/config.rs
+++ b/crates/mtui-core/src/commands/config.rs
@@ -23,6 +23,8 @@ fn attr_value(config: &Config, attr: &str) -> Option<String> {
         "chdir_to_template_dir" => config.chdir_to_template_dir.to_string(),
         "ssl_verify" => ssl_verify_to_string(&config.ssl_verify),
         "connection_timeout" => config.connection_timeout.to_string(),
+        "reboot_timeout" => config.reboot_timeout.to_string(),
+        "reboot_retries" => config.reboot_retries.to_string(),
         "max_parallel" => config.max_parallel.to_string(),
         "ssh_strict_host_key_checking" => config.ssh_strict_host_key_checking.clone(),
         "refhosts_resolvers" => config.refhosts_resolvers.clone(),
@@ -99,7 +101,7 @@ fn ssl_verify_to_string(v: &SslVerify) -> String {
 }
 
 /// The attribute names `show` lists when given none, in a stable order.
-const ATTRS: [&str; 38] = [
+const ATTRS: [&str; 40] = [
     "template_dir",
     "local_tempdir",
     "session_user",
@@ -107,6 +109,8 @@ const ATTRS: [&str; 38] = [
     "chdir_to_template_dir",
     "ssl_verify",
     "connection_timeout",
+    "reboot_timeout",
+    "reboot_retries",
     "max_parallel",
     "ssh_strict_host_key_checking",
     "refhosts_resolvers",
@@ -195,6 +199,8 @@ fn set_attr(config: &mut Config, attr: &str, raw: &str) -> Result<(), String> {
         "pool_reap_stale" => config.pool_reap_stale = parse_bool(raw)?,
         "lock_pi_autolock" => config.lock_pi_autolock = parse_bool(raw)?,
         "connection_timeout" => config.connection_timeout = parse_positive_u64(raw)?,
+        "reboot_timeout" => config.reboot_timeout = parse_positive_u64(raw)?,
+        "reboot_retries" => config.reboot_retries = parse_positive_u64(raw)?,
         "max_parallel" => config.max_parallel = parse_positive_u64(raw)?,
         "refhosts_https_expiration" => config.refhosts_https_expiration = parse_positive_u64(raw)?,
         "lock_stale_age" => config.lock_stale_age = parse_u64(raw)?,
@@ -479,6 +485,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_and_show_reboot_backoff_roundtrips() {
+        let (mut session, _buf) = empty_session();
+        ConfigCmd
+            .call(
+                &mut session,
+                &matches(&ConfigCmd, &["set", "reboot_timeout", "20"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(session.config.reboot_timeout, 20);
+        assert_eq!(
+            attr_value(&session.config, "reboot_timeout").as_deref(),
+            Some("20")
+        );
+
+        ConfigCmd
+            .call(
+                &mut session,
+                &matches(&ConfigCmd, &["set", "reboot_retries", "5"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(session.config.reboot_retries, 5);
+        assert_eq!(
+            attr_value(&session.config, "reboot_retries").as_deref(),
+            Some("5")
+        );
+    }
+
+    #[tokio::test]
     async fn set_bool_parses_config_spellings() {
         let (mut session, _buf) = empty_session();
         let args = matches(&ConfigCmd, &["set", "chdir_to_template_dir", "yes"]);
@@ -511,6 +547,8 @@ mod tests {
         // value the file would refuse, breaking the command's own contract.
         for attr in [
             "connection_timeout",
+            "reboot_timeout",
+            "reboot_retries",
             "max_parallel",
             "refhosts_https_expiration",
             "slack_poll_interval",

--- a/crates/mtui-core/src/entrypoint.rs
+++ b/crates/mtui-core/src/entrypoint.rs
@@ -206,6 +206,8 @@ mod tests {
             template_dir: None,
             sut: Vec::new(),
             connection_timeout: None,
+            reboot_timeout: None,
+            reboot_retries: None,
             debug: false,
             config: None,
             color: crate::args::ColorArg::Never,

--- a/crates/mtui-core/tests/snapshots/args__help.snap
+++ b/crates/mtui-core/tests/snapshots/args__help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/mtui-core/tests/args.rs
+assertion_line: 30
 expression: "rendered(&[\"--help\"])"
 ---
 Maintenance Test Update Installer
@@ -15,6 +16,12 @@ Options:
 
   -w, --connection-timeout <SECONDS>
           Override config `mtui.connection_timeout` (seconds)
+
+      --reboot-timeout <SECONDS>
+          Override config `connection.reboot_timeout`: the backoff base (seconds) for post-reboot reconnect retries
+
+      --reboot-retries <COUNT>
+          Override config `connection.reboot_retries`: the number of post-reboot reconnect attempts beyond the first probe
 
   -d, --debug
           Enable debugging output

--- a/crates/mtui-hosts/Cargo.toml
+++ b/crates/mtui-hosts/Cargo.toml
@@ -45,7 +45,7 @@ russh-config = "0.58"
 quick-xml.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tempfile = "3"
 # Used only in tests to assert command lines re-split to a single literal token.
 shlex.workspace = true

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -128,6 +128,11 @@ pub struct MockConnection {
     reconnects: Arc<Mutex<usize>>,
     /// When `true`, [`reconnect`](Connection::reconnect) fails.
     reconnect_fails: bool,
+    /// The `(retry, backoff)` args of the most recent
+    /// [`reconnect`](Connection::reconnect) call, so a test can assert the
+    /// caller passed the expected budget (e.g. the reboot lifecycle's
+    /// `(config.reboot_retries, true)` vs. a fast-path `(0, false)`).
+    last_reconnect_args: Arc<Mutex<Option<(usize, bool)>>>,
     /// Commands dispatched via [`fire_and_forget`](Connection::fire_and_forget).
     fired: Arc<Mutex<Vec<String>>>,
     /// SFTP operations observed, in order.
@@ -247,6 +252,7 @@ impl MockConnection {
             close_fails: false,
             reconnects: Arc::new(Mutex::new(0)),
             reconnect_fails: false,
+            last_reconnect_args: Arc::new(Mutex::new(None)),
             fired: Arc::new(Mutex::new(Vec::new())),
             sftp_ops: Arc::new(Mutex::new(Vec::new())),
             sftp_sessions: Arc::new(Mutex::new(0)),
@@ -552,6 +558,15 @@ impl MockConnection {
         *self.reconnects.lock().expect("mock reconnects lock")
     }
 
+    /// The `(retry, backoff)` args of the most recent
+    /// [`reconnect`](Connection::reconnect) call, or `None` if never called.
+    pub fn last_reconnect_args(&self) -> Option<(usize, bool)> {
+        *self
+            .last_reconnect_args
+            .lock()
+            .expect("mock last reconnect args lock")
+    }
+
     /// Returns the commands dispatched via
     /// [`fire_and_forget`](Connection::fire_and_forget), in order.
     #[must_use]
@@ -815,8 +830,12 @@ impl Connection for MockConnection {
         Ok(())
     }
 
-    async fn reconnect(&mut self) -> Result<()> {
+    async fn reconnect(&mut self, retry: usize, backoff: bool) -> Result<()> {
         *self.reconnects.lock().expect("mock reconnects lock") += 1;
+        *self
+            .last_reconnect_args
+            .lock()
+            .expect("mock last reconnect args lock") = Some((retry, backoff));
         if self.reconnect_fails {
             return Err(HostError::ReconnectFailed {
                 host: self.hostname.clone(),
@@ -1056,7 +1075,7 @@ impl Connection for MockConnection {
         // entry if inactive, mirroring the ssh impl (and `parse_system`'s
         // reconnect-then-retry expectations under `Target::connect`).
         if !self.active {
-            self.reconnect().await?;
+            self.reconnect(0, false).await?;
         }
         if !self.sftp_session_delay.is_zero() {
             tokio::time::sleep(self.sftp_session_delay).await;
@@ -1171,7 +1190,7 @@ mod tests {
     async fn reconnect_counts_and_reactivates() {
         let mut conn = MockConnection::new("h1").inactive();
         assert!(!conn.is_active());
-        conn.reconnect().await.expect("reconnect ok");
+        conn.reconnect(0, false).await.expect("reconnect ok");
         assert!(conn.is_active());
         assert_eq!(conn.reconnect_count(), 1);
     }
@@ -1179,7 +1198,7 @@ mod tests {
     #[tokio::test]
     async fn failing_reconnect_surfaces_error() {
         let mut conn = MockConnection::new("h1").failing_reconnect();
-        let err = conn.reconnect().await.expect_err("should fail");
+        let err = conn.reconnect(0, false).await.expect_err("should fail");
         assert!(matches!(err, HostError::ReconnectFailed { host } if host == "h1"));
         assert_eq!(conn.reconnect_count(), 1);
     }

--- a/crates/mtui-hosts/src/connection/mod.rs
+++ b/crates/mtui-hosts/src/connection/mod.rs
@@ -113,14 +113,18 @@ pub trait Connection: Send + Sync {
 
     /// Re-establishes the transport if it has dropped.
     ///
-    /// Mirrors upstream `Connection.reconnect`: bounded retries, quiet while
-    /// the host is (e.g.) rebooting, then a single surfaced failure.
+    /// Mirrors upstream `Connection.reconnect(retry, timeout, backoff)`:
+    /// `retry` is the number of probe attempts beyond the first, and
+    /// `backoff` selects between a flat per-probe sleep and one that grows
+    /// (`2*(base + 5*count)`) across attempts. Callers recovering from a
+    /// reboot pass a generous `retry` with `backoff = true`; every other
+    /// caller (a dead link mid-command) passes `(0, false)` to fail fast.
     ///
     /// # Errors
     ///
     /// Returns [`HostError::ReconnectFailed`](crate::HostError::ReconnectFailed)
     /// if the retry budget is exhausted while the link is still down.
-    async fn reconnect(&mut self) -> Result<()>;
+    async fn reconnect(&mut self, retry: usize, backoff: bool) -> Result<()>;
 
     /// Dispatches a command without waiting for it to complete, then closes the
     /// local connection.

--- a/crates/mtui-hosts/src/connection/ssh.rs
+++ b/crates/mtui-hosts/src/connection/ssh.rs
@@ -381,6 +381,12 @@ pub struct SshConnection {
     /// the initial [`connect`](Self::connect) used (tests point it at a temp
     /// file to stay out of the developer's real store).
     known_hosts: Option<PathBuf>,
+    /// Backoff base for [`reconnect`](Connection::reconnect)'s post-reboot
+    /// budget (config `reboot_timeout`, default 10s). Only consulted when the
+    /// caller passes `backoff = true`; set via [`with_reboot_budget`].
+    ///
+    /// [`with_reboot_budget`]: Self::with_reboot_budget
+    reconnect_backoff_base: Duration,
 }
 
 impl std::fmt::Debug for SshConnection {
@@ -430,6 +436,7 @@ impl SshConnection {
             is_repl: false,
             timeout_prompt: None,
             known_hosts,
+            reconnect_backoff_base: Duration::from_secs(10),
         })
     }
 
@@ -461,6 +468,16 @@ impl SshConnection {
         self
     }
 
+    /// Sets the backoff base [`reconnect`](Connection::reconnect) uses when a
+    /// caller passes `backoff = true` (the post-reboot recovery path).
+    /// Mirrors config `[connection] reboot_timeout`; unset callers keep the
+    /// 10s default set in [`connect`](Self::connect).
+    #[must_use]
+    pub fn with_reboot_budget(mut self, base: Duration) -> Self {
+        self.reconnect_backoff_base = base;
+        self
+    }
+
     /// Returns the live handle or a [`HostError::Transport`] "not connected".
     fn handle(&self) -> Result<&Handle<ClientHandler>> {
         self.handle.as_ref().ok_or_else(|| HostError::Transport {
@@ -473,7 +490,7 @@ impl SshConnection {
     /// link has dropped. Mirrors upstream `_sftp` (open per operation).
     async fn sftp(&mut self) -> Result<RusshSftpSession> {
         if !self.is_active() {
-            self.reconnect().await?;
+            self.reconnect(0, false).await?;
         }
         let channel = self
             .handle()?
@@ -726,6 +743,12 @@ fn persist_host_key_inner(
     mtui_config::atomic::write(&contents, path)
 }
 
+/// The next `reconnect` backoff sleep after `count` attempts, mirroring
+/// upstream `2 * (timeout + 5 * count)`.
+fn reconnect_delay(count: usize, base: Duration) -> Duration {
+    (base + Duration::from_secs(5 * count as u64)) * 2
+}
+
 /// Establishes the transport and authenticates. Shared by `connect` and
 /// `reconnect`.
 async fn establish(
@@ -952,6 +975,7 @@ impl Connection for SshConnection {
             is_repl: self.is_repl,
             timeout_prompt: self.timeout_prompt.clone(),
             known_hosts: self.known_hosts.clone(),
+            reconnect_backoff_base: self.reconnect_backoff_base,
         })
     }
 
@@ -963,7 +987,7 @@ impl Connection for SshConnection {
         let mut attempt = 0;
         let mut channel = loop {
             if !self.is_active() {
-                self.reconnect().await?;
+                self.reconnect(0, false).await?;
             }
             match self.handle()?.channel_open_session().await {
                 Ok(ch) => break ch,
@@ -975,7 +999,7 @@ impl Connection for SshConnection {
                         });
                     }
                     tracing::debug!(host = %self.hostname, "channel open failed ({e}); retrying");
-                    self.reconnect().await?;
+                    self.reconnect(0, false).await?;
                 }
             }
         };
@@ -1117,12 +1141,25 @@ impl Connection for SshConnection {
         Ok(())
     }
 
-    async fn reconnect(&mut self) -> Result<()> {
+    async fn reconnect(&mut self, retry: usize, backoff: bool) -> Result<()> {
         if self.is_active() {
             return Ok(());
         }
+        let mut count = 0usize;
+        let mut rtimeout = self.reconnect_backoff_base;
         let mut last_err = None;
-        for attempt in 0..=RETRIES {
+        while !self.is_active() && count <= retry {
+            count += 1;
+            // Ported from upstream `Connection.reconnect`: sleep before each
+            // probe, growing the wait when `backoff`. Unlike upstream, the
+            // pre-sleep itself is gated on `backoff` — non-reboot callers pass
+            // `(0, false)` and must fail fast (no multi-second pause) on a
+            // genuinely dead link mid-command; only the reboot-recovery budget
+            // (`backoff = true`) pays the wait.
+            if backoff {
+                tokio::time::sleep(rtimeout).await;
+                rtimeout = reconnect_delay(count, self.reconnect_backoff_base);
+            }
             match establish(
                 &self.hostname,
                 &self.resolved,
@@ -1134,15 +1171,15 @@ impl Connection for SshConnection {
             {
                 Ok(handle) => {
                     self.handle = Some(handle);
-                    return Ok(());
                 }
                 Err(e) => {
-                    tracing::debug!(host = %self.hostname, attempt, "reconnect attempt failed: {e}");
+                    tracing::debug!(host = %self.hostname, attempt = count, "reconnect attempt failed: {e}");
                     last_err = Some(e);
-                    // brief backoff between attempts
-                    tokio::time::sleep(Duration::from_millis(200)).await;
                 }
             }
+        }
+        if self.is_active() {
+            return Ok(());
         }
         tracing::debug!(host = %self.hostname, "reconnect gave up: {last_err:?}");
         Err(HostError::ReconnectFailed {
@@ -1456,7 +1493,7 @@ impl Connection for SshConnection {
         let mut attempt = 0;
         let channel = loop {
             if !self.is_active() {
-                self.reconnect().await?;
+                self.reconnect(0, false).await?;
             }
             match self.handle()?.channel_open_session().await {
                 Ok(ch) => break ch,
@@ -1468,7 +1505,7 @@ impl Connection for SshConnection {
                         });
                     }
                     tracing::debug!(host = %self.hostname, "shell channel open failed ({e}); retrying");
-                    self.reconnect().await?;
+                    self.reconnect(0, false).await?;
                 }
             }
         };
@@ -1838,6 +1875,7 @@ mod tests {
             is_repl: false,
             timeout_prompt: None,
             known_hosts: None,
+            reconnect_backoff_base: Duration::from_secs(10),
         };
         let s = format!("{conn:?}");
         assert!(s.contains("example.host"), "{s}");
@@ -1847,6 +1885,88 @@ mod tests {
         // A disconnected connection reports inactive and errors on handle().
         assert!(!conn.is_active());
         assert!(conn.handle().is_err());
+    }
+
+    // --- reconnect budget (fix-reboot-reconnect-window) ---
+
+    /// A disconnected `SshConnection` pointed at a port nothing listens on
+    /// (127.0.0.1:1 refuses immediately), so `establish()` fails fast with no
+    /// timer involved — isolating the reconnect loop's own sleeps from real
+    /// network latency.
+    fn dead_port_connection(base: Duration) -> SshConnection {
+        SshConnection {
+            hostname: "127.0.0.1".to_owned(),
+            resolved: Resolved {
+                connect_host: "127.0.0.1".to_owned(),
+                port: 1,
+                user: "root".to_owned(),
+                identity_files: Vec::new(),
+            },
+            policy: HostKeyPolicy::AutoAdd,
+            timeout: CommandTimeout::new(Duration::from_millis(200)),
+            handle: None,
+            is_repl: false,
+            timeout_prompt: None,
+            known_hosts: None,
+            reconnect_backoff_base: base,
+        }
+    }
+
+    #[test]
+    fn reconnect_delay_matches_upstream_formula() {
+        // Upstream `2 * (timeout + 5 * count)`.
+        let base = Duration::from_secs(10);
+        assert_eq!(reconnect_delay(1, base), Duration::from_secs(2 * (10 + 5)));
+        assert_eq!(reconnect_delay(2, base), Duration::from_secs(2 * (10 + 10)));
+        assert_eq!(reconnect_delay(3, base), Duration::from_secs(2 * (10 + 15)));
+        assert_eq!(
+            reconnect_delay(10, base),
+            Duration::from_secs(2 * (10 + 50))
+        );
+    }
+
+    #[tokio::test]
+    async fn reconnect_fast_path_probes_once_and_fails_fast() {
+        // retry=0, backoff=false: the non-reboot (run/shell/sftp) call shape.
+        // Must not pay the backoff base's pre-sleep — a single immediate probe.
+        let mut conn = dead_port_connection(Duration::from_secs(10));
+        let started = std::time::Instant::now();
+        let err = conn.reconnect(0, false).await.expect_err("dead port fails");
+        assert!(matches!(err, HostError::ReconnectFailed { host } if host == "127.0.0.1"));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "fast path must not sleep by the reboot backoff base: took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_backoff_makes_retry_plus_one_attempts_then_gives_up() {
+        // retry=3, backoff=true: the reboot-recovery call shape. Every attempt
+        // is preceded by a sleep (base, then the grown `reconnect_delay`); with
+        // a paused clock the sleeps resolve instantly while still advancing
+        // tokio's virtual clock by the exact scheduled amount, so the elapsed
+        // virtual time proves both the attempt count and the backoff formula
+        // without the test taking minutes of wall-clock time.
+        let base = Duration::from_secs(10);
+        let mut conn = dead_port_connection(base);
+        let started = tokio::time::Instant::now();
+        let err = conn
+            .reconnect(3, true)
+            .await
+            .expect_err("dead port fails after exhausting the budget");
+        assert!(matches!(err, HostError::ReconnectFailed { host } if host == "127.0.0.1"));
+        let expected =
+            base + reconnect_delay(1, base) + reconnect_delay(2, base) + reconnect_delay(3, base);
+        // Paused virtual time still accrues the dead-port connect attempts'
+        // small real wall-clock latency alongside the auto-advanced sleeps, so
+        // allow a little slack rather than requiring byte-exact equality.
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed.abs_diff(expected) < Duration::from_secs(5),
+            "expected ~4 attempts (retry+1) with sleeps base, then reconnect_delay(1..=3): \
+             elapsed={elapsed:?}, expected={expected:?}"
+        );
     }
 
     // --- host-key verification (th4o.4) ---

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1125,7 +1125,8 @@ impl HostsGroup {
                 let outcomes = &outcomes;
                 Box::pin(async move {
                     let hostname = t.hostname().to_owned();
-                    let outcome = match t.reconnect().await {
+                    let retry = t.reboot_retries();
+                    let outcome = match t.reconnect(retry, true).await {
                         Ok(()) => {
                             tracing::info!(host = %hostname, "is back up");
                             Ok(())
@@ -1228,7 +1229,8 @@ impl HostsGroup {
             |t| reboot.contains_key(t.hostname()),
             |t| {
                 Box::pin(async move {
-                    if let Err(e) = t.reconnect().await {
+                    let retry = t.reboot_retries();
+                    if let Err(e) = t.reconnect(retry, true).await {
                         tracing::error!(host = %t.hostname(), error = %e, "reconnect after reboot failed");
                     } else {
                         tracing::info!(host = %t.hostname(), "is back up");
@@ -1857,6 +1859,11 @@ mod tests {
         assert_eq!(outcomes.len(), 2);
         assert!(outcomes["h1"].is_ok());
         assert!(outcomes["h2"].is_ok());
+        // The reboot lifecycle grants the boot-aware backoff budget (the
+        // target's config default is `reboot_retries = 10`), not the fast-path
+        // `(0, false)` used by run/shell/sftp.
+        assert_eq!(h1.last_reconnect_args(), Some((10, true)));
+        assert_eq!(h2.last_reconnect_args(), Some((10, true)));
     }
 
     #[tokio::test]
@@ -2039,6 +2046,8 @@ mod tests {
             vec!["transactional-update reboot".to_owned()]
         );
         assert_eq!(h1.reconnect_count(), 1);
+        // The transactional reboot path also grants the boot-aware budget.
+        assert_eq!(h1.last_reconnect_args(), Some((10, true)));
         // h2 was not in the map: untouched.
         assert!(h2.fired_commands().is_empty());
         assert_eq!(h2.reconnect_count(), 0);

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -680,6 +680,14 @@ impl Target {
         }
     }
 
+    /// The post-reboot reconnect attempt budget (`[connection]
+    /// reboot_retries`) this target was built with, for callers driving the
+    /// reboot lifecycle (`HostsGroup::reboot`/`reboot_transactional`).
+    #[must_use]
+    pub fn reboot_retries(&self) -> usize {
+        self.config.reboot_retries as usize
+    }
+
     /// Re-establishes the transport after a reboot dropped it.
     ///
     /// Ports upstream `Target.reconnect(retry, backoff)`: delegates to
@@ -691,9 +699,9 @@ impl Target {
     ///
     /// Propagates [`HostError::ReconnectFailed`] when the retry budget is
     /// exhausted while the host is still down.
-    pub async fn reconnect(&mut self) -> Result<()> {
+    pub async fn reconnect(&mut self, retry: usize, backoff: bool) -> Result<()> {
         match self.connection.as_mut() {
-            Some(conn) => conn.reconnect().await,
+            Some(conn) => conn.reconnect(retry, backoff).await,
             None => {
                 tracing::debug!(host = %self.hostname, "reconnect: not connected");
                 Ok(())
@@ -984,6 +992,8 @@ impl Target {
                 Some(prompt) => conn.with_timeout_prompt(prompt.clone()),
                 None => conn,
             };
+            let conn =
+                conn.with_reboot_budget(std::time::Duration::from_secs(self.config.reboot_timeout));
             let conn: Box<dyn Connection> = Box::new(conn);
             // Build the operation lock over a clone of the live connection,
             // mirroring upstream `self._lock = TargetLock(self.connection,
@@ -2295,21 +2305,30 @@ mod tests {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
         let mut t = enabled_with(conn);
-        t.reconnect().await.expect("reconnect ok");
+        t.reconnect(10, true).await.expect("reconnect ok");
         assert_eq!(handle.reconnect_count(), 1);
+        assert_eq!(handle.last_reconnect_args(), Some((10, true)));
+    }
+
+    #[tokio::test]
+    async fn reboot_retries_reads_from_config() {
+        let mut cfg = Config::default();
+        cfg.reboot_retries = 3;
+        let t = Target::new(&cfg, "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        assert_eq!(t.reboot_retries(), 3);
     }
 
     #[tokio::test]
     async fn reconnect_surfaces_failure() {
         let conn = MockConnection::new("h1").failing_reconnect();
         let mut t = enabled_with(conn);
-        assert!(t.reconnect().await.is_err());
+        assert!(t.reconnect(0, false).await.is_err());
     }
 
     #[tokio::test]
     async fn reconnect_unconnected_is_ok_noop() {
         let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
-        t.reconnect().await.expect("noop reconnect ok");
+        t.reconnect(0, false).await.expect("noop reconnect ok");
     }
 
     // --- lock / is_locked delegators ----------------------------------------

--- a/crates/mtui-hosts/tests/ssh_integration.rs
+++ b/crates/mtui-hosts/tests/ssh_integration.rs
@@ -923,7 +923,7 @@ async fn reconnect_reestablishes_after_close() {
     let mut conn = connect(port, CommandTimeout::from_secs(5)).await;
     conn.close().await.expect("close");
     assert!(!conn.is_active());
-    conn.reconnect().await.expect("reconnect");
+    conn.reconnect(0, false).await.expect("reconnect");
     assert!(conn.is_active());
     // Still usable after reconnect.
     let log = conn.run("echo hello").await.expect("run after reconnect");

--- a/dist/completions/bash/mtui.bash
+++ b/dist/completions/bash/mtui.bash
@@ -23,7 +23,7 @@ _mtui() {
 
     case "${cmd}" in
         mtui)
-            opts="-t -s -w -d -c -g -a -k -h -V --template-dir --sut --connection-timeout --debug --config --color --gitea-token --ssl-verify --auto-review-id --kernel-review-id --help --version"
+            opts="-t -s -w -d -c -g -a -k -h -V --template-dir --sut --connection-timeout --reboot-timeout --reboot-retries --debug --config --color --gitea-token --ssl-verify --auto-review-id --kernel-review-id --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -50,6 +50,14 @@ _mtui() {
                     return 0
                     ;;
                 -w)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --reboot-timeout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --reboot-retries)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/dist/completions/fish/mtui.fish
+++ b/dist/completions/fish/mtui.fish
@@ -1,6 +1,8 @@
 complete -c mtui -s t -l template-dir -d 'Override config `mtui.template_dir`' -r -F
 complete -c mtui -s s -l sut -d 'Cumulatively override the default hosts from the template (format: `hostname,hostname2`). May be given more than once' -r
 complete -c mtui -s w -l connection-timeout -d 'Override config `mtui.connection_timeout` (seconds)' -r
+complete -c mtui -l reboot-timeout -d 'Override config `connection.reboot_timeout`: the backoff base (seconds) for post-reboot reconnect retries' -r
+complete -c mtui -l reboot-retries -d 'Override config `connection.reboot_retries`: the number of post-reboot reconnect attempts beyond the first probe' -r
 complete -c mtui -s c -l config -d 'Override the default config path' -r -F
 complete -c mtui -l color -d 'Control coloured output' -r -f -a "auto\t'Colour iff stderr is a TTY and `NO_COLOR` is unset. The default'
 always\t'Always emit colour escapes'

--- a/dist/completions/zsh/_mtui
+++ b/dist/completions/zsh/_mtui
@@ -21,6 +21,8 @@ _mtui() {
 '*--sut=[Cumulatively override the default hosts from the template (format\: \`hostname,hostname2\`). May be given more than once]:HOSTS:_default' \
 '-w+[Override config \`mtui.connection_timeout\` (seconds)]:SECONDS:_default' \
 '--connection-timeout=[Override config \`mtui.connection_timeout\` (seconds)]:SECONDS:_default' \
+'--reboot-timeout=[Override config \`connection.reboot_timeout\`\: the backoff base (seconds) for post-reboot reconnect retries]:SECONDS:_default' \
+'--reboot-retries=[Override config \`connection.reboot_retries\`\: the number of post-reboot reconnect attempts beyond the first probe]:COUNT:_default' \
 '-c+[Override the default config path]:FILE:_files' \
 '--config=[Override the default config path]:FILE:_files' \
 '--color=[Control coloured output]:COLOR:((auto\:"Colour iff stderr is a TTY and \`NO_COLOR\` is unset. The default"

--- a/dist/man/mtui.1
+++ b/dist/man/mtui.1
@@ -4,7 +4,7 @@
 .SH NAME
 mtui \- Maintenance Test Update Installer
 .SH SYNOPSIS
-\fBmtui\fR [\fB\-t\fR|\fB\-\-template\-dir\fR] [\fB\-s\fR|\fB\-\-sut\fR] [\fB\-w\fR|\fB\-\-connection\-timeout\fR] [\fB\-d\fR|\fB\-\-debug\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-\-color\fR] [\fB\-g\fR|\fB\-\-gitea\-token\fR] [\fB\-\-ssl\-verify\fR] [\fB\-a\fR|\fB\-\-auto\-review\-id\fR] [\fB\-k\fR|\fB\-\-kernel\-review\-id\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBmtui\fR [\fB\-t\fR|\fB\-\-template\-dir\fR] [\fB\-s\fR|\fB\-\-sut\fR] [\fB\-w\fR|\fB\-\-connection\-timeout\fR] [\fB\-\-reboot\-timeout\fR] [\fB\-\-reboot\-retries\fR] [\fB\-d\fR|\fB\-\-debug\fR] [\fB\-c\fR|\fB\-\-config\fR] [\fB\-\-color\fR] [\fB\-g\fR|\fB\-\-gitea\-token\fR] [\fB\-\-ssl\-verify\fR] [\fB\-a\fR|\fB\-\-auto\-review\-id\fR] [\fB\-k\fR|\fB\-\-kernel\-review\-id\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 Maintenance Test Update Installer
 .SH OPTIONS
@@ -17,6 +17,12 @@ Cumulatively override the default hosts from the template (format: `hostname,hos
 .TP
 \fB\-w\fR, \fB\-\-connection\-timeout\fR \fI<SECONDS>\fR
 Override config `mtui.connection_timeout` (seconds)
+.TP
+\fB\-\-reboot\-timeout\fR \fI<SECONDS>\fR
+Override config `connection.reboot_timeout`: the backoff base (seconds) for post\-reboot reconnect retries
+.TP
+\fB\-\-reboot\-retries\fR \fI<COUNT>\fR
+Override config `connection.reboot_retries`: the number of post\-reboot reconnect attempts beyond the first probe
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 Enable debugging output

--- a/dist/mtui.toml.example
+++ b/dist/mtui.toml.example
@@ -29,6 +29,12 @@
 [connection]
 # SSH connect + command timeout, in seconds.
 # connection_timeout = 300
+# Backoff base (seconds) for reconnecting after a reboot (prepare/reboot/update).
+# Sleeps grow as 2*(reboot_timeout + 5*count) across attempts.
+# reboot_timeout = 10
+# Number of post-reboot reconnect attempts beyond the first. With the
+# defaults this gives a rebooting host up to ~12.7 minutes to come back.
+# reboot_retries = 10
 # Max hosts to fan out to concurrently (SSH/SFTP/lock/connect batches).
 # max_parallel = 50
 # Max concurrent openQA/QAM HTTP requests in the overview search.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -62,12 +62,18 @@ Defaults below are the built-in (upstream-matching) values.
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
 | `connection_timeout` | seconds (>0) | `300` | SSH connect + command timeout. |
+| `reboot_timeout` | seconds (>0) | `10` | Backoff base for reconnecting after a reboot (`prepare`/`reboot`/`update`). Sleeps grow as `2*(reboot_timeout + 5*count)` across attempts. |
+| `reboot_retries` | int (>0) | `10` | Number of post-reboot reconnect attempts beyond the first. With the defaults this gives a rebooting host up to ~12.7 minutes to come back. |
 | `max_parallel` | int (>0) | `50` | Max hosts to fan out to concurrently (SSH/SFTP/lock/connect batches). |
 | `max_oqa_parallel` | int (>0) | `8` | Max concurrent openQA/QAM HTTP requests in the overview search (kept low to be polite to shared hosts). |
 | `ssh_strict_host_key_checking` | string | `auto_add` | SSH host-key checking policy (`auto_add`, `strict`, `warn`, …). |
 
 > **SSH is pubkey-only by design.** mtui authenticates from the SSH agent or
 > `~/.ssh/id_*`; there is no password auth.
+
+> `reboot_timeout`/`reboot_retries` only apply to the post-reboot reconnect
+> budget. A dead SSH link mid-`run`/`shell`, or the `sftp` pre-op check, still
+> fails on the first probe — those are not recovering from a reboot.
 
 ### `[refhosts]`
 
@@ -232,6 +238,8 @@ oscrc.
 ```toml
 [connection]
 connection_timeout = 300
+reboot_timeout = 10
+reboot_retries = 10
 max_parallel = 8
 
 [refhosts]

--- a/docs/src/invocation.md
+++ b/docs/src/invocation.md
@@ -23,6 +23,12 @@ Options:
   -w, --connection-timeout <SECONDS>
           Override config `mtui.connection_timeout` (seconds)
 
+      --reboot-timeout <SECONDS>
+          Override config `connection.reboot_timeout`: the backoff base (seconds) for post-reboot reconnect retries
+
+      --reboot-retries <COUNT>
+          Override config `connection.reboot_retries`: the number of post-reboot reconnect attempts beyond the first probe
+
   -d, --debug
           Enable debugging output
 


### PR DESCRIPTION
## Summary

`prepare`/`reboot`/`update` intermittently mark slow/high-latency refhosts
(notably aarch64, cross-site) as "reconnect after reboot failed" even though
the host rebooted fine. `SshConnection::reconnect()` retried a fixed 6 times
with a flat 200ms backoff (~1.2s total) — far shorter than a real reboot, and
unrelated to `connection_timeout` (which only caps *hanging* connects, not
refused ones). Because fan-out aggregates per-host failures, one false
failure fails the whole batch.

This ports upstream Python's `reconnect(retry, timeout, backoff)` shape: a
growing backoff for the post-reboot recovery budget, while keeping non-reboot
paths (a dropped link mid-`run`/`shell`, the `sftp` pre-op check) on today's
fast fail — they are not recovering from a reboot, so a dead link there means
the host is genuinely gone and should fail immediately, not hang for minutes.

## What changed

- New `[connection]` config keys `reboot_timeout` (backoff base, default 10s)
  and `reboot_retries` (attempt count, default 10), with `config show`/`set`
  support and `--reboot-timeout`/`--reboot-retries` CLI flags on `mtui`.
  Defaults give a rebooting host up to ~12.7 minutes to come back.
- `Connection::reconnect` gains `(retry: usize, backoff: bool)`. The SSH impl
  loops `count <= retry`, sleeping before each probe only when `backoff` is
  set, growing the wait via `reconnect_delay(count, base) = 2*(base +
  5*count)` (upstream's formula). `retry=0` is a single probe with **no
  sleep** — run/shell/sftp call sites pass `(0, false)` and keep failing fast.
- The reboot lifecycle (`HostsGroup::reboot`/`reboot_transactional`) now
  calls `reconnect(reboot_retries, true)`, reading the budget back off the
  target's own config via a new `Target::reboot_retries()` accessor.
- Docs (`configuration.md`, `invocation.md`), the man page, shell completions,
  and `mtui.toml.example` are regenerated/updated for the new keys/flags.

## Testing

- New unit tests: `reconnect_delay` arithmetic against the upstream formula,
  a paused-clock test proving `retry+1` attempts occur before
  `ReconnectFailed`, a real-time test proving the fast path never sleeps, and
  mock-recorded assertions that the reboot lifecycle passes the
  config-derived budget (not the fast-path default).
- Full workspace gate green: `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace`, and the compile-only feature matrix
  (`--no-default-features` / `--all-features`).
- `mtui-hosts` patch coverage held at ~94.8% (`cargo llvm-cov`).

## Compatibility

- Existing `ReconnectFailed` error text/contract is unchanged.
- Non-reboot reconnect callers are behaviorally unchanged (still fail fast).
- `mtui-mcp` picks this up for free (same registry/engine); its own CLI
  stays a curated subset of `mtui`'s flags (mirroring how it already omits
  `--max-parallel` etc.), but `[connection] reboot_timeout`/`reboot_retries`
  in the config file, and `config set`, apply identically there.