### PR TITLE
docs: retire the Python implementation as a behavioural reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,49 @@ Preserve the **data-format and workflow contracts** that let mtui interoperate
 with the SUSE maintenance ecosystem (see "Contracts" below); break compatibility
 only when the task explicitly calls for it.
 
+### The Python implementation is no longer a reference
+mtui was originally ported from a Python implementation, removed in `ec80791c`
+(the old tree is readable at `git show ec80791c^:mtui/...`, and on the
+`archive/python-main` tag and the `16.0.x`–`19.0.x` branches). **Do not treat it
+as an authority.** Matching its behaviour is not a goal and "upstream does X" is
+not a justification. Use the archive to understand *why* a shape exists — then
+record what you learn as a statement about the constraint, not as a citation.
+
+- **Never** preserve a bug, a typo, or an awkward shape for parity with it.
+  Fixing one is welcome — **in its own commit**, with a CHANGELOG entry if a user
+  or MCP client would notice. Retiring a *rationale* is prose; changing the
+  *bytes* is not, and the two must not ride in the same commit.
+- **Check first that the shape is not a contract in disguise.** If it is written
+  to a host (`/var/lock/mtui*.lock`, `/var/log/mtui.log`, a zypper repo alias —
+  `repo_manager.rs::issue_alias`), signed or transmitted to a live service (the
+  openQA HMAC path encoding, `openqa/client.rs::encode_path_for_signing`), or is
+  user-facing text an LLM client consumes, it is load-bearing **even when the
+  only comment about it says "upstream did X"**. Replace the stale rationale;
+  do not delete the constraint.
+- A note recording a **deliberate departure** is a guard-rail, not a citation —
+  it stays. Reframe it as a positive statement of the choice ("mtui is XDG-first:
+  history lives at `$XDG_DATA_HOME/mtui/history`") rather than a comparison.
+  Keep the constraint, drop the comparison. Likewise for a bare `Ports upstream
+  mtui.commands.foo`: keep the behavioural description, drop the citation, and if
+  the line was *only* a citation, drop the line.
+- **Never strip a licence or provenance citation**, even when it routes through
+  the old tree — `obs/inference.rs`'s GPL-2.0-only attribution chain to
+  openSUSE/osc-plugin-qam is a legal requirement, not archaeology, and
+  `Cargo.toml`'s relicensing note explains a deliberate difference.
+- `upstream` is **not always** the old implementation, and the distinction is by
+  *referent, not by path* — the same file mixes both. Where the sentence cites a
+  `.py` file or a Python identifier it means the removed tree; where it names a
+  live external it stays: `openSUSE/osc-plugin-qam`, `mjdonis/oqa-search`, the
+  `osc` tool's own `oscrc` lookup (`obs/oscrc.rs`), the openQA server's signing
+  rules (`openqa/client.rs`), and Rust crates such as `russh`/`rsa`. Read each
+  site; do not sweep the term.
+- "Python" is also a **domain word** here. Never rename or delete it in SUSE
+  package flavours (`pythonNNN-foo` → `python-foo`,
+  `oqa_search/heuristics.rs::PYTHON_FLAVOR_RE` — live openQA build-check
+  matching), product names in fixtures (`sle-module-python2-*`), or `typos.toml`
+  entries that keep the append-only CHANGELOG spell-checkable. Note `typos` is a
+  CI-only job the local gate does not run.
+
 ### Design invariants (do not regress)
 - **Safety & robustness:** strong types, exhaustive error enums (`thiserror`);
   prefer a typed `Result` over silent `None`-swallowing.
@@ -178,8 +221,14 @@ next actionable task before working on a subsystem.
   layout: the operation lock `/var/lock/mtui.lock` (PID-based ownership, guards
   serialized zypper transactions) and the pool-claim lock
   `/var/lock/mtui-pool.lock` (RRID-based ownership; the comment carries
-  `mtui pool <RRID> [<owner>]`). Other tools on the fleet parse the same layout;
-  snapshot-test it (`crates/mtui-hosts/tests/lock_format.rs`).
+  `mtui pool <RRID> [<owner>]`). Every mtui sharing the fleet parses this layout,
+  including older releases — snapshot-test it
+  (`crates/mtui-hosts/tests/lock_format.rs`).
+- **Remote history format** — one `timestamp:user:field1[:field2…]` line appended
+  to `/var/log/mtui.log` on each enabled host, written with `sftp_append`
+  (`O_APPEND|O_CREAT`, never read-modify-write) so concurrent testers on one host
+  do not clobber one another, and read back by `list_history`. The append-only
+  primitive exists *for* this contract — do not collapse it into `sftp_write`.
 - **MCP tool names/schemas** — downstream LLM configs depend on them; snapshot the
   synthesised + slimmed schemas.
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,16 @@ a request by RRID, install and test it on reference hosts over SSH in parallel,
 then approve or reject. It drives OBS/IBS and Gitea review workflows, `svn`, and
 openQA/QEM under the hood.
 
