### PR TITLE
ci: fuzz the untrusted-input parsers with ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,15 @@
+# ClusterFuzzLite build image for the cargo-fuzz targets in fuzz/.
+# Digest-pinned like every other external dependency; v1 currently aliases
+# latest.
+FROM gcr.io/oss-fuzz-base/base-builder-rust:v1@sha256:8a5b2b370c7778ce0190986e487dde952aa1d80496721f5647a3f11838a00a1c
+# The pinned builder ships nightly-2025-09-05 (rustc 1.91), which is older
+# than the workspace MSRV (rust-version = "1.96"). Install a newer dated
+# nightly for the fuzz build; -Zsanitizer needs nightly, so a stable
+# toolchain is not an option here. The base image selects its toolchain
+# through the RUSTUP_TOOLCHAIN env var, which shadows `rustup default`, so
+# override the env var.
+RUN rustup toolchain install nightly-2026-07-01 --profile minimal
+ENV RUSTUP_TOOLCHAIN=nightly-2026-07-01-x86_64-unknown-linux-gnu
+COPY . $SRC/mtui
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/mtui

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+# oss-fuzz/ClusterFuzzLite build contract: build every cargo-fuzz target and
+# place the resulting binaries in $OUT. cargo-fuzz comes preinstalled in the
+# base-builder-rust image and picks up fuzz/ automatically.
+cargo fuzz build
+find fuzz/target/x86_64-unknown-linux-gnu/release -maxdepth 1 -type f -executable ! -name '*.d' -exec cp -t "$OUT" {} +

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+*
+# ClusterFuzzLite fuzz build context (.clusterfuzzlite/Dockerfile). The fuzz
+# crate's path deps point into crates/, and loading any member of the parent
+# workspace requires every member manifest to be present — so the whole
+# crates/ tree plus xtask/ is whitelisted, but nothing else (no target/,
+# .git/, docs, or local work dirs).
+!/.clusterfuzzlite/
+!/.clusterfuzzlite/Dockerfile
+!/.clusterfuzzlite/build.sh
+!/.clusterfuzzlite/project.yaml
+!/Cargo.toml
+!/Cargo.lock
+!/crates/
+!/xtask/
+!/fuzz/
+!/fuzz/Cargo.toml
+!/fuzz/fuzz_targets/
+!/fuzz/fuzz_targets/*.rs

--- a/.github/workflows/cflite_fuzz.yml
+++ b/.github/workflows/cflite_fuzz.yml
@@ -1,0 +1,43 @@
+---
+name: fuzz
+# ClusterFuzzLite: builds the cargo-fuzz targets in fuzz/ and runs each for
+# a short burst on every pull request and main push. A crash fails the
+# job and is uploaded as an artifact. Rust uses the address sanitizer.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let main runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: rust
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: ${{ matrix.sanitizer }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ SUSE:*/
 
 # Release artifacts produced by `cargo xtask package` (built in CI, not committed)
 /dist/release/
+
+# cargo-fuzz build state (fuzz/ is a detached crate; its lockfile, corpus and
+# crash artifacts are machine-local)
+/fuzz/target/
+/fuzz/corpus/
+/fuzz/artifacts/
+/fuzz/coverage/
+/fuzz/Cargo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,12 @@ crates/
   mtui-core/         Command trait + registry + Session + engine + wiring (composition root)
   mtui-cli/          reedline REPL + `mtui` binary
   mtui-mcp/          rmcp server + `mtui-mcp` binary
