### PR TITLE
ci: build & test on macOS, publish macOS release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,32 @@ jobs:
       # default workspace test run never exercises them.
       - name: Run mtui-mcp tests
         run: cargo test -p mtui-mcp -F mcp
+  macos:
+    runs-on: macos-latest
+    name: MTUI macOS (Apple Silicon)
+    # Portability early-warning on aarch64-apple-darwin: clippy + the test
+    # suite (incl. the mcp-gated tests) so macOS stays viable for release
+    # binaries. No fmt leg — formatting is platform-independent and covered by
+    # the ubuntu `fmt` job.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - name: Install clippy
+        run: rustup component add clippy
+      # The SSH integration suite authenticates from an identity file; the
+      # in-process fixture accepts any key but the runner ships none. Generate a
+      # throwaway ed25519 key so the pubkey path is exercised. (svn is omitted:
+      # the file:// repo tests skip cleanly when it is absent.)
+      - name: SSH fixture
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+      - name: Clippy (warnings as errors)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Run tests (default features)
+        run: cargo test --workspace
+      - name: Run mtui-mcp tests
+        run: cargo test -p mtui-mcp -F mcp
+
   coverage:
     runs-on: ubuntu-latest
     name: MTUI coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,23 +16,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  build:
+    name: build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    permissions:
-      # required for `gh release create`
-      contents: write
-    env:
-      TARGET: x86_64-unknown-linux-musl
+    strategy:
+      # Build every platform even if one fails, so a single broken target
+      # surfaces on its own. The release job needs all legs to succeed, so a
+      # failure still blocks publishing a partial set of artifacts.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macos-latest  # Apple Silicon
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The release is published with `gh release create` using
-          # ${{ github.token }}; no git push happens, so the checkout does not
-          # need a credential left behind in .git/config.
+          # ${{ github.token }} in a separate job; no git push happens here, so
+          # the checkout does not need a credential left behind in .git/config.
           persist-credentials: false
 
       - name: Verify tag matches workspace version
+        shell: bash
         run: |
           pkg="$(sed -n 's/^version = "\(.*\)".*/\1/p' Cargo.toml | head -1)"
           if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
@@ -40,10 +48,12 @@ jobs:
             exit 1
           fi
 
-      - name: Add musl target
-        run: rustup target add "$TARGET"
+      - name: Add Rust target
+        run: rustup target add "${{ matrix.target }}"
 
+      # musl is Linux-only; the macOS leg builds natively for aarch64-apple-darwin.
       - name: Install musl tools
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       # `--locked` so a release is built from the dependency versions committed
@@ -51,17 +61,44 @@ jobs:
       # transitive crate could differ from anything CI ever tested.
       - name: Build release binaries
         run: |
-          cargo build --release --locked --target "$TARGET" -p mtui-cli
-          cargo build --release --locked --target "$TARGET" -p mtui-mcp --features mcp
+          cargo build --release --locked --target "${{ matrix.target }}" -p mtui-cli
+          cargo build --release --locked --target "${{ matrix.target }}" -p mtui-mcp --features mcp
 
+      # xtask stages the two binaries with completions/man/terms/vim-plugin from
+      # dist/ and writes a `sha256sum -c`-compatible checksum (sha256sum on Linux,
+      # shasum -a 256 on macOS) into dist/release/.
       - name: Package release tarball