-This is a **redesign, not a transpile**: MTUI is the behavioral reference and
-source of domain truth, but mtui aims to be memory-safe, async-native, and
-distributable as a single static binary — while preserving the data-format and
-workflow contracts that keep it interoperable with the SUSE maintenance
-ecosystem.
+mtui is memory-safe, async-native, and distributed as static binaries, while
+preserving the data-format and workflow contracts that keep it interoperable with
+the SUSE maintenance ecosystem.
 
-## Why a rewrite
+## Design goals
 
 - **Safety & robustness** — strong types, exhaustive error enums, no interpreter.
 - **Performance** — async I/O (`tokio`), true parallel host fan-out, fast startup.
-- **Distribution** — two static binaries (`mtui`, `mtui-mcp`), no Python runtime
-  or virtualenv; generated shell completions and man pages.
+- **Distribution** — two static binaries (`mtui`, `mtui-mcp`), no runtime
+  interpreter or virtualenv; generated shell completions and man pages.
 - **Maintainability** — a Cargo workspace with clean crate boundaries and one
   composition root.
 
@@ -57,8 +55,8 @@ authenticated boundary trusted to operate the remaining maintenance tools.
   regeneration (`regenerate`).
 - Reference-host discovery via `refhosts.yml` (HTTPS- or filesystem-resolved,
   cached) and offline inventory search (`list_refhosts`).
-- Cooperative reference-host locking (`/var/lock/mtui.lock`), interoperable with
-  Python MTUI on a shared fleet.
+- Cooperative reference-host locking (`/var/lock/mtui.lock`) so concurrent
+  testers can share a fleet.
 - Test-report lifecycle: `load_template`, `checkout`, `commit`, `edit`, `export`
   (SVN and Gitea backends).
 - File transfer (`put`/`get`) over SFTP.

--- a/crates/mtui-core/src/args.rs
+++ b/crates/mtui-core/src/args.rs
@@ -7,10 +7,9 @@
 //! overrides, colour mode, Gitea token) and the mutually-exclusive update
 //! selector that seeds a workflow.
 //!
-//! ## Intentional deviations from upstream
+//! ## Deliberate design choices
 //!
-//! This is a redesign, not a 1:1 transpile (see `AGENTS.md`), so a few surfaces
-//! differ where it improves the tool:
+//! A few surfaces are shaped for this tool rather than inherited:
 //!
 //! * **`-V/--version`** prints `mtui <version> (<sha>[-dirty], <profile>,
 //!   <target>)`. Upstream listed separately-installed *runtime* dependency

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -55,14 +55,18 @@ composition root — never introduce a crate cycle.**
 ## Contracts
 
 These data-format and workflow contracts keep mtui interoperable with the SUSE
