### PR TITLE
fix(gitea): record token owner's login in assign comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Gitea assign/unassign/approve/reject markers now record the login of the
+  Gitea account that owns the configured token (resolved once via
+  `GET /api/v1/user`) instead of the local session user. When the two names
+  differed, the marker disagreed with the account Gitea attributes the comment
+  to. If the lookup fails, it falls back to the session user so the action still
+  completes. Passing an explicit user still overrides both.
 - `prepare`/`reboot`/`update` no longer falsely mark a slow-to-reboot host as
   "reconnect after reboot failed" when it is still mid-boot: reconnect after a
   reboot now retries with a growing backoff (`reboot_timeout`/`reboot_retries`,

--- a/crates/mtui-datasources/benches/datasources.rs
+++ b/crates/mtui-datasources/benches/datasources.rs
@@ -156,6 +156,14 @@ async fn gitea_approve_fixture(server: &MockServer) -> Gitea {
         )
         .mount(server)
         .await;
+    // The token-owner lookup is resolved once and cached, so it does not add a
+    // round trip to the steady-state `approve` measured below; mount it so the
+    // resolution takes the real (not fallback) path.
+    Mock::given(method("GET"))
+        .and(path("/api/v1/user"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "login": "benchuser" })))
+        .mount(server)
+        .await;
     let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
     let pr_api = format!("{}/api/v1/repos/owner/repo/pulls/1", server.uri());
     Gitea::with_client(

--- a/crates/mtui-datasources/src/gitea.rs
+++ b/crates/mtui-datasources/src/gitea.rs
@@ -32,6 +32,7 @@ use mtui_types::Assignment;
 use regex::Regex;
 use reqwest::Method;
 use serde_json::json;
+use tokio::sync::OnceCell;
 
 use crate::error::GiteaError;
 use crate::http::{
@@ -247,8 +248,17 @@ struct RawComment {
 pub struct Gitea {
     http: HttpClient,
     token: String,
-    /// The session user this client acts as by default.
-    user: String,
+    /// The local session user, used as a *fallback* identity when the token
+    /// owner's login cannot be resolved (see [`Gitea::acting_user`]).
+    session_user: String,
+    /// The Gitea API root (`.../api/v1`) for endpoints not tied to the PR,
+    /// such as the authenticated-user lookup (`.../api/v1/user`).
+    api_base: String,
+    /// The login of the Gitea account that owns the [`token`](Self::token),
+    /// resolved lazily once via `GET /api/v1/user` and cached. Comments are
+    /// attributed by Gitea to this account, so assign/approve markers must
+    /// record *its* login rather than the local session user.
+    resolved_user: OnceCell<String>,
     /// The review group this client operates on behalf of.
     group: String,
     /// The PR API URL (`.../pulls/<n>`).
@@ -322,10 +332,18 @@ impl Gitea {
         // `.../pulls/<n>` -> `.../issues/<n>/comments`, matching upstream's
         // `giteaprapi.replace("pulls", "issues") + "/comments"`.
         let prissues = format!("{}/comments", giteaprapi.replace("pulls", "issues"));
+        // The API root for endpoints not tied to the PR, matching upstream's
+        // `giteaprapi.split("/api/v1/", 1)[0] + "/api/v1"`.
+        let api_root = giteaprapi
+            .split_once("/api/v1/")
+            .map_or(giteaprapi, |(root, _)| root);
+        let api_base = format!("{api_root}/api/v1");
         Ok(Self {
             http,
             token,
-            user,
+            session_user: user,
+            api_base,
+            resolved_user: OnceCell::new(),
             group: group.unwrap_or(DEFAULT_GROUP).to_string(),
             pr: giteaprapi.to_string(),
             prissues,
@@ -425,6 +443,44 @@ impl Gitea {
             })?;
         serde_json::from_slice::<serde_json::Value>(&bytes)
             .map_err(|e| GiteaError::FailedCall(format!("{method} - {}: {e}", sanitize_url(url))))
+    }
+
+    /// Resolve the acting user for a write operation.
+    ///
+    /// Returns `other` verbatim when supplied. Otherwise returns the login of
+    /// the Gitea account that owns the token, resolved once via
+    /// `GET /api/v1/user` and cached in [`resolved_user`](Self::resolved_user):
+    /// comments are attributed by Gitea to that account, so an assign/approve
+    /// marker must record *its* login rather than the local session user, which
+    /// need not match. If the lookup fails (or the payload has no `login`), it
+    /// falls back to [`session_user`](Self::session_user) so review actions
+    /// still work — with the historical, possibly mismatched, name — and the
+    /// fallback is cached too (a short-lived CLI/MCP action does not retry).
+    async fn acting_user(&self, other: Option<&str>) -> String {
+        if let Some(user) = other {
+            return user.to_string();
+        }
+        self.resolved_user
+            .get_or_init(|| async {
+                let url = format!("{}/user", self.api_base);
+                match self.request(Method::GET, &url, None).await {
+                    Ok(data) => data
+                        .get("login")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .map_or_else(|| self.session_user.clone(), str::to_string),
+                    Err(_) => {
+                        tracing::warn!(
+                            "Could not resolve the Gitea user from the token; \
+                             falling back to session user {:?}",
+                            self.session_user
+                        );
+                        self.session_user.clone()
+                    }
+                }
+            })
+            .await
+            .clone()
     }
 
     /// Fetch and deserialise all comments on the pull request.
@@ -537,9 +593,9 @@ impl Gitea {
     /// [`GiteaError::AssignInvalid`] if the PR is not assigned to the acting
     /// user; [`GiteaError::NoReview`] if it was already approved/rejected.
     pub async fn approve(&self, other: Option<&str>) -> Result<(), GiteaError> {
-        let a_user = other.unwrap_or(&self.user);
+        let a_user = self.acting_user(other).await;
         let comments = self.load_sorted_comments().await?;
-        let state = self.assign_state(&comments, a_user);
+        let state = self.assign_state(&comments, &a_user);
         if state != Assignment::AssignedUser {
             return Err(GiteaError::AssignInvalid {
                 state,
@@ -572,9 +628,9 @@ impl Gitea {
         other: Option<&str>,
         message: &str,
     ) -> Result<(), GiteaError> {
-        let a_user = other.unwrap_or(&self.user);
+        let a_user = self.acting_user(other).await;
         let comments = self.load_sorted_comments().await?;
-        let state = self.assign_state(&comments, a_user);
+        let state = self.assign_state(&comments, &a_user);
         if state != Assignment::AssignedUser {
             return Err(GiteaError::AssignInvalid {
                 state,
@@ -611,7 +667,7 @@ impl Gitea {
     /// the PR was already decided; [`GiteaError::AssignInvalid`] if the PR is
     /// not unassigned (and not `force`).
     pub async fn assign(&self, other: Option<&str>, force: bool) -> Result<(), GiteaError> {
-        let a_user = other.unwrap_or(&self.user);
+        let a_user = self.acting_user(other).await;
         if !force && !self.has_review().await? {
             return Err(GiteaError::NoReview(format!(
                 "There is no review for {}-review",
@@ -625,7 +681,7 @@ impl Gitea {
             ));
         }
         if !force {
-            let state = self.assign_state(&comments, a_user);
+            let state = self.assign_state(&comments, &a_user);
             if state != Assignment::Unassigned {
                 return Err(GiteaError::AssignInvalid {
                     state,
@@ -634,7 +690,7 @@ impl Gitea {
             }
         }
         tracing::info!("Assigning PR to {a_user} for group {}", self.group);
-        let msg = assign_marker(a_user, &self.group);
+        let msg = assign_marker(&a_user, &self.group);
         self.request(Method::POST, &self.prissues, Some(json!({ "body": msg })))
             .await?;
         Ok(())
@@ -646,9 +702,9 @@ impl Gitea {
     ///
     /// [`GiteaError::AssignInvalid`] if the PR is not assigned to the user.
     pub async fn unassign(&self, other: Option<&str>) -> Result<(), GiteaError> {
-        let a_user = other.unwrap_or(&self.user);
+        let a_user = self.acting_user(other).await;
         let comments = self.load_sorted_comments().await?;
-        let state = self.assign_state(&comments, a_user);
+        let state = self.assign_state(&comments, &a_user);
         if state != Assignment::AssignedUser {
             return Err(GiteaError::AssignInvalid {
                 state,
@@ -656,7 +712,7 @@ impl Gitea {
             });
         }
         tracing::info!("Unassigning user {a_user} for group {}", self.group);
-        let msg = unassign_marker(a_user, &self.group);
+        let msg = unassign_marker(&a_user, &self.group);
         self.request(Method::POST, &self.prissues, Some(json!({ "body": msg })))
             .await?;
         Ok(())
@@ -857,7 +913,7 @@ mod tests {
     fn default_group_and_url_derivation() {
         let g = dummy();
         assert_eq!(g.group, DEFAULT_GROUP);
-        assert_eq!(g.user, "testuser");
+        assert_eq!(g.session_user, "testuser");
         assert_eq!(
             g.pr,
             "https://gitea.example.com/api/v1/repos/owner/repo/pulls/1"
@@ -866,6 +922,7 @@ mod tests {
             g.prissues,
             "https://gitea.example.com/api/v1/repos/owner/repo/issues/1/comments"
         );
+        assert_eq!(g.api_base, "https://gitea.example.com/api/v1");
     }
 
     #[test]

--- a/crates/mtui-datasources/tests/gitea.rs
+++ b/crates/mtui-datasources/tests/gitea.rs
@@ -41,6 +41,8 @@ fn gitea_for(server: &MockServer) -> Gitea {
 
 const PR_PATH: &str = "/api/v1/repos/owner/repo/pulls/1";
 const COMMENTS_PATH: &str = "/api/v1/repos/owner/repo/issues/1/comments";
+/// The authenticated-user lookup used to resolve the token owner's login.
+const USER_PATH: &str = "/api/v1/user";
 
 fn ts(day: u32) -> String {
     format!("2024-01-{day:02}T00:00:00+00:00")
@@ -79,16 +81,30 @@ async fn mount_post_comment(server: &MockServer) {
         .await;
 }
 
+/// Mount the authenticated-user lookup so the token owner resolves to `login`.
+///
+/// A write op with no explicit user resolves its acting identity via
+/// `GET /api/v1/user`; mounting this makes the default (`None`) path record the
+/// token owner's login rather than falling back to the session user.
+async fn mount_user(server: &MockServer, login: &str) {
+    Mock::given(method("GET"))
+        .and(path(USER_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "login": login })))
+        .mount(server)
+        .await;
+}
+
 #[tokio::test]
 async fn assign_success_when_review_requested_and_unassigned() {
     let server = MockServer::start().await;
     mount_comments(&server, json!([])).await; // no markers -> unassigned, not done
     mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await; // token owner resolves to USER
 
     gitea_for(&server).assign(None, false).await.unwrap();
 
-    // The POST carries an assignment marker for the session user.
+    // The POST carries an assignment marker for the resolved token owner.
     let posts: Vec<_> = server
         .received_requests()
         .await
@@ -111,6 +127,7 @@ async fn assign_force_posts_even_when_assigned_to_other() {
     )
     .await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).assign(None, true).await.unwrap();
 
@@ -135,6 +152,7 @@ async fn assign_without_force_refuses_when_assigned_to_other() {
     )
     .await;
     mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
+    mount_user(&server, USER).await;
 
     let err = gitea_for(&server).assign(None, false).await.unwrap_err();
     assert!(matches!(
@@ -156,7 +174,7 @@ async fn assign_no_review_raises() {
 #[tokio::test]
 async fn approve_uses_last_assignee() {
     let server = MockServer::start().await;
-    // alice then the session user assigned -> last assignee is us.
+    // alice then the token owner assigned -> last assignee is us.
     mount_comments(
         &server,
         json!([
@@ -166,6 +184,7 @@ async fn approve_uses_last_assignee() {
     )
     .await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).approve(None).await.unwrap();
 
@@ -197,6 +216,7 @@ async fn approve_request_count() {
     )
     .await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).approve(None).await.unwrap();
 
@@ -209,14 +229,19 @@ async fn approve_request_count() {
         .iter()
         .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == PR_PATH)
         .count();
+    let user_gets = reqs
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == USER_PATH)
+        .count();
     let posts = reqs
         .iter()
         .filter(|r| r.method == wiremock::http::Method::POST)
         .count();
     // Deduplicated: comments fetched once per approve; no PR GET (no decision);
-    // one POST.
+    // one user lookup to resolve the token owner; one POST.
     assert_eq!(comment_gets, 1, "approve fetches comments once; see 0mop.8");
     assert_eq!(pr_gets, 0, "no decision comment -> no has_review PR GET");
+    assert_eq!(user_gets, 1, "token owner resolved once");
     assert_eq!(posts, 1);
 }
 
@@ -235,6 +260,7 @@ async fn approve_after_rebuild_rerequest_posts_comment() {
     .await;
     mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).approve(None).await.unwrap();
 
@@ -262,6 +288,7 @@ async fn approve_when_already_decided_raises() {
     )
     .await;
     mount_pr_reviewers(&server, json!([])).await;
+    mount_user(&server, USER).await;
 
     let err = gitea_for(&server).approve(None).await.unwrap_err();
     assert!(matches!(err, mtui_datasources::GiteaError::NoReview(_)));
@@ -288,6 +315,7 @@ async fn reject_posts_decline_with_reason() {
     )
     .await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server)
         .reject("broke boot", None, "see logs")
@@ -319,6 +347,7 @@ async fn reject_request_count() {
     )
     .await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).reject("", None, "").await.unwrap();
 
@@ -331,12 +360,17 @@ async fn reject_request_count() {
         .iter()
         .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == PR_PATH)
         .count();
+    let user_gets = reqs
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == USER_PATH)
+        .count();
     let posts = reqs
         .iter()
         .filter(|r| r.method == wiremock::http::Method::POST)
         .count();
     assert_eq!(comment_gets, 1, "reject fetches comments once");
     assert_eq!(pr_gets, 0, "no decision comment -> no has_review PR GET");
+    assert_eq!(user_gets, 1, "token owner resolved once");
     assert_eq!(posts, 1);
 }
 
@@ -351,6 +385,7 @@ async fn assign_request_count() {
     mount_comments(&server, json!([])).await; // unassigned, no decision
     mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
     mount_post_comment(&server).await;
+    mount_user(&server, USER).await;
 
     gitea_for(&server).assign(None, false).await.unwrap();
 
@@ -363,6 +398,10 @@ async fn assign_request_count() {
         .iter()
         .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == PR_PATH)
         .count();
+    let user_gets = reqs
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::GET && r.url.path() == USER_PATH)
+        .count();
     let posts = reqs
         .iter()
         .filter(|r| r.method == wiremock::http::Method::POST)
@@ -372,6 +411,7 @@ async fn assign_request_count() {
         pr_gets, 1,
         "one has_review PR GET (the review-requested guard)"
     );
+    assert_eq!(user_gets, 1, "token owner resolved once");
     assert_eq!(posts, 1);
 }
 
@@ -460,6 +500,131 @@ async fn assignee_returns_current_user() {
         gitea_for(&server).assignee().await.unwrap(),
         Some("alice".to_string())
     );
+}
+
+// --- token-owner login resolution (ported from test_gitea.py TestUser) -------
+
+/// With no explicit user, the assignment marker records the *token owner's*
+/// Gitea login (from `GET /api/v1/user`), not the local session user.
+#[tokio::test]
+async fn assign_records_resolved_token_owner_not_session_user() {
+    let server = MockServer::start().await;
+    mount_comments(&server, json!([])).await;
+    mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
+    mount_post_comment(&server).await;
+    // Token owner is "gitea_bot", which differs from the session user (USER).
+    mount_user(&server, "gitea_bot").await;
+
+    gitea_for(&server).assign(None, false).await.unwrap();
+
+    let posts: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method == wiremock::http::Method::POST)
+        .collect();
+    assert_eq!(posts.len(), 1);
+    let body = String::from_utf8_lossy(&posts[0].body);
+    assert!(body.contains("assigned to user: gitea_bot"), "{body}");
+    assert!(
+        !body.contains(&format!("assigned to user: {USER}")),
+        "{body}"
+    );
+}
+
+/// When the user lookup fails (non-2xx), the acting identity falls back to the
+/// session user so the review action still completes.
+#[tokio::test]
+async fn assign_falls_back_to_session_user_when_lookup_fails() {
+    let server = MockServer::start().await;
+    mount_comments(&server, json!([])).await;
+    mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
+    mount_post_comment(&server).await;
+    // The user endpoint errors -> fall back to the session user.
+    Mock::given(method("GET"))
+        .and(path(USER_PATH))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    gitea_for(&server).assign(None, false).await.unwrap();
+
+    let posts: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method == wiremock::http::Method::POST)
+        .collect();
+    assert_eq!(posts.len(), 1);
+    let body = String::from_utf8_lossy(&posts[0].body);
+    assert!(
+        body.contains(&format!("assigned to user: {USER}")),
+        "{body}"
+    );
+}
+
+/// A payload missing a (non-empty) `login` also falls back to the session user.
+#[tokio::test]
+async fn assign_falls_back_when_login_absent() {
+    let server = MockServer::start().await;
+    mount_comments(&server, json!([])).await;
+    mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
+    mount_post_comment(&server).await;
+    Mock::given(method("GET"))
+        .and(path(USER_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "login": "" })))
+        .mount(&server)
+        .await;
+
+    gitea_for(&server).assign(None, false).await.unwrap();
+
+    let posts: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method == wiremock::http::Method::POST)
+        .collect();
+    assert_eq!(posts.len(), 1);
+    let body = String::from_utf8_lossy(&posts[0].body);
+    assert!(
+        body.contains(&format!("assigned to user: {USER}")),
+        "{body}"
+    );
+}
+
+/// An explicit `other` user bypasses the token-owner lookup entirely.
+#[tokio::test]
+async fn explicit_user_skips_token_owner_lookup() {
+    let server = MockServer::start().await;
+    mount_comments(&server, json!([])).await;
+    mount_pr_reviewers(&server, json!([{ "login": "qam-sle-review" }])).await;
+    mount_post_comment(&server).await;
+    // Any hit here would mean an unnecessary lookup was made.
+    Mock::given(method("GET"))
+        .and(path(USER_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "login": "gitea_bot" })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    gitea_for(&server)
+        .assign(Some("carol"), false)
+        .await
+        .unwrap();
+
+    let posts: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method == wiremock::http::Method::POST)
+        .collect();
+    assert_eq!(posts.len(), 1);
+    let body = String::from_utf8_lossy(&posts[0].body);
+    assert!(body.contains("assigned to user: carol"), "{body}");
 }
 
 /// Capture the `message` field of every tracing event emitted by `f`.


### PR DESCRIPTION
## Summary

Gitea assign/unassign/approve/reject markers embedded the local session user, but Gitea attributes the posted comment to the account that owns the API token; when those names differ the marker disagreed with the comment's real author.

## Changes

- Resolve the token owner's login lazily via GET /api/v1/user (cached once per client) and record it in assign/unassign/approve/reject markers when no explicit user is given.
- Rename the private user field to session_user; it is now the fallback identity used only when the lookup fails or returns an empty login. An explicit user still overrides both.
- Add private api_base + cached resolved_user: OnceCell<String> and an acting_user() helper shared by all four write ops. The lookup shares the existing trusted-origin guard, so the token is never sent off-origin.
- Bench fixture mounts /api/v1/user to measure the real (not fallback) path.
- Record the fix in CHANGELOG.md under [Unreleased] → Fixed.