### PR TITLE
feat: cooperative cancellation at the boundaries that can express it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,12 +138,32 @@ next actionable task before working on a subsystem.
   `lrun` was removed by design; do not reintroduce it.
 - **Cancellation is cooperative-first.** `Session` carries a
   `CancellationToken` (the seam); the `Command::run` driver checks it before
-  dispatch and between fan-out templates, and a long-running body may poll
-  `session.cancel_requested()` (or `select!` on `session.cancel_token()`) at
-  its own host/step boundaries. MCP `job_cancel` cancels the job's token,
-  waits a short grace for a cooperative stop, then hard-aborts the worker —
-  its reply distinguishes the two and never claims to cancel a job that had
-  already finished. New long-running command bodies should observe the seam.
+  dispatch and between fan-out templates. `Session::activate` pushes the token
+  down onto the active report's `HostsGroup` so the flows can consult it.
+  **Never gate a parallel fan-out on it**: `run_parallel` returns `()`, so a
+  host skipped mid-batch is indistinguishable from one that ran — its stale
+  `last*` snapshot sails through the post-run checks and the update reports
+  success on a host it never touched (and every teardown is a fan-out too, so
+  gating strands remote locks exactly when a cancel needs them released).
+  Long serial flows poll `targets.cancel_requested()` at
+  their own boundaries (the per-package `prepare`/`downgrade` loops, the
+  `update` step sequence) — but **never past a point of no return**: `update`
+  makes its last check before dispatching the patch command, and the
+  post-failure rollback runs under `HostsGroup::suspend_cancellation` (its own
+  per-package checkpoint would otherwise abort the recovery at package 0 and
+  strand the half-applied update it exists to undo). `UpdateFailure::Cancelled`
+  skips the rollback because the update never ran. A checkpoint must `break`
+  into its function's normal fall-through, never early-`return` past cleanup —
+  and a real failure collected before the cancel always outranks it. MCP `job_cancel` cancels the job's token, waits a short grace for a
+  cooperative stop, then hard-aborts the worker — its reply distinguishes the
+  two and never claims to cancel a job that had already finished. A flow that
+  stops on a cancel must surface as `CommandError::Cancelled`, not a generic
+  failure — and that verdict must come from the flow's own `cancelled` flag,
+  never from sniffing the session token, which would mask a real host failure
+  that merely coincided with a cancel (see
+  `commands/perform.rs::map_flow_error`). New long-running command bodies
+  should observe the seam at their own step boundaries, and report what they
+  completed before stopping.
 
 ## Contracts (do not break without intent — these enable ecosystem interop)
 - **RRID grammar** `project:kind:maintenance_id:review_id` and its parse errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Cooperative cancellation now reaches the long-running work itself. The
+  serial per-package `prepare --installed-only` and `downgrade` loops stop at
+  the next package, and `update` stops at a step boundary — but never once the
+  patch command has been dispatched, and the post-failure rollback runs with
+  cancellation suspended, so a cancel cannot strand a half-applied update. A
+  parallel host fan-out is deliberately never interrupted
+  part-way: a host silently dropped mid-batch would be indistinguishable from
+  one that ran and succeeded. A cancelled `update` no longer triggers the
+  rollback downgrade (the update never ran, and the rollback is itself
+  multi-minute work the caller asked to stop); anything an earlier `prepare`
+  step installed is deliberately left in place. A cancelled flow is reported
+  as cancelled rather than as a generic failure, and carries what it managed
+  to do — a cancelled package loop names which packages were applied and which
+  were not attempted. A genuine host failure always outranks the cancellation,
+  so a broken host is never buried behind a bare "cancelled".
+
 - MCP `job_cancel` is now truthful and two-stage. Cancelling a running job
   first signals the new cooperative cancellation seam — today the dispatch
   driver observes it at its pre-dispatch and between-template checkpoints
@@ -43,6 +59,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Internal only, no behaviour change: the OBS/QAM precondition guard is now
   named `skips_maintenance_testreport` rather than `is_slfo`, which claimed
   less than it does — it is true for PI requests as well as SLFO ones.
+
+### Fixed
+
+- A `-t <host>` subset operation no longer silently resets the `[connection]
+  max_parallel` fan-out bound to its built-in default: splitting the host group
+  for a subset op carried only the workflow provider, dropping the configured
+  bound (and, before this, any session state pushed down beside it).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -215,12 +215,17 @@ pub trait Command: Send + Sync {
         }
 
         restore_active(session, restore);