-maintenance ecosystem and with a Python MTUI sharing the same fleet. They are
-preserved deliberately; upstream `tests/` fixtures are the authority for the
-formats.
+maintenance ecosystem. Each is owed to something live: the RRID grammar to
+OBS/IBS/QEM, the `refhosts.yml` schema to the qam-metadata fleet database, the
+testreport/export format to SVN/Gitea/TeReGen, the MCP tool surface to downstream
+LLM clients, and the on-host formats to **other mtui processes sharing a fleet**
+— including older releases, which is why they are a wire format and not an
+implementation detail. The `crates/*/tests/` fixtures are the authority.
 
 - **RRID grammar** — `project:kind:maintenance_id:review_id` and its parse errors
   (see the [FAQ](faq.md#what-is-an-rrid)).
 - **`refhosts.yml` schema** — location-grouped on disk, but rows are
-  merged/flattened/de-duplicated at load; parses identically to upstream fixtures.
+  merged/flattened/de-duplicated at load; parses identically to the golden
+  fixtures.
 - **Testreport / export text format** — including the idempotent
   `overview_inject` BEGIN/END block under `regression tests:`.
 - **Remote-lock wire format** — one line, `timestamp:user:pid[:comment]`, shared
@@ -71,11 +75,10 @@ formats.
 - **MCP tool names/schemas** — downstream LLM configs depend on them; the
   synthesised, slimmed schemas are snapshot-tested.
 
-## Intentional deviations from upstream
+## Deliberate design choices
 
-mtui is a redesign, not a transpile. The deliberate departures:
-
-- **TOML config**, not INI (defaults still match upstream exactly).
+- **TOML config**, not INI.
 - **Native OBS/IBS API** for the QAM review workflow, not an `osc` subprocess.
-- **Two static binaries** (`mtui`, `mtui-mcp`), no Python runtime or virtualenv.
+- **Two static binaries** (`mtui`, `mtui-mcp`), no runtime interpreter or
+  virtualenv to install.
 - **Async I/O** (`tokio`) with true parallel host fan-out.

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -95,8 +95,9 @@ concurrently across enabled hosts.
 ## Locking
 
 Two independent locks coordinate concurrent testers on a shared fleet. Both use
-the same on-host wire format (`timestamp:user:pid[:comment]`), so a Rust `mtui` and
-a Python MTUI interoperate.
+the same on-host wire format (`timestamp:user:pid[:comment]`), so concurrent
+`mtui` processes — and any other fleet tooling that reads the same files —
+cooperate rather than clobber one another.
 
 - **Operation / zypper lock** (`/var/lock/mtui.lock`, PID-based) — guards
   serialized repository transactions (enabling/disabling the test repo,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,9 +1,7 @@
 # Configuration
 
-mtui is configured with a **sectioned TOML** file. (This is an intentional
-deviation from upstream mtui's INI; every option's default matches upstream
-exactly.) All configuration is optional: with no file present, mtui runs on
-built-in defaults.
+mtui is configured with a **sectioned TOML** file. All configuration is optional:
+with no file present, mtui runs on built-in defaults.
 
 ## File resolution
 
@@ -44,7 +42,7 @@ configured secret (currently `gitea_token`) instead of its value.
 
 ## Options
 
-Defaults below are the built-in (upstream-matching) values.
+Defaults below are the built-in values.
 
 ### `[mtui]`
 
@@ -177,8 +175,7 @@ channel = "#qam-review"
 
 ### `[lock]`
 
-Remote-lock behaviour on target hosts (interoperable with Python mtui on a shared
-fleet).
+Remote-lock behaviour on target hosts, so concurrent testers can share a fleet.
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
@@ -201,15 +198,16 @@ fleet).
 | `max_active_jobs` | int | `16` | Ceiling on concurrent background jobs per session. `0` disables. |
 | `max_completed_jobs` | int | `128` | Ceiling on retained terminal job records per session (FIFO eviction). `0` disables. |
 | `session_cap` | int (>0) | `32` | Ceiling on concurrent per-client sessions under `--transport http`. |
-| `session_idle_timeout` | seconds (>0) | `14400` | Inactivity before an idle http session is swept. Deliberately higher than upstream's `1800` so it comfortably exceeds rmcp's own HTTP session keep-alive floor. |
+| `session_idle_timeout` | seconds (>0) | `14400` | Inactivity before an idle http session is swept. Also pins rmcp's streamable-HTTP keep-alive (rmcp's own default is 300 s), so the transport never tears a quiet session down before this sweeper would. |
 | `sweep_parallel` | int (>0) | `4` | Max stale sessions the idle sweeper tears down concurrently per cycle. |
 | `profile` | string | `full` | Tool-surface profile: `full` (every synthesised tool) or `core` (curated everyday subset). Unknown → `full` with a warning. |
 | `tools_allow` | array of strings | *(empty)* | Extra tool names to keep on top of the profile. |
 | `tools_deny` | array of strings | *(empty)* | Tool names to remove regardless of profile/allow (deny wins last). |
 
-> Upstream names the profile key `tool_profile`; here it is `profile` under the
-> already tool-scoped `[mcp]` table. `tools_allow`/`tools_deny` are native TOML
-> arrays rather than upstream's comma-separated strings.
+> The profile key is `profile`, not `tool_profile` — it already sits under the
+> tool-scoped `[mcp]` table. `tools_allow`/`tools_deny` are native TOML arrays,
+> not comma-separated strings. (Both matter if you are carrying over a config
+> from a pre-26.0 release.)
 
 ### `[obs]`
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -36,11 +36,14 @@ template). Host-action commands need a loaded template with connected hosts.
 No — and it never will. mtui is **pubkey-only by design**: it authenticates from
 your SSH agent or `~/.ssh/id_*`. This is preserved from MTUI.
 
