### PR TITLE
refactor(hosts): remove the serial ExecutionMode from Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   MCP tool it synthesises). This is an intentional deviation from upstream
   mtui: hosts now support only `enabled`/`disabled`. A `dryrun` value is
   rejected as an invalid state, not silently remapped.
+- The `serial`/`parallel` execution modes have been dropped from
+  `set_host_state` (and the MCP tool it synthesises). This is an intentional
+  deviation from upstream mtui: every host now runs in the parallel batch, and
+  the serial-barrier "press Enter key to proceed with `<host>`" prompt no
+  longer occurs. `list_hosts` no longer prints a `(parallel)`/`(serial)`
+  suffix. A `serial` or `parallel` value is rejected as an invalid state, not
+  silently remapped.
 
 ### Fixed
 

--- a/crates/mtui-cli/src/main.rs
+++ b/crates/mtui-cli/src/main.rs
@@ -73,11 +73,11 @@ fn main() -> anyhow::Result<()> {
 
     // Composition root: install the REPL-only serialised interactive prompter
     // (upstream `main.py`'s `prompter = Prompter()`). It backs the SSH
-    // command-timeout question ("keep waiting? [Y/n]") and the serial-barrier
-    // Enter prompt, serialised across parallel host tasks and suspending any live
-    // spinner. Installed *before* `seed_session` so hosts connected during `-a`
-    // seeding already carry the timeout prompt. `mtui-mcp` never installs one
-    // (headless → immediate abort / back-to-back, upstream `prompter=None`).
+    // command-timeout question ("keep waiting? [Y/n]"), serialised across
+    // parallel host tasks and suspending any live spinner. Installed *before*
+    // `seed_session` so hosts connected during `-a` seeding already carry the
+    // timeout prompt. `mtui-mcp` never installs one (headless → immediate
+    // abort, upstream `prompter=None`).
     session.set_prompter(mtui_hosts::Prompter::stdin());
 
     // Seed the session from `-a`/`-k` (load the update) and `--sut` (add hosts)

--- a/crates/mtui-cli/src/shell.rs
+++ b/crates/mtui-cli/src/shell.rs
@@ -314,7 +314,7 @@ pub(crate) async fn run_shell(session: &mut Session, argv: &[String]) -> anyhow:
 mod tests {
     use super::*;
     use mtui_hosts::{HostsGroup, MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
@@ -411,12 +411,7 @@ mod tests {
             conn = conn.with_shell_output(c.to_vec());
         }
         let handle = conn.clone();
-        let target = Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        );
+        let target = Target::with_connection(host, TargetState::Enabled, Box::new(conn));
         (target, handle)
     }
 
@@ -551,12 +546,7 @@ mod tests {
         let targets = hosts
             .iter()
             .map(|(h, state)| {
-                Target::with_connection(
-                    *h,
-                    *state,
-                    ExecutionMode::Serial,
-                    Box::new(MockConnection::new(*h)),
-                )
+                Target::with_connection(*h, *state, Box::new(MockConnection::new(*h)))
             })
             .collect();
         HostsGroup::new(targets, true)

--- a/crates/mtui-core/src/commands/addhost.rs
+++ b/crates/mtui-core/src/commands/addhost.rs
@@ -150,7 +150,7 @@ impl Command for AddHost {
 mod tests {
     use super::*;
     use mtui_hosts::{MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use crate::commands::testkit::{matches, session_with_hosts};
@@ -177,12 +177,7 @@ mod tests {
     /// group, so a subsequent `add_host -t host` sees `connect` short-circuit.
     fn add_mock_host(session: &mut Session, host: &str) {
         let conn = MockConnection::new(host).with_default(CommandLog::new("", "ok", "", 0, 0));
-        let target = Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        );
+        let target = Target::with_connection(host, TargetState::Enabled, Box::new(conn));
         session.targets_mut().add(target);
     }
 

--- a/crates/mtui-core/src/commands/hoststate.rs
+++ b/crates/mtui-core/src/commands/hoststate.rs
@@ -2,26 +2,24 @@
 
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 
 use super::support::{add_hosts_arg, select_names};
 use crate::command::Command;
 use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
-/// The four `state` choices upstream accepts.
-const STATES: [&str; 4] = ["parallel", "serial", "disabled", "enabled"];
+/// The two `state` choices this command accepts.
+const STATES: [&str; 2] = ["disabled", "enabled"];
 
-/// Sets the state and execution mode of a host.
+/// Sets the state of a host.
 ///
 /// Ports upstream `mtui.commands.hoststate.HostState`. A host can be:
 /// * `enabled` — runs all issued commands,
-/// * `disabled` — runs nothing,
+/// * `disabled` — runs nothing.
 ///
-/// and its execution mode either `parallel` (default) or `serial`. The
-/// `serial`/`parallel` choices set the mode; the others set the state. Selection
-/// acts on named hosts (or all, disabled included) exactly like upstream's
-/// `parse_hosts(enabled=False)`.
+/// Selection acts on named hosts (or all, disabled included) exactly like
+/// upstream's `parse_hosts(enabled=False)`.
 pub struct HostState;
 
 #[async_trait]
@@ -31,7 +29,7 @@ impl Command for HostState {
     }
 
     fn about(&self) -> Option<&'static str> {
-        Some("Sets the state and execution mode of a host.")
+        Some("Sets the state of a host.")
     }
 
     fn configure(&self, cmd: clap::Command) -> clap::Command {
@@ -39,7 +37,7 @@ impl Command for HostState {
             Arg::new("state")
                 .required(true)
                 .value_parser(clap::builder::PossibleValuesParser::new(STATES))
-                .help("enabled | disabled | parallel | serial"),
+                .help("enabled | disabled"),
         )
     }
 
@@ -69,8 +67,6 @@ impl Command for HostState {
                 continue;
             };
             match state.as_str() {
-                "serial" => t.set_mode(ExecutionMode::Serial),
-                "parallel" => t.set_mode(ExecutionMode::Parallel),
                 "enabled" => t.set_state(TargetState::Enabled),
                 "disabled" => t.set_state(TargetState::Disabled),
                 other => return Err(CommandError::Other(format!("unknown state: {other}"))),
@@ -111,17 +107,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn serial_sets_mode_not_state() {
-        let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
-        let args = matches(&HostState, &["serial"]);
-        HostState.call(&mut session, &args).await.unwrap();
-        let t = session.targets().get("h1").unwrap();
-        assert_eq!(t.mode(), ExecutionMode::Serial);
-        // State untouched.
-        assert_eq!(t.state(), TargetState::Enabled);
-    }
-
-    #[tokio::test]
     async fn applies_even_to_disabled_hosts() {
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
         // Disable, then re-enable via the command — proves enabled=false.
@@ -158,5 +143,14 @@ mod tests {
         let base = clap::Command::new(HostState.name()).no_binary_name(true);
         let parsed = HostState.configure(base).try_get_matches_from(["dryrun"]);
         assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn serial_and_parallel_rejected_by_parser() {
+        for choice in ["serial", "parallel"] {
+            let base = clap::Command::new(HostState.name()).no_binary_name(true);
+            let parsed = HostState.configure(base).try_get_matches_from([choice]);
+            assert!(parsed.is_err(), "{choice} should be rejected");
+        }
     }
 }

--- a/crates/mtui-core/src/commands/list_refhosts.rs
+++ b/crates/mtui-core/src/commands/list_refhosts.rs
@@ -25,7 +25,7 @@ use mtui_datasources::http::VerifyPolicy;
 use mtui_datasources::refhost::{Attributes, RefhostsFactory, ResolveConfig};
 use mtui_hosts::Target;
 use mtui_types::Host;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use serde_json::{Value, json};
 use tokio::task::JoinSet;
 
@@ -397,12 +397,7 @@ async fn probe_locks(config: &mtui_config::Config, records: &mut [Record]) {
             // Held for the task's lifetime; the semaphore has as many permits as
             // the bound, so at most `bound` probes run concurrently.
             let _permit = sem.acquire_owned().await.expect("semaphore is not closed");
-            let mut target = Target::new(
-                &config,
-                name.clone(),
-                TargetState::Enabled,
-                ExecutionMode::Serial,
-            );
+            let mut target = Target::new(&config, name.clone(), TargetState::Enabled);
             let state = match target.connect().await {
                 Ok(()) => match target.is_locked().await {
                     Ok(true) => "locked",

--- a/crates/mtui-core/src/commands/listhosts.rs
+++ b/crates/mtui-core/src/commands/listhosts.rs
@@ -2,25 +2,25 @@
 
 use async_trait::async_trait;
 use clap::ArgMatches;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::system::System;
 
 use crate::command::{Command, Scope};
 use crate::error::CommandResult;
 use crate::session::Session;
 
-/// Lists all connected hosts with their system, state, and execution mode.
+/// Lists all connected hosts with their system and state.
 ///
 /// Ports upstream `mtui.commands.simplelists.ListHosts`, which calls
 /// `targets.report_self(display.list_host)`. Each host's status tuple
-/// (`hostname, system, transactional, state, mode` — the
+/// (`hostname, system, transactional, state` — the
 /// [`Reporter::self_`](mtui_hosts) fields) is snapshotted first so the report
 /// borrow does not overlap the display's mutable borrow, then rendered through
 /// the display's `list_host` sink.
 pub struct ListHosts;
 
 /// One host's full status tuple, snapshotted for rendering.
-type HostStatus = (String, System, bool, TargetState, ExecutionMode);
+type HostStatus = (String, System, bool, TargetState);
 
 #[async_trait]
 impl Command for ListHosts {
@@ -29,7 +29,7 @@ impl Command for ListHosts {
     }
 
     fn about(&self) -> Option<&'static str> {
-        Some("Lists all connected hosts with their system, state, and execution mode.")
+        Some("Lists all connected hosts with their system and state.")
     }
 
     fn scope(&self) -> Scope {
@@ -46,7 +46,6 @@ impl Command for ListHosts {
                     t.system().clone(),
                     t.transactional(),
                     t.state(),
-                    t.mode(),
                 )
             })
             .collect();
@@ -54,10 +53,10 @@ impl Command for ListHosts {
             session.display.println("No hosts connected.");
             return Ok(());
         }
-        for (name, system, transactional, state, mode) in rows {
+        for (name, system, transactional, state) in rows {
             session
                 .display
-                .list_host(&name, &system, transactional, state, mode);
+                .list_host(&name, &system, transactional, state);
         }
         Ok(())
     }
@@ -111,12 +110,8 @@ mod tests {
             .with_listing("/etc/products.d", ["SLES.prod"])
             .with_link("/etc/products.d/baseproduct", "SLES.prod")
             .with_file("/etc/products.d/SLES.prod", prod.to_vec());
-        let mut target = Target::with_connection(
-            "dove.qam.suse.cz",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut target =
+            Target::with_connection("dove.qam.suse.cz", TargetState::Enabled, Box::new(conn));
         target.connect().await.expect("connect parses the system");
 
         let (mut session, buf) = session_with_targets("SUSE:Maintenance:1:1", vec![target]);

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -154,7 +154,7 @@ pub(crate) mod testkit {
     use mtui_hosts::{HostsGroup, MockConnection, RepoOp, SetRepo, Target};
     use mtui_testreport::{HashCheck, TestReport, TestReportBase};
     use mtui_types::SystemProduct;
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use crate::display::{ColorMode, CommandPromptDisplay};
@@ -320,15 +320,10 @@ pub(crate) mod testkit {
     }
 
     /// Builds a `Target` backed by a mock whose every command returns `stdout`
-    /// with exit code 0 (serial mode keeps output deterministic).
+    /// with exit code 0.
     fn scripted_target(host: &str, stdout: &str) -> Target {
         let conn = MockConnection::new(host).with_default(CommandLog::new("", stdout, "", 0, 0));
-        Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        )
+        Target::with_connection(host, TargetState::Enabled, Box::new(conn))
     }
 
     /// A session (interactive `false`) whose active report has the named hosts,
@@ -361,12 +356,7 @@ pub(crate) mod testkit {
                 if !ok {
                     conn = conn.with_sftp_put_failure(format!("{name} disk full"));
                 }
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         session_with_targets(rrid, targets)
@@ -406,12 +396,7 @@ pub(crate) mod testkit {
                         ),
                     );
                 }
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         session_with_targets(rrid, targets)
@@ -436,12 +421,7 @@ pub(crate) mod testkit {
                 if !ok {
                     conn = conn.failing_sftp_get();
                 }
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         let buf = Buffer(Arc::new(Mutex::new(Vec::new())));
@@ -535,12 +515,7 @@ pub(crate) mod testkit {
                 if !ok {
                     conn = conn.with_exclusive_write_error("/var/lock/mtui.lock");
                 }
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         session_with_targets(rrid, targets)
@@ -564,12 +539,7 @@ pub(crate) mod testkit {
                 } else {
                     CommandLog::new("zypper -n ref", "", "refresh failed", 1, 0)
                 });
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         let buf = Buffer(Arc::new(Mutex::new(Vec::new())));
@@ -676,12 +646,7 @@ pub(crate) mod testkit {
 
         let conn = MockConnection::new(host)
             .with_response(command, CommandLog::new(command, stdout, "", 0, 0));
-        let target = Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        );
+        let target = Target::with_connection(host, TargetState::Enabled, Box::new(conn));
         let mut base = TestReportBase::new(Config::default());
         base.targets = HostsGroup::new(vec![target], false);
         base.rrid = rrid.parse().ok();

--- a/crates/mtui-core/src/commands/quit.rs
+++ b/crates/mtui-core/src/commands/quit.rs
@@ -150,7 +150,7 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use mtui_hosts::{MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use super::*;
@@ -236,12 +236,7 @@ mod tests {
     /// Builds a target whose mock connection is scripted with `build`.
     fn target_with(host: &str, build: impl FnOnce(MockConnection) -> MockConnection) -> Target {
         let conn = build(MockConnection::new(host));
-        Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        )
+        Target::with_connection(host, TargetState::Enabled, Box::new(conn))
     }
 
     #[tokio::test]

--- a/crates/mtui-core/src/commands/reload.rs
+++ b/crates/mtui-core/src/commands/reload.rs
@@ -78,7 +78,7 @@ mod tests {
     use super::*;
     use crate::commands::testkit::{matches, session_with_hosts};
     use mtui_hosts::{MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
 
     #[test]
     fn name_and_active_scope() {
@@ -96,12 +96,7 @@ mod tests {
             .with_listing("/etc/products.d", ["SLES.prod"])
             .with_link("/etc/products.d/baseproduct", "SLES.prod")
             .with_file("/etc/products.d/SLES.prod", prod.to_vec());
-        let target = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &[], "ok");
         session.targets_mut().add(target);
         assert_eq!(

--- a/crates/mtui-core/src/commands/run.rs
+++ b/crates/mtui-core/src/commands/run.rs
@@ -13,10 +13,10 @@ use crate::session::Session;
 
 /// Runs a command on a specified host or on all enabled targets.
 ///
-/// Ports upstream `mtui.commands.run.Run`. The command is dispatched in parallel
-/// across every selected target (serially for hosts set to serial mode); after
-/// it returns, each host's input line, exit code, stdout, and any stderr are
-/// collected and paged to the display.
+/// Ports upstream `mtui.commands.run.Run`. The command is dispatched in
+/// parallel across every selected target; after it returns, each host's input
+/// line, exit code, stdout, and any stderr are collected and paged to the
+/// display.
 ///
 /// The positional command tokens are quoted back together with `shlex::join`
 /// before being sent, so a single token containing shell metacharacters (e.g.
@@ -257,7 +257,7 @@ mod tests {
     async fn nonzero_exit_appends_failed_summary_but_returns_ok() {
         use crate::commands::testkit::session_with_targets;
         use mtui_hosts::{MockConnection, Target};
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
         use mtui_types::hostlog::CommandLog;
 
         // h1 exits 0, h2 exits 1, h3 exits 127 — the summary lists only the
@@ -267,12 +267,7 @@ mod tests {
             .map(|(name, code)| {
                 let conn =
                     MockConnection::new(name).with_default(CommandLog::new("", "out", "", code, 0));
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         let (mut session, buf) = session_with_targets("SUSE:Maintenance:1:1", targets);
@@ -304,7 +299,7 @@ mod tests {
     async fn interactive_pages_output_and_keeps_failed_summary() {
         use crate::commands::testkit::session_with_targets;
         use mtui_hosts::{MockConnection, Prompter, Target};
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
         use mtui_types::hostlog::CommandLog;
 
         // Tiny screen so the aggregated output actually needs paging, and a
@@ -320,12 +315,7 @@ mod tests {
             .map(|(name, code)| {
                 let conn =
                     MockConnection::new(name).with_default(CommandLog::new("", "out", "", code, 0));
-                Target::with_connection(
-                    name,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(name, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         let (mut session, buf) = session_with_targets("SUSE:Maintenance:1:1", targets);
@@ -373,18 +363,13 @@ mod tests {
 
     use crate::commands::testkit::session_with_targets;
     use mtui_hosts::{MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     /// A free, enabled host that locks cleanly (Acquired) and echoes its run.
     fn free_host(name: &str) -> Target {
         let conn = MockConnection::new(name).with_default(CommandLog::new("", "ok", "", 0, 0));
-        Target::with_connection(
-            name,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        )
+        Target::with_connection(name, TargetState::Enabled, Box::new(conn))
     }
 
     /// An enabled host carrying a foreign operation lock → `Contended`.
@@ -392,12 +377,7 @@ mod tests {
         let conn = MockConnection::new(name)
             .with_default(CommandLog::new("", "ok", "", 0, 0))
             .with_file(LOCK_PATH, b"1700000000:alice:4242:busy".to_vec());
-        Target::with_connection(
-            name,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        )
+        Target::with_connection(name, TargetState::Enabled, Box::new(conn))
     }
 
     /// An enabled host whose lock-file write hard-fails → `Failed`.
@@ -405,12 +385,7 @@ mod tests {
         let conn = MockConnection::new(name)
             .with_default(CommandLog::new("", "ok", "", 0, 0))
             .with_exclusive_write_error(LOCK_PATH);
-        Target::with_connection(
-            name,
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        )
+        Target::with_connection(name, TargetState::Enabled, Box::new(conn))
     }
 
     #[tokio::test]

--- a/crates/mtui-core/src/commands/support.rs
+++ b/crates/mtui-core/src/commands/support.rs
@@ -501,7 +501,7 @@ pub(crate) async fn page_output(session: &mut Session, output: &[String]) {
 mod tests {
     use super::*;
     use mtui_hosts::{HostsGroup, MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
 
     fn cmd() -> clap::Command {
         add_hosts_arg(clap::Command::new("t").no_binary_name(true))
@@ -662,12 +662,7 @@ mod tests {
         let targets = hosts
             .iter()
             .map(|(h, state)| {
-                Target::with_connection(
-                    *h,
-                    *state,
-                    ExecutionMode::Serial,
-                    Box::new(MockConnection::new(*h)),
-                )
+                Target::with_connection(*h, *state, Box::new(MockConnection::new(*h)))
             })
             .collect();
         HostsGroup::new(targets, false)

--- a/crates/mtui-core/src/display.rs
+++ b/crates/mtui-core/src/display.rs
@@ -24,7 +24,7 @@
 use std::io::{IsTerminal, Write};
 
 use chrono::DateTime;
-use mtui_types::{ExecutionMode, RPMVersion, System, SystemProduct, TargetState};
+use mtui_types::{RPMVersion, System, SystemProduct, TargetState};
 use owo_colors::OwoColorize;
 
 /// One host and its resolved [`System`], as passed to
@@ -309,7 +309,6 @@ impl CommandPromptDisplay {
         system: &System,
         transactional: bool,
         state: TargetState,
-        mode: ExecutionMode,
     ) {
         let state_label = match state {
             TargetState::Enabled => Self::green(self, "Enabled"),
@@ -322,7 +321,7 @@ impl CommandPromptDisplay {
         };
         let sys = system.to_string();
         self.println(&format!(
-            "{hostname:<20} ({sys:<28}): {state_label:<8} - {trn:<15} - ({mode})"
+            "{hostname:<20} ({sys:<28}): {state_label:<8} - {trn:<15}"
         ));
     }
 
@@ -666,7 +665,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::{Arc, Mutex};
 
-    use mtui_types::{ExecutionMode, RPMVersion, System, SystemProduct, TargetState};
+    use mtui_types::{RPMVersion, System, SystemProduct, TargetState};
 
     use super::*;
 
@@ -824,34 +823,20 @@ mod tests {
     #[test]
     fn list_host_shows_state_label() {
         let (mut d, buf) = buffered(ColorMode::Never);
-        d.list_host(
-            "test_host",
-            &system("SLES"),
-            false,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        d.list_host("test_host", &system("SLES"), false, TargetState::Enabled);
         let out = rendered(&buf);
         assert!(out.contains("test_host"));
         assert!(out.contains("Enabled"));
         assert!(out.contains("standard"));
-        assert!(out.contains("(parallel)"));
     }
 
     #[test]
     fn list_host_transactional_and_disabled() {
         let (mut d, buf) = buffered(ColorMode::Never);
-        d.list_host(
-            "h",
-            &system("SLES"),
-            true,
-            TargetState::Disabled,
-            ExecutionMode::Serial,
-        );
+        d.list_host("h", &system("SLES"), true, TargetState::Disabled);
         let out = rendered(&buf);
         assert!(out.contains("Disabled"));
         assert!(out.contains("transactional"));
-        assert!(out.contains("(serial)"));
     }
 
     #[test]

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -21,7 +21,7 @@ use mtui_datasources::refhost::{Attributes, Refhosts, RefhostsFactory, ResolveCo
 use mtui_hosts::{HostArbiter, HostError, HostsGroup, Owner, Prompter, Target};
 use mtui_testreport::{NullReport, TestReport, UpdateKind, make_testreport};
 use mtui_types::UpdateID;
-use mtui_types::enums::{ExecutionMode, TargetState, Workflow};
+use mtui_types::enums::{TargetState, Workflow};
 use tokio::sync::OwnedMutexGuard;
 use tracing::{info, warn};
 
@@ -94,10 +94,8 @@ pub struct Session {
     /// for the REPL; `mtui-mcp` leaves it unset (upstream `prompter=None`). It is
     /// pushed down two ways: the command-timeout prompt onto each freshly-built
     /// [`Target`] in [`connect_and_add_hosts`](Self::connect_and_add_hosts), and
-    /// onto the active report's [`HostsGroup`] via
-    /// [`HostsGroup::set_prompter`] (for the serial-barrier Enter prompt). When
-    /// `None`, a command timeout aborts immediately and serial hosts run
-    /// back-to-back.
+    /// onto the active report's [`HostsGroup`] via [`HostsGroup::set_prompter`].
+    /// When `None`, a command timeout aborts immediately.
     prompter: Option<Prompter>,
     /// Test-only count of how many times [`http_client`](Self::http_client)
     /// actually *built* a client (vs. handing back a cached clone). The
@@ -821,7 +819,7 @@ impl Session {
         let mut live: std::collections::HashSet<String> = std::collections::HashSet::new();
         let targets = self.targets_mut();
         // Ensure the (possibly freshly-loaded) active group carries the prompter
-        // so its serial-barrier Enter prompt fires; a group built by a later
+        // so its command-timeout prompt fires; a group built by a later
         // `load_update` would otherwise start without it.
         if let Some(prompter) = prompter {
             targets.set_prompter(prompter);
@@ -865,12 +863,7 @@ impl Session {
         store: Option<&Refhosts>,
         is_pool_claim: bool,
     ) -> Option<(Target, (String, Option<Vec<String>>))> {
-        let mut target = Target::new(
-            config,
-            host.clone(),
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let mut target = Target::new(config, host.clone(), TargetState::Enabled);
         target.set_rrid(rrid.to_owned());
         // Wire the interactive command-timeout prompt before connecting
         // so `Target::connect` applies it to the transport (REPL only).
@@ -1469,13 +1462,12 @@ impl Session {
     /// The composition root (`mtui-cli`'s `main.rs`) wires a
     /// [`Prompter::stdin`](mtui_hosts::Prompter::stdin)-backed prompter here for
     /// the REPL; `mtui-mcp` leaves it unset. Also pushes the prompter onto the
-    /// active report's [`HostsGroup`] so any already-connected hosts (and the
-    /// serial-barrier Enter prompt) pick it up immediately; freshly-connected
-    /// hosts inherit the derived command-timeout prompt via
-    /// [`connect_and_add_hosts`](Self::connect_and_add_hosts).
+    /// active report's [`HostsGroup`] so any already-connected hosts pick up the
+    /// derived command-timeout prompt immediately; freshly-connected hosts
+    /// inherit it via [`connect_and_add_hosts`](Self::connect_and_add_hosts).
     pub fn set_prompter(&mut self, prompter: Prompter) {
-        // Push onto the active report's group first (already-connected hosts +
-        // the serial-barrier prompt), then retain a clone for future connects.
+        // Push onto the active report's group first (already-connected hosts),
+        // then retain a clone for future connects.
         self.targets_mut().set_prompter(prompter.clone());
         self.prompter = Some(prompter);
     }
@@ -1890,7 +1882,6 @@ mod tests {
         Target::with_connection(
             host,
             TargetState::Enabled,
-            ExecutionMode::Serial,
             Box::new(MockConnection::new(host)),
         )
     }
@@ -1931,12 +1922,8 @@ mod tests {
             "/var/lock/mtui.lock",
             format!("{}:someone-else:2147483647", i64::MAX),
         );
-        let mut t = Target::with_connection(
-            "refhost.example",
-            TargetState::Enabled,
-            ExecutionMode::Serial,
-            Box::new(conn),
-        );
+        let mut t =
+            Target::with_connection("refhost.example", TargetState::Enabled, Box::new(conn));
         // Must not panic / propagate: the foreign lock is suppressed.
         Session::autolock_target(&mut t, "mtui pool SUSE:Maintenance:1:1 alice").await;
     }

--- a/crates/mtui-core/src/template_registry.rs
+++ b/crates/mtui-core/src/template_registry.rs
@@ -348,7 +348,7 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use mtui_hosts::{MockConnection, Owner, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use super::*;
@@ -375,12 +375,7 @@ mod tests {
     /// Builds a target whose mock connection is scripted with `build`.
     fn target_with(host: &str, build: impl FnOnce(MockConnection) -> MockConnection) -> Target {
         let conn = build(MockConnection::new(host));
-        Target::with_connection(
-            host,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        )
+        Target::with_connection(host, TargetState::Enabled, Box::new(conn))
     }
 
     fn healthy(host: &str) -> Target {

--- a/crates/mtui-core/tests/support/mod.rs
+++ b/crates/mtui-core/tests/support/mod.rs
@@ -11,7 +11,7 @@ use mtui_config::Config;
 use mtui_hosts::{HostsGroup, MockConnection, Target};
 use mtui_testreport::{HashCheck, TestReport, TestReportBase};
 use mtui_types::SystemProduct;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
 
 /// A minimal [`TestReport`] double with a settable RRID and host group.
@@ -40,12 +40,7 @@ impl FakeReport {
         let targets: Vec<Target> = hosts
             .iter()
             .map(|h| {
-                Target::with_connection(
-                    *h,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(MockConnection::new(*h)),
-                )
+                Target::with_connection(*h, TargetState::Enabled, Box::new(MockConnection::new(*h)))
             })
             .collect();
         base.targets = HostsGroup::new(targets, false);
@@ -66,12 +61,7 @@ impl FakeReport {
             .map(|h| {
                 let conn = MockConnection::new(*h)
                     .with_response(command, CommandLog::new(command, stdout, "", 0, 0));
-                Target::with_connection(
-                    *h,
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(conn),
-                )
+                Target::with_connection(*h, TargetState::Enabled, Box::new(conn))
             })
             .collect();
         base.targets = HostsGroup::new(targets, false);

--- a/crates/mtui-hosts/benches/fanout.rs
+++ b/crates/mtui-hosts/benches/fanout.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use mtui_hosts::connection::Connection;
 use mtui_hosts::{HostsGroup, MockConnection, Target, parse_system};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
 
 /// Fleet sizes swept across every fan-out group.
@@ -55,12 +55,7 @@ fn build_group(n: usize, delay: Duration) -> HostsGroup {
             let conn = MockConnection::new(&host)
                 .with_default(CommandLog::new("", "ok", "", 0, 1))
                 .with_run_delay(delay);
-            Target::with_connection(
-                host,
-                TargetState::Enabled,
-                ExecutionMode::Parallel,
-                Box::new(conn),
-            )
+            Target::with_connection(host, TargetState::Enabled, Box::new(conn))
         })
         .collect();
     HostsGroup::new(targets, false)
@@ -342,12 +337,7 @@ fn bench_history_append(c: &mut Criterion) {
                         }
                         let conn =
                             MockConnection::new("host-0000").with_file("/var/log/mtui.log", prior);
-                        Target::with_connection(
-                            "host-0000",
-                            TargetState::Enabled,
-                            ExecutionMode::Parallel,
-                            Box::new(conn),
-                        )
+                        Target::with_connection("host-0000", TargetState::Enabled, Box::new(conn))
                     },
                     |mut target| async move {
                         target

--- a/crates/mtui-hosts/src/prompter.rs
+++ b/crates/mtui-hosts/src/prompter.rs
@@ -140,10 +140,10 @@ impl Prompter {
     /// [`ask`](Prompter::ask).
     ///
     /// The single place the boxed-closure shape lives, so the composition root
-    /// (`Session` → [`Target::set_timeout_prompt`]) and the serial-barrier path
-    /// both wire the same serialised prompt (spinner-suspend + cross-task lock)
-    /// instead of a bare closure. Upstream `Target.connect` passes
-    /// `self._prompter.ask`; this is the Rust analogue.
+    /// (`Session` → [`Target::set_timeout_prompt`]) wires the same serialised
+    /// prompt (spinner-suspend + cross-task lock) instead of a bare closure.
+    /// Upstream `Target.connect` passes `self._prompter.ask`; this is the Rust
+    /// analogue.
     ///
     /// [`Target::set_timeout_prompt`]: crate::Target::set_timeout_prompt
     #[must_use]

--- a/crates/mtui-hosts/src/target/actions.rs
+++ b/crates/mtui-hosts/src/target/actions.rs
@@ -1,20 +1,19 @@
-//! Parallel / serial fan-out primitives over a group of [`Target`]s.
+//! Parallel fan-out primitives over a group of [`Target`]s.
 //!
 //! ## Reference
 //!
 //! Ported from upstream `mtui/hosts/target/actions.py`. Upstream models each
 //! fan-out action as a `ThreadedTargetGroup` subclass that builds
 //! `(callable, args)` pairs and submits them to a thread pool via
-//! `run_parallel`, plus a `RunCommand` class that splits hosts into a parallel
-//! pool and a serial (one-at-a-time) barrier.
+//! `run_parallel`, plus a `RunCommand` class that dispatches a command to
+//! every host.
 //!
 //! This port keeps the same behavioural surface but is async and idiomatic:
 //!
 //! * [`run_parallel`] drives a set of caller-supplied futures to completion
 //!   concurrently (the async replacement for the thread pool).
-//! * [`RunCommand`] partitions the group into parallel and serial hosts by
-//!   [`ExecutionMode`] and dispatches a command (one string for all hosts, or a
-//!   per-host map) to each.
+//! * [`RunCommand`] dispatches a command (one string for all hosts, or a
+//!   per-host map) to every host in parallel.
 //! * [`sftp_put_all`] / [`sftp_get_all`] are the async equivalents of
 //!   upstream's `FileUpload` / `FileDownload`.
 //!
@@ -41,10 +40,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use futures::stream::{self, StreamExt};
-use mtui_types::enums::ExecutionMode;
 
 use super::Target;
-use crate::prompter::Prompter;
 
 /// Fallback fan-out width when a caller passes `0` (unconfigured). Mirrors the
 /// `[connection] max_parallel` default in `mtui-config`; kept as a local
@@ -136,30 +133,21 @@ where
 pub(crate) type BoxTargetFut<'a> =
     std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>;
 
-/// Drives a per-target async `op` across a group, honouring [`ExecutionMode`].
+/// Drives a per-target async `op` across a group in parallel.
 ///
 /// This is the single fan-out primitive every per-host I/O method on
-/// [`HostsGroup`](super::HostsGroup) routes through, so the parallel-batch +
-/// serial-barrier contract lives in exactly one place. Targets whose
-/// [`ExecutionMode`] is [`Parallel`](ExecutionMode::Parallel) are driven
-/// concurrently via [`run_parallel`]; targets marked
-/// [`Serial`](ExecutionMode::Serial) run *after* the parallel batch, one at a
-/// time in sorted hostname order.
+/// [`HostsGroup`](super::HostsGroup) routes through. Every (non-skipped)
+/// target is driven concurrently via [`run_parallel`].
 ///
-/// When `interactive` is set and a serialised [`Prompter`] is supplied, the
-/// user is asked to press Enter before each serial host (upstream's serial
-/// barrier); headless callers pass `None` and serial hosts run back-to-back.
-/// `desc` labels the optional TTY spinner for the parallel batch (a no-op off a
-/// TTY). `op` is invoked once per (non-skipped) target with `&mut Target`; the
-/// disjoint mutable borrows make the parallel batch sound without a shared lock.
+/// `desc` labels the optional TTY spinner (a no-op off a TTY). `op` is invoked
+/// once per (non-skipped) target with `&mut Target`; the disjoint mutable
+/// borrows make the parallel batch sound without a shared lock.
 ///
 /// `should_run` lets a caller skip a target entirely (e.g. a
-/// [`Command::PerHost`] map that does not cover it); return `false` to omit it
-/// from both batches.
+/// [`Command::PerHost`] map that does not cover it); return `false` to omit it.
 pub(crate) async fn run_fanout<'t, S, F>(
     targets: &'t mut BTreeMap<String, Target>,
     is_repl: bool,
-    prompter: Option<&Prompter>,
     max_parallel: usize,
     desc: Option<&str>,
     mut should_run: S,
@@ -168,18 +156,10 @@ pub(crate) async fn run_fanout<'t, S, F>(
     S: FnMut(&Target) -> bool,
     F: Fn(&'t mut Target) -> BoxTargetFut<'t>,
 {
-    let mut parallel: Vec<&'t mut Target> = Vec::new();
-    let mut serial: Vec<&'t mut Target> = Vec::new();
-    for target in targets.values_mut() {
-        if !should_run(target) {
-            continue;
-        }
-        if target.mode() == ExecutionMode::Serial {
-            serial.push(target);
-        } else {
-            parallel.push(target);
-        }
-    }
+    let parallel: Vec<&'t mut Target> = targets
+        .values_mut()
+        .filter(|target| should_run(target))
+        .collect();
 
     // Diagnostic (`mtui -d`): report the resolved fan-out shape so a missing
     // spinner is explainable. `is_repl=false` or `parallel=0` both suppress the
@@ -188,12 +168,11 @@ pub(crate) async fn run_fanout<'t, S, F>(
         is_repl,
         desc = desc.unwrap_or("<none>"),
         parallel = parallel.len(),
-        serial = serial.len(),
         "fan-out dispatch"
     );
 
-    // Parallel batch: each future borrows a distinct target mutably, so the
-    // borrows are disjoint and need no shared lock.
+    // Each future borrows a distinct target mutably, so the borrows are
+    // disjoint and need no shared lock.
     let parallel_futs: Vec<_> = parallel.into_iter().map(&op).collect();
     run_parallel(
         parallel_futs,
@@ -201,18 +180,6 @@ pub(crate) async fn run_fanout<'t, S, F>(
         max_parallel,
     )
     .await;
-
-    // Serial barrier: one host at a time. Under an interactive session with a
-    // serialised prompter, ask the user to press Enter before each serial host
-    // (upstream `prompt_user("press Enter key to proceed with …")`); headless
-    // callers run them back-to-back. Any input (incl. empty) proceeds.
-    for t in serial {
-        if is_repl && let Some(prompter) = prompter {
-            let text = format!("press Enter key to proceed with {} ", t.hostname());
-            let _ = prompter.ask(&text).await;
-        }
-        op(t).await;
-    }
 }
 
 /// A command to run across a group: one string for every host, or a per-host
@@ -260,49 +227,33 @@ impl From<BTreeMap<String, String>> for Command {
     }
 }
 
-/// Runs a [`Command`] across a group of targets: parallel hosts concurrently,
-/// then serial hosts one at a time.
+/// Runs a [`Command`] across a group of targets in parallel.
 ///
-/// Ported from upstream `RunCommand`. Hosts whose [`ExecutionMode`] is
-/// [`Serial`](ExecutionMode::Serial) run *after* the parallel batch, sequentially
-/// and in (sorted) hostname order, mirroring upstream's serial barrier. When a
-/// [`PerHost`](Command::PerHost) map is given, hosts it does not cover are
-/// skipped entirely.
-///
-/// The upstream serial barrier prompts the user (`press Enter key to proceed
-/// with <host>`) before each serial host. When a serialised [`Prompter`] is
-/// supplied and `interactive` is set (the REPL), [`run`](RunCommand::run) asks
-/// that prompt before each serial host; headless callers (`mtui-mcp`) pass
-/// `None` and serial hosts run back-to-back. No stdin/TTY code lives in this
-/// crate — the reader is injected via the [`Prompter`].
+/// Ported from upstream `RunCommand`. When a [`PerHost`](Command::PerHost) map
+/// is given, hosts it does not cover are skipped entirely.
 pub(crate) struct RunCommand<'a> {
     targets: &'a mut BTreeMap<String, Target>,
     command: Command,
     is_repl: bool,
-    prompter: Option<Prompter>,
     max_parallel: usize,
 }
 
 impl<'a> RunCommand<'a> {
     /// Builds a run over `targets` with `command`.
     ///
-    /// `prompter` is the session-level serialised [`Prompter`] (or `None` when
-    /// headless); when present and `interactive` is set, the serial barrier
-    /// prompts before each serial host. The parallel-batch width defaults to
-    /// unconfigured (`0` → [`DEFAULT_MAX_PARALLEL`]); set it with
+    /// The parallel-batch width defaults to unconfigured (`0` →
+    /// [`DEFAULT_MAX_PARALLEL`]); set it with
     /// [`with_max_parallel`](Self::with_max_parallel).
     #[must_use]
     pub(crate) fn new(
         targets: &'a mut BTreeMap<String, Target>,
         command: impl Into<Command>,
         is_repl: bool,
-        prompter: Option<Prompter>,
     ) -> Self {
         Self {
             targets,
             command: command.into(),
             is_repl,
-            prompter,
             max_parallel: 0,
         }
     }
@@ -315,26 +266,22 @@ impl<'a> RunCommand<'a> {
         self
     }
 
-    /// Executes the command: parallel hosts concurrently, then serial hosts
-    /// sequentially.
+    /// Executes the command across every (non-skipped) host in parallel.
     ///
-    /// Delegates the parallel-batch + serial-barrier split to the shared
-    /// [`run_fanout`] primitive; the only command-specific logic here is
-    /// resolving the per-host command string and skipping hosts a
-    /// [`PerHost`](Command::PerHost) map does not cover.
+    /// Delegates to the shared [`run_fanout`] primitive; the only
+    /// command-specific logic here is resolving the per-host command string
+    /// and skipping hosts a [`PerHost`](Command::PerHost) map does not cover.
     pub(crate) async fn run(self) {
         let Self {
             targets,
             command,
             is_repl,
-            prompter,
             max_parallel,
         } = self;
 
         run_fanout(
             targets,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("run"),
             // `for_host` returning None means "skip" (upstream dict subset).
@@ -434,9 +381,9 @@ mod tests {
     use super::*;
     use crate::connection::{MockConnection, MockSftpOp};
 
-    /// Builds an enabled parallel target wired to `conn`.
-    fn target(hostname: &str, mode: ExecutionMode, conn: MockConnection) -> Target {
-        Target::with_connection(hostname, TargetState::Enabled, mode, Box::new(conn))
+    /// Builds an enabled target wired to `conn`.
+    fn target(hostname: &str, conn: MockConnection) -> Target {
+        Target::with_connection(hostname, TargetState::Enabled, Box::new(conn))
     }
 
     /// A mock that echoes `stdout` for any command.
@@ -582,12 +529,9 @@ mod tests {
     async fn run_command_string_dispatches_to_all_hosts() {
         let (m1, m2) = (echo("h1", "a"), echo("h2", "b"));
         let (h1, h2) = (m1.clone(), m2.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2)]);
 
-        RunCommand::new(&mut g, "uptime", false, None).run().await;
+        RunCommand::new(&mut g, "uptime", false).run().await;
 
         assert_eq!(h1.commands(), vec!["uptime".to_owned()]);
         assert_eq!(h2.commands(), vec!["uptime".to_owned()]);
@@ -598,105 +542,14 @@ mod tests {
         // A subset command must not KeyError/panic on the uncovered host.
         let (m1, m2) = (echo("h1", "a"), echo("h2", "b"));
         let (h1, h2) = (m1.clone(), m2.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2)]);
 
         let mut map = BTreeMap::new();
         map.insert("h1".to_owned(), "only-h1".to_owned());
-        RunCommand::new(&mut g, map, false, None).run().await;
+        RunCommand::new(&mut g, map, false).run().await;
 
         assert_eq!(h1.commands(), vec!["only-h1".to_owned()]);
         assert!(h2.commands().is_empty(), "uncovered host must be skipped");
-    }
-
-    #[tokio::test]
-    async fn run_command_runs_parallel_and_serial_hosts() {
-        // Both a parallel and a serial host receive the command; the serial
-        // barrier runs after the parallel batch (no prompter here, so no prompt).
-        let (mp, ms) = (echo("par", "p"), echo("ser", "s"));
-        let (hp, hs) = (mp.clone(), ms.clone());
-        let mut g = group(vec![
-            target("par", ExecutionMode::Parallel, mp),
-            target("ser", ExecutionMode::Serial, ms),
-        ]);
-
-        RunCommand::new(&mut g, "cmd", true, None).run().await;
-
-        assert_eq!(hp.commands(), vec!["cmd".to_owned()]);
-        assert_eq!(hs.commands(), vec!["cmd".to_owned()]);
-    }
-
-    /// A recording [`Prompter`] that appends every prompt text to a shared vec
-    /// and returns an empty answer (Enter). Used to assert the serial-barrier
-    /// prompt is reached (interactive) or skipped (headless).
-    fn recording_prompter(seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Prompter {
-        Prompter::new(std::sync::Arc::new(move |text: String| {
-            let seen = std::sync::Arc::clone(&seen);
-            Box::pin(async move {
-                seen.lock().unwrap().push(text);
-                Ok(String::new())
-            })
-                as std::pin::Pin<
-                    Box<dyn std::future::Future<Output = std::io::Result<String>> + Send>,
-                >
-        }))
-    }
-
-    #[tokio::test]
-    async fn serial_barrier_prompts_before_each_serial_host_when_interactive() {
-        let _serial = super::super::spinner::TEST_SERIAL.lock().await;
-        let (ma, mb) = (echo("s-a", "a"), echo("s-b", "b"));
-        let (ha, hb) = (ma.clone(), mb.clone());
-        let mut g = group(vec![
-            target("s-a", ExecutionMode::Serial, ma),
-            target("s-b", ExecutionMode::Serial, mb),
-        ]);
-
-        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let prompter = recording_prompter(std::sync::Arc::clone(&seen));
-
-        RunCommand::new(&mut g, "cmd", true, Some(prompter))
-            .run()
-            .await;
-
-        // Both serial hosts ran, prompted in sorted hostname order.
-        assert_eq!(ha.commands(), vec!["cmd".to_owned()]);
-        assert_eq!(hb.commands(), vec!["cmd".to_owned()]);
-        assert_eq!(
-            *seen.lock().unwrap(),
-            vec![
-                "press Enter key to proceed with s-a ".to_owned(),
-                "press Enter key to proceed with s-b ".to_owned(),
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn serial_barrier_does_not_prompt_when_headless() {
-        let _serial = super::super::spinner::TEST_SERIAL.lock().await;
-        let (ma, mb) = (echo("s-a", "a"), echo("s-b", "b"));
-        let (ha, hb) = (ma.clone(), mb.clone());
-        let mut g = group(vec![
-            target("s-a", ExecutionMode::Serial, ma),
-            target("s-b", ExecutionMode::Serial, mb),
-        ]);
-
-        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let prompter = recording_prompter(std::sync::Arc::clone(&seen));
-
-        // Headless: interactive == false → no prompt even with a prompter set.
-        RunCommand::new(&mut g, "cmd", false, Some(prompter))
-            .run()
-            .await;
-
-        assert_eq!(ha.commands(), vec!["cmd".to_owned()]);
-        assert_eq!(hb.commands(), vec!["cmd".to_owned()]);
-        assert!(
-            seen.lock().unwrap().is_empty(),
-            "headless run must not prompt"
-        );
     }
 
     // --- SFTP fan-out -------------------------------------------------------
@@ -705,10 +558,7 @@ mod tests {
     async fn sftp_put_all_uploads_to_every_host() {
         let (m1, m2) = (echo("h1", ""), echo("h2", ""));
         let (h1, h2) = (m1.clone(), m2.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2)]);
 
         sftp_put_all(
             &mut g,
@@ -739,11 +589,7 @@ mod tests {
 
         let (m1, m2, m3) = (echo("h1", ""), echo("h2", ""), echo("h3", ""));
         let (h1, h2, h3) = (m1.clone(), m2.clone(), m3.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-            target("h3", ExecutionMode::Parallel, m3),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2), target("h3", m3)]);
 
         sftp_put_all(&mut g, &local, Path::new("/remote/f"), false, 0).await;
 
@@ -771,10 +617,7 @@ mod tests {
 
         let (m1, m2) = (echo("h1", ""), echo("h2", ""));
         let (h1, h2) = (m1.clone(), m2.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2)]);
 
         sftp_put_all(&mut g, &local, Path::new("/remote/f"), false, 0).await;
 
@@ -793,10 +636,7 @@ mod tests {
         // the fan-out aborts before any host op. (Read-once error handling.)
         let (m1, m2) = (echo("h1", ""), echo("h2", ""));
         let (h1, h2) = (m1.clone(), m2.clone());
-        let mut g = group(vec![
-            target("h1", ExecutionMode::Parallel, m1),
-            target("h2", ExecutionMode::Parallel, m2),
-        ]);
+        let mut g = group(vec![target("h1", m1), target("h2", m2)]);
 
         // Nonexistent path: metadata() → None branch → streaming `sftp_put`,
         // whose per-host read fails and is swallowed. No PutBytes is dispatched.
@@ -824,7 +664,7 @@ mod tests {
     async fn sftp_get_all_downloads_with_per_host_suffix() {
         let m1 = echo("h1", "");
         let h1 = m1.clone();
-        let mut g = group(vec![target("h1", ExecutionMode::Parallel, m1)]);
+        let mut g = group(vec![target("h1", m1)]);
 
         sftp_get_all(&mut g, "/remote/f", Path::new("/local/f"), false, 0).await;
 

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -108,13 +108,10 @@ pub struct HostsGroup {
     /// under headless callers (`mtui-mcp`).
     ///
     /// Pushed down from the composition root (`mtui-core::Session`) via
-    /// [`set_prompter`](Self::set_prompter): it stores the prompter on the group
-    /// (for the
-    /// serial-barrier Enter prompt in [`RunCommand`]) **and** installs the
-    /// derived command-timeout prompt on every member [`Target`] via
-    /// [`Target::set_timeout_prompt`]. `None` keeps the serial barrier
-    /// back-to-back and a command timeout an immediate abort (upstream
-    /// `prompter=None`).
+    /// [`set_prompter`](Self::set_prompter): it installs the derived
+    /// command-timeout prompt on every member [`Target`] via
+    /// [`Target::set_timeout_prompt`]. `None` keeps a command timeout an
+    /// immediate abort (upstream `prompter=None`).
     prompter: Option<crate::Prompter>,
     /// Maximum hosts to fan out to concurrently in the parallel batch. Pushed
     /// down from the composition root (`mtui-core::Session`) via
@@ -384,15 +381,14 @@ impl HostsGroup {
         self.data.remove(hostname)
     }
 
-    /// Runs a command across the group: parallel hosts concurrently, serial
-    /// hosts one at a time.
+    /// Runs a command across the group in parallel.
     ///
     /// `cmd` accepts a single string (run on every host) or a per-host
     /// [`Command::PerHost`] map (hosts absent from the map are skipped). See
     /// [`RunCommand`].
     pub async fn run(&mut self, cmd: impl Into<Command>) {
         let max_parallel = self.max_parallel;
-        RunCommand::new(&mut self.data, cmd, self.is_repl, self.prompter.clone())
+        RunCommand::new(&mut self.data, cmd, self.is_repl)
             .with_max_parallel(max_parallel)
             .run()
             .await;
@@ -454,13 +450,11 @@ impl HostsGroup {
     {
         use std::sync::Mutex;
 
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         let collected: Mutex<BTreeMap<String, LockOutcome>> = Mutex::new(BTreeMap::new());
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("lock"),
             select,
@@ -523,13 +517,11 @@ impl HostsGroup {
     {
         use std::sync::Mutex;
 
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         let collected: Mutex<BTreeMap<String, LockOutcome>> = Mutex::new(BTreeMap::new());
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("unlock"),
             select,
@@ -559,12 +551,10 @@ impl HostsGroup {
     /// a claim owned by another template), so one contended host never aborts
     /// the fan-out. `force` removes claims owned by other templates too.
     pub async fn pool_unlock(&mut self, force: bool) {
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("pool_unlock"),
             |_t| true,
@@ -581,10 +571,10 @@ impl HostsGroup {
     /// (`Some("poweroff")` → shell `halt`), or simply closes (`None`). Used on
     /// session exit; unlike [`reboot`](Self::reboot) it never reconnects.
     ///
-    /// Fans out concurrently across the group (parallel hosts together, serial
-    /// hosts one at a time) via [`run_fanout`](super::actions::run_fanout),
-    /// mirroring upstream's concurrent close. The overall wait budget is applied
-    /// by the caller. A no-op when the group is empty.
+    /// Fans out concurrently across the group via
+    /// [`run_fanout`](super::actions::run_fanout), mirroring upstream's
+    /// concurrent close. The overall wait budget is applied by the caller. A
+    /// no-op when the group is empty.
     ///
     /// Returns each host's teardown outcome keyed by hostname so `quit` can name
     /// a host that failed to disconnect (upstream `quit` logs
@@ -595,14 +585,12 @@ impl HostsGroup {
     pub async fn close(&mut self, action: Option<&str>) -> BTreeMap<String, Result<()>> {
         use std::sync::Mutex;
 
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         let action = action.map(str::to_owned);
         let collected: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("close"),
             |_t| true,
@@ -638,17 +626,15 @@ impl HostsGroup {
     {
         use std::sync::Mutex;
 
-        // Phase 1 (I/O): resolve every host's lock row concurrently (serial
-        // hosts one at a time) via the shared fan-out. Each host's
-        // `(system, row)` is collected keyed by hostname, so the drain below is
-        // deterministically sorted regardless of completion order.
+        // Phase 1 (I/O): resolve every host's lock row concurrently via the
+        // shared fan-out. Each host's `(system, row)` is collected keyed by
+        // hostname, so the drain below is deterministically sorted regardless
+        // of completion order.
         let collected: Mutex<BTreeMap<String, (System, LockRow)>> = Mutex::new(BTreeMap::new());
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("report_locks"),
             |_t| true,
@@ -676,14 +662,13 @@ impl HostsGroup {
     /// group and every member host.
     ///
     /// The single push-down point for interactive prompting: it stores the
-    /// prompter on the group (used by
-    /// the serial-barrier Enter prompt in [`RunCommand`]) and installs the
-    /// derived command-timeout prompt on each member [`Target`] via
-    /// [`Target::set_timeout_prompt`], so a target connected *after* this call
-    /// (and one already connected via the builder) both surface the timeout
-    /// prompt. The composition root (`mtui-core::Session`) calls this when a
-    /// prompter is present; headless callers (`mtui-mcp`) never do, leaving the
-    /// serial barrier back-to-back and command timeouts an immediate abort.
+    /// prompter on the group and installs the derived command-timeout prompt on
+    /// each member [`Target`] via [`Target::set_timeout_prompt`], so a target
+    /// connected *after* this call (and one already connected via the builder)
+    /// both surface the timeout prompt. The composition root
+    /// (`mtui-core::Session`) calls this when a prompter is present; headless
+    /// callers (`mtui-mcp`) never do, leaving a command timeout an immediate
+    /// abort.
     pub fn set_prompter(&mut self, prompter: crate::Prompter) {
         let timeout_prompt = prompter.as_timeout_prompt();
         for target in self.data.values_mut() {
@@ -701,19 +686,15 @@ impl HostsGroup {
     /// group never depends on the report crate.
     ///
     /// Fans out concurrently via [`run_fanout`](super::actions::run_fanout)
-    /// (upstream's `run_parallel`): parallel hosts run their repo change
-    /// together, serial hosts one at a time behind the Enter barrier — so a host
-    /// the operator marked [`Serial`](mtui_types::enums::ExecutionMode::Serial)
-    /// never has its `zypper` repo change run concurrently with another host's.
-    /// The per-host `last*` state is left in place so a caller can inspect
-    /// `lasterr()` after the fan-out (upstream's prepare abort-on-`lasterr`).
+    /// (upstream's `run_parallel`): every host runs its repo change in
+    /// parallel. The per-host `last*` state is left in place so a caller can
+    /// inspect `lasterr()` after the fan-out (upstream's prepare
+    /// abort-on-`lasterr`).
     pub async fn fanout_set_repo(&mut self, operation: RepoOp, report: &dyn SetRepo) {
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("set_repo"),
             |_t| true,
@@ -753,12 +734,10 @@ impl HostsGroup {
     /// Ports upstream `HostsGroup.add_history`: fans [`Target::add_history`] out
     /// across the group (enabled hosts only, best-effort per host).
     pub async fn add_history(&mut self, fields: &[String]) {
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("add_history"),
             |_t| true,
@@ -774,16 +753,13 @@ impl HostsGroup {
     ///
     /// The I/O phase shared by [`package_check`](Self::package_check) and the
     /// downgrade verdict: fans [`Target::query_versions`] out through the shared
-    /// [`run_fanout`](super::actions::run_fanout) primitive (parallel hosts
-    /// together, serial hosts one at a time behind the Enter barrier), so the
-    /// pure per-package bookkeeping that follows never blocks on serial I/O.
+    /// [`run_fanout`](super::actions::run_fanout) primitive in parallel, so the
+    /// pure per-package bookkeeping that follows never blocks on I/O.
     pub async fn query_versions(&mut self) {
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("query_versions"),
             |_t| true,
@@ -793,8 +769,8 @@ impl HostsGroup {
     }
 
     pub async fn package_check(&mut self, post: bool) {
-        // Phase 1 (I/O): query every host's installed versions concurrently
-        // (serial hosts one at a time), through the shared fan-out primitive.
+        // Phase 1 (I/O): query every host's installed versions concurrently,
+        // through the shared fan-out primitive.
         self.query_versions().await;
 
         // Phase 2 (pure): fold each host's queried versions into its packages'
@@ -880,18 +856,16 @@ impl HostsGroup {
     pub async fn update_lock(&mut self) -> Result<()> {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        // Probe-and-acquire concurrently across the group (serial hosts one at a
-        // time) via the shared fan-out. Each host's probe+acquire is
-        // self-contained and order-independent; a foreign-locked host flips the
-        // shared `skipped` flag. The per-host lock wire semantics are unchanged
-        // — only the fan-out is now concurrent (Contract preserved).
+        // Probe-and-acquire concurrently across the group via the shared
+        // fan-out. Each host's probe+acquire is self-contained and
+        // order-independent; a foreign-locked host flips the shared `skipped`
+        // flag. The per-host lock wire semantics are unchanged — only the
+        // fan-out is now concurrent (Contract preserved).
         let skipped = AtomicBool::new(false);
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("update_lock"),
             |_t| true,
@@ -1029,8 +1003,7 @@ impl HostsGroup {
             return BTreeMap::new();
         }
         tracing::info!(hosts = %names.join(", "), "Rebooting");
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
 
         // Phase 1: record boot ids before rebooting (concurrently), so we can
         // confirm a fresh boot afterwards.
@@ -1038,7 +1011,6 @@ impl HostsGroup {
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("boot_id"),
             &select,
@@ -1060,7 +1032,6 @@ impl HostsGroup {
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("reboot"),
             &select,
@@ -1081,7 +1052,6 @@ impl HostsGroup {
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("reconnect"),
             &select,
@@ -1112,7 +1082,6 @@ impl HostsGroup {
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("verify_reboot"),
             &select,
@@ -1164,17 +1133,15 @@ impl HostsGroup {
             hosts = %names.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "),
             "Rebooting transactional hosts"
         );
-        let (is_repl, prompter, max_parallel) =
-            (self.is_repl, self.prompter.clone(), self.max_parallel);
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
 
         // Fire the reboot on every named host first (it drops the connection),
         // then reconnect each once it is back up — both phases fan out
-        // concurrently (serial hosts one at a time) via the shared primitive.
-        // `should_run` restricts the fan-out to the named (transactional) hosts.
+        // concurrently via the shared primitive. `should_run` restricts the
+        // fan-out to the named (transactional) hosts.
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("reboot"),
             |t| reboot.contains_key(t.hostname()),
@@ -1187,7 +1154,6 @@ impl HostsGroup {
         actions::run_fanout(
             &mut self.data,
             is_repl,
-            prompter.as_ref(),
             max_parallel,
             Some("reconnect"),
             |t| reboot.contains_key(t.hostname()),
@@ -1328,7 +1294,7 @@ impl OperationGroup for HostsGroup {
 
 #[cfg(test)]
 mod tests {
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use super::*;
@@ -1339,12 +1305,12 @@ mod tests {
         MockConnection::new(hostname).with_default(CommandLog::new("", "ok", "", 0, 0))
     }
 
-    fn tgt(hostname: &str, state: TargetState, mode: ExecutionMode) -> Target {
-        Target::with_connection(hostname, state, mode, Box::new(echo(hostname)))
+    fn tgt(hostname: &str, state: TargetState) -> Target {
+        Target::with_connection(hostname, state, Box::new(echo(hostname)))
     }
 
     fn enabled(hostname: &str) -> Target {
-        tgt(hostname, TargetState::Enabled, ExecutionMode::Parallel)
+        tgt(hostname, TargetState::Enabled)
     }
 
     // --- construction / accessors ------------------------------------------
@@ -1393,12 +1359,7 @@ mod tests {
             .into_iter()
             .enumerate()
             .map(|(i, m)| {
-                Target::with_connection(
-                    format!("h{i:02}"),
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m),
-                )
+                Target::with_connection(format!("h{i:02}"), TargetState::Enabled, Box::new(m))
             })
             .collect();
         let mut g = HostsGroup::new(targets, false);
@@ -1467,7 +1428,7 @@ mod tests {
     fn add_same_hostname_replaces_last_writer_wins() {
         let mut g = HostsGroup::new(vec![enabled("h1")], true);
         // A second target with the same hostname but disabled replaces the first.
-        g.add(tgt("h1", TargetState::Disabled, ExecutionMode::Parallel));
+        g.add(tgt("h1", TargetState::Disabled));
         assert_eq!(g.len(), 1);
         assert_eq!(g.get("h1").unwrap().state(), TargetState::Disabled);
     }
@@ -1501,13 +1462,7 @@ mod tests {
 
     #[test]
     fn select_none_enabled_drops_disabled() {
-        let g = HostsGroup::new(
-            vec![
-                enabled("h1"),
-                tgt("h2", TargetState::Disabled, ExecutionMode::Parallel),
-            ],
-            true,
-        );
+        let g = HostsGroup::new(vec![enabled("h1"), tgt("h2", TargetState::Disabled)], true);
         let sel = g.select(None, true).unwrap();
         assert_eq!(sel.names(), vec!["h1".to_owned()]);
     }
@@ -1523,13 +1478,7 @@ mod tests {
 
     #[test]
     fn select_by_name_with_enabled_filters_disabled() {
-        let g = HostsGroup::new(
-            vec![
-                enabled("h1"),
-                tgt("h2", TargetState::Disabled, ExecutionMode::Parallel),
-            ],
-            true,
-        );
+        let g = HostsGroup::new(vec![enabled("h1"), tgt("h2", TargetState::Disabled)], true);
         let sel = g
             .select(Some(&["h1".to_owned(), "h2".to_owned()]), true)
             .unwrap();
@@ -1575,13 +1524,7 @@ mod tests {
     fn select_split_named_disabled_lands_in_remainder() {
         // A named host filtered out by `enabled` is preserved in the remainder,
         // not dropped — this is the whole point of the split.
-        let g = HostsGroup::new(
-            vec![
-                enabled("h1"),
-                tgt("h2", TargetState::Disabled, ExecutionMode::Parallel),
-            ],
-            true,
-        );
+        let g = HostsGroup::new(vec![enabled("h1"), tgt("h2", TargetState::Disabled)], true);
         let (sel, rem) = g
             .select_split(Some(&["h1".to_owned(), "h2".to_owned()]), true)
             .unwrap();
@@ -1613,10 +1556,7 @@ mod tests {
     fn merge_collision_is_last_writer_wins() {
         let mut g = HostsGroup::new(vec![enabled("h1")], true);
         // `other`'s h1 is disabled and must replace `self`'s enabled h1.
-        let other = HostsGroup::new(
-            vec![tgt("h1", TargetState::Disabled, ExecutionMode::Parallel)],
-            true,
-        );
+        let other = HostsGroup::new(vec![tgt("h1", TargetState::Disabled)], true);
         g.merge(other);
         assert_eq!(g.len(), 1);
         assert_eq!(g.get("h1").unwrap().state(), TargetState::Disabled);
@@ -1630,18 +1570,8 @@ mod tests {
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(m2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(m2)),
             ],
             false,
         );
@@ -1658,18 +1588,8 @@ mod tests {
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Serial,
-                    Box::new(m2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(m2)),
             ],
             false,
         );
@@ -1696,18 +1616,8 @@ mod tests {
         let bad = echo("h2").with_failing_close();
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(ok),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(bad),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(ok)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(bad)),
             ],
             false,
         );
@@ -1738,7 +1648,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -1782,18 +1691,8 @@ mod tests {
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(m2)),
             ],
             false,
         );
@@ -1827,18 +1726,8 @@ mod tests {
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(m2)),
             ],
             false,
         );
@@ -1864,7 +1753,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -1903,7 +1791,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -1931,7 +1818,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -1959,7 +1845,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -1983,18 +1868,8 @@ mod tests {
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(m2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(m2)),
             ],
             false,
         );
@@ -2023,7 +1898,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(m1),
             )],
             false,
@@ -2054,12 +1928,7 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(foreign),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(foreign)),
             ],
             false,
         );
@@ -2081,12 +1950,7 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(failing),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(failing)),
             ],
             false,
         );
@@ -2129,18 +1993,8 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(foreign),
-                ),
-                Target::with_connection(
-                    "h3",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(failing),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(foreign)),
+                Target::with_connection("h3", TargetState::Enabled, Box::new(failing)),
             ],
             false,
         );
@@ -2165,12 +2019,7 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(foreign),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(foreign)),
                 enabled("h3"),
             ],
             false,
@@ -2206,12 +2055,7 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(foreign),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(foreign)),
             ],
             false,
         );
@@ -2235,18 +2079,8 @@ mod tests {
         let (h1, h2) = (c1.clone(), c2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(c1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(c2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(c1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(c2)),
             ],
             false,
         );
@@ -2272,18 +2106,8 @@ mod tests {
         let (h1, h2) = (c1.clone(), c2.clone());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h1",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(c1),
-                ),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(c2),
-                ),
+                Target::with_connection("h1", TargetState::Enabled, Box::new(c1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(c2)),
             ],
             false,
         );
@@ -2304,12 +2128,7 @@ mod tests {
         let c2 = echo("h2").with_file(TARGET_LOCK_PATH, b"1700000000:alice:4242:busy".to_vec());
         let mut g = HostsGroup::new(
             vec![
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(c2),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(c2)),
                 enabled("h1"),
             ],
             false,
@@ -2342,7 +2161,6 @@ mod tests {
             vec![Target::with_connection(
                 "h1",
                 TargetState::Enabled,
-                ExecutionMode::Parallel,
                 Box::new(c1),
             )],
             false,
@@ -2378,12 +2196,7 @@ mod tests {
         let mut g = HostsGroup::new(
             vec![
                 enabled("h1"),
-                Target::with_connection(
-                    "h2",
-                    TargetState::Enabled,
-                    ExecutionMode::Parallel,
-                    Box::new(foreign),
-                ),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(foreign)),
             ],
             false,
         );
@@ -2432,12 +2245,7 @@ mod tests {
     fn host_with_rpm_output(hostname: &str, stdout: &str) -> Target {
         let conn =
             MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", 0, 0));
-        Target::with_connection(
-            hostname,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        )
+        Target::with_connection(hostname, TargetState::Enabled, Box::new(conn))
     }
 
     #[tokio::test]
@@ -2477,94 +2285,5 @@ mod tests {
 
         g.package_check(false).await;
         assert!(g.get("h1").unwrap().packages()[0].before().is_none());
-    }
-
-    // --- ExecutionMode::Serial is honoured by every fan-out op -------------
-
-    /// A recording [`Prompter`] appending every serial-barrier prompt text to a
-    /// shared vec (returns Enter). Reaching the barrier proves an op routed a
-    /// serial host through the shared [`run_fanout`] serial path.
-    fn recording_prompter(seen: Arc<std::sync::Mutex<Vec<String>>>) -> crate::Prompter {
-        crate::Prompter::new(Arc::new(move |text: String| {
-            let seen = Arc::clone(&seen);
-            Box::pin(async move {
-                seen.lock().unwrap().push(text);
-                Ok(String::new())
-            })
-                as std::pin::Pin<
-                    Box<dyn std::future::Future<Output = std::io::Result<String>> + Send>,
-                >
-        }))
-    }
-
-    /// Builds an interactive group with one parallel + one serial host, wiring a
-    /// recording prompter so the serial barrier is observable.
-    fn serial_barrier_group(seen: Arc<std::sync::Mutex<Vec<String>>>) -> HostsGroup {
-        let mut g = HostsGroup::new(
-            vec![
-                enabled("par"),
-                tgt("ser", TargetState::Enabled, ExecutionMode::Serial),
-            ],
-            true,
-        );
-        g.set_prompter(recording_prompter(seen));
-        g
-    }
-
-    #[tokio::test]
-    async fn fanout_set_repo_honours_serial_barrier() {
-        let _serial = super::super::spinner::TEST_SERIAL.lock().await;
-        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let mut g = serial_barrier_group(Arc::clone(&seen));
-        let report = RecordingSetRepo::default();
-
-        g.fanout_set_repo(RepoOp::Add, &report).await;
-
-        // The serial host is prompted before its repo change; the parallel host
-        // is not. Both are still visited.
-        assert_eq!(
-            *seen.lock().unwrap(),
-            vec!["press Enter key to proceed with ser ".to_owned()]
-        );
-        let hosts: Vec<String> = report
-            .seen
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(h, _)| h.clone())
-            .collect();
-        assert!(hosts.contains(&"par".to_owned()));
-        assert!(hosts.contains(&"ser".to_owned()));
-    }
-
-    #[tokio::test]
-    async fn lock_honours_serial_barrier() {
-        let _serial = super::super::spinner::TEST_SERIAL.lock().await;
-        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let mut g = serial_barrier_group(Arc::clone(&seen));
-
-        g.lock("session").await;
-
-        assert_eq!(
-            *seen.lock().unwrap(),
-            vec!["press Enter key to proceed with ser ".to_owned()]
-        );
-        assert!(g.get_mut("par").unwrap().is_locked().await.unwrap());
-        assert!(g.get_mut("ser").unwrap().is_locked().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn close_honours_serial_barrier() {
-        let _serial = super::super::spinner::TEST_SERIAL.lock().await;
-        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let mut g = serial_barrier_group(Arc::clone(&seen));
-
-        let outcomes = g.close(None).await;
-        assert!(outcomes.values().all(std::result::Result::is_ok));
-
-        assert_eq!(
-            *seen.lock().unwrap(),
-            vec!["press Enter key to proceed with ser ".to_owned()]
-        );
     }
 }

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -70,7 +70,7 @@ pub use spinner::{Sink, SpinnerGuard, Suspend, TtySpinner, set_test_sink, spinne
 use std::path::{Path, PathBuf};
 
 use mtui_config::Config;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::hostlog::{CommandLog, HostLog};
 use mtui_types::package::Package;
 use mtui_types::system::{System, SystemProduct};
@@ -102,9 +102,6 @@ pub struct Target {
     port: String,
     /// Per-host execution state.
     state: TargetState,
-    /// Whether this host runs in parallel with its group or under a serial
-    /// barrier (consumed by the P2.5 fan-out).
-    mode: ExecutionMode,
     /// Connect/command timeout, defaulted from
     /// [`Config::connection_timeout`](mtui_config::Config).
     timeout: CommandTimeout,
@@ -210,12 +207,7 @@ impl Target {
     /// and host-key policy are taken from `config`. Call
     /// [`connect`](Target::connect) to establish the transport.
     #[must_use]
-    pub fn new(
-        config: &Config,
-        hostname: impl Into<String>,
-        state: TargetState,
-        mode: ExecutionMode,
-    ) -> Self {
+    pub fn new(config: &Config, hostname: impl Into<String>, state: TargetState) -> Self {
         let hostname = hostname.into();
         let (host, port) = split_host_port(&hostname);
         Self {
@@ -223,7 +215,6 @@ impl Target {
             host,
             port,
             state,
-            mode,
             timeout: CommandTimeout::from_secs(config.connection_timeout),
             policy: HostKeyPolicy::from_config(&config.ssh_strict_host_key_checking),
             out: HostLog::new(),
@@ -252,7 +243,6 @@ impl Target {
     pub fn with_connection(
         hostname: impl Into<String>,
         state: TargetState,
-        mode: ExecutionMode,
         connection: Box<dyn Connection>,
     ) -> Self {
         let hostname = hostname.into();
@@ -277,7 +267,6 @@ impl Target {
             host,
             port,
             state,
-            mode,
             timeout: CommandTimeout::default(),
             policy: HostKeyPolicy::default(),
             out: HostLog::new(),
@@ -311,22 +300,6 @@ impl Target {
     /// Sets the per-host execution state (the REPL `hoststate` command).
     pub fn set_state(&mut self, state: TargetState) {
         self.state = state;
-    }
-
-    /// The execution mode (parallel vs serial barrier) for group fan-out.
-    #[must_use]
-    pub const fn mode(&self) -> ExecutionMode {
-        self.mode
-    }
-
-    /// Sets the per-host execution mode (the REPL `set_host_state`
-    /// `serial`/`parallel` variants).
-    ///
-    /// The mode counterpart to [`set_state`](Self::set_state): upstream
-    /// `HostState` sets `target.mode` for the `serial`/`parallel` choices and
-    /// `target.state` for the enabled/disabled choices.
-    pub fn set_mode(&mut self, mode: ExecutionMode) {
-        self.mode = mode;
     }
 
     /// Read-only access to the command log.
@@ -1305,7 +1278,6 @@ mod tests {
         Target::with_connection(
             "test-host.example.com",
             TargetState::Enabled,
-            ExecutionMode::Parallel,
             Box::new(conn),
         )
     }
@@ -1314,29 +1286,18 @@ mod tests {
 
     #[test]
     fn new_uses_upstream_defaults() {
-        let t = Target::new(
-            &cfg(),
-            "test-host.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let t = Target::new(&cfg(), "test-host.example.com", TargetState::Enabled);
         assert_eq!(t.hostname(), "test-host.example.com");
         assert_eq!(t.host, "test-host.example.com");
         assert_eq!(t.port, "");
         assert_eq!(t.state(), TargetState::Enabled);
-        assert_eq!(t.mode(), ExecutionMode::Parallel);
         assert!(t.connection.is_none());
         assert!(t.out().is_empty());
     }
 
     #[test]
     fn new_splits_host_and_port() {
-        let t = Target::new(
-            &cfg(),
-            "test-host.example.com:2222",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let t = Target::new(&cfg(), "test-host.example.com:2222", TargetState::Enabled);
         assert_eq!(t.host, "test-host.example.com");
         assert_eq!(t.port, "2222");
         assert_eq!(t.hostname(), "test-host.example.com:2222");
@@ -1346,23 +1307,13 @@ mod tests {
     fn timeout_defaults_from_config() {
         let mut c = cfg();
         c.connection_timeout = 600;
-        let t = Target::new(
-            &c,
-            "h.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let t = Target::new(&c, "h.example.com", TargetState::Enabled);
         assert_eq!(t.timeout, CommandTimeout::from_secs(600));
     }
 
     #[test]
     fn set_timeout_updates_reported_seconds() {
-        let mut t = Target::new(
-            &cfg(),
-            "h.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let mut t = Target::new(&cfg(), "h.example.com", TargetState::Enabled);
         t.set_timeout(120);
         assert_eq!(t.timeout_secs(), 120);
         // `0` disables the timeout (upstream semantics): zero duration.
@@ -1372,28 +1323,9 @@ mod tests {
 
     #[test]
     fn set_state_switches_gate() {
-        let mut t = Target::new(
-            &cfg(),
-            "h.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let mut t = Target::new(&cfg(), "h.example.com", TargetState::Enabled);
         t.set_state(TargetState::Disabled);
         assert_eq!(t.state(), TargetState::Disabled);
-    }
-
-    #[test]
-    fn set_mode_switches_execution_mode() {
-        let mut t = Target::new(
-            &cfg(),
-            "h.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
-        t.set_mode(ExecutionMode::Serial);
-        assert_eq!(t.mode(), ExecutionMode::Serial);
-        t.set_mode(ExecutionMode::Parallel);
-        assert_eq!(t.mode(), ExecutionMode::Parallel);
     }
 
     #[tokio::test]
@@ -1416,12 +1348,7 @@ mod tests {
 
     #[tokio::test]
     async fn reload_system_on_unconnected_is_noop() {
-        let mut t = Target::new(
-            &cfg(),
-            "h.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-        );
+        let mut t = Target::new(&cfg(), "h.example.com", TargetState::Enabled);
         t.reload_system().await;
         // No connection -> system untouched (still the unknown placeholder).
         assert_eq!(t.system().get_base().name, "unknown");
@@ -1448,12 +1375,7 @@ mod tests {
     async fn run_disabled_does_not_execute() {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Disabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Disabled, Box::new(conn));
 
         t.run("some command").await;
 
@@ -1479,7 +1401,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_on_unconnected_target_records_minus_one() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
 
         t.run("echo hi").await;
 
@@ -1490,7 +1412,7 @@ mod tests {
 
     #[test]
     fn last_methods_empty_log() {
-        let t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let t = Target::new(&cfg(), "h1", TargetState::Enabled);
         assert_eq!(t.lastin(), "");
         assert_eq!(t.lastout(), "");
         assert_eq!(t.lasterr(), "");
@@ -1571,7 +1493,7 @@ mod tests {
 
     #[tokio::test]
     async fn sftp_put_unconnected_records_failure() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
 
         t.sftp_put(Path::new("/local"), Path::new("/remote")).await;
 
@@ -1584,12 +1506,7 @@ mod tests {
     #[tokio::test]
     async fn sftp_put_disabled_leaves_upload_unattempted() {
         let conn = MockConnection::new("h1");
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Disabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Disabled, Box::new(conn));
 
         t.sftp_put(Path::new("/local"), Path::new("/remote")).await;
 
@@ -1669,7 +1586,7 @@ mod tests {
 
     #[tokio::test]
     async fn sftp_get_unconnected_records_failure() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
 
         t.sftp_get("/remote/file", Path::new("/local/file")).await;
 
@@ -1682,12 +1599,7 @@ mod tests {
     #[tokio::test]
     async fn sftp_get_disabled_leaves_download_unattempted() {
         let conn = MockConnection::new("h1");
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Disabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Disabled, Box::new(conn));
 
         t.sftp_get("/remote/file", Path::new("/local")).await;
 
@@ -1886,7 +1798,7 @@ mod tests {
     #[tokio::test]
     async fn check_stale_lock_is_noop_when_unconnected() {
         // No connection ⇒ no lock object built ⇒ the check returns early.
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         t.check_stale_lock().await;
     }
 
@@ -1918,7 +1830,7 @@ mod tests {
 
     #[tokio::test]
     async fn boot_id_empty_when_unconnected() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         assert_eq!(t.boot_id().await, "");
     }
 
@@ -1933,7 +1845,7 @@ mod tests {
 
     #[tokio::test]
     async fn reboot_on_unconnected_is_noop() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         // Must not panic; nothing to assert beyond the no-op completing.
         t.reboot("systemctl reboot").await;
     }
@@ -1971,7 +1883,7 @@ mod tests {
 
     #[tokio::test]
     async fn close_on_unconnected_is_noop() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         // Must not panic; no live connection to close, no action dispatched.
         t.close(Some("reboot")).await.expect("close ok");
     }
@@ -1990,7 +1902,7 @@ mod tests {
     async fn reboot_retries_reads_from_config() {
         let mut cfg = Config::default();
         cfg.reboot_retries = 3;
-        let t = Target::new(&cfg, "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let t = Target::new(&cfg, "h1", TargetState::Enabled);
         assert_eq!(t.reboot_retries(), 3);
     }
 
@@ -2003,7 +1915,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconnect_unconnected_is_ok_noop() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         t.reconnect(0, false).await.expect("noop reconnect ok");
     }
 
@@ -2026,7 +1938,7 @@ mod tests {
 
     #[tokio::test]
     async fn is_locked_false_when_unconnected() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         assert!(!t.is_locked().await.expect("is_locked ok"));
     }
 
@@ -2041,7 +1953,7 @@ mod tests {
 
     #[tokio::test]
     async fn lock_unconnected_is_ok_noop() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         t.lock("comment").await.expect("noop lock ok");
     }
 
@@ -2087,7 +1999,7 @@ mod tests {
 
     #[tokio::test]
     async fn lock_status_unconnected_is_unlocked() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         assert!(!t.lock_status(false).await.is_locked);
         assert!(!t.lock_status(true).await.is_locked);
     }
@@ -2151,12 +2063,7 @@ mod tests {
             .with_shell_output(b"welcome\n".to_vec())
             .with_shell_output(b"$ ".to_vec());
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
 
         let mut ch = t.shell(120, 40).await.expect("enabled spawns a shell");
 
@@ -2185,12 +2092,7 @@ mod tests {
     async fn shell_disabled_does_not_spawn() {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Disabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Disabled, Box::new(conn));
 
         assert!(t.shell(80, 24).await.is_none(), "disabled must not spawn");
         assert!(handle.shell_spawns().is_empty());
@@ -2199,7 +2101,7 @@ mod tests {
     #[cfg(feature = "shell")]
     #[tokio::test]
     async fn shell_on_unconnected_target_returns_none() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         assert!(
             t.shell(80, 24).await.is_none(),
             "no connection -> no shell, logged not panicked"
@@ -2246,7 +2148,7 @@ mod tests {
 
     #[tokio::test]
     async fn pool_unlock_noop_when_not_connected() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         // No pool lock built yet (unconnected): must not panic or fail.
         t.pool_unlock(false).await;
     }
@@ -2278,14 +2180,14 @@ mod tests {
 
     #[test]
     fn set_rrid_records_ownership_identity() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         t.set_rrid("SUSE:Maintenance:1:2");
         assert_eq!(t.rrid, "SUSE:Maintenance:1:2");
     }
 
     #[tokio::test]
     async fn pool_claim_noop_false_when_not_connected() {
-        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled, ExecutionMode::Parallel);
+        let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
         // No pool lock built yet (unconnected): claim returns false, no panic.
         assert!(!t.pool_claim("mtui pool RRID [RRID]").await.unwrap());
     }
@@ -2417,12 +2319,7 @@ mod tests {
     async fn add_history_skips_disabled_hosts() {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Disabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Disabled, Box::new(conn));
 
         t.add_history(&["downgrade".to_owned(), "x".to_owned()])
             .await;

--- a/crates/mtui-hosts/src/target/package_querier.rs
+++ b/crates/mtui-hosts/src/target/package_querier.rs
@@ -91,7 +91,7 @@ impl<'a> PackageQuerier<'a> {
 
 #[cfg(test)]
 mod tests {
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
 
     use super::*;
@@ -108,12 +108,7 @@ mod tests {
     /// target).
     fn target_and_mock(stdout: &str) -> (Target, MockConnection) {
         let mock = MockConnection::new("h1").with_default(CommandLog::new("", stdout, "", 0, 0));
-        let target = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(mock.clone()),
-        );
+        let target = Target::with_connection("h1", TargetState::Enabled, Box::new(mock.clone()));
         (target, mock)
     }
 

--- a/crates/mtui-hosts/src/target/repo_manager.rs
+++ b/crates/mtui-hosts/src/target/repo_manager.rs
@@ -335,7 +335,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::{Arc, Mutex};
 
-    use mtui_types::enums::{ExecutionMode, RequestKind, TargetState};
+    use mtui_types::enums::{RequestKind, TargetState};
     use mtui_types::rrid::RequestReviewID;
     use mtui_types::system::{System, SystemProduct};
 
@@ -366,12 +366,8 @@ mod tests {
     fn target_with(system: System, transactional: bool) -> (Target, MockConnection) {
         let conn = MockConnection::new("host1.example.com");
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "host1.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t =
+            Target::with_connection("host1.example.com", TargetState::Enabled, Box::new(conn));
         t.set_system(system, transactional);
         (t, handle)
     }
@@ -550,12 +546,8 @@ mod tests {
             b"1700000000:someone-else:99999:held".to_vec(),
         );
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "host1.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t =
+            Target::with_connection("host1.example.com", TargetState::Enabled, Box::new(conn));
         t.set_system(system_of(sles.clone(), &[]), false);
         let mut repos = BTreeMap::new();
         repos.insert(sles, "https://example/repo".to_owned());
@@ -629,12 +621,8 @@ mod tests {
             CommandLog::new(ar_cmd, "", "Repository already exists.", 4, 0),
         );
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "host1.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t =
+            Target::with_connection("host1.example.com", TargetState::Enabled, Box::new(conn));
         t.set_system(system_of(sles.clone(), &[]), false);
         let mut repos = BTreeMap::new();
         repos.insert(sles, "https://example/repo".to_owned());
@@ -677,12 +665,8 @@ mod tests {
             ar_cmd,
             CommandLog::new(ar_cmd, "", "Repository already exists.", 4, 0),
         );
-        let mut t = Target::with_connection(
-            "host1.example.com",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t =
+            Target::with_connection("host1.example.com", TargetState::Enabled, Box::new(conn));
         t.set_system(system_of(sles.clone(), &[]), false);
         let mut repos = BTreeMap::new();
         repos.insert(sles, "https://example/repo".to_owned());

--- a/crates/mtui-hosts/tests/fanout_spinner_production_runtime.rs
+++ b/crates/mtui-hosts/tests/fanout_spinner_production_runtime.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use mtui_hosts::{HostsGroup, MockConnection, Sink, Target, set_test_sink};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use serial_test::serial;
 
 fn shared_sink() -> (Sink, Arc<Mutex<Vec<u8>>>) {
@@ -48,12 +48,7 @@ fn production_runtime_block_on_paints_spinner_during_slow_command() {
 
     runtime.block_on(async {
         let conn = MockConnection::new("h1").with_run_delay(Duration::from_millis(800));
-        let target = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         let mut group = HostsGroup::new(vec![target], true);
         group.run("zypper up").await;
     });

--- a/crates/mtui-hosts/tests/fanout_spinner_visible.rs
+++ b/crates/mtui-hosts/tests/fanout_spinner_visible.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use mtui_hosts::{HostsGroup, MockConnection, Sink, Target, set_test_sink};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use serial_test::serial;
 
 /// A shared in-memory sink so the test can read the painted frames.
@@ -52,12 +52,7 @@ async fn interactive_fanout_run_paints_a_spinner() {
     // A connected, enabled, PARALLEL host whose command takes ~500ms — the model
     // of a real `zypper` update where the fan-out awaits long enough to paint.
     let conn = MockConnection::new("h1").with_run_delay(Duration::from_millis(500));
-    let target = Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let target = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
 
     // interactive = true — exactly what the REPL builds; this is the flag that
     // gates whether `run_parallel` receives a `desc` and starts the spinner.

--- a/crates/mtui-hosts/tests/history_append.rs
+++ b/crates/mtui-hosts/tests/history_append.rs
@@ -14,17 +14,12 @@
 
 use mtui_hosts::connection::Connection;
 use mtui_hosts::{HostsGroup, MockConnection, MockSftpOp, Target};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 
 const LOG: &str = "/var/log/mtui.log";
 
 fn enabled(conn: MockConnection) -> Target {
-    Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    )
+    Target::with_connection("h1", TargetState::Enabled, Box::new(conn))
 }
 
 /// Recording N entries issues exactly N appends and never a read/overwrite —
@@ -142,12 +137,7 @@ async fn hostsgroup_add_history_appends_once_per_host() {
     let c2 = MockConnection::new("h2");
     let (m1, m2) = (c1.clone(), c2.clone());
     let t1 = enabled(c1);
-    let t2 = Target::with_connection(
-        "h2",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(c2),
-    );
+    let t2 = Target::with_connection("h2", TargetState::Enabled, Box::new(c2));
     let mut group = HostsGroup::new(vec![t1, t2], false);
 
     group

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -16,7 +16,7 @@ use mtui_hosts::{
     Check, CheckArgs, Doer, HostError, HostsGroup, InstallOperation, Operation, OperationGroup,
     PlanProvider, Target, UninstallOperation,
 };
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
 use mtui_types::system::{System, SystemProduct};
 
@@ -80,12 +80,7 @@ fn target(
     let conn = mtui_hosts::MockConnection::new(hostname)
         .with_default(CommandLog::new("", "done", "", 0, 1));
     let handle = conn.clone();
-    let mut t = Target::with_connection(
-        hostname,
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
     let system = System::new(
         SystemProduct::new(base_name, version, "x86_64"),
         BTreeSet::new(),

--- a/crates/mtui-hosts/tests/sftp_traversal.rs
+++ b/crates/mtui-hosts/tests/sftp_traversal.rs
@@ -11,7 +11,7 @@
 //! nested separator.
 
 use mtui_hosts::{MockConnection, Target};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 
 const HOST: &str = "refhost1";
 const REMOTE_DIR: &str = "/var/log/updates";
@@ -33,12 +33,7 @@ async fn run_folder_download(entries: &[&str]) -> MockConnection {
     }
     let handle = conn.clone();
 
-    let mut target = Target::with_connection(
-        HOST,
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut target = Target::with_connection(HOST, TargetState::Enabled, Box::new(conn));
     // Trailing `/` selects the folder branch; `Target::sftp_get` appends `/` to
     // `local` before calling `sftp_get_folder`.
     target

--- a/crates/mtui-hosts/tests/ssh_integration.rs
+++ b/crates/mtui-hosts/tests/ssh_integration.rs
@@ -29,7 +29,7 @@ use mtui_hosts::{
     CommandTimeout, Connection, HostKeyPolicy, HostsGroup, MAX_STREAM_BYTES, SshConnection,
     TARGET_LOCK_PATH, Target, TargetLock,
 };
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 
 /// Bytes the `flood-stdout` scripted command emits: comfortably past the
 /// per-stream capture cap so `run` must truncate.
@@ -533,15 +533,15 @@ async fn connect(port: u16, timeout: CommandTimeout) -> SshConnection {
 }
 
 /// Builds a [`Target`] whose live connection is a real [`SshConnection`] to the
-/// in-process fixture on `port`, labelled `name` and gated by `state`/`mode`.
+/// in-process fixture on `port`, labelled `name` and gated by `state`.
 ///
 /// This is the multi-target seam the P2.5 fan-out / P2.6 lock integration tests
 /// need: several `Target`s can point at one shared server (one `SharedFs`), so
 /// `HostsGroup::run` and the remote-lock protocol are exercised over real SSH
 /// rather than a `MockConnection`.
-async fn connect_target(name: &str, port: u16, state: TargetState, mode: ExecutionMode) -> Target {
+async fn connect_target(name: &str, port: u16, state: TargetState) -> Target {
     let conn = connect(port, CommandTimeout::from_secs(5)).await;
-    Target::with_connection(name, state, mode, Box::new(conn))
+    Target::with_connection(name, state, Box::new(conn))
 }
 
 // ----------------------------------------------------------------------------
@@ -1027,10 +1027,9 @@ async fn shell_spawns_pty_and_bridges_bytes() {
 //
 // The colocated `hostgroup.rs` unit tests drive fan-out over `MockConnection`.
 // These prove the same fan-out end-to-end over the in-process russh server:
-// `run` reaches every enabled member across ≥2 real SSH sessions, in both
-// parallel and serial modes, and per-host `TargetState` gating is honoured
-// against a live transport — the epic's "run across ≥2 hosts against a local
-// sshd fixture" line.
+// `run` reaches every enabled member across ≥2 real SSH sessions, and per-host
+// `TargetState` gating is honoured against a live transport — the epic's "run
+// across ≥2 hosts against a local sshd fixture" line.
 // ----------------------------------------------------------------------------
 
 /// The scripted stdout the fixture returns for an otherwise-unknown command
@@ -1042,11 +1041,11 @@ fn ran(cmd: &str) -> String {
 
 #[tokio::test]
 async fn hostsgroup_run_parallel_reaches_every_member() {
-    // Two enabled targets in Parallel mode share one fixture server.
+    // Two enabled targets share one fixture server.
     let port = start_server(SharedFs::default()).await;
     let targets = vec![
-        connect_target("h1", port, TargetState::Enabled, ExecutionMode::Parallel).await,
-        connect_target("h2", port, TargetState::Enabled, ExecutionMode::Parallel).await,
+        connect_target("h1", port, TargetState::Enabled).await,
+        connect_target("h2", port, TargetState::Enabled).await,
     ];
     let mut group = HostsGroup::new(targets, false);
 
@@ -1061,33 +1060,13 @@ async fn hostsgroup_run_parallel_reaches_every_member() {
 }
 
 #[tokio::test]
-async fn hostsgroup_run_serial_reaches_every_member() {
-    // Same as above but Serial mode: the fan-out runs hosts one at a time; the
-    // observable outcome (every host ran, results recorded) is identical.
-    let port = start_server(SharedFs::default()).await;
-    let targets = vec![
-        connect_target("s1", port, TargetState::Enabled, ExecutionMode::Serial).await,
-        connect_target("s2", port, TargetState::Enabled, ExecutionMode::Serial).await,
-    ];
-    let mut group = HostsGroup::new(targets, false);
-
-    group.run("serial-probe").await;
-
-    for name in ["s1", "s2"] {
-        let t = group.get(name).expect("member present");
-        assert_eq!(t.lastout(), ran("serial-probe"), "{name} ran the command");
-        assert_eq!(t.lastexit(), Some(0), "{name} recorded exit 0");
-    }
-}
-
-#[tokio::test]
 async fn hostsgroup_run_honours_per_host_state_end_to_end() {
     // A mixed-state group over real SSH: enabled runs for real, disabled
     // records nothing.
     let port = start_server(SharedFs::default()).await;
     let targets = vec![
-        connect_target("on", port, TargetState::Enabled, ExecutionMode::Parallel).await,
-        connect_target("off", port, TargetState::Disabled, ExecutionMode::Parallel).await,
+        connect_target("on", port, TargetState::Enabled).await,
+        connect_target("off", port, TargetState::Disabled).await,
     ];
     let mut group = HostsGroup::new(targets, false);
 

--- a/crates/mtui-mcp/src/provider.rs
+++ b/crates/mtui-mcp/src/provider.rs
@@ -646,15 +646,10 @@ mod tests {
         use mtui_hosts::{HostsGroup, MockConnection, Target};
         use mtui_testreport::{ObsReport, TestReport};
         use mtui_types::RequestReviewID;
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
 
         let conn = MockConnection::new("slow-host").with_blocking_close(gate);
-        let target = Target::with_connection(
-            "slow-host",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("slow-host", TargetState::Enabled, Box::new(conn));
         let sess = McpSession::new(Config::default());
         {
             let mut guard = sess.session().lock().await;
@@ -673,15 +668,10 @@ mod tests {
         use mtui_hosts::{HostsGroup, MockConnection, Target};
         use mtui_testreport::{ObsReport, TestReport};
         use mtui_types::RequestReviewID;
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
 
         let conn = MockConnection::new("slow-host").with_close_delay(delay);
-        let target = Target::with_connection(
-            "slow-host",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("slow-host", TargetState::Enabled, Box::new(conn));
         let sess = McpSession::new(Config::default());
         {
             let mut guard = sess.session().lock().await;
@@ -773,17 +763,12 @@ mod tests {
         use mtui_hosts::{HostsGroup, MockConnection, Target};
         use mtui_testreport::{ObsReport, TestReport};
         use mtui_types::RequestReviewID;
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
 
         let reg = reg_with_idle(Duration::from_secs(3600));
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
-        let target = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         let session = reg.make_session();
         {
             let mut guard = session.session().lock().await;

--- a/crates/mtui-mcp/src/runner.rs
+++ b/crates/mtui-mcp/src/runner.rs
@@ -318,16 +318,11 @@ mod tests {
         use mtui_hosts::{HostsGroup, MockConnection, Target};
         use mtui_testreport::{ObsReport, TestReport};
         use mtui_types::RequestReviewID;
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
 
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
-        let target = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let target = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         let session = McpSession::new(Config::default());
         {
             let mut guard = session.session().lock().await;

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -1253,23 +1253,15 @@ mod tests {
         use mtui_hosts::{HostsGroup, MockConnection, Target};
         use mtui_testreport::{ObsReport, TestReport};
         use mtui_types::RequestReviewID;
-        use mtui_types::enums::{ExecutionMode, TargetState};
+        use mtui_types::enums::TargetState;
 
         let gate = Arc::new(tokio::sync::Notify::new());
         let wedged = MockConnection::new("wedged-host").with_blocking_close(Arc::clone(&gate));
         let good = MockConnection::new("good-host");
-        let wedged_target = Target::with_connection(
-            "wedged-host",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(wedged),
-        );
-        let good_target = Target::with_connection(
-            "good-host",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(good.clone()),
-        );
+        let wedged_target =
+            Target::with_connection("wedged-host", TargetState::Enabled, Box::new(wedged));
+        let good_target =
+            Target::with_connection("good-host", TargetState::Enabled, Box::new(good.clone()));
 
         let sess = McpSession::new(Config::default());
         {

--- a/crates/mtui-mcp/tests/session_close.rs
+++ b/crates/mtui-mcp/tests/session_close.rs
@@ -28,7 +28,7 @@ use mtui_hosts::{HostsGroup, MockConnection, Target};
 use mtui_mcp::McpSession;
 use mtui_testreport::{ObsReport, TestReport};
 use mtui_types::RequestReviewID;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 
 const RRID_A: &str = "SUSE:Maintenance:1:1";
 const RRID_B: &str = "SUSE:Maintenance:2:1";
@@ -49,12 +49,7 @@ fn session() -> Arc<McpSession> {
 /// observe `is_closed()` after the target is moved into a host group.
 fn host_with_mock(name: &str) -> (Target, MockConnection) {
     let mock = MockConnection::new(name);
-    let target = Target::with_connection(
-        name,
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(mock.clone()),
-    );
+    let target = Target::with_connection(name, TargetState::Enabled, Box::new(mock.clone()));
     (target, mock)
 }
 

--- a/crates/mtui-mcp/tests/session_registry.rs
+++ b/crates/mtui-mcp/tests/session_registry.rs
@@ -30,7 +30,7 @@ use mtui_hosts::{HostsGroup, MockConnection, Target};
 use mtui_mcp::{McpSession, SessionRegistry};
 use mtui_testreport::{ObsReport, TestReport};
 use mtui_types::RequestReviewID;
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use tokio_util::sync::CancellationToken;
 
 const RRID_A: &str = "SUSE:Maintenance:1:1";
@@ -51,12 +51,8 @@ fn registry(cap: usize, idle_secs: u64) -> SessionRegistry {
 /// a shared handle to the mock so the test can observe `is_closed()` after a sweep.
 async fn seed_host(session: &Arc<McpSession>) -> MockConnection {
     let mock = MockConnection::new("swept-host");
-    let target = Target::with_connection(
-        "swept-host",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(mock.clone()),
-    );
+    let target =
+        Target::with_connection("swept-host", TargetState::Enabled, Box::new(mock.clone()));
     let mut guard = session.session().lock().await;
     let mut report = ObsReport::new(guard.config.clone());
     report.base_mut().rrid = Some(RequestReviewID::parse(RRID_A).unwrap());

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/mtui-mcp/tests/slim_profile.rs
+assertion_line: 40
 expression: pretty
 ---
 [
@@ -1298,10 +1299,8 @@ expression: pretty
           "type": "array"
         },
         "state": {
-          "description": "enabled | disabled | parallel | serial",
+          "description": "enabled | disabled",
           "enum": [
-            "parallel",
-            "serial",
             "disabled",
             "enabled"
           ],

--- a/crates/mtui-testreport/src/lifecycle.rs
+++ b/crates/mtui-testreport/src/lifecycle.rs
@@ -305,7 +305,7 @@ pub async fn make_testreport(
     // time (the group was default-built headless). The session is the single
     // source of truth for REPL-vs-headless; this is the only place it is set, and
     // it is never toggled afterwards. Empty group here, so this only sets the flag
-    // that every later `add` / fan-out (spinner + serial-barrier prompt) reads.
+    // that every later `add` / fan-out (spinner prompt) reads.
     report.base_mut().targets.set_is_repl(is_repl);
     // Push the configured fan-out bound (`[connection] max_parallel`) onto the
     // group alongside the session mode, so every later fan-out is bounded.

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -731,8 +731,8 @@ async fn downgrade_body(
 /// completed rollback. Iterated in sorted hostname order (the group's own
 /// ordering) so the log is deterministic.
 async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<String>> {
-    // Query every host's versions concurrently (serial hosts one at a time)
-    // via the shared fan-out, then run the pure verdict scan below.
+    // Query every host's versions concurrently via the shared fan-out, then
+    // run the pure verdict scan below.
     targets.query_versions().await;
 
     let mut not_downgraded: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -990,7 +990,7 @@ mod tests {
 
     use mtui_config::options::Config;
     use mtui_hosts::{HostsGroup, MockConnection, Target};
-    use mtui_types::enums::{ExecutionMode, TargetState};
+    use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
     use mtui_types::system::{System, SystemProduct};
 
@@ -1013,12 +1013,7 @@ mod tests {
         let conn =
             MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", 0, 0));
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            hostname,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("SLES", "15.5", "x86_64"),
@@ -1136,12 +1131,7 @@ mod tests {
     /// its missing-doer early-return.
     fn missing_doer_target(hostname: &str) -> Target {
         let conn = MockConnection::new(hostname).with_default(CommandLog::new("", "", "", 0, 0));
-        let mut t = Target::with_connection(
-            hostname,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("sle-studioonsite", "11", "x86_64"),
@@ -1300,12 +1290,7 @@ mod tests {
         // flow added is removed on the abort path.
         let conn = MockConnection::new("h1").with_default(CommandLog::new("", "", "", 0, 0));
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("gentoo", "1", "x86_64"),
@@ -1514,12 +1499,7 @@ mod tests {
         let conn =
             MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", exit, 0));
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            hostname,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("SL-Micro", "6.0", "x86_64"),
@@ -1664,12 +1644,7 @@ mod tests {
                 CommandLog::new("zypper", "pkg-a = 1.0-1\n", "", 0, 0),
             );
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            "h1",
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("SLES", "15.5", "x86_64"),
@@ -1786,12 +1761,7 @@ mod tests {
         let conn = MockConnection::new(hostname)
             .with_default(CommandLog::new("zypper", stdout, "", exit, 0));
         let handle = conn.clone();
-        let mut t = Target::with_connection(
-            hostname,
-            TargetState::Enabled,
-            ExecutionMode::Parallel,
-            Box::new(conn),
-        );
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
             System::new(
                 SystemProduct::new("SLES", "15.5", "x86_64"),

--- a/crates/mtui-testreport/tests/lifecycle.rs
+++ b/crates/mtui-testreport/tests/lifecycle.rs
@@ -362,8 +362,8 @@ async fn make_testreport_auto_respects_explicit_no_autoconnect() {
 /// Regression (spinner invisible during `update`): `make_testreport` reconciles
 /// the loaded report's targets group to the session mode at **load time**, so a
 /// REPL load (`is_repl = true`) yields an interactive group — the fan-out
-/// spinner / serial-barrier prompt seam — while a headless load stays quiet.
-/// The report group is default-built headless; this is the single set-once site.
+/// spinner seam — while a headless load stays quiet. The report group is
+/// default-built headless; this is the single set-once site.
 #[tokio::test]
 async fn make_testreport_sets_targets_is_repl_from_session_mode() {
     let update = UpdateID::parse(RRID).unwrap();

--- a/crates/mtui-testreport/tests/obs_report.rs
+++ b/crates/mtui-testreport/tests/obs_report.rs
@@ -99,19 +99,14 @@ fn list_update_commands_is_a_noop_stub() {
 use std::collections::BTreeSet;
 
 use mtui_hosts::{MockConnection, RepoOp, SetRepo, Target};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::system::System;
 
 /// An enabled single target whose product matches the seeded repo.
 fn sles_target() -> (Target, MockConnection) {
     let conn = MockConnection::new("h1");
     let handle = conn.clone();
-    let mut t = Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
     t.set_system(
         System::new(
             SystemProduct::new("SLES", "15.5", "x86_64"),

--- a/crates/mtui-testreport/tests/pi_report.rs
+++ b/crates/mtui-testreport/tests/pi_report.rs
@@ -96,19 +96,14 @@ fn list_update_commands_is_a_noop_stub() {
 use std::collections::BTreeSet;
 
 use mtui_hosts::{MockConnection, RepoOp, SetRepo, Target};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::system::{System, SystemProduct};
 
 /// An enabled single target whose product matches the seeded repo.
 fn sles_target() -> (Target, MockConnection) {
     let conn = MockConnection::new("h1");
     let handle = conn.clone();
-    let mut t = Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
     t.set_system(
         System::new(
             SystemProduct::new("SLES", "15.5", "x86_64"),

--- a/crates/mtui-testreport/tests/sl_report.rs
+++ b/crates/mtui-testreport/tests/sl_report.rs
@@ -170,7 +170,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use mtui_hosts::{Check, CheckArgs, Doer, HostError, MockConnection, PlanProvider, Target};
-use mtui_types::enums::{ExecutionMode, TargetState};
+use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
 use mtui_types::system::{System, SystemProduct};
 
@@ -193,12 +193,7 @@ impl PlanProvider for FixedProvider {
 fn sles_group() -> (HostsGroup, MockConnection) {
     let conn = MockConnection::new("h1").with_default(CommandLog::new("", "done", "", 0, 1));
     let handle = conn.clone();
-    let mut t = Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
     t.set_system(
         System::new(
             SystemProduct::new("SLES", "15.5", "x86_64"),
@@ -247,12 +242,7 @@ use mtui_hosts::{RepoOp, SetRepo};
 fn sles_target() -> (Target, MockConnection) {
     let conn = MockConnection::new("h1");
     let handle = conn.clone();
-    let mut t = Target::with_connection(
-        "h1",
-        TargetState::Enabled,
-        ExecutionMode::Parallel,
-        Box::new(conn),
-    );
+    let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
     t.set_system(
         System::new(
             SystemProduct::new("SLES", "15.5", "x86_64"),

--- a/crates/mtui-types/src/enums.rs
+++ b/crates/mtui-types/src/enums.rs
@@ -63,52 +63,6 @@ impl FromStr for TargetState {
     }
 }
 
-/// Whether a host runs commands in parallel with its group or under a serial
-/// barrier.
-///
-/// Mirrors upstream `ExecutionMode` (a plain `Enum`). Wire values are
-/// `parallel` / `serial`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ExecutionMode {
-    /// The host runs concurrently with the rest of its group.
-    Parallel,
-    /// The host holds the group in a serial barrier.
-    Serial,
-}
-
-impl ExecutionMode {
-    /// Returns the upstream wire string for this mode.
-    #[must_use]
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Parallel => "parallel",
-            Self::Serial => "serial",
-        }
-    }
-}
-
-impl fmt::Display for ExecutionMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for ExecutionMode {
-    type Err = ParseEnumError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "parallel" => Ok(Self::Parallel),
-            "serial" => Ok(Self::Serial),
-            other => Err(ParseEnumError {
-                kind: "ExecutionMode",
-                got: other.to_owned(),
-            }),
-        }
-    }
-}
-
 /// Per-report update workflow mode.
 ///
 /// Mirrors upstream `Workflow` (a `StrEnum`). Wire values match the
@@ -276,27 +230,6 @@ mod tests {
         let err = "bogus".parse::<TargetState>().unwrap_err();
         assert_eq!(err.kind, "TargetState");
         assert_eq!(err.got, "bogus");
-    }
-
-    // --- ExecutionMode. ---
-
-    #[test]
-    fn execution_mode_string_values_and_parse() {
-        assert_eq!(ExecutionMode::Parallel.as_str(), "parallel");
-        assert_eq!(ExecutionMode::Serial.as_str(), "serial");
-        assert_eq!(
-            "parallel".parse::<ExecutionMode>().unwrap(),
-            ExecutionMode::Parallel
-        );
-        assert_eq!(
-            "serial".parse::<ExecutionMode>().unwrap(),
-            ExecutionMode::Serial
-        );
-    }
-
-    #[test]
-    fn execution_mode_rejects_unknown() {
-        assert!("nope".parse::<ExecutionMode>().is_err());
     }
 
     // --- Workflow. ---

--- a/crates/mtui-types/src/lib.rs
+++ b/crates/mtui-types/src/lib.rs
@@ -20,7 +20,7 @@ pub mod updateid;
 pub mod urls;
 pub mod version;
 
-pub use enums::{Assignment, ExecutionMode, RequestKind, TargetState, Workflow};
+pub use enums::{Assignment, RequestKind, TargetState, Workflow};
 pub use error::{
     Error, PackageSpecParseError, RefhostsParseError, RepoUrlParseError, RequestKindParseError,
     Result, RpmVersionParseError, RridParseError,

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -204,16 +204,16 @@ Options:
 
 ## `set_host_state`
 
-Sets the state and execution mode of a host.
+Sets the state of a host.
 
 ```text
 Usage: set_host_state [OPTIONS] <state>
 
 Arguments:
   <state>
-          enabled | disabled | parallel | serial
+          enabled | disabled
           
-          [possible values: parallel, serial, disabled, enabled]
+          [possible values: disabled, enabled]
 
 Options:
   -t, --target <HOST>
@@ -477,7 +477,7 @@ Options:
 
 ## `list_hosts`
 
-Lists all connected hosts with their system, state, and execution mode.
+Lists all connected hosts with their system and state.
 
 ```text
 Usage: list_hosts

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -81,15 +81,16 @@ addons, or a dangling `baseproduct` symlink — is logged as a **WARNING** and t
 host is **kept** (the check never aborts a connect). The `qa` product is ignored,
 and hosts not listed in `refhosts.yml` are skipped silently.
 
-## Host state and execution mode
+## Host state
 
-Each connected host has a state and an execution mode, set with
+Each connected host has a state, set with
 [`set_host_state`](cli.md#set_host_state):
 
 - **`enabled`** — runs all issued commands (the default).
 - **`disabled`** — runs nothing and prints nothing.
-- **`parallel`** (default) / **`serial`** — whether commands designed to run in
-  parallel (like [`run`](cli.md#run)) fan out concurrently or one host at a time.
+
+Commands designed to run in parallel (like [`run`](cli.md#run)) always fan out
+concurrently across enabled hosts.
 
 ## Locking
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -114,8 +114,7 @@ run zypper lr            # runs only on the still-enabled hosts
 set_host_state enabled   # re-enable all
 ```
 
-`disabled` hosts run nothing (and print nothing). You can also switch a host
-between `parallel` and `serial` execution the same way.
+`disabled` hosts run nothing (and print nothing).
 
 ## Can I export the update log from a specific refhost?
 


### PR DESCRIPTION
## Why

`ExecutionMode` (`Parallel`/`Serial`) was a second axis alongside `TargetState`, threaded as a positional constructor arg through every `Target`, a `set_host_state` choice, and a serial-barrier branch in the shared `run_fanout` primitive that prompted "press Enter key to proceed with `<host>`" one host at a time.

In practice no maintenance workflow relies on serial one-at-a-time execution — every host can safely run in the parallel batch — so the mode added a state to thread through ~200 call sites (mostly test/bench construction) for a feature nobody exercised. This mirrors the earlier `TargetState::Dryrun` removal: shrink the API to what is actually used.

## What changed

- `mtui-types` drops the `ExecutionMode` enum entirely (`as_str`/`Display`/`FromStr` impls and unit tests removed).
- `Target::{new, with_connection}` lose the `mode` positional arg; `mode()`/`set_mode()` are removed.
- `mtui-hosts::actions::run_fanout` collapses to a single parallel batch — no serial `Vec`/partition, no barrier loop; `RunCommand` drops its `prompter` field (it existed only to back the barrier prompt). Serial-barrier tests/helpers removed from `actions.rs` and `hostgroup.rs`.
- `set_host_state`'s `STATES` shrinks to `enabled`/`disabled`; a `serial`/`parallel` value is now rejected by the clap parser instead of setting a mode.
- `display::list_host` / `list_hosts` drop the `(parallel)`/`(serial)` suffix and the mode field from the status tuple.
- ~200 `Target` constructor call sites across `mtui-hosts`, `mtui-core`, `mtui-cli`, `mtui-mcp`, and `mtui-testreport` lose the `ExecutionMode` arg.
- `docs/src/{concepts,faq}.md` updated; `cli.md` regenerated via `cargo xtask gen-docs`.
- MCP tool-schema snapshot updated for the narrowed `state` enum; `tool_surface` snapshot is unaffected (`set_host_state` still exists).
- `CHANGELOG.md` entry under `[Unreleased]` / `Removed` noting the intentional deviation from upstream mtui.

## Breaking change

`set_host_state` (and its MCP tool) no longer accepts `serial`/`parallel`; all hosts now run in the parallel batch and the serial-barrier prompt is gone. `list_hosts` output no longer prints a `(parallel)`/`(serial)` suffix.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` / `--all-features`
- `rustup run 1.97.1 cargo-hawk check --manifest-path Cargo.toml -D warnings` → 0 findings (matches pre-change baseline)