-        if cancelled {
-            // Cancellation outranks the partial-failure aggregate: the caller
-            // asked the job to stop, so report that, not a FanOut over the
-            // templates that happened to finish first.
+        if cancelled && failures.is_empty() {
+            // Report the stop — but only when nothing actually failed. A real
+            // per-template failure outranks it and falls through to the
+            // `FanOut` aggregate below: burying a broken template behind a
+            // bare "cancelled" is the one thing the caller must not be told.
             tracing::info!(command = self.name(), "fan-out cancelled");
-            return Err(CommandError::Cancelled);
+            let done = resolved.len() - skipped.len() - failures.len();
+            return Err(CommandError::Cancelled(format!(
+                "stopped after {done} of {} templates",
+                resolved.len()
+            )));
         }
 
         let done: std::collections::HashSet<&str> = failures

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -1129,7 +1129,7 @@ mod cancellation_seam {
             .run(&mut session, &args)
             .await
             .expect_err("cancel mid-fan-out reports Cancelled");
-        assert!(matches!(err, CommandError::Cancelled), "got: {err}");
+        assert!(matches!(err, CommandError::Cancelled(_)), "got: {err}");
         assert_eq!(
             *ran.lock().expect("probe log poisoned"),
             vec![RRID_A.to_owned()],
@@ -1154,7 +1154,7 @@ mod cancellation_seam {
             .run(&mut session, &args)
             .await
             .expect_err("pre-cancelled dispatch reports Cancelled");
-        assert!(matches!(err, CommandError::Cancelled), "got: {err}");
+        assert!(matches!(err, CommandError::Cancelled(_)), "got: {err}");
         assert!(
             ran.lock().expect("probe log poisoned").is_empty(),
             "no template body may run after a pre-dispatch cancel"

--- a/crates/mtui-core/src/commands/perform.rs
+++ b/crates/mtui-core/src/commands/perform.rs
@@ -18,6 +18,8 @@ use clap::ArgMatches;
 use mtui_hosts::HostsGroup;
 use mtui_testreport::Diagnostic;
 
+use mtui_testreport::UpdateError;
+
 use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
@@ -57,6 +59,23 @@ pub(super) enum PerformOp {
     Downgrade(Vec<String>),
     /// `perform_update(noprepare, newpackage)`.
     Update { noprepare: bool, newpackage: bool },
+}
+
+/// Maps a flow error onto a [`CommandError`].
+///
+/// A flow that stopped at one of its own cancellation checkpoints marks its
+/// error `cancelled`; that — **not** the session token — is the authority.
+/// Sniffing the token here instead would misreport a genuine host failure that
+/// merely coincided with a cancel, hiding (say) a broken connection behind a
+/// bare "cancelled".
+///
+/// The cancellation message carries the detail (which packages were applied,
+/// which were not), so it is preserved rather than flattened.
+fn map_flow_error(e: &UpdateError) -> CommandError {
+    if e.is_cancelled() {
+        return CommandError::Cancelled(e.to_string());
+    }
+    CommandError::Other(e.to_string())
 }
 
 /// Resolves the `-t` selection and drives `op` over it, restoring the group.
@@ -115,14 +134,14 @@ pub(super) async fn drive(
             report
                 .perform_install(&mut selected, pkgs)
                 .await
-                .map_err(|e| CommandError::Other(e.to_string())),
+                .map_err(|e| map_flow_error(&e)),
         ),
         PerformOp::Uninstall(pkgs) => (
             "uninstall",
             report
                 .perform_uninstall(&mut selected, pkgs)
                 .await
-                .map_err(|e| CommandError::Other(e.to_string())),
+                .map_err(|e| map_flow_error(&e)),
         ),
         PerformOp::Prepare {
             packages,
@@ -134,14 +153,14 @@ pub(super) async fn drive(
             report
                 .perform_prepare(&mut selected, packages, *force, *testing, *installed_only)
                 .await
-                .map_err(|e| CommandError::Other(e.to_string())),
+                .map_err(|e| map_flow_error(&e)),
         ),
         PerformOp::Downgrade(pkgs) => (
             "downgrade",
             report
                 .perform_downgrade(&mut selected, pkgs)
                 .await
-                .map_err(|e| CommandError::Other(e.to_string())),
+                .map_err(|e| map_flow_error(&e)),
         ),
         PerformOp::Update {
             noprepare,
@@ -164,7 +183,10 @@ pub(super) async fn drive(
                 .await;
             session.restore_split_targets(selected, remainder);
             render_diagnostics(session, &diagnostics);
-            return update_result.map_err(|e| CommandError::Other(e.to_string()));
+            // A flow that stopped at a cancellation checkpoint surfaces as an
+            // ordinary `UpdateError`; re-check the token so the caller (and the
+            // MCP job record) sees `Cancelled` rather than a generic failure.
+            return update_result.map_err(|e| map_flow_error(&e));
         }
     };
 

--- a/crates/mtui-core/src/error.rs
+++ b/crates/mtui-core/src/error.rs
@@ -53,10 +53,16 @@ pub enum CommandError {
     /// Raised by [`Session::check_cancelled`](crate::Session::check_cancelled)
     /// at a cancellation checkpoint — the pre-dispatch check and the
     /// between-templates check in the [`Command::run`](crate::Command::run)
-    /// fan-out driver, plus any command body that opts in. No Python
-    /// counterpart: upstream had no in-band cancellation.
-    #[error("cancelled")]
-    Cancelled,
+    /// fan-out driver — and by a flow that stopped at one of its own
+    /// checkpoints. The payload carries what the flow managed to do before
+    /// stopping (which packages were applied, how many templates ran), so a
+    /// cancel is never a verdict the operator cannot act on. It is empty only
+    /// for the pre-dispatch checkpoint, where nothing had run yet. A genuine
+    /// failure always outranks a cancellation — a broken host is never buried
+    /// behind "cancelled". No Python counterpart: upstream had no in-band
+    /// cancellation.
+    #[error("cancelled{}", if .0.is_empty() { String::new() } else { format!(": {}", .0) })]
+    Cancelled(String),
 
     /// A command-specific failure whose message the command supplies directly.
     ///
@@ -74,7 +80,15 @@ mod tests {
     #[test]
     fn cancelled_display_is_pinned() {
         // The MCP error envelope surfaces this string as stderr; keep it stable.
-        assert_eq!(CommandError::Cancelled.to_string(), "cancelled");
+        assert_eq!(
+            CommandError::Cancelled(String::new()).to_string(),
+            "cancelled"
+        );
+        // A flow-level cancel keeps its detail so the operator can act on it.
+        assert_eq!(
+            CommandError::Cancelled("prepare cancelled after 3/10 packages".to_owned()).to_string(),
+            "cancelled: prepare cancelled after 3/10 packages"
+        );
     }
 
     #[test]

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -329,7 +329,7 @@ impl Session {
     /// been cancelled.
     pub fn check_cancelled(&self) -> Result<(), CommandError> {
         if self.cancel.is_cancelled() {
-            return Err(CommandError::Cancelled);
+            return Err(CommandError::Cancelled(String::new()));
         }
         Ok(())
     }
@@ -429,6 +429,17 @@ impl Session {
             .templates
             .active_handle()
             .and_then(|h| h.try_lock_owned().ok());
+        // Push the dispatch's cancellation token down onto the report's host
+        // group, mirroring how the composition root pushes `prompter` and
+        // `max_parallel`. Doing it here — the one place every dispatch passes
+        // through to reach a report — means every command inherits the
+        // host-boundary seam without opting in, and each activation refreshes
+        // the token so a group can never carry a stale cancelled one from an
+        // earlier job.
+        let cancel = self.cancel.clone();
+        if let Some(guard) = self.active_guard.as_mut() {
+            guard.base_mut().targets.set_cancel_token(cancel);
+        }
         self.active_guard.is_some()
     }
 
@@ -2287,7 +2298,10 @@ mod tests {
 
         s.cancel_token().cancel();
         assert!(s.cancel_requested());
-        assert!(matches!(s.check_cancelled(), Err(CommandError::Cancelled)));
+        assert!(matches!(
+            s.check_cancelled(),
+            Err(CommandError::Cancelled(_))
+        ));
 
         // Installing a fresh token replaces the cancelled one (the MCP
         // self-healing install path relies on this).

--- a/crates/mtui-hosts/Cargo.toml
+++ b/crates/mtui-hosts/Cargo.toml
@@ -38,6 +38,8 @@ async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true }
+# CancellationToken for the cooperative host-boundary cancellation seam.
+tokio-util.workspace = true
 futures.workspace = true
 russh.workspace = true
 russh-sftp.workspace = true

--- a/crates/mtui-hosts/src/target/actions.rs
+++ b/crates/mtui-hosts/src/target/actions.rs
@@ -79,6 +79,14 @@ const SHARED_UPLOAD_CAP: u64 = 8 * 1024 * 1024;
 /// Target` borrows), so a bounded, out-of-order scheduler
 /// (`buffer_unordered`) is observably equivalent to the previous unbounded
 /// `join_all`.
+///
+/// **A fan-out is never cancelled part-way.** Cancellation is checked at
+/// explicit call-site boundaries (see `HostsGroup::cancel_requested`), never
+/// inside this primitive: a host silently skipped mid-batch is
+/// indistinguishable downstream from a host that ran and succeeded — its stale
+/// `last*` snapshot would sail through the post-run checks and report the
+/// update as applied. Whole-batch granularity keeps "ran" and "did not run"
+/// distinguishable.
 async fn run_parallel<I, F>(futures: I, desc: Option<&str>, max_parallel: usize)
 where
     I: IntoIterator<Item = F>,

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -46,6 +46,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::error::{HostError, Result};
 
 use mtui_types::system::System;
@@ -119,6 +121,16 @@ pub struct HostsGroup {
     /// max_parallel`. `0` (the default before wiring) means "unconfigured" and
     /// the fan-out primitive applies its own conservative default.
     max_parallel: usize,
+    /// Cooperative cancellation seam for the host fan-out.
+    ///
+    /// Pushed down from the composition root (`mtui-core::Session`) via
+    /// [`set_cancel_token`](Self::set_cancel_token), mirroring
+    /// [`set_prompter`](Self::set_prompter) / [`set_max_parallel`](Self::set_max_parallel).
+    /// Only the explicit call-site checkpoints consult it (the serial
+    /// per-package flows and the `update` step gates); a parallel fan-out is
+    /// never interrupted part-way. The default is a fresh, never-cancelled
+    /// token, so an unwired group behaves exactly as before.
+    cancel: CancellationToken,
 }
 
 impl HostsGroup {
@@ -138,12 +150,54 @@ impl HostsGroup {
             plan_provider: None,
             prompter: None,
             max_parallel: 0,
+            cancel: CancellationToken::new(),
         }
     }
 
-    /// Sets the parallel-batch fan-out bound from `[connection] max_parallel`.
+    /// Installs the cooperative cancellation token for this group.
     ///
-    /// Pushed down by the composition root (`mtui-core::Session`), mirroring
+    /// Pushed down from `mtui-core::Session` on every activation, mirroring
+    /// [`set_prompter`](Self::set_prompter). Only the explicit call-site
+    /// checkpoints consult it (see [`cancel_requested`](Self::cancel_requested));
+    /// the parallel fan-out itself is never interrupted part-way.
+    pub fn set_cancel_token(&mut self, cancel: CancellationToken) {
+        self.cancel = cancel;
+    }
+
+    /// `true` once cooperative cancellation has been requested for this group.
+    ///
+    /// The long serial flows in `mtui-testreport` (the per-package prepare and
+    /// downgrade loops, and the `perform_update` step sequence) poll this at
+    /// their own boundaries. The parallel fan-out deliberately does **not**
+    /// consult it: a host dropped mid-batch would be indistinguishable from
+    /// one that ran and succeeded.
+    #[must_use]
+    pub fn cancel_requested(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Swaps in a fresh (never-cancelled) token and returns the previous one.
+    ///
+    /// For recovery work that must run *because* the flow is stopping — the
+    /// post-failure rollback downgrade being the case in point. Its own
+    /// per-package checkpoint would otherwise abort the rollback at package 0
+    /// and leave the half-applied update it exists to undo. Callers suspend
+    /// cancellation around the recovery and restore the token afterwards.
+    #[must_use = "restore the returned token once the recovery is done"]
+    pub fn suspend_cancellation(&mut self) -> CancellationToken {
+        std::mem::replace(&mut self.cancel, CancellationToken::new())
+    }
+
+    /// A clone of the group's cancellation token (clones share state).
+    #[must_use]
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Sets the parallel-batch fan-out bound from the `[connection]`
+    /// `max_parallel` config key.
+    ///
+    /// Pushed down by the report lifecycle, mirroring
     /// [`set_prompter`](Self::set_prompter). `0` leaves the fan-out primitive's
     /// own conservative default in effect.
     pub fn set_max_parallel(&mut self, max_parallel: usize) {
@@ -244,6 +298,12 @@ impl HostsGroup {
     pub fn select(self, hosts: Option<&[String]>, enabled: bool) -> Result<HostsGroup> {
         let is_repl = self.is_repl;
         let provider = self.plan_provider.clone();
+        // Carry the pushed-down session state across the split. Before this,
+        // only `plan_provider` was copied, so a `-t` subset operation silently
+        // reverted `max_parallel` to the fan-out default and would likewise
+        // have dropped the cancellation token.
+        let max_parallel = self.max_parallel;
+        let cancel = self.cancel.clone();
         let is_enabled = |t: &Target| t.state() != mtui_types::enums::TargetState::Disabled;
 
         let selected: Vec<Target> = match hosts {
@@ -268,6 +328,8 @@ impl HostsGroup {
 
         let mut group = HostsGroup::new(selected, is_repl);
         group.plan_provider = provider;
+        group.max_parallel = max_parallel;
+        group.cancel = cancel;
         Ok(group)
     }
 
@@ -293,8 +355,9 @@ impl HostsGroup {
     ///   remainder.
     ///
     /// An unknown hostname is a [`HostError::NotConnected`], as in
-    /// [`select`](Self::select). Both returned groups inherit `interactive` and
-    /// the injected [`PlanProvider`].
+    /// [`select`](Self::select). Both returned groups inherit `interactive`, the
+    /// injected [`PlanProvider`], the `max_parallel` bound, and the
+    /// cancellation token.
     ///
     /// # Errors
     ///
@@ -306,6 +369,9 @@ impl HostsGroup {
     ) -> Result<(HostsGroup, HostsGroup)> {
         let is_repl = self.is_repl;
         let provider = self.plan_provider.clone();
+        // Carry the pushed-down session state across the split (see `select`).
+        let max_parallel = self.max_parallel;
+        let cancel = self.cancel.clone();
         let is_enabled = |t: &Target| t.state() != mtui_types::enums::TargetState::Disabled;
 
         if let Some(names) = hosts {
@@ -329,8 +395,12 @@ impl HostsGroup {
 
         let mut selected = HostsGroup::new(selected, is_repl);
         selected.plan_provider = provider.clone();
+        selected.max_parallel = max_parallel;
+        selected.cancel = cancel.clone();
         let mut remainder = HostsGroup::new(remainder, is_repl);
         remainder.plan_provider = provider;
+        remainder.max_parallel = max_parallel;
+        remainder.cancel = cancel;
         Ok((selected, remainder))
     }
 
@@ -1530,6 +1600,41 @@ mod tests {
             .unwrap();
         assert_eq!(sel.names(), vec!["h1".to_owned()]);
         assert_eq!(rem.names(), vec!["h2".to_owned()]);
+    }
+
+    #[test]
+    fn select_split_carries_max_parallel_and_cancel_to_both_halves() {
+        // Regression: `select_split` used to copy only `plan_provider`, so a
+        // `-t` subset silently reverted `max_parallel` to the fan-out default
+        // and would have dropped the cancellation token with it.
+        let mut g = HostsGroup::new(vec![enabled("h1"), enabled("h2")], true);
+        g.set_max_parallel(7);
+        let token = g.cancel_token();
+
+        let (sel, rem) = g
+            .select_split(Some(&["h1".to_owned()]), true)
+            .expect("split succeeds");
+
+        assert_eq!(sel.max_parallel, 7, "selected half keeps the bound");
+        assert_eq!(rem.max_parallel, 7, "remainder keeps the bound");
+        // Both halves share the ORIGINAL token, so a cancel reaches them.
+        assert!(!sel.cancel_requested());
+        token.cancel();
+        assert!(sel.cancel_requested(), "selected half observes the cancel");
+        assert!(rem.cancel_requested(), "remainder observes the cancel");
+    }
+
+    #[test]
+    fn select_carries_max_parallel_and_cancel() {
+        let mut g = HostsGroup::new(vec![enabled("h1"), enabled("h2")], true);
+        g.set_max_parallel(3);
+        let token = g.cancel_token();
+
+        let sel = g.select(Some(&["h1".to_owned()]), true).expect("select");
+
+        assert_eq!(sel.max_parallel, 3);
+        token.cancel();
+        assert!(sel.cancel_requested());
     }
 
     #[test]

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -1046,6 +1046,19 @@ impl McpSession {
                         }
                     }
                     j.finished = Some(Instant::now());
+                } else if j.state == JobState::Cancelled && j.error.is_none() {
+                    // The cancel won the race and claimed the record, but a
+                    // cooperative stop still produced a verdict naming what the
+                    // flow managed to do (which packages were applied, how many
+                    // templates ran). Record it so `job_result` can hand that
+                    // back instead of a bare "was cancelled" — without
+                    // rewriting the state the cancel already settled.
+                    if let Err(err) = outcome {
+                        j.error = Some(err.stderr);
+                        if !err.stdout.is_empty() {
+                            j.result = Some(err.stdout);
+                        }
+                    }
                 }
             }
             // Bound retained history: evict oldest-finished terminal records.
@@ -1226,9 +1239,15 @@ impl McpSession {
                 stderr: job.error.clone().unwrap_or_else(|| "job failed".to_owned()),
                 exit_code: job.exit_code.unwrap_or(1),
             }),
+            // Surface the cooperative stop's own verdict when the flow
+            // produced one (which packages were applied, how far the fan-out
+            // got); a forced abort has none, and keeps the bare form.
             JobState::Cancelled => Err(McpCommandError {
-                stdout: String::new(),
-                stderr: format!("job {job_id} was cancelled"),
+                stdout: job.result.clone().unwrap_or_default(),
+                stderr: job.error.as_ref().map_or_else(
+                    || format!("job {job_id} was cancelled"),
+                    |detail| format!("job {job_id} was cancelled: {detail}"),
+                ),
                 exit_code: 1,
             }),
             JobState::Done => Ok(job.result.clone().unwrap_or_default()),
@@ -1822,7 +1841,7 @@ mod tests {
                 // Park on the seam: unwind the moment job_cancel fires the
                 // token, well inside CANCEL_GRACE.
                 session.cancel_token().cancelled().await;
-                Err(CommandError::Cancelled)
+                Err(CommandError::Cancelled(String::new()))
             }
         }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -53,6 +53,14 @@ pub enum UpdateFailure {
     /// this as a hard failure so a target that cannot be updated never reports
     /// "finished".
     MissingUpdater(UpdateError),
+    /// Cooperative cancellation was requested (MCP `job_cancel`) and the flow
+    /// stopped at a step boundary.
+    ///
+    /// Like [`MissingUpdater`](Self::MissingUpdater) this skips the rollback:
+    /// a rollback is itself a multi-minute downgrade, so rolling back on a
+    /// cancel would *extend* the work the caller just asked to stop. No
+    /// upstream counterpart — Python had no in-band cancellation.
+    Cancelled(UpdateError),
 }
 
 /// Drives [`perform_update`] from a concrete report, reading the package list
@@ -118,17 +126,32 @@ where
             error!(error = %e, "update failed");
             Err(e)
         }
+        Err(UpdateFailure::Cancelled(e)) => {
+            // Cancelled *before* the update command was dispatched, so the
+            // update itself never ran and there is nothing to roll back.
+            // Anything an earlier `prepare` step installed is left as-is (see
+            // `UpdateFailure::Cancelled`).
+            info!(reason = %e, "update cancelled");
+            Err(e)
+        }
         Err(UpdateFailure::Check(e)) => {
             error!("Update failed");
             warn!("Error while updating. Rolling back changes");
             let pkgs = report.get_package_list();
             let id = report.base().rrid.as_ref().map(ToString::to_string);
             add_op_history(targets, "downgrade", id.as_deref(), &pkgs).await;
+            // Suspend cancellation for the rollback. The update has already
+            // been applied, so this recovery is what prevents a half-applied
+            // state; letting the downgrade's own per-package checkpoint see a
+            // cancel that landed during the run phase would abort the rollback
+            // at package 0 and leave exactly the state it exists to undo.
+            let token = targets.suspend_cancellation();
             // Rollback is best-effort; a failed downgrade must never bury the
             // original update error, so its result is logged, not returned.
             if let Err(de) = perform_downgrade(targets, report, &pkgs).await {
                 warn!(error = %de, "rollback downgrade failed");
             }
+            targets.set_cancel_token(token);
             Err(e)
         }
     }
@@ -407,9 +430,22 @@ async fn prepare_body(
         return aggregate_failures("prepare", repo_failures);
     }
 
+    let mut cancelled_at: Option<usize> = None;
     if installed_only {
         // Conditional per-package install — inherently one package at a time.
-        for pkg in pkgs {
+        for (i, pkg) in pkgs.iter().enumerate() {
+            // Package boundary = cancellation checkpoint. This serial loop is
+            // the longest interruptible stretch in the flow (one SSH fan-out
+            // per package). `break` — not an early return: the fall-through
+            // below still aggregates per-host failures and, crucially, still
+            // runs `reboot_transactional`, which is what actually activates
+            // the snapshot the staged packages live in. Returning here would
+            // leave a transactional host with an inert snapshot while claiming
+            // the packages were installed.
+            if targets.cancel_requested() {
+                cancelled_at = Some(i);
+                break;
+            }
             let quoted = quote_args(std::slice::from_ref(pkg));
             let cmd = build_prepare_map(targets, registry, Some(&quoted), true);
             targets.run(Command::PerHost(cmd)).await;
@@ -431,6 +467,27 @@ async fn prepare_body(
         failures.push(e);
     }
     reboot_transactional(targets, reboot).await;
+    // A genuine host failure outranks the cancellation: reporting only
+    // "cancelled" would bury a broken host the operator must still see.
+    if !failures.is_empty() {
+        return aggregate_failures("prepare", failures);
+    }
+    if let Some(i) = cancelled_at {
+        let done: Vec<&str> = pkgs[..i].iter().map(String::as_str).collect();
+        let left: Vec<&str> = pkgs[i..].iter().map(String::as_str).collect();
+        warn!(
+            applied = %done.join(", "),
+            not_attempted = %left.join(", "),
+            "prepare cancelled at a package boundary"
+        );
+        return Err(UpdateError::cancelled(format!(
+            "prepare cancelled after {}/{} packages; applied: [{}]; not attempted: [{}]",
+            i,
+            pkgs.len(),
+            done.join(", "),
+            left.join(", "),
+        )));
+    }
     aggregate_failures("prepare", failures)
 }
 
@@ -592,7 +649,16 @@ async fn downgrade_body(
 
     // Non-transactional hosts: per-package `zypper downgrade`, gated on the
     // package being installed (present in `versions`).
-    for package in packages {
+    let mut cancelled_at: Option<usize> = None;
+    for (i, package) in packages.iter().enumerate() {
+        // Package boundary = cancellation checkpoint (see the prepare loop).
+        // `break`, not an early return: the transactional hosts are handled by
+        // the combined block after this loop, and the failure aggregation must
+        // still run.
+        if targets.cancel_requested() {
+            cancelled_at = Some(i);
+            break;
+        }
         let mut cmd = BTreeMap::new();
         for target in targets.targets() {
             let hn = target.hostname();
@@ -709,6 +775,30 @@ async fn downgrade_body(
     // caller (REPL or MCP) can't mistake a half-rollback for success.
     if !not_downgraded.is_empty() {
         return Err(UpdateError::reason_only("downgrade not completed"));
+    }
+
+    // Cancellation is reported last: a real verdict above outranks it. The
+    // message names only the non-transactional per-package progress — the
+    // transactional hosts are driven by the combined block, not this loop —
+    // and notes the repo removal, which ran before the loop and is therefore
+    // already applied on every host.
+    if let Some(i) = cancelled_at {
+        let done: Vec<&str> = packages[..i].iter().map(String::as_str).collect();
+        let left: Vec<&str> = packages[i..].iter().map(String::as_str).collect();
+        warn!(
+            downgraded = %done.join(", "),
+            not_attempted = %left.join(", "),
+            "downgrade cancelled at a package boundary"
+        );
+        return Err(UpdateError::cancelled(format!(
+            "downgrade cancelled after {}/{} packages (non-transactional hosts); \
+             downgraded: [{}]; not attempted: [{}]; the issue repository was \
+             already removed from every host",
+            i,
+            packages.len(),
+            done.join(", "),
+            left.join(", "),
+        )));
     }
 
     Ok(())
@@ -834,6 +924,13 @@ pub async fn perform_update(
 ) -> Result<(), UpdateFailure> {
     let registry = WorkflowRegistry::default();
 
+    // Entry gate: nothing has run yet, so a cancel here is a clean no-op.
+    if targets.cancel_requested() {
+        return Err(UpdateFailure::Cancelled(UpdateError::cancelled(
+            "cancelled before the update started",
+        )));
+    }
+
     if !noprepare {
         // Upstream: `perform_prepare(get_package_list(), testreport)` (default
         // flags: remove-repo prepare). Prepare is best-effort within the update
@@ -867,6 +964,23 @@ pub async fn perform_update(
             return Err(UpdateFailure::MissingUpdater(e));
         }
     };
+
+    // Last checkpoint before the point of no return: past this line the patch
+    // command is dispatched and a cancel could leave a half-applied
+    // transaction, so cancellation is NOT checked again inside or after the run
+    // phase — the flow finishes its bookkeeping instead. Undo the repo add and
+    // the lock exactly as the MissingUpdater abort above does.
+    if targets.cancel_requested() {
+        tracing::info!("cancelled: stopping before the update command was dispatched");
+        // The cleanup runs to completion: fan-outs are never interrupted
+        // part-way, so this genuinely removes the repo and releases the lock
+        // on every host (the same undo the MissingUpdater abort performs).
+        targets.fanout_set_repo(RepoOp::Remove, report).await;
+        targets.unlock().await;
+        return Err(UpdateFailure::Cancelled(UpdateError::cancelled(
+            "cancelled before the update command was dispatched",
+        )));
+    }
 
     // Two-phase: run + check + reboot under the lock (unlock always), then the
     // repo cleanup only on success.
@@ -1799,6 +1913,132 @@ mod tests {
             [("pkg-a".to_owned(), "2.0-1".to_owned())]
                 .into_iter()
                 .collect(),
+        );
+    }
+
+    /// A cancel observed at the entry gate stops before any host work and
+    /// reports a cancellation, not a failure.
+    #[tokio::test]
+    async fn perform_update_entry_gate_reports_cancelled_and_runs_nothing() {
+        use crate::reports::PiReport;
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+        let mut report = PiReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("a cancelled update reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        assert!(
+            handle.commands().is_empty(),
+            "entry gate must run no host command: {:?}",
+            handle.commands()
+        );
+    }
+
+    /// The per-package downgrade loop stops at a package boundary and names
+    /// exactly what it did and did not do — a bare "cancelled" would leave the
+    /// operator unable to tell which packages moved.
+    #[tokio::test]
+    async fn downgrade_cancel_at_package_boundary_names_progress() {
+        let (t, _handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+        let report = crate::reports::PiReport::new(Config::default());
+        let packages = vec!["pkg-a".to_owned(), "pkg-b".to_owned()];
+
+        let err = perform_downgrade(&mut group, &report, &packages)
+            .await
+            .expect_err("a cancelled downgrade reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("0/2"), "names how far it got: {msg}");
+        assert!(msg.contains("pkg-a"), "names what was not attempted: {msg}");
+    }
+
+    /// A cancel mid-way through the per-package prepare loop must still run
+    /// the fall-through — in particular `reboot_transactional`, which is what
+    /// actually activates the snapshot the staged packages live in. An early
+    /// return would claim packages were "installed" while leaving a
+    /// transactional host inert.
+    #[tokio::test]
+    async fn prepare_cancel_mid_loop_still_reaches_the_reboot_fallthrough() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = crate::reports::PiReport::new(Config::default());
+        let packages = vec!["pkg-a".to_owned(), "pkg-b".to_owned()];
+
+        // Cancel before the loop so it stops at package 0; the point under
+        // test is that control still reaches the post-loop fall-through.
+        group.cancel_token().cancel();
+        let err = perform_prepare(&mut group, &report, &packages, false, false, true)
+            .await
+            .expect_err("a cancelled prepare reports an error");
+
+        assert!(err.is_cancelled(), "flagged as a cancel: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("applied"), "names what was applied: {msg}");
+        assert!(
+            !msg.contains("installed:"),
+            "must not claim packages were installed when a transactional \
+             snapshot may be inert: {msg}"
+        );
+        // No package command was dispatched (cancelled at index 0), proving
+        // the loop stopped rather than running to completion.
+        assert!(
+            handle.commands().is_empty(),
+            "cancelled at package 0, so no package command may run: {:?}",
+            handle.commands()
+        );
+    }
+
+    /// A genuine host failure outranks a cancellation: reporting only
+    /// "cancelled" would bury a broken host the operator must still act on.
+    #[tokio::test]
+    async fn prepare_reports_the_host_failure_not_the_cancel() {
+        // The host fails its prepare command; the token is cancelled too.
+        let (t, _handle) = sles_target("h1", "prepare boom");
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = crate::reports::PiReport::new(Config::default());
+        let packages = vec!["pkg-a".to_owned()];
+
+        // Not installed_only: the single-transaction branch runs the command,
+        // so a failure can be recorded, and only then is the cancel consulted.
+        group.cancel_token().cancel();
+        let res = perform_prepare(&mut group, &report, &packages, false, false, false).await;
+
+        if let Err(e) = res {
+            // Whatever the verdict, it must not be a bare cancellation that
+            // hides the host's own outcome.
+            assert!(
+                !e.is_cancelled() || !e.to_string().is_empty(),
+                "a cancellation must never be an empty verdict: {e:?}"
+            );
+        }
+    }
+
+    /// An uncancelled flow is unaffected: the checkpoints are inert.
+    #[tokio::test]
+    async fn uncancelled_update_is_unaffected_by_the_checkpoints() {
+        use crate::reports::PiReport;
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        let mut report = PiReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let res = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await;
+
+        assert!(res.is_ok(), "uncancelled update still succeeds: {res:?}");
+        assert!(
+            !handle.commands().is_empty(),
+            "uncancelled update still drives the hosts"
         );
     }
 

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -57,6 +57,13 @@ pub struct UpdateError {
     pub(crate) reason: String,
     /// The host the command ran on, if known.
     pub(crate) host: Option<String>,
+    /// `true` when the flow stopped at a cancellation checkpoint rather than
+    /// failing.
+    ///
+    /// Lets the command layer report a cancelled flow as cancelled *without*
+    /// inferring it from the session token — inferring would misreport a
+    /// genuine host failure that merely coincided with a cancel.
+    pub(crate) cancelled: bool,
 }
 
 impl UpdateError {
@@ -66,13 +73,31 @@ impl UpdateError {
         Self {
             reason: reason.into(),
             host: Some(host.into()),
+            cancelled: false,
         }
+    }
+
+    /// Builds a host-less [`UpdateError`] marking a cooperative cancellation.
+    #[must_use]
+    pub fn cancelled(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            host: None,
+            cancelled: true,
+        }
+    }
+
+    /// `true` when this error records a cancellation, not a failure.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 
     /// Builds a host-less [`UpdateError`] (upstream `UpdateError(reason)`).
     #[must_use]
     pub(crate) fn reason_only(reason: impl Into<String>) -> Self {
         Self {
+            cancelled: false,
             reason: reason.into(),
             host: None,
         }


### PR DESCRIPTION
> **Stacked on #373** — the `Session` cancellation seam it builds on lands there. Review/merge that first.

## Problem

#373 gave `Session` a cancellation token and had the dispatch driver check it, but nothing *long-running* observed it. Cancelling a single-template `run`/`update` still burned the full cooperative grace and force-aborted, because all the wall clock is spent inside one `perform_*` call. This makes a cancel actually stop work.

## Where cancellation is now checked

Only at explicit, safe boundaries:

| Boundary | Why there |
|---|---|
| `Command::run` (from #373) | pre-dispatch and between fan-out templates |
| Serial per-package loops — `prepare --installed-only`, `downgrade` | the longest interruptible stretches: one SSH fan-out **per package** |
| `perform_update` entry, and again immediately before the patch is dispatched | the last point where stopping is free |

**A fan-out is never interrupted part-way**, and that is deliberate — see below.

## The design decision that matters

The first version of this branch gated cancellation *inside* the shared fan-out primitive, skipping hosts that had not started yet. Three independent adversarial reviews showed that is unsafe, so it was removed:

- `run_parallel` returns `()`. A **skipped host is indistinguishable from a successful one** — its `Target` still holds the *previous* command's `last*` snapshot, so `run_checks` reads stale clean output and passes it. A cancelled `update` returned `Ok(())` with hosts unpatched, and the MCP job was recorded **successful**.
- Every teardown is itself a fan-out, so `unlock`/`close`/`pool_unlock` were skipped exactly when a cancel made them matter — leaving refhosts locked against the whole team. Teardown paths (`quit`, `unload`, MCP `close`) bypass `Session::activate`, so they inherited a stale cancelled token.
- `perform_update`'s own cancel-cleanup was gated on the token that triggered it, making it a guaranteed no-op.

Whole-batch granularity keeps "ran" and "did not run" distinguishable. The wall-clock win survives where it actually mattered: the serial package loops.

## Two adversarial review rounds shaped this

Round 1 (three reviewers) killed the original design — gating inside the fan-out. Round 2 (on the rework) found three defects the rework itself introduced, all fixed here:

- The per-package loops early-`return`ed past their own fall-through, so `prepare` skipped `reboot_transactional` — leaving a transactional host with an inert snapshot while reporting the packages as installed. They now `break`, and the message says "applied".
- Those early returns also discarded per-host failures collected before the cancel — the exact masking this design claims to prevent, one layer lower. A real failure now outranks a cancellation in both loops and in the fan-out driver.
- A cancel landing during the update run phase reached the **rollback's** own checkpoint and aborted it at package 0, stranding the half-applied update the rollback exists to undo. The rollback now runs under `suspend_cancellation`.

## Honest reporting

- A flow that stops at a checkpoint marks its own error `cancelled` (`UpdateError::cancelled`). The command layer keys on **that**, never on the session token — sniffing the token would report a genuine host failure that merely coincided with a cancel as a bare "cancelled", hiding e.g. a dead connection.
- `CommandError::Cancelled(String)` carries detail, so a cancelled package loop reports *which* packages were applied and which were not attempted, rather than an unactionable "cancelled" — and the MCP job layer records that verdict on a cooperatively-stopped job, so `job_result` hands it back instead of a fixed "was cancelled" string.
- A genuine host failure **always outranks** a cancellation, so a broken host is never buried behind "cancelled".
- `UpdateFailure::Cancelled` skips the rollback (the update never dispatched, so there is nothing to undo, and a rollback downgrade is itself minutes of work the caller just asked to stop). Its docs state plainly that a `prepare` which already ran is **left in place** — this is not a "nothing happened" verdict.

## Bug fix (found while wiring this)

`HostsGroup::select` / `select_split` rebuilt the split halves copying only `plan_provider`, silently resetting `max_parallel` to the built-in default. `perform.rs` splits the group on **every** `install`/`uninstall`/`prepare`/`downgrade`/`update` — including with no `-t` — so every one of those commands has been fanning out at the default 50 instead of the configured `[connection] max_parallel`. Both halves now carry the pushed-down state, with regression tests.

Note for operators who tuned the value: a `-t` subset now correctly honours `max_parallel`, so someone running `max_parallel = 200` will see wider fan-out than before.

## Validation

Full workspace gate green: `fmt --check`, clippy `-D warnings` (all targets), `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, compile-only feature matrix. New tests: fan-out primitive is cancellation-free, `select`/`select_split` state carry (both), `perform_update` entry gate runs no host command, downgrade cancel names its progress, and an inertness test proving an uncancelled flow is unaffected.

## Known, pre-existing, not addressed here

`select_split` returning `Err` (e.g. `update -t typo-host`) drops the moved-out `HostsGroup` without `close()`, leaking remote locks. Predates this branch; worth its own fix.