-## Can a Rust mtui and a Python mtui share the same reference hosts?
+## Can several testers use the same reference hosts at once?
 
-Yes. The remote-lock wire format is identical across both implementations, so
-they cooperate on a shared host fleet. There are two locks with the same
-`timestamp:user:pid[:comment]` layout: the operation lock
+Yes, but the locks are **advisory and fail-fast, not a queue**. Every mtui on the
+fleet writes the same `timestamp:user:pid[:comment]` layout, so sessions see one
+another's claims — a host held by someone else is *skipped*, and an
+install/update aborts with "Hosts locked" rather than waiting. Raise
+`[lock] wait` (default `0`) to poll for a busy host during pool arbitration.
+There are two locks with that layout: the operation lock
 (`/var/lock/mtui.lock`, PID-based, guards serialized zypper transactions) and the
 pool-claim lock (`/var/lock/mtui-pool.lock`, RRID-based). Stale-lock reaping is
 configurable under `[lock]` — see [Configuration](configuration.md).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -7,12 +7,10 @@ a request by RRID, install and test it on reference hosts over SSH in parallel,
 then approve or reject. It drives the OBS/IBS and Gitea review workflows and
 openQA/QEM under the hood.
 
-This is a redesign, not a transpile: MTUI is the behavioral reference and source
-of domain truth, but mtui is memory-safe, async-native, and distributed as two
-static binaries — while preserving the data-format and workflow contracts that
-keep it interoperable with the SUSE maintenance ecosystem (RRID grammar, the
-`refhosts.yml` schema, the testreport/export text format, and the remote-lock
-wire format that lets a Rust and a Python mtui share a host fleet).
+mtui is memory-safe, async-native, and distributed as two static binaries, while
+preserving the data-format and workflow contracts that keep it interoperable with
+the SUSE maintenance ecosystem: the RRID grammar, the `refhosts.yml` schema, the
+testreport/export text format, and the remote-lock wire format.
 
 ## Two surfaces
 


### PR DESCRIPTION
## What

mtui was ported from a Python implementation removed in `ec80791c`, and the prose still treated it as the authority — the README and introduction called it "the behavioral reference and source of domain truth", and five places justified the remote-lock wire format by saying a Rust and a Python mtui share a host fleet. Matching that implementation is no longer a goal, so this retires it as a reference and records the policy in `AGENTS.md`.

