### PR TITLE
refactor(hosts): remove the unused TargetState::Dryrun variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   visible in `config show`, settable with `config set`, and overridable with
   the new `--reboot-timeout`/`--reboot-retries` CLI flags.
 
+### Removed
+
+- The `dryrun` per-host state has been dropped from `set_host_state` (and the
+  MCP tool it synthesises). This is an intentional deviation from upstream
+  mtui: hosts now support only `enabled`/`disabled`. A `dryrun` value is
+  rejected as an invalid state, not silently remapped.
+
 ### Fixed
 
 - `prepare`/`reboot`/`update` no longer falsely mark a slow-to-reboot host as

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ authenticated boundary trusted to operate the remaining maintenance tools.
 ## Features
 
 - Parallel SSH command execution across reference hosts (`run`, `update`,
-  `install`, `prepare`, `downgrade`, …) with per-host `enabled`/`disabled`/
-  `dryrun` states and `parallel`/`serial` modes. **Pubkey auth only.**
+  `install`, `prepare`, `downgrade`, …) with per-host `enabled`/`disabled`
+  states and `parallel`/`serial` modes. **Pubkey auth only.**
 - OBS/IBS and Gitea maintenance-request workflow (`assign`, `approve`, `reject`,
   `comment`, …) via the native OBS/IBS API (no `osc` subprocess).
 - Optional Slack review-request integration (`request_review`, off by default):

--- a/crates/mtui-cli/src/shell.rs
+++ b/crates/mtui-cli/src/shell.rs
@@ -225,7 +225,7 @@ fn encode_key(key: KeyEvent) -> Option<Vec<u8>> {
 /// under raw mode.
 ///
 /// Reads the current terminal size, spawns via [`Target::shell`] (state-gated:
-/// a disabled/dryrun/failed target returns `None`), then bridges until the
+/// a disabled/failed target returns `None`), then bridges until the
 /// session ends, restoring cooked mode via [`RawModeGuard`] on the way out.
 ///
 /// # Errors
@@ -271,7 +271,7 @@ fn shlex_split(line: &str) -> Option<Vec<String>> {
 /// then attach a shell on each selected host **sequentially** (upstream
 /// `for target in targets: targets[target].shell()`).
 ///
-/// A host with no attachable PTY (disabled / dryrun / spawn failure →
+/// A host with no attachable PTY (disabled / spawn failure →
 /// [`Target::shell`] `None`) is reported and skipped; the loop continues to the
 /// next host. An empty selection is reported and nothing is spawned.
 ///

--- a/crates/mtui-core/src/commands/hoststate.rs
+++ b/crates/mtui-core/src/commands/hoststate.rs
@@ -9,15 +9,14 @@ use crate::command::Command;
 use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
-/// The five `state` choices upstream accepts.
-const STATES: [&str; 5] = ["parallel", "serial", "dryrun", "disabled", "enabled"];
+/// The four `state` choices upstream accepts.
+const STATES: [&str; 4] = ["parallel", "serial", "disabled", "enabled"];
 
 /// Sets the state and execution mode of a host.
 ///
 /// Ports upstream `mtui.commands.hoststate.HostState`. A host can be:
 /// * `enabled` — runs all issued commands,
 /// * `disabled` — runs nothing,
-/// * `dryrun` — runs nothing but prints the commands,
 ///
 /// and its execution mode either `parallel` (default) or `serial`. The
 /// `serial`/`parallel` choices set the mode; the others set the state. Selection
@@ -40,7 +39,7 @@ impl Command for HostState {
             Arg::new("state")
                 .required(true)
                 .value_parser(clap::builder::PossibleValuesParser::new(STATES))
-                .help("enabled | disabled | dryrun | parallel | serial"),
+                .help("enabled | disabled | parallel | serial"),
         )
     }
 
@@ -74,7 +73,6 @@ impl Command for HostState {
                 "parallel" => t.set_mode(ExecutionMode::Parallel),
                 "enabled" => t.set_state(TargetState::Enabled),
                 "disabled" => t.set_state(TargetState::Disabled),
-                "dryrun" => t.set_state(TargetState::Dryrun),
                 other => return Err(CommandError::Other(format!("unknown state: {other}"))),
             }
         }
