### PR TITLE
refactor: state the real reason for the on-host format contracts

### DIFF
--- a/crates/mtui-cli/src/logfmt.rs
+++ b/crates/mtui-cli/src/logfmt.rs
@@ -1,14 +1,12 @@
-//! Custom compact `tracing` event format mirroring upstream's `ColorFormatter`.
+//! Custom compact `tracing` event format for the REPL.
 //!
-//! Upstream mtui routes every log record through a single
-//! `ColorFormatter("%(levelname)s: %(message)s")`
-//! (`python-mtui/mtui/cli/colors/formatter.py`): a **lowercased**, colorized
-//! level token (green `info` / yellow `warning` / red `error`), then `": "`, then
-//! the message — no timestamp, no module path. mtui already renders *command
-//! errors* that way through the session display (see `repl::render_error`); this
-//! layer brings `tracing::info!`/`warn!` (and any other event at the default
-//! verbosity) to the same look so the two channels are consistent
-//! (`mtui-rs-ilt`, follow-up to `mtui-rs-7h9`).
+//! One line per record: a **lowercased**, colorized level token (green `info` /
+//! yellow `warning` / red `error`), then `": "`, then the message — no
+//! timestamp, no module path. mtui already renders *command errors* that way
+//! through the session display (see `repl::render_error`); this layer brings
+//! `tracing::info!`/`warn!` (and any other event at the default verbosity) to
+//! the same look, so the two channels are indistinguishable to an operator
+//! reading the terminal.
 //!
 //! **ANSI decision is shared with the display.** Whether escapes are emitted is
 //! computed once from the resolved [`ColorMode`](mtui_core::ColorMode) handed to

--- a/crates/mtui-config/src/atomic.rs
+++ b/crates/mtui-config/src/atomic.rs
@@ -14,9 +14,10 @@
 //!   destination's own directory with [`create_new`](std::fs::OpenOptions::create_new)
 //!   and a **unique** name, so an attacker cannot pre-create it as a symlink to
 //!   redirect the write outside the intended directory.
-//! * **No cross-writer collision.** The temp name embeds the PID and a
-//!   nanosecond timestamp, so two concurrent writers (even a Rust and a Python
-//!   mtui sharing a directory) never race on the same temp path.
+//! * **No cross-writer collision.** The temp name embeds the PID, a nanosecond
+//!   timestamp and a process-lifetime counter, so neither two mtui processes
+//!   sharing a directory nor two threads racing within the same nanosecond ever
+//!   collide on a temp path.
 //! * **Restrictive permissions.** On unix the temp is opened `0o600`.
 //! * **Durability.** The temp is `fsync`ed before the rename, so a crash never
 //!   leaves a torn or empty destination.

--- a/crates/mtui-config/src/lib.rs
+++ b/crates/mtui-config/src/lib.rs
@@ -17,12 +17,11 @@
 //! values, and **lenient loading** (a bad or missing file is logged and skipped,
 //! never fatal).
 //!
-//! ## Scope (Phase 1)
+//! ## Scope
 //!
-//! Only the Phase-1-relevant option subset is modelled here (paths, connection
-//! timeout, refhosts, URLs, svn, target). Later phases add their own sections
-//! (`[lock]`, `[openqa]`, `[mcp]`, ...) additively. CLI-argument merging
-//! (`merge_args`) is deferred to Phase 6, where the `clap` args struct exists.
+//! Every option section mtui understands is modelled here (see [`options`]).
+//! CLI-argument merging lives with the `clap` args structs that own it —
+//! `mtui_core::args` for the REPL and `mtui_mcp::args` for the MCP server.
 
 pub mod atomic;
 pub mod error;

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -1,18 +1,15 @@
 //! Typed configuration options and their defaults.
 //!