**Prose only.** No format moves, no behaviour changes. The one non-doc file is a rustdoc heading in `args.rs` whose cross-reference this change would otherwise have broken.

## The contracts don't move — their justification does

Each now names a live counterparty: the RRID grammar to OBS/IBS/QEM, `refhosts.yml` to the qam-metadata fleet database, the testreport/export format to SVN/Gitea/TeReGen, the MCP tool surface to downstream LLM clients.

Two gaps surfaced while doing this:

- **The on-host formats had no counterparty at all.** They are owed to *other mtui processes sharing a fleet, including older releases* — which is why they are a wire format and not an implementation detail. Leaving that unstated is worse than the dead rationale it replaced: a reader who checks the stated reason and finds it obsolete could conclude the format is free to change.
- **`/var/log/mtui.log` was never in the Contracts list**, despite being the sole reason `sftp_append` exists as a separate primitive (`connection/mod.rs:250`). Without it recorded, a later refactor collapses the append into `sftp_write` and silently reintroduces clobbering between concurrent testers. Added as a contract.

## The policy is scoped to be safe to execute

`AGENTS.md` gains a section that will guide a follow-up sweep of the ~2.5k references still in the Rust sources. It is deliberately fenced, because the obvious version of this cleanup is dangerous:

- Fixing a preserved quirk is welcome — **in its own commit**. Retiring a *rationale* is prose; changing *bytes* is not.
- **Some shapes are contracts in disguise.** The zypper repo alias (`repo_manager.rs::issue_alias`) and the openQA HMAC path encoding (`openqa/client.rs::encode_path_for_signing`) are justified in-tree only by "upstream did X", yet one is written onto reference hosts and the other is signature-relevant — "fixing" the latter breaks every signed openQA request.
- **`upstream` is distinguished by referent, not by path.** The same file mixes meanings: in `obs/inference.rs` it means the removed tree, not osc-plugin-qam; in `oqa_search/` only a couple of ~40 occurrences mean the external tool. Live referents include `osc`, the openQA server, and the `russh`/`rsa` crates.
- **Licence and provenance citations are exempt** — `obs/inference.rs` carries a GPL-2.0-only attribution chain kept per its attribution requirement.
- **"Python" is also a domain word.** `PYTHON_FLAVOR_RE` maps `pythonNNN-foo` to its source package and drives live openQA build-check matching; `sle-module-python2-*` are SUSE product names; several `typos.toml` entries exist to keep the append-only CHANGELOG spell-checkable.

## Also corrects a wrong FAQ answer

The FAQ implied the locks queue. They don't: `[lock] wait` defaults to `0`, and `hostgroup.rs:957-974` skips a foreign lock without ever calling `lock()`, so an install aborts with "Hosts locked" rather than waiting. The entry now says so, and points at `[lock] wait` for the polling behaviour. `configuration.md:187` already documented the fail-fast default, so the docs were self-contradictory.

Smaller fixes in the same pass: SMELT was listed as a live consumer (it was removed in favour of TeReGen), and `tests/` is `crates/*/tests/` — there is no top-level `tests/` directory.

## Testing

Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp` (189 + 48), and the compile-only matrix (`--no-default-features`, `--all-features`). `typos` clean. `cargo test -p xtask` 18/18, including `checked_in_generated_docs_are_up_to_date`.

The book was built manually with mdBook 0.5.4 and link-checked: 14 pages, 0 broken links, no orphans in `SUMMARY.md`. Worth noting there is **no mdbook job, markdown linter, or link checker in CI**, so a docs anchor break cannot fail the build — three headings are renamed here and nothing in-repo referenced their old anchors.

## Follow-ups (not in this PR)

The ~2.5k references in the Rust sources, sequenced smallest-blast-radius first. Notable candidates already verified: the `showdiff.rs` `_VERSION_BUMP` regex whose trailing `\b` means `+Version:` lines never match (so version bumps never surface in `show_diff`), and the 340-line CPython `string.Template` reimplementation that only ever interpolates four variables.
