### PR TITLE
feat(mcp): cooperative cancellation seam + truthful job_cancel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,14 @@ next actionable task before working on a subsystem.
   `switch`) are deny-listed; the deny-list ∩ registry is consistency-tested and
   drift is warned about at boot. Local process execution has no command at all —
   `lrun` was removed by design; do not reintroduce it.
+- **Cancellation is cooperative-first.** `Session` carries a
+  `CancellationToken` (the seam); the `Command::run` driver checks it before
+  dispatch and between fan-out templates, and a long-running body may poll
+  `session.cancel_requested()` (or `select!` on `session.cancel_token()`) at
+  its own host/step boundaries. MCP `job_cancel` cancels the job's token,
+  waits a short grace for a cooperative stop, then hard-aborts the worker —
+  its reply distinguishes the two and never claims to cancel a job that had
+  already finished. New long-running command bodies should observe the seam.
 
 ## Contracts (do not break without intent — these enable ecosystem interop)
 - **RRID grammar** `project:kind:maintenance_id:review_id` and its parse errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- MCP `job_cancel` is now truthful and two-stage. Cancelling a running job
+  first signals the new cooperative cancellation seam — today the dispatch
+  driver observes it at its pre-dispatch and between-template checkpoints
+  (so a multi-template job stops at the next template boundary), and command
+  bodies can opt in to stop at their own host/step boundaries — then
+  force-aborts the worker after a 1-second grace. The reply says which
+  happened, and a forced abort warns that a host operation already in flight
+  may still finish on the host. Cancelling an already-finished job now
+  replies `job <id> already done/failed/cancelled; nothing to cancel`
+  instead of falsely claiming `cancelled job <id>`.
 - mtui is now licensed GPL-3.0-or-later (previously GPL-2.0-only, matching
   upstream); see `LICENSE`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
  "wiremock",

--- a/crates/mtui-core/Cargo.toml
+++ b/crates/mtui-core/Cargo.toml
@@ -20,6 +20,8 @@ clap.workspace = true
 shlex.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+# CancellationToken for the Session cancellation seam (MCP `job_cancel`).