-//! This is the **Phase-1 subset** of upstream `mtui/support/config.py`'s option
-//! table, since extended with the `[lock]` section (Phase 2). Options belonging
-//! to later phases — `mcp_*` (Phase 7), `openqa_*`/`teregen_*`/`qem_dashboard_*`
-//! (Phase 3) — are deliberately omitted; they will be added, additively, as
-//! their sections land.
-//!
-//! Every default here matches the corresponding upstream default value exactly,
-//! preserving behavioural parity for the options mtui already understands.
+//! Covers every option section mtui understands. Most scalar defaults are
+//! long-standing values operators already rely on and are pinned by
+//! `default_matches_upstream_scalars` below; a handful deviate deliberately, and
+//! those carry a note on their `default_*` fn.
 //!
 //! ## Shape
 //!
 //! The on-disk format is **sectioned TOML** (`[mtui]`, `[connection]`,
-//! `[refhosts]`, `[url]`, `[svn]`, `[target]`, `[lock]`). `RawConfig` mirrors that
+//! `[refhosts]`, `[url]`, `[qem_dashboard]`, `[teregen]`, `[openqa]`, `[svn]`,
+//! `[target]`, `[gitea]`, `[slack]`, `[lock]`, `[mcp]`, `[obs]`). `RawConfig` mirrors that
 //! structure for serde; [`Config`] is the flattened, fully-typed view the rest
 //! of the workspace consumes. Every serde field defaults, so an empty (or
 //! partial) TOML document deserialises into all-defaults.
