### PR TITLE
ci: harden checkouts, add beta early-warning leg, pin release toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # dtolnay/rust-toolchain is pinned to a master-branch commit SHA and the
+    # toolchain is selected via its `toolchain:` input; the action has no
+    # semver releases for Dependabot to bump to.
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
     groups:
       actions-minor-and-patch:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,12 @@ jobs:
       - name: Install llvm-tools
         run: rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        # SHA-pinned like every other action (Scorecard Pinned-Dependencies);
+        # the tool is selected via the input, not the mutable `@cargo-llvm-cov`
+        # tag alias.
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094  # v2.85.1
+        with:
+          tool: cargo-llvm-cov
       - name: Generate coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload coverage to CodeCov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI format
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install rustfmt
         run: rustup component add rustfmt
       - name: Check formatting
@@ -28,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI lint
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install clippy
         run: rustup component add clippy
       - name: Clippy (warnings as errors)
@@ -37,7 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI feature matrix (compile-only)
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build with no default features
         run: cargo build --workspace --no-default-features
       - name: Build with all features
@@ -46,7 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     name: MTUI tests
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       # The SSH integration suite authenticates the client from an identity file;
       # the in-process fixture accepts any key but the runner ships none. Generate
       # a throwaway ed25519 key so the pubkey path is exercised.
@@ -74,7 +82,9 @@ jobs:
     # binaries. No fmt leg — formatting is platform-independent and covered by
     # the ubuntu `fmt` job.
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install clippy
         run: rustup component add clippy
       # The SSH integration suite authenticates from an identity file; the
@@ -91,12 +101,36 @@ jobs:
         run: cargo test --workspace
       - name: Run mtui-mcp tests
         run: cargo test -p mtui-mcp -F mcp
-
+  beta:
+    # Early warning on the upcoming compiler: never blocks, but surfaces
+    # new-lint and regression noise before beta becomes stable. No fmt leg
+    # (beta rustfmt formatting may legitimately drift).
+    runs-on: ubuntu-latest
+    name: MTUI beta toolchain (early warning)
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install beta toolchain
+        run: rustup toolchain install beta --component clippy
+      - name: Clippy (beta)
+        run: cargo +beta clippy --workspace --all-targets -- -D warnings
+      # Same fixture as the test job: the SSH integration suite authenticates
+      # the client from an identity file and fails without one.
+      - name: SSH fixture
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+      - name: Test (beta)
+        run: cargo +beta test --workspace
   coverage:
     runs-on: ubuntu-latest
     name: MTUI coverage
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: SSH fixture
         run: |
           mkdir -p ~/.ssh && chmod 700 ~/.ssh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,16 @@ jobs:
           # the checkout does not need a credential left behind in .git/config.
           persist-credentials: false
 
+      - name: Install Rust toolchain
+        # Pin a commit from the action's master branch (commits of the
+        # toolchain branches are garbage-collected upstream) and select the
+        # toolchain via the input instead of the ref.
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: stable
+      # No cargo cache here: releases are built hermetically so restored
+      # build state can never influence published artifacts.
+
       - name: Verify tag matches workspace version
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

Same hardening wave as openSUSE/repose#260, plus release parity with repose:

1. `ci.yml`'s five checkouts left the `GITHUB_TOKEN` on disk (default `persist-credentials: true`); every other mtui workflow already disables it.
2. No early warning when the next Rust toolchain starts breaking the build.
3. `release.yml` built on the runner image's drifting rustup default instead of a pinned stable toolchain (repose pins via dtolnay/rust-toolchain).

## Fix

- `persist-credentials: false` on all five ci.yml checkouts (safe: no `git push`/`git fetch` anywhere in these jobs) + fix the stale `# v6` comments on the v7.0.1 SHA.
- New `beta` job in `ci.yml`: clippy + test on the beta toolchain, `continue-on-error: true` — pure early warning, never blocks.
- `release.yml`: pinned stable toolchain (dtolnay/rust-toolchain, master-branch SHA + `toolchain:` input, same pattern as repose) + comment documenting the deliberately cache-free hermetic build. `dependabot.yml` gains the matching `dtolnay/rust-toolchain` ignore (no semver releases to bump to).

## Release audit (already on par, verified)

mtui releases already create binaries like repose — 26.0.3 attaches `mtui-rs-26.0.3-x86_64-unknown-linux-musl.tar.gz` + `.sha256` (static musl builds of both `mtui` and `mtui-mcp` via xtask packaging, checkout already credential-free, `--locked` builds). The only genuine gaps were the unpinned toolchain and the missing hermetic-build note, both fixed here.

## Validation

YAML + actionlint clean locally; this PR's own CI exercises the modified workflows, and `beta` is `continue-on-error` so it cannot block anything.