### PR TITLE
test(rrid): pin the four kind predicates apart, and cover PI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - mtui is now licensed GPL-3.0-or-later (previously GPL-2.0-only, matching
   upstream); see `LICENSE`.
+- Internal only, no behaviour change: the OBS/QAM precondition guard is now
+  named `skips_maintenance_testreport` rather than `is_slfo`, which claimed
+  less than it does — it is true for PI requests as well as SLFO ones.
 
 ### Removed
 

--- a/crates/mtui-core/src/commands/apicall.rs
+++ b/crates/mtui-core/src/commands/apicall.rs
@@ -508,6 +508,35 @@ mod tests {
         assert!(!is_gitea_workflow(&maint));
     }
 
+    /// PI is *not* a Gitea request, even though `qam`'s precondition guard
+    /// treats PI and SLFO alike. This is a live distinction — merging the two
+    /// guards would route PI through the wrong backend.
+    #[test]
+    fn is_gitea_workflow_excludes_pi() {
+        for id in ["SUSE:PI:1.1:5", "SUSE:PI:1.2:5", "SUSE:PI:42:99"] {
+            let rrid: mtui_types::RequestReviewID = id.parse().unwrap();
+            assert!(!is_gitea_workflow(&rrid), "{id} must use the OSC backend");
+        }
+    }
+
+    /// Upstream `_is_gitea_workflow` is open-ended (`!= "1.1"`), unlike the QEM
+    /// dashboard's closed `== "1.2"`. Today only `1.1` and `1.2` occur, so the
+    /// two agree on every real RRID and this test is the only thing recording
+    /// that they are nonetheless different predicates.
+    ///
+    /// The id below is **hypothetical** — there is no SLFO 2.0 product, and none
+    /// is expected soon. The test exists so that if one ever appears, the
+    /// open-ended formulation is still in force rather than having been quietly
+    /// narrowed to `== "1.2"` while the suite stayed green.
+    #[test]
+    fn is_gitea_workflow_stays_open_ended_beyond_1_2() {
+        let rrid: mtui_types::RequestReviewID = "SUSE:SLFO:2.0:5".parse().unwrap();
+        assert!(
+            is_gitea_workflow(&rrid),
+            "a future SLFO id must still route to Gitea"
+        );
+    }
+
     #[test]
     fn reject_requires_reason_and_validates_choices() {
         let cmd = Reject.configure(clap::Command::new("reject").no_binary_name(true));

--- a/crates/mtui-datasources/src/obs/qam.rs
+++ b/crates/mtui-datasources/src/obs/qam.rs
@@ -30,8 +30,15 @@ use crate::obs::models::{
 
 const PREFIX: &str = "[oscqam] ";
 
-/// PI/SLFO requests carry no maintenance testreport or `MAINT` attribute.
-fn is_slfo(rrid: &RequestReviewID) -> bool {
+/// Whether the request carries no maintenance testreport or `MAINT` attribute,
+/// so the `qam.suse.de` preconditions do not apply. True for **both** PI and
+/// SLFO — the old name (`is_slfo`) claimed otherwise.
+///
+/// Do **not** fold this into `openqa::base`'s bare `kind == Slfo` test, which it
+/// otherwise resembles: that one excludes PI. Merging them would make PI
+/// requests demand a maintenance testreport they never have, and retag every PI
+/// openQA `build` param `git` instead of `smelt`.
+fn skips_maintenance_testreport(rrid: &RequestReviewID) -> bool {
     matches!(rrid.kind, RequestKind::Pi | RequestKind::Slfo)
 }
 
@@ -226,7 +233,7 @@ pub async fn assign(
         )));
     }
     let resolved = resolve_assign_groups(client, &request, user, groups).await?;
-    if !is_slfo(rrid) {
+    if !skips_maintenance_testreport(rrid) {
         if super::preconditions::fetch_testreport_log(reports_url, ssl_verify, rrid)
             .await
             .is_none()
@@ -338,7 +345,7 @@ pub async fn approve(
             request.reqid
         )));
     }