@@ -489,8 +486,9 @@ pub(crate) struct LockSection {
 ///
 /// Mirrors upstream `mtui/support/config.py`'s `mcp_*` options (which live under
 /// the `[mcp]` INI section). `session_cap` / `session_idle_timeout` configure the
-/// http transport's per-client session budget (enforcement is a follow-up —
-/// mtui-rs-odq8). `profile` / `tools_allow` / `tools_deny` select the exposed
+/// http transport's per-client session budget, enforced application-side by
+/// `mtui_mcp::provider::SessionRegistry`. `profile` / `tools_allow` /
+/// `tools_deny` select the exposed
 /// tool surface (see `mtui_mcp::profiles`).
 ///
 /// Note: upstream names the profile key `tool_profile`; here it is `profile`
@@ -804,8 +802,9 @@ pub struct Config {
     /// upstream equivalent — this is a hardening addition.
     pub mcp_max_completed_jobs: usize,
     /// Ceiling on concurrent per-client sessions under `--transport http` (DoS
-    /// guard). Upstream default is 32. Enforcement is a follow-up
-    /// (mtui-rs-odq8); this value is parsed and surfaced now.
+    /// guard). Default is 32. Enforced by
+    /// `mtui_mcp::provider::SessionRegistry::try_make_server`, which refuses a
+    /// new session once the cap is reached.
     pub mcp_session_cap: usize,
     /// Seconds of inactivity after which an idle http session is swept. `0`
     /// disables the sweeper. Also pins the rmcp streamable-HTTP session

--- a/crates/mtui-core/src/error.rs
+++ b/crates/mtui-core/src/error.rs
@@ -1,8 +1,9 @@
 //! The command-layer error hierarchy.
 //!
 //! Ports the command-relevant subset of upstream `mtui.support.messages`. The
-//! `Display` strings are byte-for-byte identical to the Python originals so the
-//! REPL and MCP surfaces present the same user-facing messages:
+//! `Display` strings are **frozen** — the REPL and MCP surfaces both render
+//! them, operators grep for them, and the tests below pin each one, so reword a
+//! variant only deliberately and update its test with it:
 //!
 //! * [`CommandError::NoRefhostsDefined`] ← `NoRefhostsDefinedError`
 //! * [`CommandError::HostNotConnected`] ← `HostIsNotConnectedError`

--- a/crates/mtui-core/src/registry.rs
+++ b/crates/mtui-core/src/registry.rs
@@ -114,9 +114,9 @@ impl Registry {
 /// [`register_all`], so the deny-list and the command surface it filters live in
 /// one place.
 ///
-/// Names not yet backed by a registered command are reserved for their later
-/// waves; [`mcp_denylist_is_consistent`] tolerates them so adding the command
-/// later does not require touching this list.
+/// Every name here currently resolves to a registered command or alias. The
+/// `mcp_denylist_is_consistent` test pins the exact expected set, so renaming or
+/// removing one of them is caught rather than drifting silently.
 pub const MCP_DENYLIST: &[&str] = &[
     "quit", "exit", "EOF",    // session exit (Wave 2)
     "switch", // active-template pointer, REPL-only (Wave 2)
@@ -129,10 +129,9 @@ pub const MCP_DENYLIST: &[&str] = &[
 /// Builds the process-wide command registry — the single, explicit place every
 /// command is wired (replacing upstream's `__init_subclass__` auto-discovery).
 ///
-/// The command waves (Phase 5.6+) register their commands here; until then this
-/// returns an empty registry. Both the REPL (`mtui`) and MCP (`mtui-mcp`) build
-/// their command surface from the [`Registry`] this returns, so a command added
-/// here becomes a REPL command **and** an MCP tool automatically.
+/// Both the REPL (`mtui`) and MCP (`mtui-mcp`) build their command surface from
+/// the [`Registry`] this returns, so a command added here becomes a REPL command
+/// **and** an MCP tool automatically.
 #[must_use]
 pub fn register_all() -> Registry {
     use crate::commands;
@@ -400,15 +399,13 @@ mod tests {
 
     #[test]
     fn mcp_denylist_is_consistent() {
-        // Every deny-listed name that is *registered* must be present as a name
-        // or alias; names not yet backed by a command (reserved for later waves)
-        // are tolerated. Nothing in the deny-list may be a duplicate.
+        // This loop checks only that nothing in the deny-list is duplicated;
+        // that every entry actually resolves to a registered command or alias
+        // is asserted below, against the full expected list.
         let r = register_all();
         let mut seen = std::collections::HashSet::new();
         for name in MCP_DENYLIST {
             assert!(seen.insert(*name), "duplicate deny-list entry: {name}");
-            // A registered deny-listed name resolves; an unregistered one is a
-            // reserved placeholder for a later wave.
             let _reserved_or_registered = r.contains(name);
         }
         // Sanity: the currently-registered deny-listed commands are the Wave 2

--- a/crates/mtui-datasources/src/refhost/store.rs
+++ b/crates/mtui-datasources/src/refhost/store.rs
@@ -162,9 +162,10 @@ impl Refhosts {
     /// With neither, every host is returned. A host matches an `attributes`
     /// query when it satisfies **any** of the alternatives (upstream `any`).
     ///
-    /// The loaded `data` is already de-duplicated by name at load time
-    /// (`mtui-types::load_refhosts`), so the extra dedup upstream performs here
-    /// is a no-op guard kept for byte-parity with the upstream contract.
+    /// The dedup is first-occurrence-wins. It is redundant for a store built by
+    /// [`Refhosts::from_path`] (`mtui-types::load_refhosts` already de-dups at load
+    /// time) but **load-bearing** for [`Refhosts::from_hosts`], which accepts a
+    /// raw row list — matching the first-occurrence semantics of `host_by_name`.
     #[must_use]
     pub fn query(
         &self,

--- a/crates/mtui-hosts/src/connection/mod.rs
+++ b/crates/mtui-hosts/src/connection/mod.rs
@@ -1,9 +1,9 @@
 //! The [`Connection`] abstraction: one SSH/SFTP link to a single host.
 //!
-//! This module defines the **trait** and a scriptable [`MockConnection`] test
-//! double. The concrete russh-backed implementation lands in a later Phase 2
-//! task (P2.3); the [`Target`](crate) state machine (P2.4) drives one
-//! `Box<dyn Connection>` per host and swaps in the mock under test.
+//! This module defines the **trait**, the concrete russh-backed
+//! [`SshConnection`], and a scriptable [`MockConnection`] test double. The
+//! [`Target`](crate) state machine drives one `Box<dyn Connection>` per host and
+//! swaps in the mock under test.
 //!
 //! ## Reference
 //!
@@ -15,22 +15,21 @@
 //!
 //! ## Scope
 //!
-//! This trait defines the **minimal core** needed to make the layer testable
-//! and to unblock [`Target`](crate) (P2.4): [`run`](Connection::run),
-//! [`is_active`](Connection::is_active), [`close`](Connection::close), and the
-//! cheap [`hostname`](Connection::hostname) accessor. Later tasks extend it
+//! The **core** that makes the layer testable and drives [`Target`](crate) is
+//! [`run`](Connection::run), [`is_active`](Connection::is_active),
+//! [`close`](Connection::close), and the cheap
+//! [`hostname`](Connection::hostname) accessor. The trait extends that core
 //! deliberately:
 //!
-//! * **P2.3** (landed) — `reconnect`, `fire_and_forget`, and the `sftp_*`
-//!   transfer family (`put` / `get` / `get_folder` / `listdir` / `open` /
-//!   `remove` / `rmdir` / `readlink`), plus the russh-backed
-//!   [`SshConnection`].
-//! * **P2.6** (landed) — `sftp_write` (atomic exclusive create / truncating
-//!   overwrite), the write primitive the remote-lock protocol is built on.
-//! * **P2.10** (landed, feature `shell`) — the interactive PTY `shell`,
-//!   returning an object-safe `ShellChannel` duplex. Only the transport
-//!   primitive lives here; the raw-`termios` local TTY bridge and `shell` REPL
-//!   command that consume it are a CLI concern (Phase 6).
+//! * `reconnect`, `fire_and_forget`, and the `sftp_*` transfer family
+//!   (`put` / `get` / `get_folder` / `listdir` / `open` / `remove` / `rmdir` /
+//!   `readlink`), plus the russh-backed [`SshConnection`].
+//! * `sftp_write` (atomic exclusive create / truncating overwrite), the write
+//!   primitive the remote-lock protocol is built on.
+//! * The interactive PTY `shell` (feature `shell`), returning an object-safe
+//!   `ShellChannel` duplex. Only the transport primitive lives here; the
+//!   raw-`termios` local TTY bridge and `shell` REPL command that consume it are
+//!   a CLI concern (`mtui-cli`).
 //!
 //! The trait is object-safe so callers hold `Box<dyn Connection>` and swap the
 //! russh impl for [`MockConnection`] freely.
@@ -62,8 +61,8 @@ pub(crate) const DEFAULT_USER: &str = "root";
 
 /// One SSH/SFTP connection to a single remote host.
 ///
-/// Object-safe (`Box<dyn Connection>`); see the module docs for the planned
-/// method-surface growth in later Phase 2 tasks.
+/// Object-safe (`Box<dyn Connection>`); see the module docs for the full method
+/// surface.
 #[async_trait]
 pub trait Connection: Send + Sync {
     /// The hostname this connection targets.
@@ -242,13 +241,13 @@ pub trait Connection: Send + Sync {
     /// Atomically appends `data` to the end of a remote file over SFTP.
     ///
     /// This is the additive counterpart to [`sftp_write`](Self::sftp_write):
-    /// it opens the file with `O_APPEND` (paramiko mode `"a+"`) so every write
-    /// lands at the current end-of-file, and **creates the file if it is
-    /// missing** (`O_CREAT`). Unlike the exclusive [`sftp_write`] path there is
-    /// no read-modify-write window and no TOCTOU to close — concurrent
-    /// appenders each extend the file without clobbering one another, which is
-    /// exactly what the shared `/var/log/mtui.log` history contract needs when a
-    /// Rust and a Python mtui write to the same host.
+    /// it opens the file with `O_APPEND` so every write lands at the current
+    /// end-of-file, and **creates the file if it is missing** (`O_CREAT`).
+    /// Unlike the exclusive [`sftp_write`](Self::sftp_write) path there is no
+    /// read-modify-write window and no TOCTOU to close — concurrent appenders
+    /// each extend the file without clobbering one another, which is exactly
+    /// what the shared `/var/log/mtui.log` history contract needs when several
+    /// mtui processes (including older releases) write to the same host.
     ///
     /// It never truncates: existing contents are preserved and `data` is placed
     /// after them, byte-for-byte.

--- a/crates/mtui-hosts/src/target/locks.rs
+++ b/crates/mtui-hosts/src/target/locks.rs
@@ -22,8 +22,8 @@
 //!
 //! Both locks serialize one line, `timestamp:user:pid[:comment]`, into their
 //! respective `/var/lock/*.lock` file (see [`RemoteLock::to_lockfile`]). This
-//! is a **cross-implementation contract**: a Python `mtui` and this Rust `mtui`
-//! may share a host fleet, so the byte layout must match upstream exactly. The
+//! is a **cross-process contract**: other tools on the fleet parse the same
+//! layout, including older `mtui` releases, so the bytes must not change. The
 //! `comment` field keeps any embedded colons (parsed with a 3-way split); a
 //! `PoolLock` stores `mtui pool <RRID> [<owner>]` there.
 //!
@@ -260,8 +260,8 @@ pub struct TargetLock<C: Clock = SystemClock> {
     path: PathBuf,
 }
 
-/// The default operation-lock path, `/var/lock/mtui.lock` — a cross-mtui
-/// contract (a Python and a Rust mtui may share a host fleet).
+/// The default operation-lock path, `/var/lock/mtui.lock` — a cross-process
+/// contract (other tools on the fleet parse the same layout).
 pub const TARGET_LOCK_PATH: &str = "/var/lock/mtui.lock";
 
 /// The default pool-claim-lock path, `/var/lock/mtui-pool.lock`.

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -784,16 +784,17 @@ impl Target {
     ///
     /// Ports upstream `Target.add_history`: on **enabled** hosts only, writes one
     /// `timestamp:user:field1:field2…\n` line (Unix-epoch-seconds timestamp,
-    /// `config.session_user`, then the colon-joined `fields`). The upstream
-    /// wire-format contract is shared with the Python mtui and read back by
-    /// `list_history`, so it is preserved byte-for-byte.
+    /// `config.session_user`, then the colon-joined `fields`). The wire format is
+    /// shared with every other mtui on the fleet (including older releases) and
+    /// read back by `list_history`, so it is preserved byte-for-byte.
     ///
     /// Upstream opens the file `"a+"` and writes one line; this sends only that
     /// new line via [`sftp_append`](Connection::sftp_append), which appends at
     /// end-of-file and creates the file if it is missing. Unlike the former
     /// read-concatenate-rewrite emulation, the cost per entry is now O(1) in the
-    /// line size (not O(history)), and concurrent writers (a Rust and a Python
-    /// mtui sharing the host) no longer clobber one another's entries.
+    /// line size (not O(history)), and concurrent writers (several mtui
+    /// processes, including older releases, sharing the host) no longer clobber
+    /// one another's entries.
     ///
     /// Best-effort, matching upstream: a write failure (read-only or full remote
     /// fs, unconnected host) is logged and swallowed so a bookkeeping write never

--- a/crates/mtui-hosts/tests/history_append.rs
+++ b/crates/mtui-hosts/tests/history_append.rs
@@ -72,7 +72,8 @@ async fn add_history_is_one_append_per_entry_regardless_of_size() {
 async fn concurrent_appenders_do_not_lose_entries() {
     // `MockConnection`'s file store is an `Arc<Mutex<..>>` shared across clones,
     // so two clones model two independent writers against one host's
-    // /var/log/mtui.log (mirrors a Rust and a Python mtui sharing the fleet).
+    // /var/log/mtui.log (mirrors two mtui processes, including different
+    // releases, sharing the fleet).
     let handle = MockConnection::new("h1");
     let mut alice = handle.clone();
     let mut bob = handle.clone();

--- a/crates/mtui-hosts/tests/lock_format.rs
+++ b/crates/mtui-hosts/tests/lock_format.rs
@@ -1,8 +1,9 @@
 //! Golden snapshot of the remote-lock wire format.
 //!
 //! The `/var/lock/mtui.lock` (and `/var/lock/mtui-pool.lock`) line layout is a
-//! **cross-implementation contract**: a Python `mtui` and this Rust `mtui` may
-//! share a host fleet, so the exact bytes must not drift. This test freezes the
+//! **cross-process contract**: other tools on the fleet parse the same layout,
+//! including older mtui releases, so the exact bytes must not change. This test
+//! freezes the
 //! serialized form for both the operation lock (`TargetLock`) and the pool
 //! claim lock (`PoolLock`), including the pool comment that carries the RRID.
 //!

--- a/crates/mtui-mcp/src/schema.rs
+++ b/crates/mtui-mcp/src/schema.rs
@@ -26,8 +26,8 @@
 //!   The Rust `--days` uses a `value_parser!(u32).range(1..=30)` parser; `clap`
 //!   erases the parser behind [`clap::builder::ValueParser`] and does not expose
 //!   the numeric bounds, so we emit a plain `integer` (the parser still enforces
-//!   the range at call time). The Rust arg spec — not the Python one — is the
-//!   source of truth here.
+//!   the range at call time). The `clap` arg spec is the source of truth for the
+//!   synthesised schema.
 
 use std::any::TypeId;
 

--- a/crates/mtui-mcp/src/tools.rs
+++ b/crates/mtui-mcp/src/tools.rs
@@ -376,10 +376,13 @@ fn started_jobs_reply(command: &str, job_ids: &[String]) -> String {
     )
 }
 
-/// The four background-job control tools (stubbed until `mtui-rs-76e.12`).
+/// The four background-job control tools (`job_list`, `job_status`,
+/// `job_result`, `job_cancel`).
 ///
-/// Their schemas and descriptions are final; only the handlers
-/// ([`dispatch_job_tool`]) are stubbed.
+/// Their names and schemas are a downstream contract (see `AGENTS.md`) and are
+/// snapshot-tested; the schemas are strict (`additionalProperties: false`) so a
+/// misspelled field is a clean error rather than a silently ignored argument.
+/// [`dispatch_job_tool`] routes them onto the session's job table.
 #[must_use]
 pub fn job_tool_descriptors() -> Vec<ToolDescriptor> {
     let job_id_schema = || {

--- a/crates/mtui-mcp/tests/session_concurrency.rs
+++ b/crates/mtui-mcp/tests/session_concurrency.rs
@@ -3,21 +3,20 @@
 //!
 //! Four behaviours, matching upstream 1:1:
 //!
-//! * `test_run_command_unscoped_serialises_via_exclusive_gate` — unscoped calls
-//!   (no real template) take the exclusive registry gate and never overlap.
-//! * `test_run_command_same_rrid_serialises` — two calls scoped to the *same*
-//!   template do not overlap.
-//! * `test_run_command_different_rrids_run_concurrently` — two calls scoped to
-//!   *different* templates overlap in time.
-//! * `test_concurrent_runs_do_not_clobber_each_others_stdout` — overlapping
-//!   different-RRID runs each capture only their own output.
+//! * `unscoped_serialises_via_exclusive_gate` — unscoped calls (no real
+//!   template) take the exclusive registry gate and never overlap.
+//! * `same_rrid_serialises` — two calls scoped to the *same* template do not
+//!   overlap.
+//! * `different_rrids_run_concurrently` — two calls scoped to *different*
+//!   templates overlap in time.
+//! * `do_not_clobber_each_others_stdout` — overlapping different-RRID runs each
+//!   capture only their own output.
 //!
-//! The first two assert the **lock discipline** landed by `mtui-rs-76e.11` and
-//! pass now. The last two assert **genuine wall-clock concurrency / per-call
-//! output isolation**, which additionally needs the `mtui-core` change that stops
-//! dispatch taking `&mut Session` for the whole monolithic session (and isolates
-//! per-call output) — tracked as `mtui-rs-f36r`. They are `#[ignore]`d here so
-//! the parity target is captured, not dropped; un-ignore them in `mtui-rs-f36r`.
+//! The first two assert the **lock discipline**: unscoped and same-RRID calls
+//! serialise. The last two assert **genuine wall-clock concurrency / per-call
+//! output isolation** — `run_command` dispatches a single-real-RRID call on a
+//! forked session rather than holding one session-wide mutex, so different-RRID
+//! calls overlap and each captures only its own output.
 
 #![cfg(feature = "mcp")]
 

--- a/crates/mtui-testreport/tests/overview_inject.rs
+++ b/crates/mtui-testreport/tests/overview_inject.rs
@@ -215,12 +215,14 @@ fn blank_counts_stable_across_reexports() {
 
 /// Golden snapshot of the fully-injected template.
 ///
-/// The `overview_inject` BEGIN/END block is a **cross-implementation text
-/// contract** (see `AGENTS.md`: "the `overview_inject` BEGIN/END idempotent
-/// block under `regression tests:`"). The other tests in this file assert
-/// placement, idempotency, and blank-line invariants structurally; this one
-/// freezes the exact rendered bytes so the block layout cannot silently drift
-/// away from what a Python `mtui` reading the same template would expect.
+/// The `overview_inject` BEGIN/END block is a **text contract** (see
+/// `AGENTS.md`: "the `overview_inject` BEGIN/END idempotent block under
+/// `regression tests:`"). The other tests in this file assert placement,
+/// idempotency, and blank-line invariants structurally; this one freezes the
+/// exact rendered bytes. mtui re-reads them itself: a repeat export finds the
+/// previous block by these markers and replaces it (see
+/// `export::overview_inject`), so drift would turn one block into two in a
+/// report already committed to SVN and read by human reviewers.
 #[test]
 fn injected_block_text_is_stable() {
     let mut template = template_with_regression_section();

--- a/crates/mtui-types/src/error.rs
+++ b/crates/mtui-types/src/error.rs
@@ -183,10 +183,9 @@ pub struct RequestKindParseError {
 
 /// Errors produced while parsing an OBS Request Review ID (RRID).
 ///
-/// Mirrors upstream `RequestReviewIDParseError` and its subclasses. Every
-/// message is rendered with the upstream `"OBS Request Review ID: "` prefix so
-/// the user-facing text remains a stable contract across the Python and Rust
-/// implementations.
+/// Every message is rendered with the `"OBS Request Review ID: "` prefix so a
+/// parse failure is self-identifying in a log line or a CI transcript, where the
+/// bare component error would be ambiguous.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RridParseError {

--- a/crates/mtui-types/src/rrid.rs
+++ b/crates/mtui-types/src/rrid.rs
@@ -1,10 +1,13 @@
 //! OBS Request Review ID (RRID), ported from `mtui/types/rrid.py`.
 //!
 //! An RRID is the `project:kind:maintenance_id:review_id` identifier that names
-//! a maintenance request across the SUSE ecosystem. Its grammar and parse
-//! errors are an interop **Contract** (see `AGENTS.md`): a Rust mtui and a
-//! Python mtui must agree byte-for-byte on what parses and what fails, so this
-//! module mirrors upstream's `RequestReviewID.__init__` component-by-component.
+//! a maintenance request across the SUSE ecosystem. Its grammar and parse errors
+//! are an interop **Contract** (see `AGENTS.md`): RRIDs are minted by OBS/IBS,
+//! and the rendered form becomes the on-disk testreport directory name, so what
+//! parses and what fails is not ours to choose. Loosening the grammar admits
+//! identifiers the rest of the ecosystem will reject; tightening it strands
+//! checkouts already on disk. Either way it is a breaking change, not a local
+//! refactor.
 //!
 //! ## Grammar (upstream `rrid.py`)
 //!

--- a/crates/mtui-types/src/updateid.rs
+++ b/crates/mtui-types/src/updateid.rs
@@ -8,15 +8,14 @@
 //!
 //! This is the **value-type slice only**: an [`UpdateID`] wrapping the parsed
 //! [`RequestReviewID`], constructed by parsing an RRID string. The TestReport
-//! factory, the SVN/Gitea checkout, and the interactive prompter are deferred to
-//! a later phase (the update workflow lives in `mtui-testreport` / `mtui-core`),
-//! keeping this crate I/O-free.
+//! factory, the SVN/Gitea checkout and the interactive prompter live in
+//! `mtui-testreport` / `mtui-core` — this crate is I/O-free.
 //!
 //! Because the RRID grammar is an interop **Contract** (see `AGENTS.md`),
 //! [`UpdateID::parse`] delegates verbatim to [`RequestReviewID::parse`], and
-//! [`Display`](fmt::Display) forwards to the inner RRID so that path
-//! construction downstream (upstream builds `template_dir/<str(uid.id)>`) stays
-//! byte-for-byte consistent between the Rust and Python implementations.
+//! [`Display`](fmt::Display) forwards to the inner RRID. That rendering is the
+//! per-update template directory name on disk (`template_dir/<rrid>`), so
+//! changing it orphans every existing checkout.
 
 use std::fmt;
 use std::str::FromStr;
@@ -39,10 +38,8 @@ pub struct UpdateID {
 impl UpdateID {
     /// Parses an update identifier from an RRID string.
     ///
-    /// Mirrors upstream `OBSUpdateID(rrid)`, whose `__init__` does
-    /// `id_ = RequestReviewID(rrid)`. The I/O collaborators upstream attaches
-    /// at the same point (TestReport factory, VCS checkout) are deferred to a
-    /// later phase.
+    /// Parsing only — the I/O collaborators (TestReport factory, VCS checkout)
+    /// are attached by `mtui-testreport`, keeping this crate I/O-free.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## What

Nine comments in the Rust sources justified a design by coexistence with the Python mtui, which is EOL. **The formats they protect are real**, so every rationale is replaced rather than deleted — the remote lock, the `/var/log/mtui.log` history line, the RRID grammar and the overview-inject block are all still contracts, just not with that counterparty.

Where `AGENTS.md` already names the audience ("other tools on the fleet parse the same layout"), the comment now tracks it instead of guessing at one.

**Comment-only.** Verified mechanically: no code, string literal, test assertion, or attribute changed.

## Two were load-bearing in a way the wording hid

- **`sftp_append` exists as a primitive separate from `sftp_write` *because* of the append-only history format.** That was the only place it was written down. Delete the rationale and the next refactor folds it back into `sftp_write`, silently reintroducing clobbering between concurrent testers.
- **The rendered RRID is the on-disk template directory name** (`lifecycle.rs:126`, `export/base.rs:411`). So tightening the grammar strands existing checkouts — a stronger and more actionable reason than the byte-parity one it replaces.

## Four comments were flatly false

Each would have sent a reader the wrong way:

| Site | Claimed | Actually |
|---|---|---|
| `refhost/store.rs` | dedup is "a no-op guard kept for byte-parity" | **Not a no-op.** `Refhosts::from_hosts` is public, takes raw rows without de-duplicating, and has six callers — the guard is what makes `query()` first-occurrence-wins |
| `session_concurrency.rs` | last two tests are `#[ignore]`d pending a refactor | No `#[ignore]` in the file; the refactor shipped |
| `registry.rs` | `register_all` "returns an empty registry" | Registers 61 commands; a test asserts 61 |
| `tools.rs` | the four job tools are "stubbed" | `dispatch_job_tool` is complete |

The `store.rs` one is the most dangerous: acting on that comment by deleting the "redundant" `seen` set would have silently changed `query()` results for every `from_hosts` caller.

## Scope

Two things are deliberately **not** here:

- **Stale "later Phase N" forward-references** (~50 sites). A different defect class — references to work that shipped, nothing to do with Python. Folding them in would make both unreviewable.
- **Behavioural fixes.** Per `AGENTS.md`, retiring a *rationale* is prose and changing *bytes* is not; those get their own commits.

## Testing

Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp` (189 + 48), compile-only matrix (`--no-default-features`, `--all-features`). `typos` clean.

`cargo doc --workspace --no-deps` introduces **no new warnings** — and two pre-existing broken intra-doc links that sat on rewritten lines (`[`sftp_write`]`, `[`mcp_denylist_is_consistent`]`) are fixed in passing.

No CHANGELOG entry: `CONTRIBUTING.md` § Changelog — "Internal refactors do not need an entry."

## Review

Four read-only agents enumerated candidates per crate; two more attacked the result before it was committed. They caught three defects in my own rewrites, all fixed here:

- `atomic.rs` — I had added "or two threads of one" to the collision guarantee. PID + nanos does **not** make two threads safe; a third component (an atomic counter) does. The wording would have read as licence to delete it.
- `mtui-core/src/error.rs` — my replacement was vacuous, imposing no constraint, while those `Display` strings are frozen and pinned by four tests in the same file.
- The lock-format audience had been narrowed from "other tools on the fleet" to "other mtui processes", which invites the wrong inference that we ship all the readers.