@@ -109,17 +107,6 @@ mod tests {
             buf.contents().contains("set disabled on h1"),
             "{:?}",
             buf.contents()
-        );
-    }
-
-    #[tokio::test]
-    async fn dryrun_sets_state() {
-        let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
-        let args = matches(&HostState, &["dryrun"]);
-        HostState.call(&mut session, &args).await.unwrap();
-        assert_eq!(
-            session.targets().get("h1").unwrap().state(),
-            TargetState::Dryrun
         );
     }
 
@@ -163,6 +150,13 @@ mod tests {
     fn invalid_state_rejected_by_parser() {
         let base = clap::Command::new(HostState.name()).no_binary_name(true);
         let parsed = HostState.configure(base).try_get_matches_from(["bogus"]);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn dryrun_rejected_by_parser() {
+        let base = clap::Command::new(HostState.name()).no_binary_name(true);
+        let parsed = HostState.configure(base).try_get_matches_from(["dryrun"]);
         assert!(parsed.is_err());
     }
 }

--- a/crates/mtui-core/src/display.rs
+++ b/crates/mtui-core/src/display.rs
@@ -301,7 +301,7 @@ impl CommandPromptDisplay {
 
     /// Displays the status of a host.
     ///
-    /// Mirrors upstream `list_host`: colored `state` label (green/yellow/red),
+    /// Mirrors upstream `list_host`: colored `state` label (green/red),
     /// `transactional`/`standard` label, and the fixed-width layout line.
     pub fn list_host(
         &mut self,
@@ -313,7 +313,6 @@ impl CommandPromptDisplay {
     ) {
         let state_label = match state {
             TargetState::Enabled => Self::green(self, "Enabled"),
-            TargetState::Dryrun => Self::yellow(self, "Dryrun"),
             TargetState::Disabled => Self::red(self, "Disabled"),
         };
         let trn = if transactional {

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -4,7 +4,7 @@
 //! [`Connection`] abstraction, the russh-backed [`SshConnection`] (connect /
 //! run-with-timeout / SFTP transfers), the scriptable [`MockConnection`] test
 //! double, the [`HostError`] hierarchy, the [`Target`] state machine
-//! (enabled/dryrun/disabled command gating + connection-only `connect`), and the
+//! (enabled/disabled command gating + connection-only `connect`), and the
 //! [`HostsGroup`] composite with its parallel/serial command + SFTP fan-out,
 //! the remote-lock protocol ([`TargetLock`] / [`PoolLock`] / [`RemoteLock`],
 //! P2.6), the in-process [`HostArbiter`] (P2.7), and the host-output parsers —

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -10,7 +10,7 @@
 //! dispatch. This module deliberately ports only the **state machine over
 //! `Connection`** (P2.4):
 //!
-//! * the per-host execution [`TargetState`] gate (enabled / dryrun / disabled),
+//! * the per-host execution [`TargetState`] gate (enabled / disabled),
 //! * command execution via [`Target::run`] with the upstream `-1` exit-code
 //!   sentinel and never-propagate error handling,
 //! * the `last*` output accessors,
@@ -85,10 +85,6 @@ use crate::connection::ShellChannel;
 use crate::connection::{CommandTimeout, Connection, HostKeyPolicy, SshConnection};
 use crate::error::{HostError, Result};
 
-/// The dryrun stdout marker appended for every command echoed in
-/// [`TargetState::Dryrun`], byte-identical to upstream's `"dryrun\n"`.
-const DRYRUN_MARKER: &str = "dryrun\n";
-
 /// A single reference host and its execution state.
 ///
 /// The `Target` owns at most one [`Connection`] (a `Box<dyn Connection>` so the
@@ -97,7 +93,6 @@ const DRYRUN_MARKER: &str = "dryrun\n";
 /// Commands are gated by [`TargetState`]:
 ///
 /// * [`Enabled`](TargetState::Enabled) — run for real and record the outcome.
-/// * [`Dryrun`](TargetState::Dryrun) — echo the command, record `"dryrun\n"`.
 /// * [`Disabled`](TargetState::Disabled) — record an empty entry, touch nothing.
 ///
 /// [`MockConnection`]: crate::MockConnection
@@ -353,7 +348,7 @@ impl Target {
     ///
     /// The mode counterpart to [`set_state`](Self::set_state): upstream
     /// `HostState` sets `target.mode` for the `serial`/`parallel` choices and
-    /// `target.state` for the enabled/disabled/dryrun choices.
+    /// `target.state` for the enabled/disabled choices.
     pub fn set_mode(&mut self, mode: ExecutionMode) {
         self.mode = mode;
     }
@@ -1079,8 +1074,6 @@ impl Target {
     ///   exit-code sentinel; **any** other connection error is logged and
     ///   likewise recorded as `-1` — never propagated, mirroring upstream's
     ///   catch-all so one bad host never aborts a group fan-out.
-    /// * [`Dryrun`](TargetState::Dryrun): records `command` with `"dryrun\n"`
-    ///   stdout and exit `0`, without touching the connection.
     /// * [`Disabled`](TargetState::Disabled): records an empty entry and does
     ///   nothing else.
     pub async fn run(&mut self, command: &str) {
@@ -1111,11 +1104,6 @@ impl Target {
                     }
                 };
                 self.out.push(log);
-            }
-            TargetState::Dryrun => {
-                tracing::info!(host = %self.hostname, %command, "dryrun");
-                self.out
-                    .push(CommandLog::new(command, DRYRUN_MARKER, "", 0, 0));
             }
             TargetState::Disabled => {
                 self.out.push(CommandLog::new("", "", "", 0, 0));
@@ -1153,7 +1141,7 @@ impl Target {
 
     /// The outcome of the last SFTP upload, or `None` when none was attempted.
     ///
-    /// `Some(Ok(()))` is a successful (or dry-run) transfer; `Some(Err(reason))`
+    /// `Some(Ok(()))` is a successful transfer; `Some(Err(reason))`
     /// carries the per-host failure message. `None` means the host was skipped
     /// ([`Disabled`](TargetState::Disabled)) or nothing has been uploaded yet.
     /// The `put` command aggregates these across the group.
@@ -1165,7 +1153,7 @@ impl Target {
     /// The outcome of the last SFTP download, or `None` when none was attempted.
     ///
     /// Same encoding as [`last_upload`](Self::last_upload): `Some(Ok(()))` is a
-    /// successful (or dry-run) transfer, `Some(Err(reason))` a per-host failure,
+    /// successful transfer, `Some(Err(reason))` a per-host failure,
     /// `None` a skipped ([`Disabled`](TargetState::Disabled)) or not-yet-attempted
     /// host. The `get` command aggregates these across the group.
     #[must_use]
@@ -1209,8 +1197,7 @@ impl Target {
     ///
     /// [`Enabled`](TargetState::Enabled) delegates to
     /// [`Connection::sftp_put`]; a transfer error is logged, not propagated
-    /// (upstream behaviour). [`Dryrun`](TargetState::Dryrun) logs the intended
-    /// transfer; [`Disabled`](TargetState::Disabled) does nothing.
+    /// (upstream behaviour). [`Disabled`](TargetState::Disabled) does nothing.
     pub async fn sftp_put(&mut self, local: &Path, remote: &Path) {
         match self.state {
             TargetState::Enabled => {
@@ -1229,16 +1216,6 @@ impl Target {
                         Some(Err(e.to_string()))
                     }
                 };
-            }
-            TargetState::Dryrun => {
-                tracing::info!(
-                    host = %self.hostname,
-                    "dryrun: put {} {}:{}",
-                    local.display(), self.hostname, remote.display()
-                );
-                // Record the intended transfer as a success so the fan-out
-                // reports a dry-run host as "would upload", not as skipped.
-                self.last_upload = Some(Ok(()));
             }
             // Left as `None` (not attempted) so the `put` aggregation treats a
             // disabled host as skipped rather than a success or failure.
@@ -1270,16 +1247,6 @@ impl Target {
                         Some(Err(e.to_string()))
                     }
                 };
-            }
-            TargetState::Dryrun => {
-                tracing::info!(
-                    host = %self.hostname,
-                    "dryrun: put <{} bytes> {}:{}",
-                    data.len(), self.hostname, remote.display()
-                );
-                // Record the intended transfer as a success so the fan-out
-                // reports a dry-run host as "would upload", not as skipped.
-                self.last_upload = Some(Ok(()));
             }
             // Left as `None` (not attempted) so the `put` aggregation treats a
             // disabled host as skipped rather than a success or failure.
@@ -1328,16 +1295,6 @@ impl Target {
                     }
                 };
             }
-            TargetState::Dryrun => {
-                tracing::info!(
-                    host = %self.hostname,
-                    "dryrun: get {}:{} {}",
-                    self.hostname, remote, local_target.display()
-                );
-                // Record the intended transfer as a success so the fan-out
-                // reports a dry-run host as "would download", not as skipped.
-                self.last_download = Some(Ok(()));
-            }
             // Left as `None` (not attempted) so the `get` aggregation treats a
             // disabled host as skipped rather than a success or failure.
             TargetState::Disabled => {}
@@ -1351,8 +1308,7 @@ impl Target {
     /// first via [`Connection::sftp_remove`]; if that fails the path may be a
     /// directory, so [`Connection::sftp_rmdir`] is tried as a fallback. A
     /// missing path or a failed fallback is logged, never propagated (upstream
-    /// behaviour). [`Dryrun`](TargetState::Dryrun) logs the intended removal;
-    /// [`Disabled`](TargetState::Disabled) does nothing.
+    /// behaviour). [`Disabled`](TargetState::Disabled) does nothing.
     pub async fn sftp_remove(&mut self, path: &Path) {
         match self.state {
             TargetState::Enabled => {
@@ -1379,16 +1335,6 @@ impl Target {
                     }
                 };
             }
-            TargetState::Dryrun => {
-                tracing::info!(
-                    host = %self.hostname,
-                    "dryrun: remove {}:{}",
-                    self.hostname, path.display()
-                );
-                // Record the intended removal as a success so the fan-out reports
-                // a dry-run host as "would remove", not as skipped.
-                self.last_remove = Some(Ok(()));
-            }
             // Left as `None` (not attempted) so the `remove` aggregation treats a
             // disabled host as skipped rather than a success or failure.
             TargetState::Disabled => {}
@@ -1401,9 +1347,8 @@ impl Target {
     /// target it delegates to [`Connection::shell`] and returns the
     /// [`ShellChannel`]; a spawn failure is logged and swallowed as `None`
     /// (upstream's `except Exception: log "failed to spawn shell"`), so one bad
-    /// host never aborts a sequential fan-out. [`Dryrun`](TargetState::Dryrun)
-    /// and [`Disabled`](TargetState::Disabled) do nothing and return `None`
-    /// (there is no PTY to spawn under a dry run).
+    /// host never aborts a sequential fan-out. [`Disabled`](TargetState::Disabled)
+    /// does nothing and returns `None`.
     ///
     /// The returned handle is a transport duplex only; the raw-`termios` local
     /// terminal bridge that consumes it is a CLI concern (Phase 6).
@@ -1428,10 +1373,6 @@ impl Target {
                         None
                     }
                 }
-            }
-            TargetState::Dryrun => {
-                tracing::info!(host = %self.hostname, "dryrun: shell");
-                None
             }
             TargetState::Disabled => None,
         }
@@ -1601,28 +1542,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_dryrun_does_not_execute() {
-        let conn = MockConnection::new("h1");
-        let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Dryrun,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
-
-        t.run("rm -rf /").await;
-
-        assert!(
-            handle.commands().is_empty(),
-            "dryrun must not issue commands"
-        );
-        assert_eq!(t.lastin(), "rm -rf /");
-        assert_eq!(t.lastout(), DRYRUN_MARKER);
-        assert_eq!(t.lastexit(), Some(0));
-    }
-
-    #[tokio::test]
     async fn run_disabled_does_not_execute() {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
@@ -1760,24 +1679,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sftp_put_dryrun_does_nothing() {
-        let conn = MockConnection::new("h1");
-        let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Dryrun,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
-
-        t.sftp_put(Path::new("/local"), Path::new("/remote")).await;
-
-        assert!(handle.sftp_ops().is_empty());
-        // Dry-run records the intended transfer as a success, not skipped.
-        assert_eq!(t.last_upload(), Some(&Ok(())));
-    }
-
-    #[tokio::test]
     async fn sftp_put_disabled_leaves_upload_unattempted() {
         let conn = MockConnection::new("h1");
         let mut t = Target::with_connection(
@@ -1825,24 +1726,6 @@ mod tests {
                 local: PathBuf::from("/local/"),
             }]
         );
-    }
-
-    #[tokio::test]
-    async fn sftp_get_dryrun_does_nothing() {
-        let conn = MockConnection::new("h1");
-        let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Dryrun,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
-
-        t.sftp_get("/remote/file", Path::new("/local")).await;
-
-        assert!(handle.sftp_ops().is_empty());
-        // Dry-run records the intended transfer as a success, not skipped.
-        assert_eq!(t.last_download(), Some(&Ok(())));
     }
 
     #[tokio::test]
@@ -1981,24 +1864,6 @@ mod tests {
                 MockSftpOp::Rmdir(PathBuf::from("/remote/dir")),
             ]
         );
-    }
-
-    #[tokio::test]
-    async fn sftp_remove_dryrun_does_nothing() {
-        let conn = MockConnection::new("h1");
-        let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Dryrun,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
-
-        t.sftp_remove(Path::new("/remote/file")).await;
-
-        assert!(handle.sftp_ops().is_empty());
-        // Dry-run records the intended removal as a success, not skipped.
-        assert_eq!(t.last_remove(), Some(&Ok(())));
     }
 
     #[tokio::test]
@@ -2502,22 +2367,6 @@ mod tests {
         ch.close().await.expect("close");
         assert_eq!(handle.shell_input(), b"ls\n");
         assert_eq!(handle.shell_resizes(), vec![(80, 24)]);
-    }
-
-    #[cfg(feature = "shell")]
-    #[tokio::test]
-    async fn shell_dryrun_does_not_spawn() {
-        let conn = MockConnection::new("h1");
-        let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Dryrun,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
-
-        assert!(t.shell(80, 24).await.is_none(), "dryrun must not spawn");
-        assert!(handle.shell_spawns().is_empty());
     }
 
     #[cfg(feature = "shell")]

--- a/crates/mtui-hosts/src/target/reporter.rs
+++ b/crates/mtui-hosts/src/target/reporter.rs
@@ -213,7 +213,7 @@ mod tests {
         let t = Target::new(
             &mtui_config::Config::default(),
             "test-host.example.com",
-            TargetState::Dryrun,
+            TargetState::Disabled,
             ExecutionMode::Serial,
         );
         let out = RefCell::new(None);
@@ -226,7 +226,7 @@ mod tests {
             Some((
                 "test-host.example.com".to_owned(),
                 false,
-                TargetState::Dryrun,
+                TargetState::Disabled,
                 ExecutionMode::Serial,
             ))
         );

--- a/crates/mtui-hosts/tests/ssh_integration.rs
+++ b/crates/mtui-hosts/tests/ssh_integration.rs
@@ -1082,12 +1082,11 @@ async fn hostsgroup_run_serial_reaches_every_member() {
 
 #[tokio::test]
 async fn hostsgroup_run_honours_per_host_state_end_to_end() {
-    // A mixed-state group over real SSH: enabled runs for real, dryrun echoes
-    // the marker without touching the transport, disabled records nothing.
+    // A mixed-state group over real SSH: enabled runs for real, disabled
+    // records nothing.
     let port = start_server(SharedFs::default()).await;
     let targets = vec![
         connect_target("on", port, TargetState::Enabled, ExecutionMode::Parallel).await,
-        connect_target("dry", port, TargetState::Dryrun, ExecutionMode::Parallel).await,
         connect_target("off", port, TargetState::Disabled, ExecutionMode::Parallel).await,
     ];
     let mut group = HostsGroup::new(targets, false);
@@ -1098,12 +1097,6 @@ async fn hostsgroup_run_honours_per_host_state_end_to_end() {
     let on = group.get("on").expect("on present");
     assert_eq!(on.lastout(), ran("gated"));
     assert_eq!(on.lastexit(), Some(0));
-
-    // Dryrun: the "dryrun\n" marker, exit 0, no remote round-trip.
-    let dry = group.get("dry").expect("dry present");
-    assert_eq!(dry.lastin(), "gated");
-    assert_eq!(dry.lastout(), "dryrun\n");
-    assert_eq!(dry.lastexit(), Some(0));
 
     // Disabled: an empty entry — nothing ran.
     let off = group.get("off").expect("off present");

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -1298,11 +1298,10 @@ expression: pretty
           "type": "array"
         },
         "state": {
-          "description": "enabled | disabled | dryrun | parallel | serial",
+          "description": "enabled | disabled | parallel | serial",
           "enum": [
             "parallel",
             "serial",
-            "dryrun",
             "disabled",
             "enabled"
           ],

--- a/crates/mtui-types/src/enums.rs
+++ b/crates/mtui-types/src/enums.rs
@@ -21,14 +21,12 @@ use crate::error::RequestKindParseError;
 /// Per-host execution state.
 ///
 /// Mirrors upstream `TargetState` (a `StrEnum`). Wire values are the exact
-/// lowercase tokens `enabled` / `dryrun` / `disabled`.
+/// lowercase tokens `enabled` / `disabled`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TargetState {
     /// The host runs commands normally.
     Enabled,
-    /// The host echoes commands without executing them.
-    Dryrun,
     /// The host is skipped entirely.
     Disabled,
 }
@@ -39,7 +37,6 @@ impl TargetState {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Enabled => "enabled",
-            Self::Dryrun => "dryrun",
             Self::Disabled => "disabled",
         }
     }
@@ -57,7 +54,6 @@ impl FromStr for TargetState {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "enabled" => Ok(Self::Enabled),
-            "dryrun" => Ok(Self::Dryrun),
             "disabled" => Ok(Self::Disabled),
             other => Err(ParseEnumError {
                 kind: "TargetState",
@@ -256,27 +252,23 @@ mod tests {
     #[test]
     fn target_state_carries_legacy_string_values() {
         assert_eq!(TargetState::Enabled.as_str(), "enabled");
-        assert_eq!(TargetState::Dryrun.as_str(), "dryrun");
         assert_eq!(TargetState::Disabled.as_str(), "disabled");
     }
 
     #[test]
     fn target_state_round_trips_through_str() {
-        for state in [
-            TargetState::Enabled,
-            TargetState::Dryrun,
-            TargetState::Disabled,
-        ] {
+        for state in [TargetState::Enabled, TargetState::Disabled] {
             assert_eq!(state.to_string().parse::<TargetState>().unwrap(), state);
         }
     }
 
     #[test]
     fn target_state_serde_uses_wire_strings() {
-        let json = serde_json::to_string(&TargetState::Dryrun).unwrap();
-        assert_eq!(json, "\"dryrun\"");
+        let json = serde_json::to_string(&TargetState::Enabled).unwrap();
+        assert_eq!(json, "\"enabled\"");
         let back: TargetState = serde_json::from_str("\"disabled\"").unwrap();
         assert_eq!(back, TargetState::Disabled);
+        assert!(serde_json::from_str::<TargetState>("\"dryrun\"").is_err());
     }
 
     #[test]

--- a/crates/mtui-types/src/hostlog.rs
+++ b/crates/mtui-types/src/hostlog.rs
@@ -39,7 +39,7 @@ pub struct CommandLog {
     /// Whether the captured `stdout`/`stderr` was truncated because the command
     /// exceeded the connection layer's output byte caps.
     ///
-    /// `false` for every non-SSH producer (mocks, dry-runs, synthesised logs);
+    /// `false` for every non-SSH producer (mocks, synthesised logs);
     /// only [`mtui-hosts`](../../mtui_hosts)' bounded capture sets it. When
     /// `true`, `stdout`/`stderr` hold the capped prefix and the overflow was
     /// discarded rather than buffered.
@@ -55,7 +55,7 @@ impl CommandLog {
     /// Creates a new [`CommandLog`] with the truncation/timeout flags cleared.
     ///
     /// This is the primary constructor used by every producer that cannot
-    /// truncate or deadline output (mocks, dry-runs, synthesised logs). The SSH
+    /// truncate or deadline output (mocks, synthesised logs). The SSH
     /// connection layer, which *can*, uses [`with_flags`](Self::with_flags) to
     /// record those conditions.
     #[must_use]

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -211,9 +211,9 @@ Usage: set_host_state [OPTIONS] <state>
 
 Arguments:
   <state>
-          enabled | disabled | dryrun | parallel | serial
+          enabled | disabled | parallel | serial
           
-          [possible values: parallel, serial, dryrun, disabled, enabled]
+          [possible values: parallel, serial, disabled, enabled]
 
 Options:
   -t, --target <HOST>

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -88,7 +88,6 @@ Each connected host has a state and an execution mode, set with
 
 - **`enabled`** — runs all issued commands (the default).
 - **`disabled`** — runs nothing and prints nothing.
-- **`dryrun`** — runs nothing but prints the command it *would* run.
 - **`parallel`** (default) / **`serial`** — whether commands designed to run in
   parallel (like [`run`](cli.md#run)) fan out concurrently or one host at a time.
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -114,9 +114,8 @@ run zypper lr            # runs only on the still-enabled hosts
 set_host_state enabled   # re-enable all
 ```
 
-`disabled` hosts run nothing (and print nothing); `dryrun` hosts print the command
-they *would* run without executing it. You can also switch a host between
-`parallel` and `serial` execution the same way.
+`disabled` hosts run nothing (and print nothing). You can also switch a host
+between `parallel` and `serial` execution the same way.
 
 ## Can I export the update log from a specific refhost?
 


### PR DESCRIPTION
## Summary

Removes the `dryrun` per-host execution state. `TargetState` now has only
`Enabled`/`Disabled` — `dryrun` saw no real use and added a third state to
reason about across every state-gated `Target` method for a feature nobody
exercised.

## What changed

- `TargetState` drops `Dryrun`; `"dryrun"` is now rejected by `FromStr`/serde
  as an unknown value instead of being silently accepted.
- `Target::{run, sftp_put, sftp_put_bytes, sftp_get, sftp_remove, shell}`
  collapse to two exhaustive `enabled`/`disabled` match arms; the
  `DRYRUN_MARKER` const and its dedicated unit tests are removed.
- `set_host_state` drops the `dryrun` choice (clap `PossibleValuesParser`);
  `display.rs` drops the `Dryrun` label arm.
- Docs (`concepts.md`, `faq.md`, `README.md`) updated; `cli.md` regenerated
  via `cargo xtask gen-docs`.
- MCP tool-schema snapshot updated for the narrowed `state` enum.
- `CHANGELOG.md` entry under `[Unreleased]` / `### Removed` noting the
  intentional deviation from upstream Python mtui.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 37 test binaries, 0 failures
- `cargo build --workspace --no-default-features` / `--all-features` — both compile
- `rg -i "dryrun" crates/ docs/` — only the intentional rejection-test
  literals remain (`enums.rs`, `hoststate.rs`)