+fuzz/                cargo-fuzz harness over the untrusted-input parsers.
+                     Detached from the workspace (own empty [workspace] table):
+                     fuzzing needs nightly and must not affect the MSRV,
+                     Cargo.lock, or stable CI. Run: cargo +nightly fuzz run
+                     <target>. CI runs it via ClusterFuzzLite
+                     (.clusterfuzzlite/ + .github/workflows/cflite_fuzz.yml).
 ```
 Task breakdown is tracked in the project's issue tracker; check it for the
 next actionable task before working on a subsystem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Fuzzing: a `cargo-fuzz` harness (`fuzz/`, detached from the workspace) over
+  the untrusted-input parsers — OBS API XML responses, host-fetched
+  `*.prod`/`os-release` bytes, remote lockfile lines, the RRID/UpdateID/RPM
+  version/package-spec/repo-URL grammars, and template repository metadata.
+  CI runs the targets under the address sanitizer on every PR and main push
+  via ClusterFuzzLite; a crash fails the job.
+
 - New `[connection]` config keys `reboot_timeout` (default `10` seconds) and
   `reboot_retries` (default `10`) control the reconnect budget `prepare`,
   `reboot`, and `update` use after rebooting a host: `reboot_timeout` is the

--- a/crates/mtui-datasources/src/obs/models.rs
+++ b/crates/mtui-datasources/src/obs/models.rs
@@ -15,6 +15,10 @@
 //! entities anyway (it surfaces them as distinct events), so a DTD-free body
 //! with an entity reference never expands either. This mirrors the guard in
 //! [`crate::obs::client::error_summary`].
+//!
+//! The four `parse_*` entry points are `pub` (not `pub(crate)`) solely so the
+//! detached cargo-fuzz harness in `fuzz/` can drive them with arbitrary bytes;
+//! nothing outside this crate and the harness should call them directly.
 
 use quick_xml::XmlVersion;
 use quick_xml::events::Event;
@@ -256,7 +260,7 @@ fn parse_request_element(
 /// # Errors
 ///
 /// Returns [`ObsError::Parse`] if the body carries a DTD or is malformed.
-pub(crate) fn parse_request(xml: &str) -> Result<Request, ObsError> {
+pub fn parse_request(xml: &str) -> Result<Request, ObsError> {
     let mut reader = reader(xml)?;
     let mut buf = Vec::new();
     loop {
@@ -287,7 +291,7 @@ pub(crate) fn parse_request(xml: &str) -> Result<Request, ObsError> {
 /// # Errors
 ///
 /// Returns [`ObsError::Parse`] if the body carries a DTD or is malformed.
-pub(crate) fn parse_request_collection(xml: &str) -> Result<Vec<Request>, ObsError> {
+pub fn parse_request_collection(xml: &str) -> Result<Vec<Request>, ObsError> {
     let mut reader = reader(xml)?;
     let mut buf = Vec::new();
     let mut requests = Vec::new();
@@ -320,7 +324,7 @@ pub(crate) fn parse_request_collection(xml: &str) -> Result<Vec<Request>, ObsErr
 /// # Errors
 ///
 /// Returns [`ObsError::Parse`] if the body carries a DTD or is malformed.
-pub(crate) fn parse_group_directory(xml: &str) -> Result<Vec<String>, ObsError> {
+pub fn parse_group_directory(xml: &str) -> Result<Vec<String>, ObsError> {
     let mut reader = reader(xml)?;
     let mut buf = Vec::new();
     let mut names = Vec::new();
@@ -350,7 +354,7 @@ pub(crate) fn parse_group_directory(xml: &str) -> Result<Vec<String>, ObsError> 
 /// # Errors
 ///
 /// Returns [`ObsError::Parse`] if the body carries a DTD or is malformed.
-pub(crate) fn parse_reject_reason_values(xml: &str) -> Result<Vec<String>, ObsError> {
+pub fn parse_reject_reason_values(xml: &str) -> Result<Vec<String>, ObsError> {
     let mut reader = reader(xml)?;
     let mut buf = Vec::new();
     let mut values = Vec::new();

--- a/crates/mtui-hosts/src/target/parsers/mod.rs
+++ b/crates/mtui-hosts/src/target/parsers/mod.rs
@@ -8,7 +8,9 @@
 //!   `/etc/products.d`, resolves the base product, collects addons, applies the
 //!   SLES_SAP repo workarounds, and detects transactional hosts.
 
-pub(crate) mod product;
+// `pub` (not `pub(crate)`) solely so the detached cargo-fuzz harness in
+// `fuzz/` can drive the pure parsers with arbitrary bytes.
+pub mod product;
 pub mod system;
 
 pub use system::parse_system;

--- a/crates/mtui-hosts/src/target/parsers/product.rs
+++ b/crates/mtui-hosts/src/target/parsers/product.rs
@@ -4,6 +4,10 @@
 //! they take the already-read file bytes (upstream took file-like SFTP handles;
 //! the Rust [`Connection::sftp_open`](crate::Connection::sftp_open) returns the
 //! bytes directly) and return a flat `(name, version, arch)` tuple.
+//!
+//! Both are `pub` (not `pub(crate)`) solely so the detached cargo-fuzz harness
+//! in `fuzz/` can drive them with arbitrary bytes — the content is
+//! host-controlled, so it is exactly the input a fuzzer should own.
 
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
@@ -26,7 +30,7 @@ use crate::error::{HostError, Result};
 /// # Errors
 /// Returns [`HostError::Sftp`] with a parse reason when the bytes are not valid
 /// XML.
-pub(crate) fn parse_product(bytes: &[u8]) -> Result<(String, String, String)> {
+pub fn parse_product(bytes: &[u8]) -> Result<(String, String, String)> {
     let fields = collect_fields(bytes)?;
 
     let text = |k: &str| fields.get(k).cloned().unwrap_or_default();
@@ -63,7 +67,7 @@ pub(crate) fn parse_product(bytes: &[u8]) -> Result<(String, String, String)> {
 /// Returns [`HostError::Sftp`] when the required `ID` or `VERSION_ID` keys are
 /// absent (upstream raised `KeyError`, which the caller treats as a failed
 /// parse).
-pub(crate) fn parse_os_release(bytes: &[u8]) -> Result<(String, String, String)> {
+pub fn parse_os_release(bytes: &[u8]) -> Result<(String, String, String)> {
     let text = String::from_utf8_lossy(bytes);
     let mut info: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,53 @@
+# cargo-fuzz harness for mtui's untrusted-input parsers. Deliberately detached
+# from the root workspace (empty [workspace] table below): fuzzing requires
+# nightly + cargo-fuzz and must not affect the workspace MSRV, Cargo.lock, or
+# the stable CI jobs. Run with:
+#   cargo +nightly fuzz run <target>
+[package]
+name = "mtui-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+license = "GPL-3.0-or-later"
+
+[package.metadata]
+cargo-fuzz = true
+
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mtui-types = { path = "../crates/mtui-types" }
+mtui-hosts = { path = "../crates/mtui-hosts" }
+mtui-datasources = { path = "../crates/mtui-datasources" }
+mtui-testreport = { path = "../crates/mtui-testreport" }
+
+[[bin]]
+name = "obs_xml"
+path = "fuzz_targets/obs_xml.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "prod_parse"
+path = "fuzz_targets/prod_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "lockfile"
+path = "fuzz_targets/lockfile.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "id_parse"
+path = "fuzz_targets/id_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "repo_parse"
+path = "fuzz_targets/repo_parse.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/id_parse.rs
+++ b/fuzz/fuzz_targets/id_parse.rs
@@ -1,0 +1,19 @@
+//! Fuzzes the small identifier grammars in `mtui-types`: RRID / UpdateID
+//! (CLI + OBS request IDs), RPM version strings (`rpm -q` output from managed
+//! hosts), package specs (shell-metacharacter rejection is security-relevant),
+//! and repository URLs (template metadata).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mtui_types::{PackageSpec, RPMVersion, RepoUrl, RequestReviewID, UpdateID};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = RequestReviewID::parse(s);
+    let _ = UpdateID::parse(s);
+    let _ = RPMVersion::parse(s);
+    let _ = PackageSpec::parse(s);
+    let _ = RepoUrl::parse(s);
+});

--- a/fuzz/fuzz_targets/lockfile.rs
+++ b/fuzz/fuzz_targets/lockfile.rs
@@ -1,0 +1,13 @@
+//! Fuzzes the remote lockfile line parser (`timestamp:user:pid[:comment]`).
+//! The lockfile lives on the managed host, so its content is host-controlled.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mtui_hosts::target::RemoteLock;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(line) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = RemoteLock::from_lockfile(line);
+});

--- a/fuzz/fuzz_targets/obs_xml.rs
+++ b/fuzz/fuzz_targets/obs_xml.rs
@@ -1,0 +1,22 @@
+//! Fuzzes the hand-rolled `quick-xml` parsers for OBS API responses — the
+//! `withfullhistory=1` request document, the request `<collection>`, the
+//! `group?login` directory, and the `MAINT:RejectReason` attribute envelope.
+//! This is network-controlled input (a compromised or MITM'd
+//! `ssl_verify=false` response reaches these parsers verbatim), and it is the
+//! surface the DTD/XXE pre-parse guard protects.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mtui_datasources::obs::models::{
+    parse_group_directory, parse_reject_reason_values, parse_request, parse_request_collection,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(xml) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_request(xml);
+    let _ = parse_request_collection(xml);
+    let _ = parse_group_directory(xml);
+    let _ = parse_reject_reason_values(xml);
+});

--- a/fuzz/fuzz_targets/prod_parse.rs
+++ b/fuzz/fuzz_targets/prod_parse.rs
@@ -1,0 +1,11 @@
+//! Fuzzes the `/etc/products.d/*.prod` and `/etc/os-release` parsers with
+//! host-controlled file bytes (SFTP-fetched from managed reference hosts).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mtui_hosts::target::parsers::product::{parse_os_release, parse_product};
+
+fuzz_target!(|data: &[u8]| {
+    let _ = parse_product(data);
+    let _ = parse_os_release(data);
+});

--- a/fuzz/fuzz_targets/repo_parse.rs
+++ b/fuzz/fuzz_targets/repo_parse.rs
@@ -1,0 +1,20 @@
+//! Fuzzes the template repository/product metadata parsers in
+//! `mtui-testreport`. The product strings and repository URL come from the
+//! RRID template checkout — externally-sourced metadata.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mtui_testreport::{gitrepoparse, parse_product, slrepoparse};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(text) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_product(text);
+    // Split the input: first line is the repository URL, the rest is the
+    // product-string list the `*repoparse` helpers walk.
+    let (repo, rest) = text.split_once('\n').unwrap_or((text, ""));
+    let products: Vec<String> = rest.lines().map(str::to_owned).collect();
+    let _ = slrepoparse(repo, &products);
+    let _ = gitrepoparse(repo, &products);
+});


### PR DESCRIPTION
## Problem

OSSF Scorecard's **Fuzzing** check scores 0: the project has no fuzzer integration, despite parsing plenty of untrusted input — OBS API XML responses, `*.prod`/`os-release`/lockfile content fetched from managed hosts, and identifier/metadata grammars from the CLI and template checkouts.

## Fix

A `cargo-fuzz` harness with five targets over exactly that attack surface:

| Target | Entry points | Input origin |
|---|---|---|
| `obs_xml` | `obs::models::parse_request`, `parse_request_collection`, `parse_group_directory`, `parse_reject_reason_values` | OBS API response (the DTD/XXE-guarded surface from #323) |
| `prod_parse` | `target::parsers::product::parse_product`, `parse_os_release` | SFTP-fetched bytes from managed hosts |
| `lockfile` | `RemoteLock::from_lockfile` | lockfile lines on managed hosts |
| `id_parse` | `RequestReviewID`/`UpdateID`/`RPMVersion`/`PackageSpec`/`RepoUrl` `::parse` | CLI args, `rpm -q` output, template metadata |
| `repo_parse` | `parse_product`, `slrepoparse`, `gitrepoparse` | RRID template checkout metadata |

The fuzz crate is deliberately **detached from the workspace** (empty `[workspace]` table; `cargo metadata` still reports exactly 9 members): cargo-fuzz needs nightly, and the harness must not affect the MSRV, `Cargo.lock`, or stable CI. Its build dir/corpus/lockfile are gitignored; `AGENTS.md` documents the layout.

## CI

New `fuzz` workflow: ClusterFuzzLite (SHA-pinned, like every other action) builds and runs the targets under the address sanitizer for 300s per PR / main push; a crash fails the job. This PR's own run validates the harness end-to-end. ClusterFuzzLite in `.github/workflows` is what Scorecard's Fuzzing check detects. The workflow is a new standalone file, so it cannot conflict with #369.

## Public API note

The harness drives six pure parsers that were previously `pub(crate)`; they become `pub` in `mtui-datasources` (`obs::models::parse_*`) and `mtui-hosts` (`target::parsers::product::*`), each with a doc note scoping the widening to the fuzz harness. No behavior change.

## Validation

- `cargo check --manifest-path fuzz/Cargo.toml` compiles all five harnesses (stable, no instrumentation).
- Full workspace gate green and unaffected: `fmt --check`, clippy `-D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp` (186+48 passed), feature matrix (`--no-default-features` + `--all-features`).
