### PR TITLE
fix: install and uninstall ran nothing while reporting success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ crates/
   mtui-hosts/        SSH/SFTP (russh), Target/HostsGroup, locks, arbiter   [async]
   mtui-datasources/  shared HTTP, refhosts resolve/search/verify, openQA/QEM/Gitea/native-OBS-QAM/oqa-search  [async]
   mtui-testreport/   TestReport lifecycle, metadata parsers, SVN/Gitea checkout, update workflow (actions/checks/export)
-  mtui-core/         Command trait + registry + Session + engine + wiring (composition root)
+  mtui-core/         Command trait + registry + Session + engine + dispatch
   mtui-cli/          reedline REPL + `mtui` binary
   mtui-mcp/          rmcp server + `mtui-mcp` binary
 fuzz/                cargo-fuzz harness over the untrusted-input parsers.
@@ -159,10 +159,19 @@ next actionable task before working on a subsystem.
 - **Session state.** Commands operate on a `Session` (config, `HostsGroup`
   targets, loaded `TestReport`/metadata, display) passed explicitly. No hidden
   globals.
-- **Composition root.** `mtui-core::wiring` injects the update-workflow
-  Doer/Check registries (in `mtui-testreport`) into the host `Target` dispatch
-  (in `mtui-hosts`) via traits, so `mtui-hosts` never depends on
-  `mtui-testreport`. Do not create crate cycles — add a trait and inject.
+- **Trait injection instead of crate cycles.** `mtui-hosts` drives the
+  install/uninstall template through the `PlanProvider` trait, declared in
+  `mtui-hosts` in terms of its own types; `mtui-testreport`'s `WorkflowRegistry`
+  implements it, so the doer/check tables reach the host dispatch without
+  `mtui-hosts` depending on `mtui-testreport`. Do not create crate cycles — add
+  a trait and inject.
+  **Inject at the point of use, not at construction.** `update_flow::
+  perform_install` / `perform_uninstall` install the provider immediately before
+  driving the template. `OperationGroup::plans` has exactly one consumer, so
+  there is exactly one place that cannot forget to wire it. An earlier design
+  injected at a composition root instead; nothing ever called it, every
+  `HostsGroup` was built without a provider, and `install` reported success
+  while running no command on any host for the whole life of the Rust port.
 - **Config.** **TOML** file `mtui.toml`, resolved highest-precedence first from
   `--config` → `$MTUI_CONF` → `$XDG_CONFIG_HOME/mtui/mtui.toml` → `~/.mtui.toml`
   → `/etc/mtui.toml`; the default set is merged **lowest-precedence first** so
@@ -298,7 +307,7 @@ shells out to `osc`/`osc-plugin-qam` — it talks to the OBS/IBS API natively (s
 the native OBS backend and `[obs]` config), reading credentials from `oscrc`.
 
 ## Further reading