-        run: cargo xtask package --version "$GITHUB_REF_NAME" --target "$TARGET"
+        run: cargo xtask package --version "$GITHUB_REF_NAME" --target "${{ matrix.target }}"
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.target }}
+          path: dist/release/*
+          if-no-files-found: error
+
+  release:
+    # Publish only after every platform built successfully, so a release never
+    # ships a partial artifact set.
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # required for `gh release create`
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: dist
+          merge-multiple: true
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job, so tell gh which repo to act on.
+          GH_REPO: ${{ github.repository }}
         run: >-
           gh release create "$GITHUB_REF_NAME"
           --title "$GITHUB_REF_NAME"
           --generate-notes
-          dist/release/*
+          dist/*

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -378,9 +378,9 @@ pub fn stage_package(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
 /// Assemble + archive one target: stage the tree, `tar czf` it, and write a
 /// `<tarball>.sha256`. Returns the tarball path.
 ///
-/// `tar`/`sha256sum` are shelled out (both are present on every CI runner and
-/// openSUSE); only the archive/checksum step touches a subprocess — the staging
-/// layout it archives is the offline-tested [`stage_package`].
+/// `tar` and a SHA-256 CLI (`sha256sum`, or `shasum -a 256` on macOS) are
+/// shelled out; only the archive/checksum step touches a subprocess — the
+/// staging layout it archives is the offline-tested [`stage_package`].
 pub fn package_target(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
     // Materialise the staging tree on disk; `tar` archives it by name below.
     let staging = stage_package(inputs)?;
@@ -408,8 +408,9 @@ pub fn package_target(inputs: &PackageInputs<'_>) -> Result<PathBuf> {
     Ok(tarball)
 }
 
-/// Write `<file>.sha256` next to `file` containing `sha256sum`'s output for it
-/// (the `<hash>  <basename>` line, so `sha256sum -c` works from the artifact dir).
+/// Write `<file>.sha256` next to `file` containing the checksum tool's output
+/// for it (the `<hash>  <basename>` line, so `sha256sum -c` works from the
+/// artifact dir).
 fn write_sha256(file: &Path) -> Result<()> {
     let dir = file.parent().context("artifact has no parent dir")?;
     let name = file
@@ -417,19 +418,45 @@ fn write_sha256(file: &Path) -> Result<()> {
         .context("artifact has no file name")?
         .to_str()
         .context("artifact name is not UTF-8")?;
-    let out = Command::new("sha256sum")
-        .arg(name)
-        .current_dir(dir)
-        .output()
-        .context("running sha256sum")?;
-    if !out.status.success() {
-        bail!("sha256sum failed for {}", file.display());
-    }
+    let stdout = sha256_stdout(dir, name)?;
     // Append `.sha256` to the full name (`with_extension` would clobber `.gz`).
     let sum_path = file.with_file_name(format!("{name}.sha256"));
-    std::fs::write(&sum_path, &out.stdout)
+    std::fs::write(&sum_path, &stdout)
         .with_context(|| format!("writing {}", sum_path.display()))?;
     Ok(())
+}
+
+/// Checksum `name` (relative to `dir`) with a portable SHA-256 CLI, returning
+/// the `<hash>  <name>` stdout. Prefers `sha256sum` (Linux/openSUSE runners);
+/// falls back to `shasum -a 256`, which is what macOS ships instead. Both emit
+/// the same format, so the written file stays `sha256sum -c`-compatible.
+fn sha256_stdout(dir: &Path, name: &str) -> Result<Vec<u8>> {
+    let candidates: [(&str, &[&str]); 2] =
+        [("sha256sum", &[name]), ("shasum", &["-a", "256", name])];
+    for (prog, args) in candidates {
+        if let Some(stdout) = try_sha256_tool(prog, args, dir)? {
+            return Ok(stdout);
+        }
+    }
+    bail!("no SHA-256 tool found (tried sha256sum and shasum -a 256)")
+}
+
+/// Run a single checksum tool in `dir`. Returns `Ok(Some(stdout))` on success,
+/// `Ok(None)` when the tool is not installed (so the caller falls through to the
+/// next candidate), and `Err` when it ran but failed on the input or could not
+/// be spawned for any other reason.
+fn try_sha256_tool(prog: &str, args: &[&str], dir: &Path) -> Result<Option<Vec<u8>>> {
+    match Command::new(prog).args(args).current_dir(dir).output() {
+        Ok(out) if out.status.success() => Ok(Some(out.stdout)),
+        // Present but failed on this input: surface it rather than masking.
+        Ok(out) => bail!(
+            "{prog} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        // Not installed: signal the caller to try the next tool.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("running {prog}")),
+    }
 }
 
 /// Recursively copy `src` into `dst`, creating `dst` (and parents) as needed.
@@ -479,4 +506,57 @@ fn run(cmd: &mut Command) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Happy path: whichever tool is on PATH emits `<64-hex>  <name>`. Skips
+    /// cleanly if neither `sha256sum` nor `shasum` is installed.
+    #[test]
+    fn sha256_stdout_emits_hash_and_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), b"hello\n").unwrap();
+        let out = match sha256_stdout(dir.path(), "f.txt") {
+            Ok(o) => o,
+            Err(_) => return, // no checksum tool available
+        };
+        let line = String::from_utf8(out).unwrap();
+        assert!(line.contains("f.txt"), "{line:?}");
+        assert_eq!(
+            line.split_whitespace().next().unwrap().len(),
+            64,
+            "{line:?}"
+        );
+    }
+
+    /// A missing tool maps to `Ok(None)` so the caller tries the next candidate.
+    #[test]
+    fn try_sha256_tool_missing_tool_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = try_sha256_tool("mtui-no-such-sha-tool", &["x"], dir.path()).unwrap();
+        assert!(got.is_none());
+    }
+
+    /// A tool that runs but fails on its input surfaces an error rather than
+    /// being masked. Skips if neither tool is installed.
+    #[test]
+    fn try_sha256_tool_errors_on_bad_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let candidates: [(&str, &[&str]); 2] = [
+            ("sha256sum", &["nope.txt"]),
+            ("shasum", &["-a", "256", "nope.txt"]),
+        ];
+        for (prog, args) in candidates {
+            // Only assert against a tool that is actually present.
+            if Command::new(prog).arg("--version").output().is_ok() {
+                assert!(
+                    try_sha256_tool(prog, args, dir.path()).is_err(),
+                    "{prog} should error on a missing file"
+                );
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Extends CI and the release pipeline to cover macOS (Apple Silicon / `aarch64-apple-darwin`).

- **CI:** adds a `macos-latest` leg running clippy and the full test suite (including the `-F mcp` mtui-mcp tests). No fmt leg — formatting is platform-independent and already covered by the ubuntu job. This gives an early warning for portability regressions before a release is cut.
- **xtask:** the packaging step shelled out to `sha256sum`, which macOS does not ship. It now prefers `sha256sum` (Linux/openSUSE runners) and falls back to `shasum -a 256` (macOS); both emit the same `<hash>  <name>` format, so the written checksum stays `sha256sum -c`-compatible.
- **Release:** the release workflow is refactored into a build matrix (`x86_64-unknown-linux-musl` on ubuntu, `aarch64-apple-darwin` on macos) uploading a per-target tarball artifact, plus a publish job that downloads all artifacts and attaches them to the GitHub release. musl tooling is installed only on the Linux leg; macOS builds natively.

## Testing

- macOS CI leg is green on my fork (clippy + full test suite incl. mcp tests, ~6m).
- `cargo xtask` unit tests (including the packaging + checksum test) pass locally.
- Both workflow files parse as valid YAML.