-    if !is_slfo(rrid) {
+    if !skips_maintenance_testreport(rrid) {
         let log = super::preconditions::fetch_testreport_log(reports_url, ssl_verify, rrid).await;
         if log.is_none_or(|log| super::preconditions::summary(&log) != "PASSED") {
             return Err(ObsError::Op(format!(
@@ -407,7 +414,7 @@ pub async fn reject(
         tracing::info!("reject ignores -g/--group (native reject is always by_user)");
     }
     let request = get_request(client, rrid).await?;
-    if !is_slfo(rrid) {
+    if !skips_maintenance_testreport(rrid) {
         let log = super::preconditions::fetch_testreport_log(reports_url, ssl_verify, rrid).await;
         let log = match log {
             Some(log) if super::preconditions::summary(&log) == "FAILED" => log,
@@ -430,4 +437,31 @@ pub async fn reject(
         fancy_url(fancy_reports_url, rrid)
     );
     changereviewstate(client, rrid, "declined", user, &comment).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the case that separates this predicate from the bare
+    /// `kind == Slfo` test in `openqa::base`: PI skips the preconditions too.
+    /// Without this, folding the two into one shared helper compiles, passes,
+    /// and silently makes PI requests demand a maintenance testreport that PI
+    /// requests never have.
+    #[test]
+    fn pi_and_slfo_both_skip_the_maintenance_testreport() {
+        for id in ["SUSE:PI:1.1:70000", "SUSE:PI:42:99", "SUSE:SLFO:1.1:70000"] {
+            let rrid = RequestReviewID::parse(id).unwrap();
+            assert!(
+                skips_maintenance_testreport(&rrid),
+                "{id} must skip the qam.suse.de preconditions"
+            );
+        }
+    }
+
+    #[test]
+    fn maintenance_still_requires_the_testreport() {
+        let rrid = RequestReviewID::parse("SUSE:Maintenance:1:56789").unwrap();
+        assert!(!skips_maintenance_testreport(&rrid));
+    }
 }

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -276,6 +276,22 @@ pub(crate) mod tests {
         assert_eq!(build, ":smelt:1:bash");
     }
 
+    /// PI takes the `smelt` prefix. This is the single case that separates the
+    /// bare `kind == Slfo` test here from `qam`'s precondition guard, which
+    /// groups PI *with* SLFO — merging the two would silently retag every PI
+    /// job's `build` parameter as `git` and break openQA job lookup.
+    #[test]
+    fn build_param_uses_smelt_prefix_for_pi() {
+        let base = OpenQABase::new(dummy_client(), &rrid("PI"), &MockIncident::new("bash"));
+        let build = base
+            .params
+            .iter()
+            .find(|(k, _)| k == "build")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(build, ":smelt:1:bash");
+    }
+
     #[test]
     fn build_param_uses_git_prefix_for_slfo() {
         // SLFO maintenance ids are dotted; use one that parses.

--- a/crates/mtui-datasources/src/qem_dashboard/incident.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/incident.rs
@@ -151,6 +151,32 @@ mod tests {
         assert_eq!(QemIncident::incident_number(&rrid), "1.1");
     }
 
+    /// The `1.2` here is a whole-RRID test, not a maintenance-id test: a PI
+    /// request that happens to carry `1.2` still keys on the maintenance id.
+    /// Pins the `kind` half of the guard, which a "simplification" down to
+    /// `maintenance_id == "1.2"` would drop while every other test stayed green.
+    #[test]
+    fn incident_number_ignores_maintenance_id_1_2_on_non_slfo_kinds() {
+        let pi: RequestReviewID = "SUSE:PI:1.2:199773".parse().unwrap();
+        assert_eq!(QemIncident::incident_number(&pi), "1.2");
+        let maint: RequestReviewID = "SUSE:Maintenance:1.2:199773".parse().unwrap();
+        assert_eq!(QemIncident::incident_number(&maint), "1.2");
+    }
+
+    /// This guard is closed (`== "1.2"`) where `apicall::is_gitea_workflow` is
+    /// open (`!= "1.1"`). On the ids that occur today (`1.1`, `1.2`) the two
+    /// agree, so nothing else records that they differ.
+    ///
+    /// The id below is **hypothetical** — there is no SLFO 2.0 product, and none
+    /// is expected soon. The test pins that this predicate stays closed, so a
+    /// future id would key on the maintenance id rather than silently inheriting
+    /// the review-id behaviour of `1.2`.
+    #[test]
+    fn incident_number_stays_closed_beyond_1_2() {
+        let rrid: RequestReviewID = "SUSE:SLFO:2.0:199773".parse().unwrap();
+        assert_eq!(QemIncident::incident_number(&rrid), "2.0");
+    }
+
     #[tokio::test]
     async fn metadata_and_shortest_package_name() {
         // Ported from test_qem_incident_metadata.

--- a/crates/mtui-datasources/tests/obs_qam.rs
+++ b/crates/mtui-datasources/tests/obs_qam.rs
@@ -23,8 +23,17 @@ fn rrid() -> RequestReviewID {
     RequestReviewID::parse("SUSE:Maintenance:1:56789").unwrap()
 }
 
+/// A genuine PI-kind RRID. `qam`'s precondition guard is
+/// `matches!(kind, Pi | Slfo)`, so PI is a distinct arm from SLFO and needs its
+/// own fixture — this used to return an SLFO RRID, which left every `_pi_` test
+/// below exercising the SLFO arm twice and the PI arm not at all.
 fn pi_rrid() -> RequestReviewID {
-    // SLFO kind -> skips preconditions.
+    RequestReviewID::parse("SUSE:PI:1.1:70000").unwrap()
+}
+
+/// An SLFO-kind RRID sharing the same review id, so the two kinds can be run
+/// through the identical mock setup and compared.
+fn slfo_rrid() -> RequestReviewID {
     RequestReviewID::parse("SUSE:SLFO:1.1:70000").unwrap()
 }
 
@@ -441,8 +450,10 @@ async fn assign_previous_reject_ignores_non_qam_declined() {
     assert_eq!(query_val(&q, "by_group"), Some("qam-sle"));
 }
 
-#[tokio::test]
-async fn assign_skips_preconditions_for_pi() {
+/// Asserts `assign` skipped the `qam.suse.de` preconditions for `rrid`: only
+/// the request GET and the assign POST reach OBS, and the reports server is
+/// never contacted.
+async fn assert_assign_skips_preconditions(rrid: &RequestReviewID) {
     let api = MockServer::start().await;
     let reports = MockServer::start().await;
     Mock::given(method("GET"))
@@ -456,7 +467,7 @@ async fn assign_skips_preconditions_for_pi() {
         &client_for(&api),
         &reports.uri(),
         &SslVerify::Enabled,
-        &pi_rrid(),
+        rrid,
         USER,
         &["qam-sle".to_owned()],
     )
@@ -466,6 +477,18 @@ async fn assign_skips_preconditions_for_pi() {
     // Only the request GET and the assign POST — no testreport / collection.
     assert_eq!(api.received_requests().await.unwrap().len(), 2);
     assert!(reports.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn assign_skips_preconditions_for_pi() {
+    assert_assign_skips_preconditions(&pi_rrid()).await;
+}
+
+#[tokio::test]
+async fn assign_skips_preconditions_for_slfo() {
+    // The arm the `_for_pi` test above covered before its fixture was corrected;
+    // kept so both halves of `matches!(kind, Pi | Slfo)` stay pinned.
+    assert_assign_skips_preconditions(&slfo_rrid()).await;
 }
 
 // --------------------------------------------------------------------------- //

--- a/crates/mtui-testreport/tests/metadata_parsers.rs
+++ b/crates/mtui-testreport/tests/metadata_parsers.rs
@@ -259,6 +259,57 @@ fn json_parser_tolerates_missing_optional_keys() {
     assert!(report.repositories.is_empty());
 }
 
+#[test]
+fn json_parser_drops_malformed_rrid() {
+    // `JSONParser::parse` deliberately swallows the RRID parse error
+    // (`RequestReviewID::parse(s).ok()`) so a bad id degrades to `None` instead
+    // of failing the whole load. That leniency was unpinned: nothing asserted
+    // the drop actually happens, nor that the surrounding fields survive it.
+    // One case per failure mode of the RRID grammar (an AGENTS.md Contract).
+    for rrid in [
+        "SUSE:Maintenance:24993",     // MissingComponent — truncated
+        "SUSE:Maintenance:24993:abc", // ComponentParse — non-integer review id
+        "openSUSE:Maintenance:1:2",   // ComponentParse — wrong project
+        "SUSE:boo:1:2",               // ComponentParse — unknown kind
+        "SUSE:Maintenance:1:2:3",     // TooManyComponents
+        "",                           // MissingComponent — empty
+    ] {
+        // Seed a good RRID first: `rrid` defaults to `None`, so parsing into a
+        // fresh report would assert the *initial state* and pass even against a
+        // parser that never touched the field. Starting from `Some` makes the
+        // assertion below prove the malformed value actually replaced it.
+        let mut report = empty_report();
+        JSONParser::parse_str(&mut report, r#"{"rrid": "SUSE:Maintenance:1:1"}"#)
+            .expect("valid json");
+        assert!(report.rrid.is_some(), "precondition: seeded a valid rrid");
+
+        let data = format!(r#"{{"rrid": "{rrid}", "packager": "someone@suse.de"}}"#);
+        JSONParser::parse_str(&mut report, &data).expect("valid json");
+
+        assert!(
+            report.rrid.is_none(),
+            "malformed rrid {rrid:?} must be dropped, got {:?}",
+            report.rrid
+        );
+        // The load is lenient, not aborted: neighbouring fields still apply.
+        assert_eq!(report.packager, "someone@suse.de", "for rrid {rrid:?}");
+    }
+}
+
+#[test]
+fn json_parser_clears_rrid_when_key_absent() {
+    // The other route to `None`: the assignment is unconditional, so a payload
+    // with no `rrid` key clears whatever was there. Seeded first for the same
+    // reason as above — against a fresh report this assertion is vacuous.
+    let mut report = empty_report();
+    JSONParser::parse_str(&mut report, r#"{"rrid": "SUSE:Maintenance:1:1"}"#).expect("valid json");
+    assert!(report.rrid.is_some(), "precondition: seeded a valid rrid");
+
+    JSONParser::parse_str(&mut report, r#"{"packager": "someone@suse.de"}"#).expect("valid json");
+
+    assert!(report.rrid.is_none());
+}
+
 /// Golden snapshot of the parsed `metadata.json` envelope.
 ///
 /// The field-by-field assertions in `json_parser_parses_golden_fixture` pin


### PR DESCRIPTION
## The finding

This started as a cleanup task: "hoist the four duplicated SLFO/`maintenance_id` predicates into shared helpers". **That premise is wrong.** They are not duplicates, and merging two of them is a silent behaviour change.

On the SLFO maintenance ids that occur in practice — `1.1` and `1.2`:

| RRID | `qam` skips preconditions | `is_gitea_workflow` | openQA build prefix | QEM dashboard keys on |
|---|---|---|---|---|
| `Maintenance` (any id) | no | no | `smelt` | maintenance id |
| `SLFO:1.1` | **yes** | no | **`git`** | maintenance id |
| `SLFO:1.2` | yes | **yes** | `git` | **review id** |
| `PI` (any id) | **yes** | no | **`smelt`** | maintenance id |

The live difference is **`PI`**, and it was not pinned by anything. Worse, it was actively misreported:

```rust
fn pi_rrid() -> RequestReviewID {
    // SLFO kind -> skips preconditions.
    RequestReviewID::parse("SUSE:SLFO:1.1:70000").unwrap()
}
```

So `assign_skips_preconditions_for_pi`, `reject_pi_skips_attribute_and_summary` and `reject_ignores_group` all ran the **SLFO** arm, and no test anywhere fed a PI-kind RRID through any of the four predicates.

Concretely: folding `qam`'s guard (`Pi | Slfo`) into openQA's bare `kind == Slfo` would make PI requests demand a maintenance testreport they never have, and retag every PI openQA `build` param from `smelt` to `git`. The whole suite stays green.

`SLFO:1.1` is the second live difference, separating openQA's guard from `is_gitea_workflow`.

## One difference is latent, and is labelled as such

`is_gitea_workflow` is open-ended (`!= "1.1"`) where the QEM dashboard is closed (`== "1.2"`). On `{1.1, 1.2}` those **agree on every RRID that currently exists**, so this difference is not reachable today.

They are still not the same predicate — upstream wrote one open and one closed. Two tests record that, each explicitly marked hypothetical, so that a future SLFO id cannot quietly inherit the wrong branch. There is no SLFO 2.0 product and none is expected soon; that is stated in the tests rather than implied to be a real case.

## What this PR does

- **The fixture returns a real PI RRID** (same review id, so the wiremock setups match unchanged), with `slfo_rrid()` alongside it and the assign body extracted so both arms of `matches!(kind, Pi | Slfo)` stay covered.
- **Each predicate's doc comment names the neighbour it must not be folded into**, and what breaks if it is — kept next to the predicate rather than in a table elsewhere.

## One rename, no behaviour change

`qam`'s `is_slfo` is true for PI as well as SLFO, so it is now `skips_maintenance_testreport`. Body byte-identical, three call sites, module-private, no wire format involved.

## Also: the lenient RRID parse (follow-up)

`JSONParser` drops a malformed `rrid` to `None` via `parse(s).ok()`. That leniency is deliberate and was untested. `json_parser_drops_malformed_rrid` covers one input per grammar failure mode (`MissingComponent`, `ComponentParse` ×3, `TooManyComponents`, empty) and asserts a neighbouring field still applies — leniency, not abort. `json_parser_clears_rrid_when_key_absent` covers the other route to `None`: the assignment is unconditional, so a payload without the key clears whatever was there.

Both **seed a valid RRID first**. `TestReportBase::rrid` defaults to `None`, so asserting `is_none()` on a fresh report restates the precondition and would pass against a parser that never touched the field.

## Validation

Full gate green: `fmt --check`, clippy `-D warnings` (all targets), `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, compile-only feature matrix.

Every new test was **mutation-checked** — each mutation merges a predicate into a neighbour, and every one is caught:

| Mutation | Caught by |
|---|---|
| `qam` guard → bare `kind == Slfo` | `pi_and_slfo_both_skip_the_maintenance_testreport` **+ all three PI integration tests** |
| openQA prefix → `qam`'s guard | `build_param_uses_smelt_prefix_for_pi` |
| dashboard → drop the `kind` half | `incident_number_ignores_maintenance_id_1_2_on_non_slfo_kinds` |
| `is_gitea_workflow` → dashboard predicate | `is_gitea_workflow_stays_open_ended_beyond_1_2` |
| RRID grammar → `review_id` falls back to `0` | `json_parser_drops_malformed_rrid` |
| `rrid` assignment made conditional | both `metadata_parsers` tests |

Under the first mutation `assign_skips_preconditions_for_slfo` still passes while the three PI tests fail — which is the point: before the fixture fix, all three would have sailed through.

## Deliberately not addressed

- When the RRID drops to `None`, `require_update` reports *"Metadata not loaded, please use `load_template` first"* on a template that **did** load. Real, but a production behaviour change.
- Three `# Errors` rustdoc sections in `qam.rs` still say "non-SLFO" where the condition is PI-or-SLFO. Pre-existing text this commit does not touch; worth its own pass.
- A fifth kind-keyed predicate exists in `reports/sl.rs` (`maintenance_id == "1.1"`). Left alone — it is the complement of `is_gitea_workflow` but not interchangeable with it.