-- `docs/src/architecture.md` — architecture map (crate layout, composition root,
+- `docs/src/architecture.md` — architecture map (crate layout, trait injection,
   contracts) and the rest of the mdBook under `docs/src/` (installation,
   configuration, developer, invocation, mcp).
 - `CONTRIBUTING.md` — changelog policy; `docs/src/developer.md` — dev workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,36 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   default is `14400`, chosen so an idle HTTP MCP session outlasts rmcp's own
   streamable-HTTP keep-alive floor. The runtime behaviour was never wrong —
   only the documented value was.
+- `install` and `uninstall` ran no command on any host while reporting
+  `install completed on <hosts>`. Both drive a shared operation template that
+  resolves each host's package-manager command through an injected provider;
+  nothing ever injected one, so the template failed to resolve a plan, logged to
+  the tracing subscriber, and returned as if it had succeeded. The per-host
+  verdict then read exit codes from hosts nothing had run on and found no
+  failures. Over MCP the diagnostic went to the server's stderr, so a client saw
+  only success. Both commands now execute, and a run that cannot start (no
+  package-manager command for a host's product release, or a host locked by
+  another tester) is reported instead of being logged and swallowed.
+  `prepare`, `update`, and `downgrade` were never affected — they resolve their
+  commands directly and bypass that seam.
+- `uninstall` would have run the *install* command had the provider been wired:
+  the only test covering it used a stub that returned the same command for every
+  role, so the assertion pinned `zypper -n in -y -l` for an uninstall. It now
+  runs `zypper -n rm` from the uninstaller table.
+- An `install` that finishes with one of zypper's informational exit codes
+  (100-103, 106 — "update needed", "reboot needed", "restart needed", "repo
+  skipped") is no longer reported as a failure. The verdict now consults the
+  install check table, which also names the failure it finds ("package not
+  found", "update stack locked", "RPM Error", "Dependency Error") instead of a
+  flat "install command failed". Output on stderr no longer fails an install
+  that exited cleanly — zypper, `transactional-update` and `yum` all write
+  warnings there on success. Product keys with no check table (`slmicro`, `YUM`)
+  are judged on the exit code alone.
+- An `install` or `uninstall` that cannot start because a host's product has no
+  package-manager command now names that host and its product. The underlying
+  error reports only the role and release, and a host whose product never parsed
+  has no release, so the message read `Missing Installer for ` — while aborting
+  the operation for every host in the group.
 
 ## [26.0.1] - 2026-07-22
 

--- a/crates/mtui-hosts/src/error.rs
+++ b/crates/mtui-hosts/src/error.rs
@@ -216,11 +216,14 @@ pub enum HostError {
     /// No update-workflow [`PlanProvider`](crate::PlanProvider) has been wired
     /// into the [`HostsGroup`](crate::HostsGroup).
     ///
-    /// This has no upstream analogue — upstream's `Target` always has the
-    /// registries imported at module load. In the Rust redesign the doer/check
-    /// resolver is injected by the composition root (`mtui-core::wiring`) to
-    /// keep the crate graph acyclic; an operation attempted on a group before
-    /// that injection surfaces this rather than silently doing nothing.
+    /// The doer/check resolver is injected by `mtui-testreport`'s
+    /// `update_flow::perform_install` / `perform_uninstall` (keeping the crate
+    /// graph acyclic), so reaching this means an [`Operation`](crate::Operation)
+    /// was driven directly against an un-injected group.
+    ///
+    /// [`Operation::run`](crate::Operation::run) returns it rather than logging
+    /// and carrying on. It used to log and return `()`, which is how the whole
+    /// install/uninstall path came to run nothing while reporting success.
     #[error("no update-workflow provider wired into the host group")]
     NoPlanProvider,
 

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -98,13 +98,15 @@ pub struct HostsGroup {
     /// fan-out helpers as the (Phase 6) spinner/prompt seam; see
     /// [`actions`](super::actions).
     is_repl: bool,
-    /// The injected update-workflow doer/check resolver, or `None` before the
-    /// composition root wires one in.
+    /// The injected update-workflow doer/check resolver, or `None` until the
+    /// install/uninstall flow injects one.
     ///
     /// Held as `mtui-hosts`' own [`PlanProvider`] (not the `mtui-testreport`
-    /// registry directly) so the crate graph stays acyclic; `mtui-core::wiring`
-    /// supplies the concrete adapter. When absent, [`OperationGroup::plans`]
-    /// returns [`HostError::NoPlanProvider`] — the update workflow is unwired.
+    /// registry directly) so the crate graph stays acyclic; `mtui-testreport`'s
+    /// `WorkflowRegistry` is the concrete adapter, injected via
+    /// [`set_plan_provider`](Self::set_plan_provider). When absent,
+    /// [`OperationGroup::plans`] returns [`HostError::NoPlanProvider`] — the
+    /// update workflow is unwired.
     plan_provider: Option<Arc<dyn PlanProvider>>,
     /// The session-level serialised [`Prompter`](crate::Prompter), or `None`
     /// under headless callers (`mtui-mcp`).
@@ -207,13 +209,27 @@ impl HostsGroup {
     /// Injects the update-workflow [`PlanProvider`] (builder-style), enabling the
     /// [`OperationGroup`] surface (install / uninstall).
     ///
-    /// Called by the composition root (`mtui-core::wiring`) with the concrete
-    /// adapter over the `mtui-testreport` doer/check registries. Without it,
-    /// [`OperationGroup::plans`] returns [`HostError::NoPlanProvider`].
+    /// The builder form is for tests that own the group by value. Production
+    /// injects through [`set_plan_provider`](Self::set_plan_provider) at the
+    /// point of use, because that is the only place that cannot forget.
     #[must_use]
     pub fn with_plan_provider(mut self, provider: Arc<dyn PlanProvider>) -> Self {
         self.plan_provider = Some(provider);
         self
+    }
+
+    /// Injects the update-workflow [`PlanProvider`] in place.
+    ///
+    /// Called by `mtui-testreport`'s `perform_install` / `perform_uninstall`
+    /// immediately before driving the [`Operation`](super::operation::Operation)
+    /// template, which is the sole consumer of
+    /// [`OperationGroup::plans`]. Injecting there rather than at construction
+    /// is deliberate: a `HostsGroup` is built in a dozen places (the session,
+    /// each report, every test fixture), and wiring that any one of them can
+    /// omit is wiring that silently disables `install`. Without a provider,
+    /// [`OperationGroup::plans`] returns [`HostError::NoPlanProvider`].
+    pub fn set_plan_provider(&mut self, provider: Arc<dyn PlanProvider>) {
+        self.plan_provider = Some(provider);
     }
 
     /// Whether the surrounding session is the interactive REPL (spinner / prompt
@@ -751,9 +767,10 @@ impl HostsGroup {
     ///
     /// Ports upstream `HostsGroup._fanout_set_repo`, which runs
     /// `t.repo_manager.set(operation, testreport)` on every host. `report` is the
-    /// object-safe [`SetRepo`] hook the composition root supplies (the concrete
-    /// `SlReport`/`ObsReport`/… `set_repo` impl in `mtui-testreport`), so the
-    /// group never depends on the report crate.
+    /// object-safe [`SetRepo`] hook the caller passes in (the concrete
+    /// `SlReport`/`ObsReport`/… `set_repo` impl in `mtui-testreport`, handed over
+    /// by `update_flow::perform_prepare`), so the group never depends on the
+    /// report crate.
     ///
     /// Fans out concurrently via [`run_fanout`](super::actions::run_fanout)
     /// (upstream's `run_parallel`): every host runs its repo change in

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -882,8 +882,8 @@ impl Target {
     /// does not swallow a `parse_system` failure. (This differs from
     /// [`reload_system`](Target::reload_system), which degrades to the sentinel
     /// because the host is already a live group member there.) The
-    /// reboot/reconnect/operation lifecycle is bound at the composition root —
-    /// see the module docs.
+    /// reboot/reconnect/operation lifecycle is bound in
+    /// `hostgroup` — see the module docs.
     ///
     /// # Errors
     ///

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -217,44 +217,41 @@ pub trait Operation: Send + Sync {
 
     /// Executes the full `lock → run → check → reboot → unlock` skeleton.
     ///
-    /// Mirrors upstream `Operation.run`:
-    ///
-    /// * resolve per-host plans; on the configured `missing_error`, log and
-    ///   return **without** taking any lock,
+    /// * resolve per-host plans; on the configured `missing_error`, return
+    ///   **without** taking any lock,
     /// * `update_lock()`,
-    /// * run the commands, invoke each host's check with its `last*` values,
-    ///   then reboot the transactional hosts,
-    /// * `unlock()` unconditionally afterwards (upstream's `finally`).
+    /// * run the commands, invoke each host's check, then reboot the
+    ///   transactional hosts,
+    /// * `unlock()` unconditionally afterwards.
     ///
-    /// The per-host `last*` values are read from `group` *after* `run`, matching
-    /// upstream's `t.lastout()`/etc. call-time reads.
-    async fn run(&self, group: &mut dyn OperationGroup) {
-        let plans = match group.plans(self.role()) {
-            Ok(plans) => plans,
-            Err(e) => {
-                // Upstream: `logger.error("%s", e); return` — no lock is taken.
-                tracing::error!("{e}");
-                return;
-            }
-        };
+    /// # Errors
+    ///
+    /// Returns the resolver's error when no host plan can be built (no
+    /// [`PlanProvider`] injected, or no doer registered for a host's
+    /// `(release, transactional)` key), and [`HostError::Update`] when
+    /// `update_lock` finds a host held by another owner. In both cases nothing
+    /// ran on any host.
+    ///
+    /// Both were previously logged and swallowed, which is how upstream behaves.
+    /// mtui reports them instead: a caller that cannot distinguish "installed"
+    /// from "could not even start" will print success for an update that never
+    /// touched a host — the same reasoning that makes
+    /// `UpdateFailure::MissingUpdater` a hard failure in the update flow.
+    async fn run(&self, group: &mut dyn OperationGroup) -> Result<(), HostError> {
+        let plans = group.plans(self.role())?;
 
         let (commands, reboot, mut plans) = self.collect(plans);
 
-        // Upstream calls `update_lock()` *outside* the try/finally: if it raises
-        // `UpdateError` (a host is locked by another owner) it has already
-        // released the locks it took, so `run` aborts here without entering the
-        // run/unlock section — no separate unlock is issued.
-        if let Err(e) = group.update_lock().await {
-            tracing::error!("{e}");
-            return;
-        }
+        // `update_lock` runs *outside* the unlock-always section: when it fails
+        // (a host is locked by another owner) it has already released the locks
+        // it took, so `run` aborts here without entering the run/unlock section
+        // — no separate unlock is issued.
+        group.update_lock().await?;
 
-        // Upstream wraps run→check→reboot in `try` with `unlock` in `finally`.
-        // Rust has no `finally`; drive the fallible section in a nested async
-        // block and always unlock afterwards. The section itself never returns
-        // an error today (run/reboot are infallible over the group), but this
-        // structure preserves the "unlock always happens" contract for when it
-        // grows fallible steps.
+        // Everything past the lock must reach `unlock()`, so this section stays
+        // free of `?`. It is infallible over the group seam today (run/reboot
+        // return `()`); a future fallible step must capture its error and fall
+        // through to the unlock rather than returning early.
         group.run(commands).await;
         for plan in &mut plans {
             (plan.check)(CheckArgs {
@@ -264,6 +261,7 @@ pub trait Operation: Send + Sync {
         group.reboot(reboot).await;
 
         group.unlock().await;
+        Ok(())
     }
 }
 
@@ -337,13 +335,19 @@ impl Operation for UninstallOperation {
 /// The injectable seam that resolves one target's [`Doer`] + [`Check`] for a
 /// role, keyed on the target's `(release, transactional)` state.
 ///
-/// This is the `mtui-hosts`-local half of the composition-root injection: it is
-/// defined here (in terms of `mtui-hosts` types only — [`Doer`] / [`Check`]) so
+/// This is the `mtui-hosts`-local half of the injection: it is defined here (in
+/// terms of `mtui-hosts` types only — [`Doer`] / [`Check`]) so
 /// [`HostsGroup`](super::HostsGroup) can hold it and drive
 /// [`OperationGroup::plans`] **without** depending on `mtui-testreport`. The
 /// concrete implementation lives in `mtui-testreport` (its `WorkflowRegistry`
 /// adapts its own `Role` / `ActionCommands` / `CheckFn` tables into a `Doer` and
-/// a `Check`) and is bound in at the composition root (`mtui-core::wiring`).
+/// a `Check`) and is injected by that crate's `update_flow::perform_install` /
+/// `perform_uninstall`, immediately before the template runs.
+///
+/// Note the returned [`Check`] is a no-op in production: it receives only a
+/// hostname and returns `()`, so it cannot see a command's output or report a
+/// verdict. The real install/uninstall check runs in `mtui-testreport` after
+/// the template returns, over each target's `last*` snapshot.
 ///
 /// Mirrors upstream `Target.doer(role)` / `Target.check(role)`, which key the
 /// registry lookup by `(self.system.get_release(), self.transactional)`.
@@ -632,7 +636,11 @@ mod tests {
         }));
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await;
+        let err = op
+            .run(&mut group)
+            .await
+            .expect_err("a missing doer is reported");
+        assert!(matches!(err, HostError::MissingInstaller { .. }), "{err:?}");
 
         assert!(
             group.events().is_empty(),
@@ -659,7 +667,7 @@ mod tests {
         let mut group = MockGroup::new(Ok(plans));
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await;
+        op.run(&mut group).await.expect("a clean run succeeds");
 
         let events = group.events();
         assert_eq!(events.first(), Some(&Event::UpdateLock));
@@ -689,7 +697,11 @@ mod tests {
         let mut group = MockGroup::new(Ok(plans)).failing_update_lock();
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await;
+        let err = op
+            .run(&mut group)
+            .await
+            .expect_err("a foreign-held lock is reported, not swallowed");
+        assert!(matches!(err, HostError::Update(_)), "{err:?}");
 
         // update_lock was attempted, but no run / check / reboot / unlock
         // followed: the failing lock self-cleaned and aborted the operation.
@@ -708,7 +720,7 @@ mod tests {
         let mut group = MockGroup::new(Ok(plans));
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await;
+        op.run(&mut group).await.expect("a clean run succeeds");
 
         let checks: Vec<Event> = sink.lock().unwrap().clone();
         assert_eq!(
@@ -738,7 +750,8 @@ mod tests {
 
         InstallOperation::new(strs(&["pkg-a"]))
             .run(&mut group)
-            .await;
+            .await
+            .expect("a clean run succeeds");
 
         let events = group.events();
         // lock → run → check → reboot → unlock.
@@ -797,7 +810,8 @@ mod tests {
 
         UninstallOperation::new(strs(&["pkg"]))
             .run(&mut group)
-            .await;
+            .await
+            .expect("a clean run succeeds");
 
         assert_eq!(group.roles(), vec!["uninstaller".to_owned()]);
     }

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -1,5 +1,5 @@
-//! Integration test for `impl OperationGroup for HostsGroup` — the
-//! composition-root binding that drives the install/uninstall
+//! Integration test for `impl OperationGroup for HostsGroup` — the binding that
+//! drives the install/uninstall
 //! [`Operation`](mtui_hosts::Operation) template against a real
 //! [`HostsGroup`](mtui_hosts::HostsGroup) via an injected
 //! [`PlanProvider`](mtui_hosts::PlanProvider).
@@ -100,7 +100,8 @@ async fn install_drives_doer_and_reboots_only_transactional() {
 
     InstallOperation::new(vec!["pkg-a".to_owned(), "pkg-b".to_owned()])
         .run(&mut group)
-        .await;
+        .await
+        .expect("a wired group installs");
 
     // The provider was consulted for each host with the release derived from
     // its parsed system: SLES 15.5 -> "15", SL-Micro -> "slmicro".
@@ -150,7 +151,8 @@ async fn install_shell_quotes_malicious_package_name_end_to_end() {
 
     InstallOperation::new(vec!["foo; rm -rf /".to_owned()])
         .run(&mut group)
-        .await;
+        .await
+        .expect("a wired group installs");
 
     let cmd = m1.commands().into_iter().next().expect("one command ran");
     assert!(
@@ -181,7 +183,8 @@ async fn uninstall_uses_uninstaller_role() {
 
     UninstallOperation::new(vec!["pkg".to_owned()])
         .run(&mut group)
-        .await;
+        .await
+        .expect("a wired group uninstalls");
 
     let looked = lookups.lock().unwrap().clone();
     assert_eq!(
@@ -228,7 +231,8 @@ async fn select_preserves_injected_provider() {
     let mut sub = group.select(Some(&["h1".to_owned()]), false).unwrap();
     InstallOperation::new(vec!["pkg".to_owned()])
         .run(&mut sub)
-        .await;
+        .await
+        .expect("a wired group installs");
 
     assert_eq!(
         lookups.lock().unwrap().clone(),

--- a/crates/mtui-testreport/src/reports/obs.rs
+++ b/crates/mtui-testreport/src/reports/obs.rs
@@ -27,9 +27,7 @@
 use std::collections::HashMap;
 
 use mtui_config::options::Config;
-use mtui_hosts::{
-    HostsGroup, InstallOperation, Operation, RepoOp, SetRepo, Target, UninstallOperation,
-};
+use mtui_hosts::{HostsGroup, RepoOp, SetRepo, Target};
 use mtui_types::{RequestReviewID, SystemProduct};
 use tracing::debug;
 
@@ -118,8 +116,7 @@ impl TestReport for ObsReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "install", None, packages).await;
-        InstallOperation::new(packages.to_vec()).run(targets).await;
-        update_flow::install_verdict("install", targets)
+        update_flow::perform_install(targets, packages).await
     }
 
     async fn perform_uninstall(
@@ -128,10 +125,7 @@ impl TestReport for ObsReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "uninstall", None, packages).await;
-        UninstallOperation::new(packages.to_vec())
-            .run(targets)
-            .await;
-        update_flow::install_verdict("uninstall", targets)
+        update_flow::perform_uninstall(targets, packages).await
     }
 
     async fn perform_prepare(

--- a/crates/mtui-testreport/src/reports/pi.rs
+++ b/crates/mtui-testreport/src/reports/pi.rs
@@ -24,9 +24,7 @@
 use std::collections::HashMap;
 
 use mtui_config::options::Config;
-use mtui_hosts::{
-    HostsGroup, InstallOperation, Operation, RepoOp, SetRepo, Target, UninstallOperation,
-};
+use mtui_hosts::{HostsGroup, RepoOp, SetRepo, Target};
 use mtui_types::{RequestReviewID, SystemProduct};
 use tracing::debug;
 
@@ -108,8 +106,7 @@ impl TestReport for PiReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "install", None, packages).await;
-        InstallOperation::new(packages.to_vec()).run(targets).await;
-        update_flow::install_verdict("install", targets)
+        update_flow::perform_install(targets, packages).await
     }
 
     async fn perform_uninstall(
@@ -118,10 +115,7 @@ impl TestReport for PiReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "uninstall", None, packages).await;
-        UninstallOperation::new(packages.to_vec())
-            .run(targets)
-            .await;
-        update_flow::install_verdict("uninstall", targets)
+        update_flow::perform_uninstall(targets, packages).await
     }
 
     async fn perform_prepare(

--- a/crates/mtui-testreport/src/reports/sl.rs
+++ b/crates/mtui-testreport/src/reports/sl.rs
@@ -21,9 +21,7 @@ use std::collections::HashMap;
 use mtui_config::options::Config;
 use mtui_datasources::error::GiteaError;
 use mtui_datasources::gitea::Gitea;
-use mtui_hosts::{
-    HostsGroup, InstallOperation, Operation, RepoOp, SetRepo, Target, UninstallOperation,
-};
+use mtui_hosts::{HostsGroup, RepoOp, SetRepo, Target};
 use mtui_types::{RequestReviewID, SystemProduct};
 use tracing::debug;
 
@@ -123,8 +121,7 @@ impl TestReport for SlReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "install", None, packages).await;
-        InstallOperation::new(packages.to_vec()).run(targets).await;
-        update_flow::install_verdict("install", targets)
+        update_flow::perform_install(targets, packages).await
     }
 
     async fn perform_uninstall(
@@ -133,10 +130,7 @@ impl TestReport for SlReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         update_flow::add_op_history(targets, "uninstall", None, packages).await;
-        UninstallOperation::new(packages.to_vec())
-            .run(targets)
-            .await;
-        update_flow::install_verdict("uninstall", targets)
+        update_flow::perform_uninstall(targets, packages).await
     }
 
     async fn perform_prepare(

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -24,8 +24,12 @@
 //! transactional)`, mirroring upstream `Target.doer(role)` / `Target.check(role)`.
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
-use mtui_hosts::{Command, HostsGroup, OperationGroup, RepoOp, SetRepo};
+use mtui_hosts::{
+    Command, HostError, HostsGroup, InstallOperation, Operation, OperationGroup, RepoOp, SetRepo,
+    UninstallOperation,
+};
 use mtui_types::shellquote::quote_args;
 use tracing::{debug, error, info, warn};
 
@@ -324,20 +328,209 @@ fn host_command_failures(targets: &HostsGroup, reason: &str) -> Vec<UpdateError>
     failures
 }
 
+/// Installs `packages` on every host in `targets`.
+///
+/// The shared body behind every report's `perform_install`. Injects the
+/// [`WorkflowRegistry`] as the group's
+/// [`PlanProvider`](mtui_hosts::PlanProvider) and drives the
+/// [`InstallOperation`](mtui_hosts::InstallOperation) template, then returns the
+/// verdict from [`install_verdict`].
+///
+/// Injecting here rather than where the group is built is deliberate:
+/// [`OperationGroup::plans`](mtui_hosts::OperationGroup::plans) has exactly one
+/// consumer — the template these two functions drive — so this is the one place
+/// that cannot forget. Construction sites can: for the whole life of the Rust
+/// port none of them injected a provider, so `plans()` failed with
+/// `NoPlanProvider`, the template logged and returned, and `install` reported
+/// success having run nothing.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] when the template could not start (no doer for a
+/// host's `(release, transactional)` key, or a host locked by another owner) or
+/// when a host's post-run check reports a failed install.
+pub async fn perform_install(
+    targets: &mut HostsGroup,
+    packages: &[String],
+) -> Result<(), UpdateError> {
+    perform_operation(targets, Role::Install, packages).await
+}
+
+/// Uninstalls `packages` from every host in `targets`.
+///
+/// See [`perform_install`]; the only differences are the role (and so the
+/// command table) and the label on the aggregated summary. Uninstall shares the
+/// *install* check table — a removal is judged by the same package-manager
+/// outcomes — which [`CheckProvider`] encodes.
+///
+/// # Errors
+///
+/// As [`perform_install`].
+pub async fn perform_uninstall(
+    targets: &mut HostsGroup,
+    packages: &[String],
+) -> Result<(), UpdateError> {
+    perform_operation(targets, Role::Uninstall, packages).await
+}
+
+/// The shared body of [`perform_install`] / [`perform_uninstall`].
+async fn perform_operation(
+    targets: &mut HostsGroup,
+    role: Role,
+    packages: &[String],
+) -> Result<(), UpdateError> {
+    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
+
+    // Matched exhaustively on purpose: a `_ =>` arm defaulting to install would
+    // quietly run the wrong package-manager command if a role were ever added,
+    // which is the same shape of silent-wrong-default this function exists to
+    // fix. Only the two template roles reach here.
+    let (op, outcome) = match role {
+        Role::Install => (
+            "install",
+            InstallOperation::new(packages.to_vec()).run(targets).await,
+        ),
+        Role::Uninstall => (
+            "uninstall",
+            UninstallOperation::new(packages.to_vec())
+                .run(targets)
+                .await,
+        ),
+        Role::Update | Role::Prepare | Role::Downgrade => {
+            return Err(UpdateError::reason_only(format!(
+                "{} is not driven by the install/uninstall template",
+                role.as_operation_role()
+            )));
+        }
+    };
+
+    // The template ran nothing at all — a missing doer, or a host held by
+    // another tester. Report it instead of falling through to a verdict that
+    // would read stale `last*` values and call it success.
+    if let Err(e) = outcome {
+        return Err(UpdateError::reason_only(describe_start_failure(
+            &e, role, targets,
+        )));
+    }
+
+    install_verdict(op, role, targets)
+}
+
+/// Turns an [`Operation::run`](mtui_hosts::Operation::run) start failure into a
+/// message that names the hosts responsible.
+///
+/// `plans()` aborts on the first host it cannot resolve and reports only the
+/// role and release — and a host whose product never parsed has no release, so
+/// the bare error reads `Missing Installer for ` with nothing actionable in it.
+/// Since the whole group is aborted, re-resolve every host here and name each
+/// one that has no command, so the tester knows which refhost to fix rather than
+/// which of them to guess.
+fn describe_start_failure(err: &HostError, role: Role, targets: &HostsGroup) -> String {
+    if !matches!(
+        err,
+        HostError::MissingInstaller { .. } | HostError::MissingUninstaller { .. }
+    ) {
+        // A lock conflict already names the host and holder.
+        return err.to_string();
+    }
+
+    let registry = WorkflowRegistry::default();
+    let mut unresolved: Vec<String> = Vec::new();
+    for target in targets.targets() {
+        let resolved = host_key(target).is_some_and(|(release, transactional)| {
+            registry.doer(role, &release, transactional).is_ok()
+        });
+        if !resolved {
+            let base = target.system().get_base();
+            let product = if base.name.is_empty() || base.name == "unknown" {
+                "unrecognised product".to_owned()
+            } else {
+                format!("{} {}", base.name, base.version)
+            };
+            unresolved.push(format!("{} ({product})", target.hostname()));
+        }
+    }
+
+    if unresolved.is_empty() {
+        return err.to_string();
+    }
+    format!(
+        "{err}: no {} command for {}; no host was touched",
+        role.as_operation_role(),
+        unresolved.join(", ")
+    )
+}
+
 /// Reports whether a shared install/uninstall [`Operation`](mtui_hosts::Operation)
 /// fan-out succeeded on every host.
 ///
-/// The template's own per-host check lives in `mtui-hosts` and only logs; this
-/// gives the report-level `perform_install`/`perform_uninstall` a returned
-/// verdict by scanning each host's post-fan-out `lasterr()`/`lastexit()`
-/// snapshot (bead P3a-1's stable outcome accessors). `op` labels the aggregated
-/// summary. Public so the report impls (SL/PI/OBS) can call it after
-/// `Operation::run`.
-pub fn install_verdict(op: &str, targets: &HostsGroup) -> Result<(), UpdateError> {
-    aggregate_failures(
-        op,
-        host_command_failures(targets, &format!("{op} command failed")),
-    )
+/// The template's own per-host check hook cannot produce a verdict — it receives
+/// only a hostname and returns `()` — so the real check runs here, over each
+/// target's post-fan-out `last*` snapshot, reusing the same registry `CheckFn`
+/// that `perform_prepare` and `perform_update` drive through `run_checks`.
+/// Unlike those flows, this one runs the check *instead of* a raw exit-code
+/// scan rather than in addition to it, because the check already classifies
+/// every exit code it cares about. `op` labels the aggregated summary.
+///
+/// Where the registry has a check for a host's `(release, transactional)` key,
+/// it is authoritative: it knows that zypper's exit codes 100-103 and 106
+/// ("update needed", "reboot needed", "repo skipped") are *informational*, and
+/// classifies real failures as "package not found" / "update stack locked" /
+/// "RPM Error" / "Dependency Error". A bare `lastexit() != 0` scan would call a
+/// routine post-kernel-install "reboot needed" a failed install.
+///
+/// Keys with no registered check — `slmicro` (transactional) and `YUM` — fall
+/// back to that raw scan, which is better than no verdict at all.
+///
+/// # Errors
+///
+/// Returns the aggregated [`UpdateError`] when any host failed.
+pub fn install_verdict(op: &str, role: Role, targets: &HostsGroup) -> Result<(), UpdateError> {
+    let registry = WorkflowRegistry::default();
+    let reason = format!("{op} command failed");
+    let mut failures = Vec::new();
+
+    for target in targets.targets() {
+        let check = host_key(target)
+            .and_then(|(release, transactional)| registry.check(role, &release, transactional));
+
+        let Some(check) = check else {
+            // No check table for this key (`slmicro`, `YUM`): fall back to the
+            // exit code alone. Deliberately *not* "any stderr output is a
+            // failure" — `transactional-update` and `yum` both write progress
+            // and warnings to stderr on a successful run, and no check table in
+            // this crate treats bare stderr as a failure either; they all match
+            // specific markers.
+            if target.lastexit().is_some_and(|c| c != 0) {
+                failures.push(UpdateError::new(reason.clone(), target.hostname()));
+            }
+            continue;
+        };
+
+        // The install checks emit no diagnostics (only the update checks do),
+        // but drain the channel rather than assuming that stays true.
+        let mut diagnostics = Vec::new();
+        match check(CheckArgs {
+            hostname: target.hostname(),
+            stdout: target.lastout(),
+            stdin: target.lastin(),
+            stderr: target.lasterr(),
+            exitcode: target.lastexit().map_or(0, i32::from),
+        }) {
+            Ok(diags) => diagnostics.extend(diags),
+            Err(mut e) => {
+                if e.host.is_none() {
+                    e.host = Some(target.hostname().to_owned());
+                }
+                failures.push(e);
+            }
+        }
+        for d in diagnostics {
+            info!("{}", d.text);
+        }
+    }
+
+    aggregate_failures(op, failures)
 }
 
 /// Reboots the transactional hosts named in `reboot` (upstream `group._reboot`).
@@ -1312,6 +1505,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn perform_install_surfaces_a_missing_installer() {
+        // A host whose (release, transactional) key has no installer doer: the
+        // template runs nothing at all. Reporting Ok here is what made `install`
+        // print "install completed" for hosts it never touched.
+        let mut group = HostsGroup::new(vec![missing_doer_target("h1")], false);
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a missing installer must not report success");
+        assert!(
+            err.reason.contains("Missing Installer"),
+            "reason: {}",
+            err.reason
+        );
+        // The bare error names only the role and release, and a host whose
+        // product never parsed has no release — so the message must name the
+        // host the tester has to go fix.
+        assert!(
+            err.reason.contains("h1"),
+            "the offending host must be named: {}",
+            err.reason
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_install_names_the_unresolvable_host_and_product() {
+        // An unparsed system yields `MissingInstaller { release: "" }`, whose
+        // Display is "Missing Installer for " — nothing actionable. The whole
+        // group aborts, so the message must say which host caused it.
+        let conn = MockConnection::new("h2").with_default(CommandLog::new("", "", "", 0, 0));
+        let t = Target::with_connection("h2", TargetState::Enabled, Box::new(conn));
+        let (ok, _h) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![ok, t], false);
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("an unresolvable host aborts the group");
+
+        assert!(err.reason.contains("h2"), "reason: {}", err.reason);
+        assert!(
+            err.reason.contains("unrecognised product"),
+            "reason: {}",
+            err.reason
+        );
+        assert!(
+            err.reason.contains("no host was touched"),
+            "reason: {}",
+            err.reason
+        );
+        // h1 resolves fine, so it must not be blamed.
+        assert!(!err.reason.contains("h1 ("), "reason: {}", err.reason);
+    }
+
+    #[tokio::test]
+    async fn install_verdict_fallback_ignores_stderr_on_a_clean_exit() {
+        // `transactional-update` and `yum` write progress and warnings to stderr
+        // on a successful run. Treating any stderr as failure would fail every
+        // SL Micro install.
+        let conn = MockConnection::new("h1").with_default(CommandLog::new(
+            "t-u",
+            "",
+            "warning: chatty",
+            0,
+            0,
+        ));
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+        group.run(Command::All("t-u pkg install".to_owned())).await;
+
+        assert!(
+            install_verdict("install", Role::Install, &group).is_ok(),
+            "stderr alone on a zero exit is not a failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_install_runs_the_installer_command() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect("a clean install");
+        assert_eq!(handle.commands(), vec!["zypper -n in -y -l pkg-a"]);
+    }
+
+    #[tokio::test]
+    async fn perform_uninstall_runs_the_uninstaller_command() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        perform_uninstall(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect("a clean uninstall");
+        assert_eq!(handle.commands(), vec!["zypper -n rm pkg-a"]);
+    }
+
+    #[tokio::test]
     async fn install_verdict_surfaces_per_host_command_failure() {
         // A host left with a non-zero lastexit after an install fan-out is
         // reported by install_verdict (the report-level install/uninstall hook).
@@ -1319,13 +1615,13 @@ mod tests {
         let mut group = HostsGroup::new(vec![t], false);
         // Run one command so the host records its (failing) last* snapshot.
         group.run(Command::All("zypper in".to_owned())).await;
-        let err = install_verdict("install", &group).expect_err("non-zero exit surfaces as Err");
+        let err = install_verdict("install", Role::Install, &group)
+            .expect_err("non-zero exit surfaces as Err");
         assert_eq!(err.host.as_deref(), Some("h1"));
-        assert!(
-            err.reason.contains("install command failed"),
-            "reason: {}",
-            err.reason
-        );
+        // 104 is zypper's ZYPPER_EXIT_INF_CAP_NOT_FOUND, which the install check
+        // table classifies. The verdict reports *what* went wrong, not just that
+        // the exit was non-zero.
+        assert_eq!(err.reason, "package not found");
     }
 
     #[tokio::test]
@@ -1333,7 +1629,61 @@ mod tests {
         let (t, _h) = sles_target("h1", "");
         let mut group = HostsGroup::new(vec![t], false);
         group.run(Command::All("zypper in".to_owned())).await;
-        assert!(install_verdict("install", &group).is_ok());
+        assert!(install_verdict("install", Role::Install, &group).is_ok());
+    }
+
+    #[tokio::test]
+    async fn install_verdict_accepts_zyppers_informational_exit_codes() {
+        // zypper exits 100-103/106 to mean "update needed", "reboot needed",
+        // "restart needed", "repo skipped" — all *successful* installs. Exit 102
+        // (reboot needed) is routine after a kernel update, so a bare
+        // `lastexit() != 0` scan would report a false failure on a perfectly
+        // good install.
+        for exit in [100, 101, 102, 103, 106] {
+            let (t, _h) = sles_target_with_exit("h1", "", exit);
+            let mut group = HostsGroup::new(vec![t], false);
+            group.run(Command::All("zypper in".to_owned())).await;
+            let res = install_verdict("install", Role::Install, &group);
+            assert!(
+                res.is_ok(),
+                "exit {exit} is informational, not a failure: {res:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn install_verdict_falls_back_to_raw_scan_without_a_check_table() {
+        // slmicro/YUM keys have no install check registered. They must still get
+        // a verdict rather than an unconditional pass.
+        let conn = MockConnection::new("h1").with_default(CommandLog::new("t-u", "", "", 1, 0));
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+        group.run(Command::All("t-u pkg install".to_owned())).await;
+
+        let key = host_key(group.targets().next().expect("one target"));
+        assert!(
+            WorkflowRegistry::default()
+                .check(
+                    Role::Install,
+                    &key.clone().expect("key").0,
+                    key.expect("key").1
+                )
+                .is_none(),
+            "this test is only meaningful while the key has no check table"
+        );
+
+        let err = install_verdict("install", Role::Install, &group)
+            .expect_err("a non-zero exit must still be reported");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        assert_eq!(err.reason, "install command failed");
     }
 
     #[test]

--- a/crates/mtui-testreport/src/testreport.rs
+++ b/crates/mtui-testreport/src/testreport.rs
@@ -607,7 +607,8 @@ pub trait TestReport {
     /// Drives the [`InstallOperation`](mtui_hosts::InstallOperation) template
     /// through the group's [`OperationGroup`](mtui_hosts::OperationGroup) impl,
     /// which resolves each host's installer doer/check via the injected
-    /// `PlanProvider` (wired at the composition root). The default is a no-op —
+    /// `PlanProvider` (injected by `update_flow::perform_install`, which is the
+    /// shared body behind this method). The default is a no-op —
     /// the null report has nothing to install — so only reports backed by real
     /// doer tables override it.
     ///

--- a/crates/mtui-testreport/src/update_workflow/actions/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/mod.rs
@@ -139,6 +139,24 @@ impl ActionCommands {
         }
     }
 
+    /// The raw, unrendered [`command`](Self::command) template.
+    ///
+    /// Needed by the [`PlanProvider`](mtui_hosts::PlanProvider) adapter, which
+    /// hands the template to a [`Doer`](mtui_hosts::Doer) that performs the
+    /// `$packages` substitution itself (the package list is only known inside
+    /// `mtui-hosts`, at
+    /// [`Operation::collect`](mtui_hosts::Operation::collect) time). Prefer
+    /// [`render_command`](Self::render_command) everywhere else.
+    pub(crate) fn command_template(&self) -> &str {
+        &self.command
+    }
+
+    /// The raw, unrendered [`reboot`](Self::reboot) template, if any. See
+    /// [`command_template`](Self::command_template).
+    pub(crate) fn reboot_template(&self) -> Option<&str> {
+        self.reboot.as_deref()
+    }
+
     /// Renders [`installed_only`](Self::installed_only) with `vars` if present,
     /// honouring the action's [`mode`](Self::mode).
     ///

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -15,15 +15,15 @@
 //!   `(hostname, stdout, stdin, stderr, exitcode) -> None` that raises
 //!   [`UpdateError`] when it recognises a failure.
 //!
-//! ## Scope (P4.6): tables + traits, no wiring
+//! ## How the tables reach the hosts
 //!
-//! This lands the tables, the [`template`] helper, and the injectable
-//! [`DoerProvider`] / [`CheckProvider`] seams that `mtui-core::wiring` will later
-//! bind to `mtui_hosts::OperationGroup`. It deliberately does **not** implement
-//! `impl OperationGroup for HostsGroup` — that binding (and the
-//! `(release, transactional)` key derivation from live `Target` state) is the
-//! composition-root task, kept out of here so `mtui-hosts` never depends on
-//! `mtui-testreport`.
+//! [`WorkflowRegistry`] implements three seams over these tables: the crate-local
+//! [`DoerProvider`] / [`CheckProvider`] (used directly by the bespoke
+//! prepare/update/downgrade flows) and `mtui_hosts::PlanProvider` (used by the
+//! shared install/uninstall template). The `PlanProvider` impl lives in this
+//! crate because the trait is foreign and the type is local — and because the
+//! check tables' `CheckArgs` fields are `pub(crate)`. `impl OperationGroup for
+//! HostsGroup` stays in `mtui-hosts`, so that crate never depends on this one.
 
 pub mod actions;
 pub mod checks;
@@ -131,6 +131,37 @@ pub enum Role {
 }
 
 impl Role {
+    /// The role string `mtui-hosts` dispatches on
+    /// (`mtui_hosts::Operation::role`).
+    #[must_use]
+    pub const fn as_operation_role(self) -> &'static str {
+        match self {
+            Role::Install => "installer",
+            Role::Uninstall => "uninstaller",
+            Role::Update => "updater",
+            Role::Prepare => "preparer",
+            Role::Downgrade => "downgrader",
+        }
+    }
+
+    /// Parses the role string `mtui-hosts` dispatches on back into a typed role.
+    ///
+    /// `mtui_hosts::PlanProvider` is keyed by `&str` because `mtui-hosts` cannot
+    /// name this enum without a crate cycle; this is the inverse of
+    /// [`as_operation_role`](Self::as_operation_role) and the only place that
+    /// stringly-typed seam is decoded.
+    #[must_use]
+    pub fn from_operation_role(role: &str) -> Option<Self> {
+        match role {
+            "installer" => Some(Role::Install),
+            "uninstaller" => Some(Role::Uninstall),
+            "updater" => Some(Role::Update),
+            "preparer" => Some(Role::Prepare),
+            "downgrader" => Some(Role::Downgrade),
+            _ => None,
+        }
+    }
+
     /// Builds the role's "missing doer" [`HostError`] for `release`.
     ///
     /// Mirrors the per-module `key_error=Missing*Error` on upstream's
@@ -151,9 +182,10 @@ impl Role {
 /// The injectable seam that resolves an action's command templates for a
 /// `(release, transactional)` key.
 ///
-/// The composition root (`mtui-core::wiring`) implements this over the
-/// [`actions`] tables and hands it to `mtui-hosts` so `OperationGroup::plans`
-/// can build a `mtui_hosts::Doer` without `mtui-hosts` depending on this crate.
+/// Implemented by [`WorkflowRegistry`] over the [`actions`] tables. The
+/// install/uninstall path reaches it through that type's
+/// `mtui_hosts::PlanProvider` impl, so `OperationGroup::plans` can build a
+/// `mtui_hosts::Doer` without `mtui-hosts` depending on this crate.
 pub trait DoerProvider: Send + Sync {
     /// Resolves the action command set for `role` at `(release, transactional)`.
     ///
@@ -172,10 +204,9 @@ pub trait DoerProvider: Send + Sync {
 /// The injectable seam that resolves a post-run check for a
 /// `(release, transactional)` key.
 ///
-/// The composition root implements this over the [`checks`] tables. A check is
-/// returned as a boxed function with the upstream signature; an unknown key
-/// yields `None` (upstream's plain `dict.get`, which the caller treats as
-/// "no check to run").
+/// Implemented by [`WorkflowRegistry`] over the [`checks`] tables. A check is
+/// returned as a boxed function; an unknown key yields `None`, which the caller
+/// treats as "no check to run".
 pub trait CheckProvider: Send + Sync {
     /// Resolves the post-run check for `role` at `(release, transactional)`, or
     /// `None` when no check is registered for the key.
@@ -185,7 +216,8 @@ pub trait CheckProvider: Send + Sync {
 /// The default [`DoerProvider`] / [`CheckProvider`], backed by the ported
 /// [`actions`] and [`checks`] tables.
 ///
-/// This is the concrete registry `mtui-core::wiring` injects. It carries the
+/// The concrete registry every flow builds and, for install/uninstall, injects
+/// into the `HostsGroup` as a `mtui_hosts::PlanProvider`. It carries the
 /// prepare-only `force` / `testing` flags (the other actions ignore them),
 /// mirroring how upstream threads them into `t.doer("preparer", force, testing)`.
 #[derive(Debug, Clone, Copy, Default)]
@@ -236,6 +268,61 @@ impl CheckProvider for WorkflowRegistry {
             Role::Prepare => checks::prepare::prepare_check(release, transactional),
             Role::Downgrade => checks::downgrade::downgrade_check(release, transactional),
         }
+    }
+}
+
+/// Adapts the registry to the `mtui-hosts` install/uninstall template seam.
+///
+/// [`mtui_hosts::Operation`] resolves each host's command through
+/// [`mtui_hosts::PlanProvider`], a trait declared in `mtui-hosts` purely in
+/// terms of `mtui-hosts` types so that crate never has to depend on this one.
+/// This impl is the other half: it is legal here (foreign trait, local type)
+/// and nowhere else, because the check tables' `CheckArgs` fields are
+/// `pub(crate)`.
+///
+/// Injected by `update_flow::perform_install` / `perform_uninstall` immediately
+/// before the template runs.
+impl mtui_hosts::PlanProvider for WorkflowRegistry {
+    fn doer(
+        &self,
+        role: &str,
+        release: &str,
+        transactional: bool,
+    ) -> Result<mtui_hosts::Doer, HostError> {
+        // An unrecognised role string cannot resolve to a table; report it as a
+        // missing installer rather than panicking. Only "installer" and
+        // "uninstaller" ever reach here (`Operation::role`).
+        let Some(role) = Role::from_operation_role(role) else {
+            return Err(HostError::MissingInstaller {
+                release: release.to_owned(),
+            });
+        };
+        let commands = DoerProvider::doer(self, role, release, transactional)?;
+        // The raw templates go across the seam, not rendered strings: the
+        // package list is only known inside `mtui-hosts`, at
+        // `Operation::collect` time. `Doer` substitutes `$packages` with a plain
+        // `replace`, which agrees with this crate's `string.Template`
+        // semantics for every install/uninstall template (each holds exactly one
+        // `$packages` and no `$$` or `${}`); `doer_templates_render_like_the_action_tables`
+        // pins that agreement.
+        Ok(mtui_hosts::Doer::new(
+            commands.command_template(),
+            // Only read back for a transactional host, which is exactly when the
+            // table carries a reboot.
+            commands.reboot_template().unwrap_or_default(),
+        ))
+    }
+
+    fn check(&self, _role: &str, _release: &str, _transactional: bool) -> mtui_hosts::Check {
+        // Deliberately a no-op: the real check needs the command's
+        // stdout/stderr/exit code, which `mtui_hosts::CheckArgs` does not carry
+        // (it holds only the hostname) and which `mtui_hosts::Check` could not
+        // report anyway, since it returns `()`. The install/uninstall verdict is
+        // therefore produced *after* the template returns, by
+        // `update_flow::install_verdict`, which reads each target's `last*`
+        // snapshot and runs this same registry's `CheckFn` over it — the same
+        // path `perform_prepare` / `perform_update` / `perform_downgrade` use.
+        Box::new(|_a: mtui_hosts::CheckArgs<'_>| {})
     }
 }
 
@@ -367,5 +454,93 @@ mod tests {
     fn registry_check_unknown_key_is_none() {
         let reg = WorkflowRegistry::default();
         assert!(reg.check(Role::Update, "slmicro", true).is_none());
+    }
+
+    // --- the mtui-hosts PlanProvider adapter --------------------------------
+
+    #[test]
+    fn operation_role_strings_round_trip() {
+        for role in [
+            Role::Install,
+            Role::Uninstall,
+            Role::Update,
+            Role::Prepare,
+            Role::Downgrade,
+        ] {
+            assert_eq!(
+                Role::from_operation_role(role.as_operation_role()),
+                Some(role)
+            );
+        }
+        assert_eq!(Role::from_operation_role("nonesuch"), None);
+    }
+
+    #[test]
+    fn plan_provider_resolves_the_role_specific_table() {
+        use mtui_hosts::PlanProvider;
+
+        let reg = WorkflowRegistry::default();
+        // The role string must actually select the table: an adapter that
+        // ignored it would make `uninstall` run the *install* command.
+        let install = PlanProvider::doer(&reg, "installer", "15", false).expect("installer");
+        let uninstall = PlanProvider::doer(&reg, "uninstaller", "15", false).expect("uninstaller");
+        assert_ne!(
+            format!("{install:?}"),
+            format!("{uninstall:?}"),
+            "installer and uninstaller must not resolve to the same doer"
+        );
+    }
+
+    #[test]
+    fn plan_provider_surfaces_missing_and_unknown_roles() {
+        use mtui_hosts::PlanProvider;
+
+        let reg = WorkflowRegistry::default();
+        assert!(matches!(
+            PlanProvider::doer(&reg, "installer", "99", false),
+            Err(HostError::MissingInstaller { .. })
+        ));
+        assert!(matches!(
+            PlanProvider::doer(&reg, "uninstaller", "99", false),
+            Err(HostError::MissingUninstaller { .. })
+        ));
+        assert!(
+            PlanProvider::doer(&reg, "nonesuch", "15", false).is_err(),
+            "an unrecognised role must not resolve to a command"
+        );
+    }
+
+    /// `mtui_hosts::Doer` substitutes `$packages` with a plain `str::replace`,
+    /// while this crate renders the same templates through `string.Template`
+    /// semantics. They agree for every install/uninstall entry today; this
+    /// fails if a future template gains `$$` or `${}`, which `replace` would
+    /// mangle.
+    #[test]
+    fn doer_templates_render_like_the_action_tables() {
+        use std::collections::HashMap;
+
+        for (release, transactional) in [
+            ("11", false),
+            ("12", false),
+            ("15", false),
+            ("16", false),
+            ("YUM", false),
+            ("slmicro", true),
+        ] {
+            for role in [Role::Install, Role::Uninstall] {
+                let commands = WorkflowRegistry::default()
+                    .doer(role, release, transactional)
+                    .expect("a table entry");
+                let vars: HashMap<&str, &str> = [("packages", "pkg-a pkg-b")].into_iter().collect();
+                let expected = commands.render_command(&vars).expect("renders");
+                let naive = commands
+                    .command_template()
+                    .replace("$packages", "pkg-a pkg-b");
+                assert_eq!(
+                    naive, expected,
+                    "{role:?} @ ({release}, {transactional}) renders differently across the seam"
+                );
+            }
+        }
     }
 }

--- a/crates/mtui-testreport/tests/sl_report.rs
+++ b/crates/mtui-testreport/tests/sl_report.rs
@@ -167,30 +167,20 @@ fn list_update_commands_is_a_noop_stub() {
 // --- perform_install / perform_uninstall (OperationGroup seam) --------------
 
 use std::collections::BTreeSet;
-use std::sync::Arc;
 
-use mtui_hosts::{Check, CheckArgs, Doer, HostError, MockConnection, PlanProvider, Target};
+use mtui_hosts::{MockConnection, Target};
 use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
 use mtui_types::system::{System, SystemProduct};
 
-/// A minimal provider yielding one fixed installer/uninstaller doer, so the
-/// report's `perform_*` drives a real command through the group.
-struct FixedProvider;
-
-impl PlanProvider for FixedProvider {
-    fn doer(&self, _role: &str, _release: &str, _transactional: bool) -> Result<Doer, HostError> {
-        Ok(Doer::new(
-            "zypper -n in -y -l $packages",
-            "systemctl reboot",
-        ))
-    }
-    fn check(&self, _role: &str, _release: &str, _transactional: bool) -> Check {
-        Box::new(|_a: CheckArgs<'_>| {})
-    }
-}
-
-fn sles_group() -> (HostsGroup, MockConnection) {
+/// An enabled SLES 15.5 host in a group built exactly the way production builds
+/// it — `HostsGroup::new` and nothing else.
+///
+/// There is deliberately no test-only `PlanProvider` here. An earlier stub
+/// provider returned the same doer for every role, which both hid that
+/// production injected no provider at all (so `install` ran nothing) and made
+/// `perform_uninstall` look correct while asserting an *install* command.
+fn production_sles_group() -> (HostsGroup, MockConnection) {
     let conn = MockConnection::new("h1").with_default(CommandLog::new("", "done", "", 0, 1));
     let handle = conn.clone();
     let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
@@ -202,14 +192,28 @@ fn sles_group() -> (HostsGroup, MockConnection) {
         ),
         false,
     );
-    let group = HostsGroup::new(vec![t], false).with_plan_provider(Arc::new(FixedProvider));
-    (group, handle)
+    (HostsGroup::new(vec![t], false), handle)
+}
+
+#[tokio::test]
+async fn perform_install_runs_a_command_on_a_production_built_group() {
+    let r = SlReport::new(config());
+    let (mut group, handle) = production_sles_group();
+
+    let res = r.perform_install(&mut group, &["pkg-a".to_owned()]).await;
+
+    assert_eq!(
+        handle.commands(),
+        vec!["zypper -n in -y -l pkg-a".to_owned()],
+        "install must reach the host when the group is built the production way"
+    );
+    assert!(res.is_ok(), "a clean install returns Ok: {res:?}");
 }
 
 #[tokio::test]
 async fn perform_install_drives_installer_doer() {
     let r = SlReport::new(config());
-    let (mut group, handle) = sles_group();
+    let (mut group, handle) = production_sles_group();
 
     let res = r
         .perform_install(&mut group, &["pkg-a".to_owned(), "pkg-b".to_owned()])
@@ -225,12 +229,13 @@ async fn perform_install_drives_installer_doer() {
 #[tokio::test]
 async fn perform_uninstall_drives_uninstaller_doer() {
     let r = SlReport::new(config());
-    let (mut group, handle) = sles_group();
+    let (mut group, handle) = production_sles_group();
 
     let res = r.perform_uninstall(&mut group, &["pkg".to_owned()]).await;
     assert!(res.is_ok(), "a clean uninstall returns Ok: {res:?}");
 
-    assert_eq!(handle.commands(), vec!["zypper -n in -y -l pkg".to_owned()]);
+    // The *uninstaller* table, not the installer: `rm`, not `in`.
+    assert_eq!(handle.commands(), vec!["zypper -n rm pkg".to_owned()]);
 }
 
 // --- set_repo (SetRepo impl -> RepoManager::run_zypper) ---------------------

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -44,13 +44,23 @@ loaded templates/metadata, the display) passed into each call — there are no
 hidden globals. This is the Rust replacement for MTUI's `CommandPrompt`
 god-object.
 
-## Composition root and the no-cycles rule
+## Trait injection and the no-cycles rule
 
-`mtui-core`'s wiring injects the update-workflow doer/check registries (which live
-in `mtui-testreport`) into the host `Target` dispatch (in `mtui-hosts`) **via
-traits**, so `mtui-hosts` never has to depend on `mtui-testreport`. The rule when
-two lower crates need to cooperate: **define a trait and inject it at the
-composition root — never introduce a crate cycle.**
+The update-workflow doer/check registries live in `mtui-testreport`, but the
+install/uninstall template that needs them lives in `mtui-hosts` — the lower
+crate. `mtui-hosts` therefore declares a `PlanProvider` trait in terms of its own
+types, and `mtui-testreport`'s `WorkflowRegistry` implements it. The rule when
+two crates need to cooperate across that boundary: **define a trait in the lower
+crate and inject an implementation from the higher one — never introduce a crate
+cycle.**
+
+**Inject at the point of use.** `update_flow::perform_install` /
+`perform_uninstall` install the provider on the `HostsGroup` immediately before
+driving the template. `OperationGroup::plans` has exactly one consumer, so there
+is exactly one site that cannot forget. Injecting where the group is *built*
+looks tidier but is not equivalent: an earlier design that wired one central
+spot was never called at all, leaving `install` and `uninstall` running no
+command while still reporting success.
 
 ## Contracts
 


### PR DESCRIPTION
## What was wrong

`install` and `uninstall` ran **no command on any host**, then printed `install completed on <hosts>`.

Both drive the shared `Operation` template, which resolves each host's package-manager command through a `PlanProvider` injected into the `HostsGroup`. Nothing ever injected one — `HostsGroup::new` left the field `None`, and the only setter was a consuming builder that just the tests called. So `plans()` returned `NoPlanProvider`, `Operation::run` logged it and returned `()`, and `install_verdict` — which decides success by reading each host's last exit code — found `None` on hosts nothing had run on and reported no failures.

Over MCP the log line goes to the server's stderr, so a client saw only the success message.

The seam was added complete but unused; a later dead-code sweep removed the never-called injector rather than calling it, which took the evidence with it. **`prepare`, `update` and `downgrade` were never affected** — they resolve their commands straight from the registry and bypass the seam.

Reproduced in-tree before fixing, with the group built the way production builds it:

```
left:  []
right: ["zypper -n in -y -l pkg-a"]
```

…while the returned verdict was `Ok`.

## The fix

`WorkflowRegistry` now implements `mtui_hosts::PlanProvider`, and `update_flow::perform_install` / `perform_uninstall` inject it immediately before driving the template.

Injecting at the point of use rather than where the group is built is deliberate: `OperationGroup::plans` has exactly one consumer, so there is exactly one place that cannot forget. Construction sites can — and did.

Three adjacent false-success paths go with it:

- **`Operation::run` returns `Result`** instead of logging and returning `()`. A missing package-manager command for a host's product release, or a host locked by another tester, aborted the run while still reporting success.
- **The verdict consults the install check table** rather than scanning exit codes. zypper exits 100–103 and 106 to report "update needed", "reboot needed", "restart needed" and "repo skipped" — all *successful* installs — so a bare non-zero scan would have turned this fix into a new false failure on every routine post-kernel-install reboot notice. The table also names what went wrong ("package not found", "update stack locked", "RPM Error", "Dependency Error").
- **A run that cannot start names the host and product.** The underlying error carries only role and release, and a host whose product never parsed has no release, so the message read `Missing Installer for ` — while aborting for the whole group.

## Testing

The regression test builds the group the way production does and asserts a command reaches the host. Verified by mutation: **deleting the injection line turns 3 tests red.**

The previous tests injected a stub provider, which is what let the gap survive for the life of the port. That stub also returned the same command for every role, so the uninstall test asserted `zypper -n in -y -l` — an *install* command. It now asserts `zypper -n rm` from the uninstaller table.

Gate: `fmt` clean, `clippy -D warnings` clean, 37 test suites pass (0 failures), `-p mtui-mcp -F mcp` passes, both feature-matrix builds compile, `typos` clean, no new rustdoc warnings. MCP schema snapshots unchanged.

## Deliberately not in this PR

Found while reviewing; each is pre-existing and independent:

- A transactional host that reboots and never comes back still reports success — `HostsGroup::reboot`'s reconnect fan-out logs and discards the outcome. Affects `prepare`/`update`/`downgrade` equally.
- The real check now runs *after* the reboot rather than before it, so a failed transactional install is rebooted into before the error surfaces. Moving it back means giving the template a verdict channel.
- `install`/`uninstall` observe no cancellation checkpoint.
- `add_op_history` writes the history line before the operation runs, so a run that legitimately fails to start still leaves a row.
