### PR TITLE
fix: retire four bugs preserved for parity with the removed implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Internal only, no behaviour change: the OBS/QAM precondition guard is now
   named `skips_maintenance_testreport` rather than `is_slfo`, which claimed
   less than it does — it is true for PI requests as well as SLFO ones.
+- The `update`/`downgrade` commands sent to reference hosts no longer carry
+  doubled awk braces (`'{{ print $2; }}'` → `'{ print $2; }'`), a leftover of
+  an older templating scheme. The two forms are equivalent to awk, so the
+  update itself behaves identically; what changes is the command text shown by
+  `show_log` and written into the exported `install_logs/<host>.log`, which is
+  now what a person would type when reproducing the run by hand.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   bump appeared in the report depended on the packager's whitespace style. Both
   added and removed `Version:` lines are now listed under "Version / macro
   changes:"; `%define`/`%global …ver…` macro bumps match exactly as before.
+- Corrected a user-facing typo: `list_products` labelled each host's product
+  list "Referenece host:" — inherited verbatim from the Python implementation,
+  where it was the string's only occurrence and had no consumer — and now
+  prints "Reference host:". Affects the REPL and the `list_products` MCP tool.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   max_parallel` fan-out bound to its built-in default: splitting the host group
   for a subset op carried only the workflow provider, dropping the configured
   bound (and, before this, any session state pushed down beside it).
+- `analyze_diff` now reports plain `Version:` bumps in a spec file. A misplaced
+  word boundary meant the pattern demanded a word character straight after
+  `Version:`, so the conventional form (`Version:` then whitespace, then the
+  value) was skipped while the unusual `Version:1.2.3` was matched — whether a
+  bump appeared in the report depended on the packager's whitespace style. Both
+  added and removed `Version:` lines are now listed under "Version / macro
+  changes:"; `%define`/`%global …ver…` macro bumps match exactly as before.
 
 ### Removed
 

--- a/crates/mtui-core/src/commands/products.rs
+++ b/crates/mtui-core/src/commands/products.rs
@@ -91,8 +91,8 @@ mod tests {
         let args = matches(&ListProducts, &["-t", "h1"]);
         ListProducts.call(&mut session, &args).await.unwrap();
         let out = buf.contents();
-        // Upstream's (sic) label + the host name are rendered.
-        assert!(out.contains("Referenece host"), "{out}");
+        // The label + the host name are rendered.
+        assert!(out.contains("Reference host"), "{out}");
         assert!(out.contains("h1"), "{out}");
     }
 

--- a/crates/mtui-core/src/commands/showdiff.rs
+++ b/crates/mtui-core/src/commands/showdiff.rs
@@ -37,13 +37,13 @@ static ARCHIVE: LazyLock<Regex> =
 // Reviewer-relevant references from changelog text.
 static REFERENCE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b(?:CVE-\d{4}-\d+|b(?:sc|oo|nc)#\d+|jsc#\w+-\d+)\b").unwrap());
-// Version / global macro bumps worth surfacing. Ported verbatim from upstream
-// `_VERSION_BUMP`, including its quirk: the trailing `\b` sits after `Version:`
-// (a non-word `:` followed by whitespace is not a word boundary), so plain
-// `+Version:` lines never actually match — only the `%define`/`%global …ver…`
-// macro branch does. Preserved for behavioural parity rather than "fixed".
+// Version / global macro bumps worth surfacing: `Version:` spec tags and
+// `%define`/`%global …ver…` macros, on added or removed lines. The `\b` belongs
+// to the macro alternative only — after `Version:` it would demand a word
+// character next, so the conventional `Version:` + whitespace + value form would
+// not match while `Version:1.2.3` would.
 static VERSION_BUMP: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^[+-]\s*(?:Version:|%(?:define|global)\s+\S*ver\w*)\b").unwrap()
+    Regex::new(r"(?i)^[+-]\s*(?:Version:|%(?:define|global)\s+\S*ver\w*\b)").unwrap()
 });
 
 /// A parsed `(header, body_lines)` section of a `source.diff`.
@@ -411,6 +411,33 @@ mod tests {
         assert_eq!(archives(&slices), vec!["foo-1.2.tar.gz".to_owned()]);
     }
 
+    #[test]
+    fn version_bump_matches_plain_version_tag_lines() {
+        // RPM spec convention: `Version:` then whitespace, then the value.
+        assert!(VERSION_BUMP.is_match("+Version:        1.2.3"));
+        assert!(VERSION_BUMP.is_match("-Version:        1.2.2"));
+        assert!(VERSION_BUMP.is_match("+Version:\t1.2.3"));
+        assert!(VERSION_BUMP.is_match("+Version: 1.2.3"));
+        // Value glued to the colon — the one plain form that matched before.
+        assert!(VERSION_BUMP.is_match("+Version:1.2.3"));
+        assert!(VERSION_BUMP.is_match("+version:        1.2.3"));
+        assert!(VERSION_BUMP.is_match("+ Version:   1.2.3"));
+    }
+
+    #[test]
+    fn version_bump_keeps_macro_branch_and_ignores_other_lines() {
+        assert!(VERSION_BUMP.is_match("+%global libver 1.1"));
+        assert!(VERSION_BUMP.is_match("-%define srcver 2.0"));
+        assert!(VERSION_BUMP.is_match("+%define ver 1.0"));
+        assert!(!VERSION_BUMP.is_match("+%global nothing here"));
+        assert!(!VERSION_BUMP.is_match("+Release:        1"));
+        assert!(!VERSION_BUMP.is_match("+BuildRequires:  pkgconfig"));
+        assert!(!VERSION_BUMP.is_match("+Requires:       foo = %{version}"));
+        assert!(!VERSION_BUMP.is_match("+#Version:       1.0"));
+        // Unchanged context lines carry no +/- marker and are not bumps.
+        assert!(!VERSION_BUMP.is_match(" Version:        1.2.3"));
+    }
+
     #[tokio::test]
     async fn show_diff_no_report_errors() {
         let (mut session, _buf) = empty_session();
@@ -528,6 +555,27 @@ changes files:
         assert!(out.contains("bsc#1200000"), "{out}");
     }
 
+    /// A spec bumping only the `Version:` tag — no `%define`/`%global` — must
+    /// still produce the "Version / macro changes:" block.
+    #[tokio::test]
+    async fn analyze_diff_surfaces_plain_version_tag_bump() {
+        let diff = "\
+spec files:
+-----
+-Version:        1.2.2
++Version:        1.2.3
++Patch1:  fix.patch
++%autosetup -p1
+";
+        let (mut session, buf, _dir) = session_with_diff(diff);
+        let args = matches(&AnalyzeDiff, &[]);
+        AnalyzeDiff.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        assert!(out.contains("Version / macro changes:"), "{out}");
+        assert!(out.contains("+Version:        1.2.3"), "{out}");
+        assert!(out.contains("-Version:        1.2.2"), "{out}");
+    }
+
     #[tokio::test]
     async fn analyze_diff_removed_and_automacro_and_unmentioned() {
         let diff = "\
@@ -546,5 +594,8 @@ spec files:
         assert!(out.contains("%autosetup/%autopatch"), "{out}");
         // new.patch is not in any changelog section.
         assert!(out.contains("(not in changelog)"), "{out}");
+        // Over-match guard: this diff has no `Version:` tag and no `%define`/
+        // `%global …ver…`, so the block must be absent entirely.
+        assert!(!out.contains("Version / macro changes:"), "{out}");
     }
 }

--- a/crates/mtui-core/src/display.rs
+++ b/crates/mtui-core/src/display.rs
@@ -394,11 +394,10 @@ impl CommandPromptDisplay {
 
     /// Displays the products of a reference host.
     ///
-    /// Mirrors upstream `list_products`. Note: upstream literally prints
-    /// "Referenece host" (sic) — preserved for byte-parity with existing tools.
+    /// Mirrors upstream `list_products`, except for the label: upstream printed
+    /// "Referenece host" (sic), a typo with no consumer, corrected here.
     pub(crate) fn list_products(&mut self, hostname: &str, system: &System) {
-        // sic: upstream typo "Referenece", kept for output parity.
-        let label = Self::green(self, "Referenece host");
+        let label = Self::green(self, "Reference host");
         let host = Self::yellow(self, hostname);
         self.println(&format!("{label}: {host}"));
         for x in system.pretty() {
@@ -931,11 +930,11 @@ mod tests {
     }
 
     #[test]
-    fn list_products_preserves_upstream_typo() {
+    fn list_products_labels_the_reference_host() {
         let (mut d, buf) = buffered(ColorMode::Never);
         d.list_products("refhost", &system("SLES"));
         let out = rendered(&buf);
-        assert!(out.contains("Referenece host: refhost"));
+        assert!(out.contains("Reference host: refhost"));
         assert!(out.contains("Base product: SLES-15.5-x86_64"));
     }
 

--- a/crates/mtui-testreport/src/products/sle11.rs
+++ b/crates/mtui-testreport/src/products/sle11.rs
@@ -1,8 +1,8 @@
 //! Normalizer for the SLE 11 product family.
 //!
-//! Ported from `mtui/test_reports/products/sle11.py`. The upstream if-chain is
-//! order-sensitive and contains a deliberate non-returning fallthrough on the
-//! `CORE` branch; both are preserved exactly.
+//! Ported from `mtui/test_reports/products/sle11.py`. The if-chain is
+//! order-sensitive, and the `CORE` branch does not return — see the comment on
+//! that branch for why it is left that way.
 
 use mtui_types::SystemProduct;
 
@@ -24,8 +24,15 @@ pub fn normalize_sle11(mut x: SystemProduct) -> SystemProduct {
         x.version = x.version.replace("-LTSS", "").replace("-CLIENT-TOOLS", "");
         return x;
     }
-    // Upstream intentionally does NOT return here — the `CORE` rewrite falls
-    // through to the subsequent suffix checks. Preserved verbatim.
+    // No `return` here, deliberately kept. The fall-through is inert for every
+    // known product string: after the rewrite the name is
+    // `SUSE_SLES_LTSS-EXTREME-CORE`, so the trailing SLE-SMT/SLE-HAE *name*
+    // checks cannot match, and the post-strip version ends in none of
+    // TERADATA/SECURITY/PUBCLOUD — so all three of those checks are no-ops too.
+    // Only a doubly-suffixed version (`…-TERADATA-LTSS-EXTREME-CORE`) would
+    // reach one, and no such string has been observed. Left as-is rather than
+    // "fixed", because there is no evidence which answer it would want, and
+    // this key selects the update repository a host gets.
     if x.version.ends_with("CORE") {
         x.name = "SUSE_SLES_LTSS-EXTREME-CORE".to_string();
         x.version = x.version.replace("-LTSS-EXTREME-CORE", "");

--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -9,12 +9,13 @@
 //! (see `hostgroup.py::perform_downgrade`) so the shell/awk `$`-tokens survive.
 //! The `slmicro` entry is transactional with a reboot.
 //!
-//! Template strings are ported **verbatim**, including leading newlines.
+//! `LIST_COMMAND`'s leading newline keeps the first command off the prompt line
+//! in the transcript `show_log` prints.
 
 use crate::update_workflow::actions::{ActionCommands, SubstMode};
 
 /// zypper/slmicro downgrade list command (upstream `list_command_template`),
-/// verbatim and shared by both.
+/// shared by both.
 ///
 /// One `zypper -n se -s` invocation for the whole package list (upstream
 /// PR #336): a per-package `for p in $packages; do zypper ... $$p; done` loop
@@ -27,7 +28,7 @@ zypper -n se -s --match-exact -t package $packages \
 | grep -v "(System" \
 | grep ^[iv] \
 | sed "s, ,,g" \
-| awk -F "|" '{{ print $2,"=",$4 }}'
+| awk -F "|" '{ print $2,"=",$4 }'
 "#;
 
 /// zypper downgrade command (upstream `zypper()["command"]`), verbatim.
@@ -120,7 +121,9 @@ mod tests {
             "{listed}"
         );
         // awk field refs preserved.
-        assert!(listed.contains("print $2,\"=\",$4"));
+        assert!(listed.contains("{ print $2,\"=\",$4 }"));
+        // Discriminating: the doubled form contains the single-brace substring.
+        assert!(!listed.contains("{{"), "{listed}");
     }
 
     #[test]

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -6,37 +6,37 @@
 //! (`awk … print $2`, `while read r … $$r`) that must reach the remote shell
 //! unaltered. The `slmicro` (`slm_update`) entry is transactional with a reboot.
 //!
-//! The template strings are ported **verbatim**, including their leading
-//! newline, so the emitted commands are byte-identical to upstream.
+//! Each template's leading newline keeps the first command off the prompt line
+//! in the transcript `show_log` prints.
 
 use crate::update_workflow::actions::{ActionCommands, SubstMode};
 
-/// yum update command (upstream `yum_update["command"]`), verbatim.
+/// yum update command (upstream `yum_update["command"]`).
 const YUM_UPDATE: &str = "
 export LANG=
 yum repolist
 yum -y update $packages
 ";
 
-/// zypper update command (upstream `zypper_update["command"]`), verbatim.
+/// zypper update command (upstream `zypper_update["command"]`).
 const ZYPPER_UPDATE: &str = r#"
 export LANG=
 zypper -n lr -puU
 zypper -n refresh
 zypper -n patches | grep $repa
-zypper -n in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ {{ print $2; }}')
+zypper -n in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
 zypper -n patches | grep $repa
-zypper -n lr | awk -F "|" '/$repa\>/ {{ print $2; }}' | while read r; do zypper -n rr $$r; done
+zypper -n lr | awk -F "|" '/$repa\>/ { print $2; }' | while read r; do zypper -n rr $$r; done
 "#;
 
-/// slmicro update command (upstream `slm_update["command"]`), verbatim.
+/// slmicro update command (upstream `slm_update["command"]`).
 const SLM_UPDATE: &str = r#"
 export LANG=
 zypper -n lr -puU
 zypper -n patches | grep $repa
-transactional-update -n pkg in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ {{ print $2; }}')
+transactional-update -n pkg in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
 zypper -n patches | grep $repa
-zypper -n lr | awk -F "|" '/$repa\>/ {{ print $2; }}' | while read r; do zypper -n rr $$r; done
+zypper -n lr | awk -F "|" '/$repa\>/ { print $2; }' | while read r; do zypper -n rr $$r; done
 "#;
 
 fn yum() -> ActionCommands {
@@ -98,8 +98,12 @@ mod tests {
         assert!(rendered.contains("print $2;"));
         // `$$r` -> literal `$r` for the shell loop.
         assert!(rendered.contains("zypper -n rr $r; done"));
-        // Template braces `{{ }}` are literal in string.Template.
-        assert!(rendered.contains("{{ print $2; }}"));
+        // Braces are literal to the substituter — only `$` is special — so the
+        // awk action reaches the remote shell exactly as written.
+        assert!(rendered.contains("{ print $2; }"));
+        // Discriminating: `"{{ print $2; }}"` *contains* `"{ print $2; }"`, so
+        // the assertion above alone would also pass on the old doubled form.
+        assert!(!rendered.contains("{{"), "{rendered}");
     }
 
     #[test]
@@ -118,6 +122,8 @@ mod tests {
         );
         let rendered = cmds.render_command(&vars(":p=1:2", "p")).unwrap();
         assert!(rendered.contains("transactional-update -n pkg in -l -y -t patch"));
+        assert!(rendered.contains("{ print $2; }"));
+        assert!(!rendered.contains("{{"), "{rendered}");
     }
 
     #[test]

--- a/crates/mtui-testreport/tests/products.rs
+++ b/crates/mtui-testreport/tests/products.rs
@@ -47,6 +47,16 @@ fn sle11_branches() {
 
     let out = normalize_sle11(p("SLES-SAP", "11-CORE", "x86_64"));
     assert_eq!(out.name, "SUSE_SLES_LTSS-EXTREME-CORE");
+    assert_eq!(out.version, "11-CORE");
+
+    // The only input that exercises the `-LTSS-EXTREME-CORE` strip: the branch
+    // rewrites the name, strips the suffix, then falls through to the final
+    // return. Every other CORE case leaves the version untouched, so without
+    // this the strip is a no-op in the whole suite.
+    let out = normalize_sle11(p("SLE-SERVER", "11-SP3-LTSS-EXTREME-CORE", "x86_64"));
+    assert_eq!(out.name, "SUSE_SLES_LTSS-EXTREME-CORE");
+    assert_eq!(out.version, "11-SP3");
+    assert_eq!(out.arch, "x86_64");
 
     let out = normalize_sle11(p("SLES-SAP", "11-TERADATA", "x86_64"));
     assert_eq!(out.name, "teradata");

--- a/typos.toml
+++ b/typos.toml
@@ -14,8 +14,9 @@ extend-exclude = [
 # Accepted alternative spelling of "cannot be parsed", used consistently across
 # the datasources/testreport crates and their tests (error text, doc comments).
 unparseable = "unparseable"
-# Deliberate `sic`: upstream mtui literally prints "Referenece host"; the Rust
-# port preserves the byte-for-byte output for tool parity (see display.rs).
+# The label was corrected to "Reference host". This entry stays for the two
+# places that still quote the old misspelling: the CHANGELOG entry recording
+# the fix, and the `list_products` doc comment in display.rs explaining it.
 referenece = "referenece"
 # SUSE product name: SLE-HAE (High Availability Extension), e.g. "SLE-HAE",
 # "sle-hae" in product-normalisation code and its tests.


### PR DESCRIPTION
## What

Four bugs were preserved deliberately, each justified by parity with the Python implementation removed in `ec80791c`. That implementation is EOL, so the parity argument no longer holds. Each fix is its own commit.

Two change behaviour and carry a CHANGELOG entry; one is test-only; one is a comment correction plus restored coverage.

## `analyze_diff` never reported plain `Version:` bumps

`VERSION_BUMP`'s `\b` sat outside the alternation, so after `Version:` it demanded a word character. A colon followed by whitespace is not a word boundary.

The in-tree comment called this "plain `+Version:` lines never actually match". **That understates it** — `+Version:1.2.3`, value glued to the colon, *did* match. So whether a version bump appeared in a review report depended on the packager's whitespace style. Two updates with the same real bump produced different reports, which is a worse failure than a clean "never".

A version bump is the single most review-relevant fact in a maintenance `source.diff` — it decides whether the update is a rebase or a backport. The block header has been advertising "Version / macro changes:" while only ever able to contain macro changes.

The fix moves one character. Verified as a strict superset by fuzzing old vs new over 630k structured macro permutations and 3M random strings: **zero divergences on the macro branch, and nothing that matched before stops matching.**

## Doubled awk braces in the update templates

`awk ... '/$repa\>/ {{ print $2; }}'` — plain `&str` constants, not `format!`, so the doubling reached the remote shell. `{{ ... }}` parses in awk as an action wrapping a nested compound statement, so it is output-identical; confirmed byte-for-byte against the exact template strings and 5000 randomised inputs. Single braces are the strict subset form, so this can only widen awk compatibility.

The command text is not internal — it reaches `show_log` and is written into the exported `install_logs/<host>.log`, which the testreport links and the checkout commits to SVN. Hence the changelog entry.

## `Referenece host` → `Reference host`

Justified in-tree as "byte-parity with existing tools". No such tool is in evidence: in the Python tree the string occurred exactly once, as a producer, with no consumer and no test. It appears in no snapshot, fixture, generated man page, completion, vim-plugin rule, packaging file, or doc.

The `typos.toml` entry **stays** — the CHANGELOG bullet and a doc comment still quote the old spelling, so removing it turns the `typos` job red.

## SLE11 fall-through — deliberately NOT changed

`normalize_sle11`'s `CORE` branch has no `return`. Real, but unobservable: the only inputs where it matters are doubly-suffixed versions like `…-TERADATA-LTSS-EXTREME-CORE`, which appear nowhere in this repo or the archived tree. This key selects which update repository a host gets, so guessing has no upside.

What this does fix is a coverage gap: the `-LTSS-EXTREME-CORE` strip was a **no-op in every existing test**, because the only CORE input was `11-CORE`. The deleted Python suite pinned that case; the port dropped it. Restored, along with the comments — the module doc called the fall-through "deliberate", which the history does not support.

## Testing

Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, compile-only matrix (`--no-default-features`, `--all-features`), `typos`. CHANGELOG verified strictly append-only.

Both behavioural changes are **mutation-verified** — the new tests go red when the old behaviour is restored.

One guard was wrong on the first pass and is worth calling out: the brace assertion originally read `contains("{ print $2; }")`, which **passes against the doubled form too**, since `"{{ print $2; }}"` contains it as a substring. Reverting that commit left the suite green. Each template now also asserts the rendered text contains no `{{`, which is what actually discriminates.