+tokio-util.workspace = true
 futures.workspace = true
 tracing.workspace = true
 owo-colors.workspace = true

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -141,7 +141,16 @@ pub trait Command: Send + Sync {
     /// connected host is skipped up front (when the invocation named no `-t`
     /// hosts); if every template was skipped the command ran nowhere and
     /// [`CommandError::NoRefhostsDefined`] is returned.
+    ///
+    /// Cancellation (MCP `job_cancel`): the driver is the seam's chokepoint. It
+    /// bails with [`CommandError::Cancelled`] before dispatching at all, and —
+    /// on the fan-out path — re-checks between templates, so a cancelled
+    /// multi-template job stops at the next template boundary instead of
+    /// grinding through the rest. A cancel arriving *mid*-`call` is only
+    /// observed if the body opts in ([`Session::cancel_requested`]); otherwise
+    /// the MCP job layer hard-aborts after its grace period.
     async fn run(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
+        session.check_cancelled()?;
         let resolved = resolve_templates(self.scope(), session, args)?;
 
         if resolved.len() <= 1 {
@@ -183,7 +192,14 @@ pub trait Command: Send + Sync {
         let mut failures: Vec<(String, CommandError)> = Vec::new();
         let mut skipped: Vec<String> = Vec::new();
 
+        let mut cancelled = false;
         for rrid in &resolved {
+            // Template boundary = cancellation checkpoint: a job_cancel that
+            // lands while template N runs stops the fan-out before N+1.
+            if session.cancel_requested() {
+                cancelled = true;
+                break;
+            }
             let is_empty = session.is_hostless(rrid);
             if skippable && is_empty {
                 tracing::warn!(command = self.name(), rrid = %rrid, "skipped: no connected hosts");
@@ -199,6 +215,13 @@ pub trait Command: Send + Sync {
         }
 
         restore_active(session, restore);
+        if cancelled {
+            // Cancellation outranks the partial-failure aggregate: the caller
+            // asked the job to stop, so report that, not a FanOut over the
+            // templates that happened to finish first.
+            tracing::info!(command = self.name(), "fan-out cancelled");
+            return Err(CommandError::Cancelled);
+        }
 
         let done: std::collections::HashSet<&str> = failures
             .iter()

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -1064,3 +1064,100 @@ mod mcp_nonempty_success_guard {
         );
     }
 }
+
+/// Driver-level tests for the cancellation seam (`Session::cancel` +
+/// [`Command::run`](crate::Command::run) checkpoints). They live here — not in
+/// `command.rs` — for the same reason as the guard above: the [`testkit`]
+/// multi-template session builders are `#[cfg(test)]` `pub(crate)` in this
+/// module.
+#[cfg(test)]
+mod cancellation_seam {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use clap::ArgMatches;
+
+    use super::testkit::{fake_report, matches, session_with_hosts};
+    use crate::command::{Command, Scope};
+    use crate::error::{CommandError, CommandResult};
+    use crate::session::Session;
+
+    const RRID_A: &str = "SUSE:Maintenance:1:1";
+    const RRID_B: &str = "SUSE:Maintenance:2:2";
+
+    /// A fan-out probe that records each template it runs on and cancels the
+    /// session's token from inside its first `call`.
+    struct CancelAfterFirst {
+        ran: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Command for CancelAfterFirst {
+        fn name(&self) -> &'static str {
+            "cancel_probe"
+        }
+        fn scope(&self) -> Scope {
+            Scope::Fanout
+        }
+        async fn call(&self, session: &mut Session, _args: &ArgMatches) -> CommandResult {
+            self.ran
+                .lock()
+                .expect("probe log poisoned")
+                .push(session.templates.active_rrid().unwrap_or("").to_owned());
+            // A job_cancel landing mid-call: the driver must stop at the next
+            // template boundary.
+            session.cancel_token().cancel();
+            Ok(())
+        }
+    }
+
+    /// Two loaded templates, cancel fired during the first `call`: the driver
+    /// stops at the boundary — the second template never runs — and reports
+    /// [`CommandError::Cancelled`], not a `FanOut` aggregate.
+    #[tokio::test]
+    async fn fanout_driver_stops_at_template_boundary_on_cancel() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.templates.add(fake_report(RRID_B, &["h2"], "ok"));
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = CancelAfterFirst {
+            ran: Arc::clone(&ran),
+        };
+        let args = matches(&cmd, &[]);
+
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("cancel mid-fan-out reports Cancelled");
+        assert!(matches!(err, CommandError::Cancelled), "got: {err}");
+        assert_eq!(
+            *ran.lock().expect("probe log poisoned"),
+            vec![RRID_A.to_owned()],
+            "the second template must never run after the cancel"
+        );
+    }
+
+    /// A token cancelled *before* dispatch: the pre-flight check bails without
+    /// running any template at all.
+    #[tokio::test]
+    async fn driver_preflight_bails_before_dispatch_when_cancelled() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.cancel_token().cancel();
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = CancelAfterFirst {
+            ran: Arc::clone(&ran),
+        };
+        let args = matches(&cmd, &[]);
+
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("pre-cancelled dispatch reports Cancelled");
+        assert!(matches!(err, CommandError::Cancelled), "got: {err}");
+        assert!(
+            ran.lock().expect("probe log poisoned").is_empty(),
+            "no template body may run after a pre-dispatch cancel"
+        );
+    }
+}

--- a/crates/mtui-core/src/error.rs
+++ b/crates/mtui-core/src/error.rs
@@ -48,6 +48,16 @@ pub enum CommandError {
     #[error("fan-out failed on {} ({})", .0.iter().map(|(r, _)| r.as_str()).collect::<Vec<_>>().join(", "), .0.iter().map(|(r, e)| format!("{r}: {e}")).collect::<Vec<_>>().join("; "))]
     FanOut(Vec<(String, CommandError)>),
 
+    /// The dispatch was cancelled mid-flight (MCP `job_cancel`).
+    ///
+    /// Raised by [`Session::check_cancelled`](crate::Session::check_cancelled)
+    /// at a cancellation checkpoint — the pre-dispatch check and the
+    /// between-templates check in the [`Command::run`](crate::Command::run)
+    /// fan-out driver, plus any command body that opts in. No Python
+    /// counterpart: upstream had no in-band cancellation.
+    #[error("cancelled")]
+    Cancelled,
+
     /// A command-specific failure whose message the command supplies directly.
     ///
     /// Catch-all for the many concrete upstream `ErrorMessage` subclasses not
@@ -60,6 +70,12 @@ pub enum CommandError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cancelled_display_is_pinned() {
+        // The MCP error envelope surfaces this string as stderr; keep it stable.
+        assert_eq!(CommandError::Cancelled.to_string(), "cancelled");
+    }
 
     #[test]
     fn no_refhosts_matches_upstream() {

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -23,9 +23,11 @@ use mtui_testreport::{NullReport, TestReport, UpdateKind, make_testreport};
 use mtui_types::UpdateID;
 use mtui_types::enums::{TargetState, Workflow};
 use tokio::sync::OwnedMutexGuard;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::display::CommandPromptDisplay;
+use crate::error::CommandError;
 use crate::template_registry::TemplateRegistry;
 
 /// The explicitly-passed state every command operates on.
@@ -110,6 +112,21 @@ pub struct Session {
     /// override it with the identity ([`ShuffleFn`]) for deterministic
     /// assertions.
     shuffle: ShuffleFn,
+    /// The cancellation seam: cooperative cancel signal for the dispatch this
+    /// session is driving (MCP `job_cancel`).
+    ///
+    /// Freshly minted (never cancelled) for a REPL/canonical session;
+    /// [`fork_for_call`](Self::fork_for_call) *clones* it so a fork shares the
+    /// parent's cancellation state, and `mtui-mcp` installs a per-job token via
+    /// [`set_cancel_token`](Self::set_cancel_token) before dispatching a
+    /// background job. Checked by the [`Command::run`](crate::Command::run)
+    /// driver before dispatch and between fan-out templates
+    /// ([`check_cancelled`](Self::check_cancelled)); a long-running command body
+    /// can additionally observe it ([`cancel_requested`](Self::cancel_requested)
+    /// / [`cancel_token`](Self::cancel_token)) to stop early. Purely
+    /// cooperative: a body that never checks still gets hard-aborted by the MCP
+    /// job layer after its grace period.
+    cancel: CancellationToken,
     /// Lazily-built, session-scoped outbound [`HttpClient`], cached with the
     /// [`VerifyPolicy`] it was built under.
     ///
@@ -213,6 +230,7 @@ impl Session {
             notify_sink: None,
             prompter: None,
             shuffle: random_shuffle,
+            cancel: CancellationToken::new(),
             http_client: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
@@ -236,6 +254,7 @@ impl Session {
             notify_sink: None,
             prompter: None,
             shuffle: random_shuffle,
+            cancel: CancellationToken::new(),
             http_client: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
@@ -278,10 +297,62 @@ impl Session {
             notify_sink: None,
             prompter: None,
             shuffle: self.shuffle,
+            // Share the parent's cancellation state: cancelling the canonical
+            // session (or the per-job token the MCP layer installs on this
+            // fork) must be observable on both sides of the fork.
+            cancel: self.cancel.clone(),
             http_client: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    /// `true` once cancellation has been requested for this dispatch.
+    ///
+    /// The cheap poll form of the seam: a command body loops on host/step
+    /// boundaries and bails when this flips. See
+    /// [`check_cancelled`](Self::check_cancelled) for the `?`-friendly form and
+    /// [`cancel_token`](Self::cancel_token) for the awaitable form.
+    #[must_use]
+    pub fn cancel_requested(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Bail with [`CommandError::Cancelled`] if cancellation has been requested.
+    ///
+    /// The `?`-friendly checkpoint the [`Command::run`](crate::Command::run)
+    /// driver calls before dispatch and between fan-out templates.
+    ///
+    /// # Errors
+    ///
+    /// [`CommandError::Cancelled`] when the session's cancellation token has
+    /// been cancelled.
+    pub fn check_cancelled(&self) -> Result<(), CommandError> {
+        if self.cancel.is_cancelled() {
+            return Err(CommandError::Cancelled);
+        }
+        Ok(())
+    }
+
+    /// A clone of the session's cancellation token (clones share state).
+    ///
+    /// For `select!`-style bodies that want `token.cancelled().await` as a
+    /// branch alongside their I/O future.
+    #[must_use]
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Install `token` as this session's cancellation token.
+    ///
+    /// The MCP job layer calls this to wire one freshly minted token per
+    /// background job into the session the job dispatches on, so
+    /// `job_cancel` cancels exactly that job's dispatch. Installing a token
+    /// *replaces* the previous one (it does not chain); the caller restores the
+    /// prior token afterwards when the session outlives the call (the exclusive
+    /// dispatch path).
+    pub fn set_cancel_token(&mut self, token: CancellationToken) {
+        self.cancel = token;
     }
 
     /// The session-scoped outbound [`HttpClient`], built lazily and reused.
@@ -2203,6 +2274,44 @@ mod tests {
             "chosen hosts must follow first-seen slot order"
         );
         assert_eq!(slot_candidates.len(), 2, "two distinct arch slots");
+    }
+
+    /// A fresh session's token is never cancelled; `check_cancelled` is `Ok`
+    /// until the token fires, then reports [`CommandError::Cancelled`] — and
+    /// [`Session::set_cancel_token`] *replaces* (never chains) the token.
+    #[test]
+    fn cancel_seam_check_and_replace() {
+        let mut s = Session::new(Config::default(), false);
+        assert!(!s.cancel_requested());
+        assert!(s.check_cancelled().is_ok());
+
+        s.cancel_token().cancel();
+        assert!(s.cancel_requested());
+        assert!(matches!(s.check_cancelled(), Err(CommandError::Cancelled)));
+
+        // Installing a fresh token replaces the cancelled one (the MCP
+        // self-healing install path relies on this).
+        s.set_cancel_token(tokio_util::sync::CancellationToken::new());
+        assert!(!s.cancel_requested());
+        assert!(s.check_cancelled().is_ok());
+    }
+
+    /// `fork_for_call` clones the token — cancellation state is shared across
+    /// the fork in both directions (the MCP job layer installs the per-job
+    /// token on the fork and cancels it from `job_cancel`).
+    #[test]
+    fn fork_for_call_shares_cancellation_state() {
+        use crate::display::{ColorMode, CommandPromptDisplay};
+
+        let s = Session::new(Config::default(), false);
+        let display = CommandPromptDisplay::with_sink(Box::new(Vec::new()), ColorMode::Never);
+        let fork = s.fork_for_call(display);
+
+        assert!(!fork.cancel_requested());
+        // Cancel via the parent: the fork observes it (clones share state).
+        s.cancel_token().cancel();
+        assert!(fork.cancel_requested(), "fork shares the parent's token");
+        assert!(s.cancel_requested());
     }
 
     /// `fork_for_call` shares the canonical session's loaded reports (same entry

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -94,6 +94,7 @@ use mtui_core::{
 use tokio::sync::Mutex;
 use tokio::sync::OwnedMutexGuard;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::capture::{self, SharedBuf};
 use crate::concurrency::{ExclusiveGuard, RwGate, SharedGuard};
@@ -115,6 +116,17 @@ pub(crate) const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(45);
 /// to [`McpSession::run_command_with_progress`], overridable per call so tests
 /// can drive a sub-second interval.
 pub(crate) const DEFAULT_PROGRESS_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Cooperative grace [`job_cancel`](McpSession::job_cancel) gives a worker
+/// between cancelling its token and force-aborting its task.
+///
+/// A dispatch parked at a seam checkpoint (the `Command::run` driver's
+/// pre-flight / between-templates checks, or a body watching
+/// [`mtui_core::Session::cancel_requested`]) settles well inside this; a body
+/// blocked mid host-op never observes the token and burns the full grace
+/// before the hard abort. Kept short so `job_cancel` stays responsive; not a
+/// config key (no upstream counterpart — Python cancellation was thread-kill).
+pub(crate) const CANCEL_GRACE: Duration = Duration::from_secs(1);
 
 /// A [`JoinHandle`] wrapper that aborts its task when dropped.
 ///
@@ -288,8 +300,14 @@ struct Job {
     error: Option<String>,
     /// The failure exit code when `state == Failed`.
     exit_code: Option<i32>,
-    /// The worker task handle, aborted by [`McpSession::job_cancel`].
+    /// The worker task handle, aborted by [`McpSession::job_cancel`] when the
+    /// cooperative grace elapses.
     handle: Option<JoinHandle<()>>,
+    /// This job's cancellation token, installed on the session its dispatch
+    /// runs on. [`McpSession::job_cancel`] cancels it *first* so a body
+    /// observing the seam ([`mtui_core::Session::cancel_requested`]) can stop
+    /// cooperatively before the hard abort.
+    cancel: CancellationToken,
 }
 
 /// A public, poll-facing snapshot of a [`Job`] (no task handle).
@@ -715,6 +733,26 @@ impl McpSession {
         name: &str,
         argv: &[String],
     ) -> Result<String, McpCommandError> {
+        self.run_command_cancellable(registry, name, argv, None)
+            .await
+    }
+
+    /// [`run_command`](Self::run_command) with an optional per-job cancellation
+    /// token installed on the session the dispatch runs on.
+    ///
+    /// The background-job worker passes its job's token so
+    /// [`job_cancel`](Self::job_cancel) can cancel exactly that dispatch;
+    /// foreground tool calls pass `None` and keep the session's own (never
+    /// cancelled) token. On the forked (scoped) path the token is set on the
+    /// per-call fork; on the exclusive path it is swapped onto the canonical
+    /// session for the duration of the dispatch and restored after.
+    async fn run_command_cancellable(
+        &self,
+        registry: &Registry,
+        name: &str,
+        argv: &[String],
+        cancel: Option<CancellationToken>,
+    ) -> Result<String, McpCommandError> {
         // Acquire the per-template / registry-gate hold for this invocation
         // *before* touching the session, so same-RRID and unscoped calls
         // serialise and mutators drain in-flight per-RRID work. Held for the
@@ -761,6 +799,17 @@ impl McpSession {
                     let session = self.session.lock().await;
                     session.fork_for_call(call_display)
                 };
+                // Wire the per-job token into the fork so the dispatched body
+                // (and the `Command::run` driver's checkpoints) observe a
+                // `job_cancel` cooperatively. Foreground calls get a fresh
+                // (never-cancelled) token rather than the fork's inherited one:
+                // a hard-aborted exclusive dispatch can leave a cancelled job
+                // token behind on the canonical session (its restore is skipped
+                // when the worker future is dropped), and the fork must not
+                // inherit that staleness — installing unconditionally makes
+                // every dispatch self-healing.
+                call_session
+                    .set_cancel_token(cancel.clone().unwrap_or_else(CancellationToken::new));
                 let argv_owned = argv.to_vec();
                 // Abort-on-drop: if this `run_command` future is cancelled (e.g.
                 // an aborted background-job worker), abort the dispatch task too,
@@ -792,7 +841,18 @@ impl McpSession {
             CommandLock::Exclusive(_) => {
                 let mut session = self.session.lock().await;
                 let prev_display = std::mem::replace(&mut session.display, call_display);
+                // Install this dispatch's token on the canonical session: the
+                // per-job token for a background worker, a fresh
+                // (never-cancelled) one for a foreground call. Installing
+                // unconditionally — instead of swap-and-restore — makes the
+                // token state self-healing: if a hard-aborted worker skips the
+                // restore below, the *next* dispatch's install wipes the stale
+                // cancelled token before its pre-flight check.
+                session.set_cancel_token(cancel.clone().unwrap_or_else(CancellationToken::new));
                 let result = dispatch_argv(registry, &mut session, name, argv).await;
+                // Best-effort tidy-up (skipped when the worker future is
+                // dropped mid-dispatch; see the install note above).
+                session.set_cancel_token(CancellationToken::new());
                 session.display = prev_display;
                 session.release_active_guard();
                 result
@@ -946,6 +1006,7 @@ impl McpSession {
         argv: Vec<String>,
         job_id: String,
     ) -> String {
+        let cancel = CancellationToken::new();
         let job = Arc::new(StdMutex::new(Job {
             id: job_id.clone(),
             command: name.to_owned(),
@@ -956,6 +1017,7 @@ impl McpSession {
             error: None,
             exit_code: None,
             handle: None,
+            cancel: cancel.clone(),
         }));
         jobs_guard.insert(job_id.clone(), Arc::clone(&job));
 
@@ -963,7 +1025,9 @@ impl McpSession {
         let name = name.to_owned();
         let worker_job = Arc::clone(&job);
         let handle = tokio::spawn(async move {
-            let outcome = session.run_command(&registry, &name, &argv).await;
+            let outcome = session
+                .run_command_cancellable(&registry, &name, &argv, Some(cancel))
+                .await;
             {
                 let mut j = worker_job.lock().expect("job record poisoned");
                 // A cancel may have already marked the record terminal; if so, do
@@ -1173,36 +1237,73 @@ impl McpSession {
 
     /// Cancel a running job; error if the id is unknown (upstream `job_cancel`).
     ///
-    /// Aborts the worker task and marks the record `Cancelled`. NOTE: if the job
-    /// is mid host-op (an SSH/subprocess body), aborting detaches the awaiter but
-    /// the underlying host operation may keep running to completion — the same
-    /// caveat as interrupting a foreground `run`. A finished job is a no-op.
+    /// Truthful, two-stage cancel:
+    ///
+    /// 1. **Cooperative:** the job's [`CancellationToken`] is cancelled first,
+    ///    so a dispatch parked at a seam checkpoint (the `Command::run` driver's
+    ///    pre-flight / between-templates checks, or a body observing
+    ///    [`mtui_core::Session::cancel_requested`]) unwinds cleanly. The worker
+    ///    gets [`CANCEL_GRACE`] to settle.
+    /// 2. **Forced:** if the grace elapses (the body never checks the seam —
+    ///    e.g. it is blocked mid host-op), the worker task is aborted. The
+    ///    underlying SSH/subprocess operation may still run to completion on
+    ///    the host — the same caveat as interrupting a foreground `run` — and
+    ///    the reply says the abort was forced.
+    ///
+    /// A job already in a terminal state is **not** re-cancelled: the reply
+    /// names its actual state instead of claiming a cancellation that never
+    /// happened.
     ///
     /// # Errors
     ///
     /// [`McpCommandError`] (exit 1) with `"no such job: <id>"` when unknown.
     pub async fn job_cancel(&self, job_id: &str) -> Result<String, McpCommandError> {
         let job = self.job(job_id)?;
-        let handle = {
+        let (handle, token) = {
             let mut j = job.lock().expect("job record poisoned");
-            if j.state == JobState::Running {
-                j.state = JobState::Cancelled;
-                j.finished = Some(Instant::now());
-                j.handle.take()
-            } else {
-                None
+            match j.state {
+                JobState::Running => {
+                    // Claim the cancel atomically: marking the record terminal
+                    // here means the worker's terminal-write branch (which
+                    // checks `Running`) can no longer overwrite it.
+                    j.state = JobState::Cancelled;
+                    j.finished = Some(Instant::now());
+                    (j.handle.take(), j.cancel.clone())
+                }
+                state => {
+                    // Truthful no-op: nothing was cancelled.
+                    return Ok(format!("job {job_id} already {state}; nothing to cancel"));
+                }
             }
         };
-        if let Some(handle) = handle {
-            handle.abort();
-            // Await the aborted task so cancellation has fully unwound before we
-            // return; a `JoinError::Cancelled` is expected and ignored.
-            let _ = handle.await;
-            // The aborted worker's terminal-write branch (which normally evicts)
-            // was skipped, so reap history here now this record is terminal.
+        // Cooperative stage: signal the seam before touching the task.
+        token.cancel();
+        let mut forced = false;
+        if let Some(mut handle) = handle {
+            if tokio::time::timeout(CANCEL_GRACE, &mut handle)
+                .await
+                .is_err()
+            {
+                // Forced stage: the body never reached a checkpoint.
+                forced = true;
+                handle.abort();
+                // Await the aborted task so cancellation has fully unwound
+                // before we return; a `JoinError::Cancelled` is expected.
+                let _ = handle.await;
+            }
+            // The worker's terminal-write branch skipped its eviction (state
+            // was already `Cancelled`), so reap history here.
             self.evict_completed();
         }
-        Ok(format!("cancelled job {job_id}"))
+        if forced {
+            Ok(format!(
+                "cancelled job {job_id} (forced abort after {}s grace; a host \
+                 operation already in flight may still finish on the host)",
+                CANCEL_GRACE.as_secs()
+            ))
+        } else {
+            Ok(format!("cancelled job {job_id}"))
+        }
     }
 
     /// Look up a job record by id, or the `"no such job"` envelope.
@@ -1506,6 +1607,7 @@ mod tests {
                 error: None,
                 exit_code: None,
                 handle: None,
+                cancel: CancellationToken::new(),
             }))
         };
         {
@@ -1560,6 +1662,7 @@ mod tests {
                         error: None,
                         exit_code: None,
                         handle: None,
+                        cancel: CancellationToken::new(),
                     })),
                 );
             }
@@ -1680,9 +1783,161 @@ mod tests {
         assert_eq!(sess.job_status(&job_id).unwrap().state, JobState::Done);
 
         let msg = sess.job_cancel(&job_id).await.expect("cancel is a no-op");
-        assert_eq!(msg, format!("cancelled job {job_id}"));
+        // Truthful no-op: the reply names the actual terminal state instead of
+        // claiming a cancellation that never happened.
+        assert_eq!(msg, format!("job {job_id} already done; nothing to cancel"));
         // State is unchanged: a finished job is not rewritten to Cancelled.
         assert_eq!(sess.job_status(&job_id).unwrap().state, JobState::Done);
+        // The result is preserved and still retrievable.
+        assert!(
+            sess.job_result(&job_id).is_ok(),
+            "result survives the no-op"
+        );
+    }
+
+    /// A body watching the cancellation seam settles inside the grace window:
+    /// `job_cancel` reports a plain (cooperative) cancel, not a forced abort.
+    #[tokio::test]
+    async fn job_cancel_cooperative_body_settles_within_grace() {
+        use clap::ArgMatches;
+        use mtui_core::{Command, CommandResult, Scope};
+
+        // Signals the test once the body is parked on the seam, so the cancel
+        // is issued only after the dispatch is genuinely mid-flight.
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+
+        struct Cooperative(StdMutex<Option<tokio::sync::oneshot::Sender<()>>>);
+        #[async_trait::async_trait]
+        impl Command for Cooperative {
+            fn name(&self) -> &'static str {
+                "cooperative_probe"
+            }
+            fn scope(&self) -> Scope {
+                Scope::Fanout
+            }
+            async fn call(&self, session: &mut Session, _args: &ArgMatches) -> CommandResult {
+                if let Some(tx) = self.0.lock().expect("probe channel poisoned").take() {
+                    let _ = tx.send(());
+                }
+                // Park on the seam: unwind the moment job_cancel fires the
+                // token, well inside CANCEL_GRACE.
+                session.cancel_token().cancelled().await;
+                Err(CommandError::Cancelled)
+            }
+        }
+
+        let sess = session(Config::default());
+        let mut registry = register_all();
+        registry.register(Arc::new(Cooperative(StdMutex::new(Some(started_tx)))));
+
+        let job_id = sess
+            .start_job(Arc::new(registry), "cooperative_probe", Vec::new())
+            .expect("start_job succeeds");
+        started_rx.await.expect("probe body started");
+
+        let before = Instant::now();
+        let msg = sess.job_cancel(&job_id).await.expect("cancel succeeds");
+        // Cooperative: the body observed the token, so no forced abort — and
+        // the whole cancel settles well inside the grace window.
+        assert_eq!(msg, format!("cancelled job {job_id}"));
+        assert!(
+            before.elapsed() < CANCEL_GRACE,
+            "cooperative cancel must not burn the grace: {:?}",
+            before.elapsed()
+        );
+        assert_eq!(sess.job_status(&job_id).unwrap().state, JobState::Cancelled);
+    }
+
+    /// A body that never checks the seam burns the full grace and is then
+    /// force-aborted; the reply says so instead of claiming a clean cancel.
+    #[tokio::test]
+    async fn job_cancel_unobservant_body_is_force_aborted_after_grace() {
+        use clap::ArgMatches;
+        use mtui_core::{Command, CommandResult, Scope};
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+
+        struct Stubborn(StdMutex<Option<tokio::sync::oneshot::Sender<()>>>);
+        #[async_trait::async_trait]
+        impl Command for Stubborn {
+            fn name(&self) -> &'static str {
+                "stubborn_probe"
+            }
+            fn scope(&self) -> Scope {
+                Scope::Fanout
+            }
+            async fn call(&self, _session: &mut Session, _args: &ArgMatches) -> CommandResult {
+                if let Some(tx) = self.0.lock().expect("probe channel poisoned").take() {
+                    let _ = tx.send(());
+                }
+                // Simulates a body blocked mid host-op: never observes the
+                // token, only the hard abort can stop it.
+                tokio::time::sleep(Duration::from_secs(600)).await;
+                Ok(())
+            }
+        }
+
+        let mut config = Config::default();
+        config.session_user = "testuser".to_owned();
+        let sess = session(config);
+        let mut registry = register_all();
+        registry.register(Arc::new(Stubborn(StdMutex::new(Some(started_tx)))));
+        let registry = Arc::new(registry);
+
+        let job_id = sess
+            .start_job(Arc::clone(&registry), "stubborn_probe", Vec::new())
+            .expect("start_job succeeds");
+        started_rx.await.expect("probe body started");
+
+        let msg = sess.job_cancel(&job_id).await.expect("cancel succeeds");
+        assert!(
+            msg.contains("forced abort"),
+            "unobservant body must report the forced abort: {msg}"
+        );
+        assert_eq!(sess.job_status(&job_id).unwrap().state, JobState::Cancelled);
+        // The cancelled record still reports the standard envelope on read.
+        let err = sess.job_result(&job_id).expect_err("cancelled job raises");
+        assert!(err.stderr.contains("was cancelled"), "got: {err:?}");
+
+        // Self-healing end-to-end: the hard abort skipped the exclusive path's
+        // token restore, leaving the cancelled job token on the canonical
+        // session — the next dispatch must install a fresh token before its
+        // pre-flight check and therefore succeed, not report "cancelled".
+        let out = sess
+            .run_command(&registry, "whoami", &[])
+            .await
+            .expect("dispatch after a forced abort must not see a stale cancelled token");
+        assert!(out.contains("testuser"), "got: {out}");
+    }
+
+    /// The truthful no-op replies for the two other terminal states: a failed
+    /// and an already-cancelled job each name their actual state.
+    #[tokio::test]
+    async fn job_cancel_failed_and_cancelled_jobs_reply_truthfully() {
+        let sess = session(Config::default());
+        for (id, state) in [
+            ("probe-failed-1", JobState::Failed),
+            ("probe-cancelled-1", JobState::Cancelled),
+        ] {
+            let job = Arc::new(StdMutex::new(Job {
+                id: id.to_owned(),
+                command: "probe".to_owned(),
+                state,
+                started: Instant::now(),
+                finished: Some(Instant::now()),
+                result: None,
+                error: None,
+                exit_code: None,
+                handle: None,
+                cancel: CancellationToken::new(),
+            }));
+            sess.jobs.lock().unwrap().insert(id.to_owned(), job);
+
+            let msg = sess.job_cancel(id).await.expect("terminal cancel is Ok");
+            assert_eq!(msg, format!("job {id} already {state}; nothing to cancel"));
+            // The record's state is not rewritten.
+            assert_eq!(sess.job_status(id).unwrap().state, state);
+        }
     }
 
     /// `job_result` on a cancelled job surfaces the "was cancelled" envelope.
@@ -1700,6 +1955,7 @@ mod tests {
             error: None,
             exit_code: None,
             handle: None,
+            cancel: CancellationToken::new(),
         }));
         sess.jobs.lock().unwrap().insert("whoami-1".to_owned(), job);
 

--- a/crates/mtui-mcp/tests/mcp_jobs.rs
+++ b/crates/mtui-mcp/tests/mcp_jobs.rs
@@ -321,7 +321,13 @@ async fn cancel_one_template_job_leaves_others() {
     // Wait until the blocking body is running, then cancel it and release.
     started.notified().await;
     let msg = sess.job_cancel(&first).await.expect("cancel succeeds");
-    assert_eq!(msg, format!("cancelled job {first}"));
+    // The blocker never observes the cancellation token, so the two-stage
+    // cancel burns its cooperative grace and reports the forced abort.
+    assert!(
+        msg.starts_with(&format!("cancelled job {first}")),
+        "got: {msg}"
+    );
+    assert!(msg.contains("forced abort"), "got: {msg}");
     release.notify_waiters();
 
     assert_eq!(


### PR DESCRIPTION
## Problem

MCP `job_cancel` lied and had no seam. It returned `Ok("cancelled job <id>")` **unconditionally** — including for jobs that had already finished (a test pinned the lie) — and cancellation was abort-only: `handle.abort()` drops the worker future at its next await point, no command body could ever observe a cancel, clean up, or acknowledge, and mid-flight host operations kept running with no honest signal to the caller.

## Fix

**The seam (`mtui-core`):** `Session` now carries a `CancellationToken`. The `Command::run` driver checks it before dispatch and between fan-out templates — one chokepoint covers all commands without touching their bodies; a multi-template job now stops at the next template boundary. Long-running bodies can additionally opt in (`session.cancel_requested()` poll, or `select!` on `session.cancel_token()`). `fork_for_call` clones the token, so cancellation state crosses the MCP per-call fork. New typed `CommandError::Cancelled`. REPL behavior is unchanged: its token exists but nothing ever cancels it.

**Truthful `job_cancel` (`mtui-mcp`):** two-stage —

1. **Cooperative:** cancel the job's own token, give the worker `CANCEL_GRACE` (1 s) to settle. A body parked at a checkpoint unwinds cleanly; the reply is `cancelled job <id>`.
2. **Forced:** if the grace elapses, hard-abort as before — and the reply says so, including the standing caveat that a host operation already in flight may still finish on the host.

A job already in a terminal state now replies `job <id> already done/failed/cancelled; nothing to cancel` instead of claiming a cancellation that never happened.

**Wiring:** each background job mints its own token (per-job isolation — cancelling one per-template job provably leaves siblings running). It is installed on the dispatch session on both paths: set on the per-call fork (scoped), installed on the canonical session (exclusive). The install is **unconditional** — foreground calls install a fresh never-cancelled token — so a hard-aborted worker that skipped the exclusive path's restore can never leave a stale cancelled token poisoning later dispatches; the next install wipes it before the pre-flight check (asserted end-to-end in a test).

## Adversarial review

Three independent read-only reviews ran before this PR (concurrency/races, behavioral semantics/regressions, test-quality/flakiness/docs); every constructed failure scenario was refuted, and the surviving low-severity findings were fixed: truthful-reply tests for the `failed`/`cancelled` terminal states, an end-to-end self-heal assertion after a forced abort, the `Cancelled` display string pinned, CHANGELOG wording made precise. Notable refutations: the `mint_job` handle-store window is unreachable (jobs-table lock held across mint), post-timeout `abort(); await` has no lost-wakeup, `job_cancel` holds no lock across the grace await, and the cancel-vs-complete tie always resolves under one record mutex.

## Behavior notes

- `job_cancel` on an unobservant (blocked) body now takes ~1 s (the grace) before the forced abort — bounded, and the price of giving cooperative bodies a chance.
- The previously-pinned lie (`job_cancel_finished_job_is_noop` asserting `cancelled job <id>` for a `Done` job) now pins the truthful reply.

## Validation

Full workspace gate green locally: `fmt --check`, clippy `-D warnings` (all targets), `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp` (188 lib + 48 integration), compile-only feature matrix. New tests: cooperative-settles-within-grace, forced-abort-after-grace + self-heal, terminal-state truthful replies, fan-out boundary stop, pre-flight bail, fork token sharing, token replace semantics.
