### PR TITLE
fix: surface lost transactional hosts, check-before-reboot ordering, install/uninstall cancellation, and history-write timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `install`/`uninstall`/`prepare`/`downgrade`/`update` now fail, naming the
+  host, when a transactional (read-only-root) host reboots and does not
+  reconnect. The reboot outcome used to be logged at ERROR and discarded, so
+  every one of these commands reported success on a host it had just lost;
+  `update` specifically reports the new `UpdateFailure::Reboot` and — since
+  the host is unreachable — skips the rollback downgrade it runs for a check
+  failure.
 - A `-t <host>` subset operation no longer silently resets the `[connection]
   max_parallel` fan-out bound to its built-in default: splitting the host group
   for a subset op carried only the workflow provider, dropping the configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `update` specifically reports the new `UpdateFailure::Reboot` and — since
   the host is unreachable — skips the rollback downgrade it runs for a check
   failure.
+- `install`/`uninstall`/`downgrade`/`update` now write their
+  `/var/log/mtui.log` history row *after* dispatching a command on the host,
+  not before. A run that never starts (no doer resolves, the host is held by
+  another tester, or it is cancelled at the entry gate) leaves no row at all,
+  where it previously left one recording work that never happened; a run
+  that dispatched a command and then failed still leaves exactly one row, now
+  timestamped at the end of the operation rather than the start. A run hard-
+  aborted mid-flight (MCP `job_cancel`'s post-grace abort) now leaves no row
+  where it previously left one recorded before the work started.
 - A `-t <host>` subset operation no longer silently resets the `[connection]
   max_parallel` fan-out bound to its built-in default: splitting the host group
   for a subset op carried only the workflow provider, dropping the configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   to do — a cancelled package loop names which packages were applied and which
   were not attempted. A genuine host failure always outranks the cancellation,
   so a broken host is never buried behind a bare "cancelled".
+- `install` and `uninstall` now observe cancellation too: MCP `job_cancel`
+  stops either one cleanly if it lands before the shared install/uninstall
+  template dispatches any command, reporting a cancellation rather than
+  running to completion. Previously they had no checkpoint of their own.
 
 - MCP `job_cancel` is now truthful and two-stage. Cancelling a running job
   first signals the new cooperative cancellation seam — today the dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `install`/`uninstall` now check whether a host's install/uninstall command
+  actually succeeded *before* rebooting its transactional (read-only-root)
+  snapshot into it. The install/uninstall template used to reboot first and
+  run its real verdict afterward, so a failed install on a transactional host
+  was rebooted into anyway; the check now runs first and a failed host is
+  named at WARN and excluded from the reboot — healthy transactional hosts in
+  the same run still reboot.
 - `install`/`uninstall`/`prepare`/`downgrade`/`update` now fail, naming the
   host, when a transactional (read-only-root) host reboots and does not
   reconnect. The reboot outcome used to be logged at ERROR and discarded, so

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -449,9 +449,8 @@ impl MockConnection {
 
     /// Scripts [`reconnect`](Connection::reconnect) to fail with
     /// [`HostError::ReconnectFailed`].
-    #[cfg(test)]
     #[must_use]
-    pub(crate) fn failing_reconnect(mut self) -> Self {
+    pub fn failing_reconnect(mut self) -> Self {
         self.reconnect_fails = true;
         self
     }

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -34,9 +34,9 @@ pub use prompter::{Prompter, Reader};
 #[cfg(test)]
 pub(crate) use target::POOL_LOCK_PATH;
 pub use target::{
-    Check, CheckArgs, Clock, Command, Doer, HostArbiter, HostPlan, HostsGroup, InstallOperation,
-    LockOutcome, Operation, OperationGroup, Owner, PackageQuerier, PlanProvider, PoolLock,
-    RemoteLock, RepoManager, RepoOp, SetRepo, Sink, SpinnerGuard, Suspend, SystemClock,
-    TARGET_LOCK_PATH, Target, TargetLock, TtySpinner, UninstallOperation, get_arbiter,
-    parse_system, set_test_sink, spinner, suspend,
+    Check, CheckArgs, Clock, Command, Doer, HostArbiter, HostOutput, HostPlan, HostsGroup,
+    InstallOperation, LockOutcome, Operation, OperationGroup, OperationReport, Owner,
+    PackageQuerier, PlanProvider, PoolLock, RemoteLock, RepoManager, RepoOp, SetRepo, Sink,
+    SpinnerGuard, Suspend, SystemClock, TARGET_LOCK_PATH, Target, TargetLock, TtySpinner,
+    UninstallOperation, get_arbiter, parse_system, set_test_sink, spinner, suspend,
 };

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1370,6 +1370,16 @@ impl OperationGroup for HostsGroup {
         HostsGroup::run(self, Command::PerHost(map)).await;
     }
 
+    fn last_output(&self, hostname: &str) -> Option<super::operation::HostOutput> {
+        let target = self.data.get(hostname)?;
+        Some(super::operation::HostOutput {
+            stdout: target.lastout().to_owned(),
+            stdin: target.lastin().to_owned(),
+            stderr: target.lasterr().to_owned(),
+            exitcode: target.lastexit().map_or(0, i32::from),
+        })
+    }
+
     async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
         // Only transactional hosts contribute reboot entries; the reboot is
         // fired fire-and-forget on each, then each is reconnected

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1192,9 +1192,20 @@ impl HostsGroup {
     /// backoff. Unlike [`reboot`](Self::reboot) this path takes no boot-id
     /// snapshot / verification, and is a no-op
     /// when the map is empty.
-    async fn reboot_transactional(&mut self, reboot: &BTreeMap<String, String>) {
+    ///
+    /// Returns each named host's reconnect outcome, mirroring
+    /// [`reboot_where`](Self::reboot_where): `Ok(())` when the host reconnected,
+    /// `Err(HostError)` when it did not come back. A caller that discards this
+    /// map cannot tell a transactional host that rebooted into an unreachable
+    /// state from one that came back healthy.
+    async fn reboot_transactional(
+        &mut self,
+        reboot: &BTreeMap<String, String>,
+    ) -> BTreeMap<String, Result<()>> {
+        use std::sync::Mutex;
+
         if reboot.is_empty() {
-            return;
+            return BTreeMap::new();
         }
         let mut names: Vec<&String> = reboot.keys().collect();
         names.sort();
@@ -1220,6 +1231,8 @@ impl HostsGroup {
             },
         )
         .await;
+
+        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
         actions::run_fanout(
             &mut self.data,
             is_repl,
@@ -1227,17 +1240,26 @@ impl HostsGroup {
             Some("reconnect"),
             |t| reboot.contains_key(t.hostname()),
             |t| {
+                let outcomes = &outcomes;
                 Box::pin(async move {
+                    let hostname = t.hostname().to_owned();
                     let retry = t.reboot_retries();
-                    if let Err(e) = t.reconnect(retry, true).await {
-                        tracing::error!(host = %t.hostname(), error = %e, "reconnect after reboot failed");
-                    } else {
-                        tracing::info!(host = %t.hostname(), "is back up");
-                    }
+                    let outcome = match t.reconnect(retry, true).await {
+                        Ok(()) => {
+                            tracing::info!(host = %hostname, "is back up");
+                            Ok(())
+                        }
+                        Err(e) => {
+                            tracing::error!(host = %hostname, error = %e, "reconnect after reboot failed");
+                            Err(e)
+                        }
+                    };
+                    outcomes.lock().unwrap().insert(hostname, outcome);
                 }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
+        outcomes.into_inner().unwrap()
     }
 
     /// Decides whether `hostname`'s boot id confirms a reboot, logging as before.
@@ -1348,12 +1370,16 @@ impl OperationGroup for HostsGroup {
         HostsGroup::run(self, Command::PerHost(map)).await;
     }
 
-    async fn reboot(&mut self, reboot: HostCommandMap) {
+    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
         // Only transactional hosts contribute reboot entries; the reboot is
         // fired fire-and-forget on each, then each is reconnected
         // (sorted) with the connection's retry + backoff.
         let map: BTreeMap<String, String> = reboot.into_iter().collect();
-        HostsGroup::reboot_transactional(self, &map).await;
+        HostsGroup::reboot_transactional(self, &map)
+            .await
+            .into_iter()
+            .filter_map(|(host, outcome)| outcome.err().map(|e| (host, e.to_string())))
+            .collect()
     }
 
     async fn unlock(&mut self) {
@@ -2006,9 +2032,35 @@ mod tests {
             )],
             false,
         );
-        OperationGroup::reboot(&mut g, Vec::new()).await;
+        let failures = OperationGroup::reboot(&mut g, Vec::new()).await;
         assert!(h1.fired_commands().is_empty());
         assert_eq!(h1.reconnect_count(), 0);
+        assert!(failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reboot_transactional_records_reconnect_failure() {
+        // A transactional host that reboots and never reconnects must be named
+        // in the outcome map, not silently dropped: `Operation::run` (and every
+        // flow above it) relies on this to fail the operation instead of
+        // reporting success on a host it lost.
+        let m1 = reboot_mock("h1", "id-1").failing_reconnect();
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "systemctl reboot".to_owned())];
+        let failures = OperationGroup::reboot(&mut g, map).await;
+
+        assert_eq!(h1.reconnect_count(), 1);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].0, "h1");
     }
 
     // --- update_lock / lock / unlock fan-out (P2.9) -------------------------

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -53,8 +53,8 @@ pub use hostgroup::{HostsGroup, LockOutcome};
 pub(crate) use locks::POOL_LOCK_PATH;
 pub use locks::{Clock, LockRow, PoolLock, RemoteLock, SystemClock, TARGET_LOCK_PATH, TargetLock};
 pub use operation::{
-    Check, CheckArgs, Doer, HostPlan, InstallOperation, Operation, OperationGroup, PlanProvider,
-    UninstallOperation,
+    Check, CheckArgs, Doer, HostOutput, HostPlan, InstallOperation, Operation, OperationGroup,
+    OperationReport, PlanProvider, UninstallOperation,
 };
 pub use package_querier::PackageQuerier;
 pub use parsers::parse_system;

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -163,10 +163,28 @@ pub trait OperationGroup: Send {
     async fn run(&mut self, commands: HostCommandMap);
 
     /// Reboots the transactional hosts named in `reboot`.
-    async fn reboot(&mut self, reboot: HostCommandMap);
+    ///
+    /// Returns `(hostname, reason)` for every host that did not reconnect —
+    /// a transactional host that rebooted and never came back must fail the
+    /// operation, not report success on a host it lost.
+    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)>;
 
     /// Releases the shared operation lock.
     async fn unlock(&mut self);
+}
+
+/// The outcome of a completed [`Operation::run`]: the run *started* (the
+/// template got past `plans()` and `update_lock()`), but a transactional
+/// host's post-reboot reconnect can still fail.
+///
+/// `Err` from [`Operation::run`] keeps meaning "never started" (no plans, or a
+/// foreign lock); `Ok(report)` means it ran, and `reboot_failures` names any
+/// host whose reboot left it unreachable.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct OperationReport {
+    /// `(hostname, reason)` for every transactional host that rebooted and did
+    /// not reconnect.
+    pub reboot_failures: Vec<(String, String)>,
 }
 
 /// The install/uninstall template method.
@@ -218,6 +236,10 @@ pub trait Operation: Send + Sync {
     ///   transactional hosts,
     /// * `unlock()` unconditionally afterwards.
     ///
+    /// Returns the started run's [`OperationReport`], which names any
+    /// transactional host that rebooted and did not reconnect — a caller that
+    /// discards it cannot tell that host apart from one that came back healthy.
+    ///
     /// # Errors
     ///
     /// Returns the resolver's error when no host plan can be built (no
@@ -231,7 +253,7 @@ pub trait Operation: Send + Sync {
     /// from "could not even start" will print success for an update that never
     /// touched a host — the same reasoning that makes
     /// `UpdateFailure::MissingUpdater` a hard failure in the update flow.
-    async fn run(&self, group: &mut dyn OperationGroup) -> Result<(), HostError> {
+    async fn run(&self, group: &mut dyn OperationGroup) -> Result<OperationReport, HostError> {
         let plans = group.plans(self.role())?;
 
         let (commands, reboot, mut plans) = self.collect(plans);
@@ -252,10 +274,10 @@ pub trait Operation: Send + Sync {
                 hostname: &plan.hostname,
             });
         }
-        group.reboot(reboot).await;
+        let reboot_failures = group.reboot(reboot).await;
 
         group.unlock().await;
-        Ok(())
+        Ok(OperationReport { reboot_failures })
     }
 }
 
@@ -440,6 +462,9 @@ mod tests {
         /// When `true`, `update_lock` records its event then returns
         /// [`HostError::Update`] to model a foreign-locked host.
         fail_update_lock: bool,
+        /// What `reboot` should report as failed, modelling a transactional
+        /// host that rebooted and did not reconnect.
+        reboot_failures: Vec<(String, String)>,
     }
 
     impl MockGroup {
@@ -459,12 +484,20 @@ mod tests {
                 roles_seen: Arc::new(Mutex::new(Vec::new())),
                 events,
                 fail_update_lock: false,
+                reboot_failures: Vec::new(),
             }
         }
 
         /// Marks `update_lock` to fail, modelling a foreign-locked host.
         fn failing_update_lock(mut self) -> Self {
             self.fail_update_lock = true;
+            self
+        }
+
+        /// Scripts `reboot` to report `failures`, modelling a transactional
+        /// host whose post-reboot reconnect never came back.
+        fn with_reboot_failures(mut self, failures: Vec<(String, String)>) -> Self {
+            self.reboot_failures = failures;
             self
         }
 
@@ -498,8 +531,9 @@ mod tests {
             self.events.lock().unwrap().push(Event::Run(commands));
         }
 
-        async fn reboot(&mut self, reboot: HostCommandMap) {
+        async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
             self.events.lock().unwrap().push(Event::Reboot(reboot));
+            self.reboot_failures.clone()
         }
 
         async fn unlock(&mut self) {
@@ -754,6 +788,35 @@ mod tests {
         if let Event::Reboot(map) = &events[3] {
             assert_eq!(map, &vec![("h1".to_owned(), "systemctl reboot".to_owned())]);
         }
+    }
+
+    // --- run(): a reboot failure is reported, not swallowed -----------------
+
+    #[tokio::test]
+    async fn run_reports_a_transactional_reboot_failure_and_still_unlocks() {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![plan_with_recording_check(
+            "h1",
+            true,
+            Doer::new("in $packages", "systemctl reboot"),
+            sink,
+        )];
+        let mut group = MockGroup::new(Ok(plans))
+            .with_reboot_failures(vec![("h1".to_owned(), "reconnect failed".to_owned())]);
+
+        let op = InstallOperation::new(strs(&["pkg-a"]));
+        let report = op
+            .run(&mut group)
+            .await
+            .expect("the run started; the reboot failure is carried in the report, not Err");
+
+        assert_eq!(
+            report.reboot_failures,
+            vec![("h1".to_owned(), "reconnect failed".to_owned())]
+        );
+        // Unlock must still be the last event: a lost host does not skip
+        // releasing the operation lock.
+        assert_eq!(group.events().last(), Some(&Event::Unlock));
     }
 
     // --- role strings + missing_error sentinels -----------------------------

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -96,16 +96,41 @@ impl Doer {
 
 /// The post-run *check* callable for one target.
 ///
-/// Invoked once per target as `check(hostname)`. Boxed so it is object-safe
-/// and can be produced per
-/// target by the doer/check registry seam.
-pub type Check = Box<dyn FnMut(CheckArgs<'_>) + Send>;
+/// Invoked once per target with that host's post-run output, and returns
+/// `Err(reason)` when it recognises a failure. Boxed so it is object-safe and
+/// can be produced per target by the doer/check registry seam.
+pub type Check = Box<dyn FnMut(CheckArgs<'_>) -> Result<(), String> + Send>;
 
 /// The argument tuple passed to a [`Check`], keeping the call site readable.
 #[derive(Debug, Clone, Copy)]
 pub struct CheckArgs<'a> {
     /// The host the command ran on.
     pub hostname: &'a str,
+    /// The command's stdout.
+    pub stdout: &'a str,
+    /// The command that was run.
+    pub stdin: &'a str,
+    /// The command's stderr.
+    pub stderr: &'a str,
+    /// The command's exit code.
+    pub exitcode: i32,
+}
+
+/// One host's post-run output snapshot, read back by
+/// [`OperationGroup::last_output`] for the [`Check`] call.
+///
+/// Owned (not borrowed) so the read does not hold the group borrowed across
+/// the check call sandwiched between it and the reboot fan-out.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HostOutput {
+    /// The command's stdout.
+    pub stdout: String,
+    /// The command that was run.
+    pub stdin: String,
+    /// The command's stderr.
+    pub stderr: String,
+    /// The command's exit code.
+    pub exitcode: i32,
 }
 
 /// One host's contribution to an [`Operation`], resolved during
@@ -162,6 +187,13 @@ pub trait OperationGroup: Send {
     /// Runs the per-host command map.
     async fn run(&mut self, commands: HostCommandMap);
 
+    /// Reads back `hostname`'s post-run output, for the [`Check`] call.
+    ///
+    /// Returns `None` for a host outside the group (should not happen for a
+    /// host with a [`HostPlan`]); the template treats that as an empty
+    /// snapshot rather than panicking.
+    fn last_output(&self, hostname: &str) -> Option<HostOutput>;
+
     /// Reboots the transactional hosts named in `reboot`.
     ///
     /// Returns `(hostname, reason)` for every host that did not reconnect —
@@ -174,16 +206,19 @@ pub trait OperationGroup: Send {
 }
 
 /// The outcome of a completed [`Operation::run`]: the run *started* (the
-/// template got past `plans()` and `update_lock()`), but a transactional
-/// host's post-reboot reconnect can still fail.
+/// template got past `plans()` and `update_lock()`), but a host's check can
+/// still fail and a transactional host's post-reboot reconnect can still fail.
 ///
 /// `Err` from [`Operation::run`] keeps meaning "never started" (no plans, or a
-/// foreign lock); `Ok(report)` means it ran, and `reboot_failures` names any
-/// host whose reboot left it unreachable.
+/// foreign lock); `Ok(report)` means it ran, and the two failure lists name any
+/// host that failed its check or was left unreachable by its reboot.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OperationReport {
+    /// `(hostname, reason)` for every host whose post-run [`Check`] failed.
+    pub check_failures: Vec<(String, String)>,
     /// `(hostname, reason)` for every transactional host that rebooted and did
-    /// not reconnect.
+    /// not reconnect. A host whose check already failed is excluded — its
+    /// reboot was skipped, not attempted and lost.
     pub reboot_failures: Vec<(String, String)>,
 }
 
@@ -232,13 +267,18 @@ pub trait Operation: Send + Sync {
     /// * resolve per-host plans; on the configured `missing_error`, return
     ///   **without** taking any lock,
     /// * `update_lock()`,
-    /// * run the commands, invoke each host's check, then reboot the
-    ///   transactional hosts,
+    /// * run the commands, invoke each host's check over its post-run output,
+    ///   then reboot the transactional hosts whose check passed,
     /// * `unlock()` unconditionally afterwards.
     ///
-    /// Returns the started run's [`OperationReport`], which names any
-    /// transactional host that rebooted and did not reconnect — a caller that
-    /// discards it cannot tell that host apart from one that came back healthy.
+    /// A host whose check fails is excluded from the reboot map for that host
+    /// only — a healthy transactional host still reboots so its snapshot
+    /// activates; a host left inert by a failed check is named at WARN.
+    ///
+    /// Returns the started run's [`OperationReport`], which names any host
+    /// that failed its check and any transactional host that rebooted and did
+    /// not reconnect — a caller that discards it cannot tell either apart from
+    /// a host that came back healthy.
     ///
     /// # Errors
     ///
@@ -269,15 +309,44 @@ pub trait Operation: Send + Sync {
         // return `()`); a future fallible step must capture its error and fall
         // through to the unlock rather than returning early.
         group.run(commands).await;
+
+        let mut check_failures: Vec<(String, String)> = Vec::new();
         for plan in &mut plans {
-            (plan.check)(CheckArgs {
+            let output = group.last_output(&plan.hostname).unwrap_or_default();
+            let args = CheckArgs {
                 hostname: &plan.hostname,
-            });
+                stdout: &output.stdout,
+                stdin: &output.stdin,
+                stderr: &output.stderr,
+                exitcode: output.exitcode,
+            };
+            if let Err(reason) = (plan.check)(args) {
+                check_failures.push((plan.hostname.clone(), reason));
+            }
         }
+
+        // A failed check excludes its host from the reboot map: rebooting a
+        // host whose install/uninstall failed would activate a snapshot the
+        // operator has not yet seen the failure for.
+        let failed: std::collections::HashSet<&str> =
+            check_failures.iter().map(|(h, _)| h.as_str()).collect();
+        let reboot: HostCommandMap = reboot
+            .into_iter()
+            .filter(|(host, _)| {
+                let ok = !failed.contains(host.as_str());
+                if !ok {
+                    tracing::warn!(host = %host, "check failed; skipping reboot");
+                }
+                ok
+            })
+            .collect();
         let reboot_failures = group.reboot(reboot).await;
 
         group.unlock().await;
-        Ok(OperationReport { reboot_failures })
+        Ok(OperationReport {
+            check_failures,
+            reboot_failures,
+        })
     }
 }
 
@@ -360,11 +429,6 @@ impl Operation for UninstallOperation {
 /// a `Check`) and is injected by that crate's `update_flow::perform_install` /
 /// `perform_uninstall`, immediately before the template runs.
 ///
-/// Note the returned [`Check`] is a no-op in production: it receives only a
-/// hostname and returns `()`, so it cannot see a command's output or report a
-/// verdict. The real install/uninstall check runs in `mtui-testreport` after
-/// the template returns, over each target's `last*` snapshot.
-///
 /// Keys the
 /// registry lookup by `(self.system.get_release(), self.transactional)`.
 pub trait PlanProvider: Send + Sync {
@@ -408,7 +472,7 @@ mod plan_provider_tests {
             Ok(Doer::new("zypper -n in $packages", "systemctl reboot"))
         }
         fn check(&self, _role: &str, _release: &str, _transactional: bool) -> Check {
-            Box::new(|_a: CheckArgs<'_>| {})
+            Box::new(|_a: CheckArgs<'_>| Ok(()))
         }
     }
 
@@ -417,9 +481,18 @@ mod plan_provider_tests {
         let p = FakeProvider;
         let doer = p.doer("installer", "15", false).expect("doer");
         assert_eq!(doer.command("pkg"), "zypper -n in pkg");
-        // The no-op check does not panic and returns unit.
+        // The no-op check does not panic and returns Ok.
         let mut check = p.check("installer", "15", false);
-        check(CheckArgs { hostname: "h1" });
+        assert!(
+            check(CheckArgs {
+                hostname: "h1",
+                stdout: "",
+                stdin: "",
+                stderr: "",
+                exitcode: 0,
+            })
+            .is_ok()
+        );
     }
 
     #[test]
@@ -531,6 +604,12 @@ mod tests {
             self.events.lock().unwrap().push(Event::Run(commands));
         }
 
+        fn last_output(&self, _hostname: &str) -> Option<HostOutput> {
+            // The tests below assert on the Check event log, not the output
+            // snapshot, so an empty snapshot is enough here.
+            Some(HostOutput::default())
+        }
+
         async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
             self.events.lock().unwrap().push(Event::Reboot(reboot));
             self.reboot_failures.clone()
@@ -541,17 +620,31 @@ mod tests {
         }
     }
 
-    /// Builds a [`HostPlan`] whose check records a [`Event::Check`] into `sink`.
+    /// Builds a [`HostPlan`] whose check records a [`Event::Check`] into `sink`
+    /// and passes.
     fn plan_with_recording_check(
         hostname: &str,
         transactional: bool,
         doer: Doer,
         sink: Arc<Mutex<Vec<Event>>>,
     ) -> HostPlan {
+        plan_with_check(hostname, transactional, doer, sink, Ok(()))
+    }
+
+    /// Builds a [`HostPlan`] whose check records a [`Event::Check`] into `sink`
+    /// and returns `result`, so a failing check can be scripted per host.
+    fn plan_with_check(
+        hostname: &str,
+        transactional: bool,
+        doer: Doer,
+        sink: Arc<Mutex<Vec<Event>>>,
+        result: Result<(), String>,
+    ) -> HostPlan {
         let check: Check = Box::new(move |a: CheckArgs<'_>| {
             sink.lock()
                 .unwrap()
                 .push(Event::Check(a.hostname.to_owned()));
+            result.clone()
         });
         HostPlan {
             hostname: hostname.to_owned(),
@@ -817,6 +910,63 @@ mod tests {
         // Unlock must still be the last event: a lost host does not skip
         // releasing the operation lock.
         assert_eq!(group.events().last(), Some(&Event::Unlock));
+    }
+
+    // --- run(): a failed check excludes its host from the reboot map --------
+
+    #[tokio::test]
+    async fn failed_check_excludes_its_host_from_the_reboot_map() {
+        // Two transactional hosts; h1's check fails, h2's passes. Only h2 may
+        // be rebooted — activating a snapshot for a host whose install/
+        // uninstall failed would hide the failure behind a routine reboot.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![
+            plan_with_check(
+                "h1",
+                true,
+                Doer::new("in $packages", "systemctl reboot"),
+                log.clone(),
+                Err("boom".to_owned()),
+            ),
+            plan_with_check(
+                "h2",
+                true,
+                Doer::new("in $packages", "systemctl reboot"),
+                log.clone(),
+                Ok(()),
+            ),
+        ];
+        let mut group = MockGroup::with_event_log(Ok(plans), log);
+
+        let op = InstallOperation::new(strs(&["pkg-a"]));
+        let report = op.run(&mut group).await.expect("the run started");
+
+        assert_eq!(
+            report.check_failures,
+            vec![("h1".to_owned(), "boom".to_owned())]
+        );
+
+        let events = group.events();
+        // Both checks ran before the (single) reboot event.
+        let reboot_idx = events
+            .iter()
+            .position(|e| matches!(e, Event::Reboot(_)))
+            .expect("a reboot event was recorded");
+        let last_check_idx = events
+            .iter()
+            .rposition(|e| matches!(e, Event::Check(_)))
+            .expect("a check event was recorded");
+        assert!(
+            last_check_idx < reboot_idx,
+            "checks must run before the reboot: {events:?}"
+        );
+        if let Event::Reboot(map) = &events[reboot_idx] {
+            assert_eq!(
+                map,
+                &vec![("h2".to_owned(), "systemctl reboot".to_owned())],
+                "only the passing host's reboot may run: {map:?}"
+            );
+        }
     }
 
     // --- role strings + missing_error sentinels -----------------------------

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -140,6 +140,38 @@ async fn install_drives_doer_and_reboots_only_transactional() {
 }
 
 #[tokio::test]
+async fn install_reports_a_transactional_host_that_never_reconnects() {
+    // A transactional host reboots into an unreachable state: the run still
+    // started (unlike a missing doer or a foreign lock), so it must not
+    // return `Err`, but the lost host must be named in the report rather
+    // than silently dropped.
+    let (provider, _lookups, _checked) = RecordingProvider::new();
+    let conn = mtui_hosts::MockConnection::new("h1")
+        .with_default(CommandLog::new("", "done", "", 0, 1))
+        .failing_reconnect();
+    let handle = conn.clone();
+    let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+    let system = System::new(
+        SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+        BTreeSet::new(),
+        false,
+    );
+    t.set_system(system, true);
+    let mut group = HostsGroup::new(vec![t], false).with_plan_provider(Arc::new(provider));
+
+    let report = InstallOperation::new(vec!["pkg-a".to_owned()])
+        .run(&mut group)
+        .await
+        .expect("the run started even though the reboot failed");
+
+    assert_eq!(
+        report.reboot_failures,
+        vec![("h1".to_owned(), "failed to reconnect to h1".to_owned())]
+    );
+    assert_eq!(handle.reconnect_count(), 1);
+}
+
+#[tokio::test]
 async fn install_shell_quotes_malicious_package_name_end_to_end() {
     // Trust-boundary regression: a package name carrying shell metacharacters,
     // driven through the real HostsGroup install path, must reach the host as a

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -63,6 +63,7 @@ impl PlanProvider for RecordingProvider {
         let checked = self.checked.clone();
         Box::new(move |a: CheckArgs<'_>| {
             checked.lock().unwrap().push(a.hostname.to_owned());
+            Ok(())
         })
     }
 }
@@ -137,6 +138,67 @@ async fn install_drives_doer_and_reboots_only_transactional() {
     let mut who = checked.lock().unwrap().clone();
     who.sort();
     assert_eq!(who, vec!["h1".to_owned(), "h2".to_owned()]);
+}
+
+/// One host's output as seen by [`OutputRecordingProvider`]'s check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SeenOutput {
+    hostname: String,
+    stdout: String,
+    exitcode: i32,
+}
+
+/// A [`PlanProvider`] whose check records the [`CheckArgs`] it is called with,
+/// so a test can assert the check actually sees the host's post-run output
+/// rather than a hostname-only stub.
+struct OutputRecordingProvider {
+    seen: Arc<Mutex<Vec<SeenOutput>>>,
+}
+
+impl PlanProvider for OutputRecordingProvider {
+    fn doer(&self, _role: &str, _release: &str, _transactional: bool) -> Result<Doer, HostError> {
+        Ok(Doer::new(
+            "zypper -n in -y -l $packages",
+            "systemctl reboot",
+        ))
+    }
+
+    fn check(&self, _role: &str, _release: &str, _transactional: bool) -> Check {
+        let seen = self.seen.clone();
+        Box::new(move |a: CheckArgs<'_>| {
+            seen.lock().unwrap().push(SeenOutput {
+                hostname: a.hostname.to_owned(),
+                stdout: a.stdout.to_owned(),
+                exitcode: a.exitcode,
+            });
+            Ok(())
+        })
+    }
+}
+
+#[tokio::test]
+async fn install_check_sees_the_hosts_post_run_output() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let provider = OutputRecordingProvider { seen: seen.clone() };
+    let (h1, _m1) = target("h1", "SLES", "15.5", false);
+    let mut group = HostsGroup::new(vec![h1], false).with_plan_provider(Arc::new(provider));
+
+    InstallOperation::new(vec!["pkg-a".to_owned()])
+        .run(&mut group)
+        .await
+        .expect("a wired group installs");
+
+    // `target()`'s mock answers every command with a fixed "done"/exit-0
+    // `CommandLog`; the check must see exactly that snapshot, not a
+    // hostname-only stub.
+    assert_eq!(
+        seen.lock().unwrap().clone(),
+        vec![SeenOutput {
+            hostname: "h1".to_owned(),
+            stdout: "done".to_owned(),
+            exitcode: 0,
+        }]
+    );
 }
 
 #[tokio::test]

--- a/crates/mtui-testreport/src/reports/obs.rs
+++ b/crates/mtui-testreport/src/reports/obs.rs
@@ -110,7 +110,6 @@ impl TestReport for ObsReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "install", None, packages).await;
         update_flow::perform_install(targets, packages).await
     }
 
@@ -119,7 +118,6 @@ impl TestReport for ObsReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "uninstall", None, packages).await;
         update_flow::perform_uninstall(targets, packages).await
     }
 
@@ -140,8 +138,7 @@ impl TestReport for ObsReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         let id = self.rrid().map(ToString::to_string);
-        update_flow::add_op_history(targets, "downgrade", id.as_deref(), packages).await;
-        update_flow::perform_downgrade(targets, self, packages).await
+        update_flow::perform_downgrade(targets, self, packages, id.as_deref()).await
     }
 
     async fn perform_update(
@@ -151,9 +148,6 @@ impl TestReport for ObsReport {
         newpackage: bool,
         diagnostics: &mut Vec<crate::update_workflow::Diagnostic>,
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        let id = self.rrid().map(ToString::to_string);
-        let packages = self.get_package_list();
-        update_flow::add_op_history(targets, "update", id.as_deref(), &packages).await;
         update_flow::perform_update_with_rollback(self, targets, noprepare, newpackage, diagnostics)
             .await
     }

--- a/crates/mtui-testreport/src/reports/pi.rs
+++ b/crates/mtui-testreport/src/reports/pi.rs
@@ -102,7 +102,6 @@ impl TestReport for PiReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "install", None, packages).await;
         update_flow::perform_install(targets, packages).await
     }
 
@@ -111,7 +110,6 @@ impl TestReport for PiReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "uninstall", None, packages).await;
         update_flow::perform_uninstall(targets, packages).await
     }
 
@@ -132,8 +130,7 @@ impl TestReport for PiReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         let id = self.rrid().map(ToString::to_string);
-        update_flow::add_op_history(targets, "downgrade", id.as_deref(), packages).await;
-        update_flow::perform_downgrade(targets, self, packages).await
+        update_flow::perform_downgrade(targets, self, packages, id.as_deref()).await
     }
 
     async fn perform_update(
@@ -143,9 +140,6 @@ impl TestReport for PiReport {
         newpackage: bool,
         diagnostics: &mut Vec<crate::update_workflow::Diagnostic>,
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        let id = self.rrid().map(ToString::to_string);
-        let packages = self.get_package_list();
-        update_flow::add_op_history(targets, "update", id.as_deref(), &packages).await;
         update_flow::perform_update_with_rollback(self, targets, noprepare, newpackage, diagnostics)
             .await
     }

--- a/crates/mtui-testreport/src/reports/sl.rs
+++ b/crates/mtui-testreport/src/reports/sl.rs
@@ -118,7 +118,6 @@ impl TestReport for SlReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "install", None, packages).await;
         update_flow::perform_install(targets, packages).await
     }
 
@@ -127,7 +126,6 @@ impl TestReport for SlReport {
         targets: &mut HostsGroup,
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        update_flow::add_op_history(targets, "uninstall", None, packages).await;
         update_flow::perform_uninstall(targets, packages).await
     }
 
@@ -148,8 +146,7 @@ impl TestReport for SlReport {
         packages: &[String],
     ) -> Result<(), crate::update_workflow::UpdateError> {
         let id = self.rrid().map(ToString::to_string);
-        update_flow::add_op_history(targets, "downgrade", id.as_deref(), packages).await;
-        update_flow::perform_downgrade(targets, self, packages).await
+        update_flow::perform_downgrade(targets, self, packages, id.as_deref()).await
     }
 
     async fn perform_update(
@@ -159,9 +156,6 @@ impl TestReport for SlReport {
         newpackage: bool,
         diagnostics: &mut Vec<crate::update_workflow::Diagnostic>,
     ) -> Result<(), crate::update_workflow::UpdateError> {
-        let id = self.rrid().map(ToString::to_string);
-        let packages = self.get_package_list();
-        update_flow::add_op_history(targets, "update", id.as_deref(), &packages).await;
         update_flow::perform_update_with_rollback(self, targets, noprepare, newpackage, diagnostics)
             .await
     }

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -380,28 +380,40 @@ async fn perform_operation(
     role: Role,
     packages: &[String],
 ) -> Result<(), UpdateError> {
-    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
-
     // Matched exhaustively on purpose: a `_ =>` arm defaulting to install would
     // quietly run the wrong package-manager command if a role were ever added,
     // which is the same shape of silent-wrong-default this function exists to
     // fix. Only the two template roles reach here.
-    let (op, outcome) = match role {
-        Role::Install => (
-            "install",
-            InstallOperation::new(packages.to_vec()).run(targets).await,
-        ),
-        Role::Uninstall => (
-            "uninstall",
-            UninstallOperation::new(packages.to_vec())
-                .run(targets)
-                .await,
-        ),
+    let op = match role {
+        Role::Install => "install",
+        Role::Uninstall => "uninstall",
         Role::Update | Role::Prepare | Role::Downgrade => {
             return Err(UpdateError::reason_only(format!(
                 "{} is not driven by the install/uninstall template",
                 role.as_operation_role()
             )));
+        }
+    };
+
+    // Entry gate: nothing has run yet, so a cancel here is a clean no-op,
+    // mirroring `perform_update`'s own entry gate.
+    if targets.cancel_requested() {
+        return Err(UpdateError::cancelled(format!(
+            "cancelled before the {op} started"
+        )));
+    }
+
+    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
+
+    let outcome = match role {
+        Role::Install => InstallOperation::new(packages.to_vec()).run(targets).await,
+        Role::Uninstall => {
+            UninstallOperation::new(packages.to_vec())
+                .run(targets)
+                .await
+        }
+        Role::Update | Role::Prepare | Role::Downgrade => {
+            unreachable!("returned above for these roles")
         }
     };
 
@@ -1578,6 +1590,41 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn install_stops_at_the_entry_gate_when_cancelled() {
+        // install/uninstall had no cancellation checkpoint of their own; a
+        // cancel requested before the run must stop it before any command
+        // reaches a host, exactly like `perform_update`'s entry gate.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a cancelled install reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        assert!(
+            handle.commands().is_empty(),
+            "entry gate must dispatch no command: {:?}",
+            handle.commands()
+        );
+    }
+
+    #[tokio::test]
+    async fn uninstall_stops_at_the_entry_gate_when_cancelled() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+
+        let err = perform_uninstall(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a cancelled uninstall reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        assert!(handle.commands().is_empty());
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -91,6 +91,7 @@ where
         debug!("perform_update: no RRID loaded; nothing to update");
         return Ok(());
     };
+    let id = rrid.to_string();
     let maintenance_id = rrid.maintenance_id.clone();
     let review_id = rrid.review_id.to_string();
     let packages = report.get_package_list();
@@ -100,6 +101,7 @@ where
         &packages,
         &maintenance_id,
         &review_id,
+        Some(&id),
         noprepare,
         newpackage,
         diagnostics,
@@ -150,7 +152,6 @@ where
             warn!("Error while updating. Rolling back changes");
             let pkgs = report.get_package_list();
             let id = report.base().rrid.as_ref().map(ToString::to_string);
-            add_op_history(targets, "downgrade", id.as_deref(), &pkgs).await;
             // Suspend cancellation for the rollback. The update has already
             // been applied, so this recovery is what prevents a half-applied
             // state; letting the downgrade's own per-package checkpoint see a
@@ -159,7 +160,7 @@ where
             let token = targets.suspend_cancellation();
             // Rollback is best-effort; a failed downgrade must never bury the
             // original update error, so its result is logged, not returned.
-            if let Err(de) = perform_downgrade(targets, report, &pkgs).await {
+            if let Err(de) = perform_downgrade(targets, report, &pkgs, id.as_deref()).await {
                 warn!(error = %de, "rollback downgrade failed");
             }
             targets.set_cancel_token(token);
@@ -429,6 +430,10 @@ async fn perform_operation(
         Ok(report) => report,
     };
 
+    // The template has now dispatched a command on every host, whatever the
+    // verdict: record the history row here, not before the run started.
+    add_op_history(targets, op, None, packages).await;
+
     // A host whose post-run check failed, and any transactional host that
     // rebooted and never reconnected, both fail the operation by name. A
     // failed check already excluded its host from the reboot map (see
@@ -686,10 +691,14 @@ fn build_prepare_map(
 }
 
 /// Rolls `packages` back to the pre-update version on every host.
+///
+/// `id` is the RRID string recorded in the remote history line once the
+/// downgrade has dispatched a command (`None` when no RRID is available).
 pub async fn perform_downgrade(
     targets: &mut HostsGroup,
     report: &dyn SetRepo,
     packages: &[String],
+    id: Option<&str>,
 ) -> Result<(), UpdateError> {
     // Nothing to downgrade: return before locking or touching repos.
     // The guard also keeps the probe template from rendering with an
@@ -712,7 +721,7 @@ pub async fn perform_downgrade(
         return Err(UpdateError::reason_only(e.to_string()));
     }
 
-    let result = downgrade_body(targets, &registry, report, packages, reboot).await;
+    let result = downgrade_body(targets, &registry, report, packages, reboot, id).await;
     targets.unlock().await;
     result
 }
@@ -724,6 +733,7 @@ async fn downgrade_body(
     report: &dyn SetRepo,
     packages: &[String],
     reboot: BTreeMap<String, String>,
+    id: Option<&str>,
 ) -> Result<(), UpdateError> {
     targets.fanout_set_repo(RepoOp::Remove, report).await;
 
@@ -916,6 +926,10 @@ async fn downgrade_body(
         .collect();
     failures.extend(reboot_transactional(targets, healthy_reboot).await);
 
+    // The downgrade commands have now dispatched, whatever the verdict:
+    // record the history row here, not before the run started.
+    add_op_history(targets, "downgrade", id, packages).await;
+
     let not_downgraded = downgrade_verdict(targets).await;
 
     // A per-host check failure aborts first (matches the pre-#336 aggregation).
@@ -1063,11 +1077,14 @@ fn parse_downgrade_versions(output: &str) -> HashMap<String, String> {
 /// Runs the full update: prepare, patch, check, reboot, and repo cleanup.
 ///
 /// `packages` is the report's package list; `maintenance_id`/`review_id` build
-/// the `$repa` selector. `noprepare` skips the initial prepare; `newpackage`
-/// runs a testing prepare after the update. `prepare` is the closure the caller
-/// uses to run [`perform_prepare`] (the report drives it so this module does not
-/// need to know the report type). `diagnostics` collects the update check's
-/// recognised-but-non-fatal output sections for the command layer to render.
+/// the `$repa` selector. `id` is the RRID string recorded in the remote
+/// history line once the update has dispatched a command (`None` when no RRID
+/// is available, e.g. a direct call with no report). `noprepare` skips the
+/// initial prepare; `newpackage` runs a testing prepare after the update.
+/// `prepare` is the closure the caller uses to run [`perform_prepare`] (the
+/// report drives it so this module does not need to know the report type).
+/// `diagnostics` collects the update check's recognised-but-non-fatal output
+/// sections for the command layer to render.
 // Plain positional args plus the diagnostic sink threaded from the
 // display-owning command layer; grouping them into a struct would only
 // obscure the call site for no real gain.
@@ -1078,6 +1095,7 @@ pub async fn perform_update(
     packages: &[String],
     maintenance_id: &str,
     review_id: &str,
+    id: Option<&str>,
     noprepare: bool,
     newpackage: bool,
     diagnostics: &mut Vec<Diagnostic>,
@@ -1144,6 +1162,10 @@ pub async fn perform_update(
     // Two-phase: run + check + reboot under the lock (unlock always), then the
     // repo cleanup only on success.
     let update_result = update_run_phase(targets, &registry, commands, reboot, diagnostics).await;
+
+    // The updater command has now dispatched, whatever the verdict: record
+    // the history row here, not before the run started.
+    add_op_history(targets, "update", id, packages).await;
 
     if let Err(e) = update_result {
         // KEEP the test update repositories in place for retry/diagnosis.
@@ -1451,7 +1473,7 @@ mod tests {
     #[tokio::test]
     async fn perform_downgrade_surfaces_missing_downgrader() {
         let mut group = HostsGroup::new(vec![missing_doer_target("h1")], false);
-        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()]).await;
+        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
         let err = res.expect_err("missing downgrader must surface as Err");
         assert!(
             err.reason.contains("missing downgrader"),
@@ -1627,6 +1649,118 @@ mod tests {
         assert!(handle.commands().is_empty());
     }
 
+    // --- history is written after the operation ran, not before -----------
+
+    const HISTORY_LOG: &str = "/var/log/mtui.log";
+
+    #[tokio::test]
+    async fn install_writes_no_history_when_no_doer_resolves() {
+        // A run that never starts (no installer doer for this host) must not
+        // record a history row: nothing happened on the host.
+        let conn = MockConnection::new("h1").with_default(CommandLog::new("", "", "", 0, 0));
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("sle-studioonsite", "11", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+
+        perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("no installer doer resolves for this host");
+
+        assert!(
+            handle.file_contents(HISTORY_LOG).is_none(),
+            "a run that never started must leave no history row"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_writes_history_when_the_command_failed() {
+        // The install command ran and failed; the host was touched, so the
+        // history row must still be written even though the command failed.
+        let (t, handle) = sles_target_with_exit("h1", "", 104);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a failed install command surfaces as Err");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a run that dispatched a command records history"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1);
+        assert!(
+            contents.contains(":install:pkg-a"),
+            "history line: {contents:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn downgrade_rollback_still_records_history() {
+        // perform_update_with_rollback's best-effort rollback dispatches a
+        // real downgrade; it must record its own history row like a
+        // directly-invoked downgrade would.
+        let probe = {
+            let cmds = crate::update_workflow::actions::downgrade::downgrader("15", false).unwrap();
+            let vars: std::collections::HashMap<&str, &str> =
+                [("packages", "pkg-a")].into_iter().collect();
+            cmds.render_list_command(&vars).unwrap().unwrap()
+        };
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("zypper", "pkg-a = 1.0-1\n", "", 104, 0))
+            .with_response(
+                probe,
+                CommandLog::new("zypper", "pkg-a = 1.0-1\n", "", 0, 0),
+            );
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("the update check fails, triggering the rollback");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("the rollback downgrade records its own history row"),
+        )
+        .unwrap();
+        let downgrade_lines: Vec<&str> = contents
+            .lines()
+            .filter(|l| l.contains(":downgrade:"))
+            .collect();
+        assert_eq!(
+            downgrade_lines.len(),
+            1,
+            "exactly one downgrade history row: {contents:?}"
+        );
+        assert!(
+            downgrade_lines[0].contains("SUSE:Maintenance:42:7"),
+            "the rollback's history row carries the RRID: {contents:?}"
+        );
+    }
+
     #[tokio::test]
     async fn perform_install_accepts_zyppers_informational_exit_codes() {
         // zypper exits 100-103/106 to mean "update needed", "reboot needed",
@@ -1721,6 +1855,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -1763,6 +1898,7 @@ mod tests {
             &["pkg-a".to_owned()],
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -1801,7 +1937,7 @@ mod tests {
         let (t, handle) = sles_target("h1", "pkg-a = 1.0-1\n");
         let mut group = HostsGroup::new(vec![t], false);
 
-        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()]).await;
+        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
         assert!(res.is_ok(), "a clean downgrade returns Ok: {res:?}");
 
         let cmds = handle.commands();
@@ -1819,7 +1955,7 @@ mod tests {
         let (t, handle) = sles_target("h1", "pkg-a = 1.0-1\n");
         let mut group = HostsGroup::new(vec![t], false);
 
-        let res = perform_downgrade(&mut group, &NoopRepo, &[]).await;
+        let res = perform_downgrade(&mut group, &NoopRepo, &[], None).await;
         assert!(res.is_ok(), "empty list is a no-op Ok: {res:?}");
         assert!(
             handle.commands().is_empty(),
@@ -1835,7 +1971,7 @@ mod tests {
         let (t, handle) = sles_target_with_exit("h1", "", -1);
         let mut group = HostsGroup::new(vec![t], false);
 
-        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()]).await;
+        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
         let err = res.expect_err("a dead probe must abort");
         assert_eq!(err.reason, "package version probe failed");
         assert_eq!(err.host.as_deref(), Some("h1"));
@@ -1855,7 +1991,7 @@ mod tests {
         let (t2, h2) = sles_target_with_exit("h2", "", -1);
         let mut group = HostsGroup::new(vec![t1, t2], false);
 
-        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()]).await;
+        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
         let err = res.expect_err("a partial dead probe still fails the command");
         assert_eq!(err.reason, "package version probe failed");
         assert_eq!(err.host.as_deref(), Some("h2"));
@@ -2040,7 +2176,7 @@ mod tests {
         let (t, _handle) = slmicro_target_failing_reconnect("h1");
         let mut group = HostsGroup::new(vec![t], false);
 
-        let err = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()])
+        let err = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None)
             .await
             .expect_err("a lost transactional host must not report success");
         assert!(
@@ -2092,6 +2228,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -2129,6 +2266,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -2166,6 +2304,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -2253,6 +2392,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             true,
             false,
             &mut Vec::new(),
@@ -2283,6 +2423,7 @@ mod tests {
             &packages,
             "42",
             "7",
+            None,
             false,
             false,
             &mut Vec::new(),
@@ -2308,6 +2449,7 @@ mod tests {
             &mut group,
             &NoopRepo,
             &["pkg-a".to_owned(), "pkg-b".to_owned()],
+            None,
         )
         .await;
         assert!(res.is_ok(), "a clean downgrade returns Ok: {res:?}");
@@ -2405,7 +2547,7 @@ mod tests {
         let report = crate::reports::PiReport::new(Config::default());
         let packages = vec!["pkg-a".to_owned(), "pkg-b".to_owned()];
 
-        let err = perform_downgrade(&mut group, &report, &packages)
+        let err = perform_downgrade(&mut group, &report, &packages, None)
             .await
             .expect_err("a cancelled downgrade reports an error");
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -333,8 +333,9 @@ fn host_command_failures(targets: &HostsGroup, reason: &str) -> Vec<UpdateError>
 /// The shared body behind every report's `perform_install`. Injects the
 /// [`WorkflowRegistry`] as the group's
 /// [`PlanProvider`](mtui_hosts::PlanProvider) and drives the
-/// [`InstallOperation`](mtui_hosts::InstallOperation) template, then returns the
-/// verdict from [`install_verdict`].
+/// [`InstallOperation`](mtui_hosts::InstallOperation) template, whose own
+/// per-host [`Check`](mtui_hosts::Check) — also adapted from this registry —
+/// now produces the verdict, before the (possible) reboot.
 ///
 /// Injecting here rather than where the group is built is deliberate:
 /// [`OperationGroup::plans`](mtui_hosts::OperationGroup::plans) has exactly one
@@ -416,19 +417,18 @@ async fn perform_operation(
         Ok(report) => report,
     };
 
-    // A transactional host that rebooted and never reconnected must fail the
-    // operation by name, alongside any install-check failure `install_verdict`
-    // finds over the other hosts' `last*` snapshots.
+    // A host whose post-run check failed, and any transactional host that
+    // rebooted and never reconnected, both fail the operation by name. A
+    // failed check already excluded its host from the reboot map (see
+    // `Operation::run`), so the two lists never double-name the same host.
     let mut failures: Vec<UpdateError> = report
-        .reboot_failures
+        .check_failures
         .into_iter()
-        .map(|(host, reason)| {
-            UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
-        })
+        .map(|(host, reason)| UpdateError::new(reason, host))
         .collect();
-    if let Err(e) = install_verdict(op, role, targets) {
-        failures.push(e);
-    }
+    failures.extend(report.reboot_failures.into_iter().map(|(host, reason)| {
+        UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
+    }));
     aggregate_failures(op, failures)
 }
 
@@ -475,78 +475,6 @@ fn describe_start_failure(err: &HostError, role: Role, targets: &HostsGroup) -> 
         role.as_operation_role(),
         unresolved.join(", ")
     )
-}
-
-/// Reports whether a shared install/uninstall [`Operation`](mtui_hosts::Operation)
-/// fan-out succeeded on every host.
-///
-/// The template's own per-host check hook cannot produce a verdict — it receives
-/// only a hostname and returns `()` — so the real check runs here, over each
-/// target's post-fan-out `last*` snapshot, reusing the same registry `CheckFn`
-/// that `perform_prepare` and `perform_update` drive through `run_checks`.
-/// Unlike those flows, this one runs the check *instead of* a raw exit-code
-/// scan rather than in addition to it, because the check already classifies
-/// every exit code it cares about. `op` labels the aggregated summary.
-///
-/// Where the registry has a check for a host's `(release, transactional)` key,
-/// it is authoritative: it knows that zypper's exit codes 100-103 and 106
-/// ("update needed", "reboot needed", "repo skipped") are *informational*, and
-/// classifies real failures as "package not found" / "update stack locked" /
-/// "RPM Error" / "Dependency Error". A bare `lastexit() != 0` scan would call a
-/// routine post-kernel-install "reboot needed" a failed install.
-///
-/// Keys with no registered check — `slmicro` (transactional) and `YUM` — fall
-/// back to that raw scan, which is better than no verdict at all.
-///
-/// # Errors
-///
-/// Returns the aggregated [`UpdateError`] when any host failed.
-pub fn install_verdict(op: &str, role: Role, targets: &HostsGroup) -> Result<(), UpdateError> {
-    let registry = WorkflowRegistry::default();
-    let reason = format!("{op} command failed");
-    let mut failures = Vec::new();
-
-    for target in targets.targets() {
-        let check = host_key(target)
-            .and_then(|(release, transactional)| registry.check(role, &release, transactional));
-
-        let Some(check) = check else {
-            // No check table for this key (`slmicro`, `YUM`): fall back to the
-            // exit code alone. Deliberately *not* "any stderr output is a
-            // failure" — `transactional-update` and `yum` both write progress
-            // and warnings to stderr on a successful run, and no check table in
-            // this crate treats bare stderr as a failure either; they all match
-            // specific markers.
-            if target.lastexit().is_some_and(|c| c != 0) {
-                failures.push(UpdateError::new(reason.clone(), target.hostname()));
-            }
-            continue;
-        };
-
-        // The install checks emit no diagnostics (only the update checks do),
-        // but drain the channel rather than assuming that stays true.
-        let mut diagnostics = Vec::new();
-        match check(CheckArgs {
-            hostname: target.hostname(),
-            stdout: target.lastout(),
-            stdin: target.lastin(),
-            stderr: target.lasterr(),
-            exitcode: target.lastexit().map_or(0, i32::from),
-        }) {
-            Ok(diags) => diagnostics.extend(diags),
-            Err(mut e) => {
-                if e.host.is_none() {
-                    e.host = Some(target.hostname().to_owned());
-                }
-                failures.push(e);
-            }
-        }
-        for d in diagnostics {
-            info!("{}", d.text);
-        }
-    }
-
-    aggregate_failures(op, failures)
 }
 
 /// Reboots the transactional hosts named in `reboot`, returning one
@@ -1574,7 +1502,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn install_verdict_fallback_ignores_stderr_on_a_clean_exit() {
+    async fn perform_install_ignores_stderr_on_a_clean_exit() {
         // `transactional-update` and `yum` write progress and warnings to stderr
         // on a successful run. Treating any stderr as failure would fail every
         // SL Micro install.
@@ -1595,10 +1523,11 @@ mod tests {
             true,
         );
         let mut group = HostsGroup::new(vec![t], false);
-        group.run(Command::All("t-u pkg install".to_owned())).await;
 
         assert!(
-            install_verdict("install", Role::Install, &group).is_ok(),
+            perform_install(&mut group, &["pkg-a".to_owned()])
+                .await
+                .is_ok(),
             "stderr alone on a zero exit is not a failure"
         );
     }
@@ -1624,14 +1553,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn install_verdict_surfaces_per_host_command_failure() {
-        // A host left with a non-zero lastexit after an install fan-out is
-        // reported by install_verdict (the report-level install/uninstall hook).
+    async fn perform_install_surfaces_a_failed_command() {
+        // A host whose install command exits 104 is reported by the template's
+        // own check — over the same host's post-run snapshot the removed
+        // `install_verdict` used to read *after* the template returned.
         let (t, _h) = sles_target_with_exit("h1", "", 104);
         let mut group = HostsGroup::new(vec![t], false);
-        // Run one command so the host records its (failing) last* snapshot.
-        group.run(Command::All("zypper in".to_owned())).await;
-        let err = install_verdict("install", Role::Install, &group)
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
             .expect_err("non-zero exit surfaces as Err");
         assert_eq!(err.host.as_deref(), Some("h1"));
         // 104 is zypper's ZYPPER_EXIT_INF_CAP_NOT_FOUND, which the install check
@@ -1641,15 +1570,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn install_verdict_ok_when_all_hosts_succeed() {
+    async fn perform_install_ok_when_all_hosts_succeed() {
         let (t, _h) = sles_target("h1", "");
         let mut group = HostsGroup::new(vec![t], false);
-        group.run(Command::All("zypper in".to_owned())).await;
-        assert!(install_verdict("install", Role::Install, &group).is_ok());
+        assert!(
+            perform_install(&mut group, &["pkg-a".to_owned()])
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
-    async fn install_verdict_accepts_zyppers_informational_exit_codes() {
+    async fn perform_install_accepts_zyppers_informational_exit_codes() {
         // zypper exits 100-103/106 to mean "update needed", "reboot needed",
         // "restart needed", "repo skipped" — all *successful* installs. Exit 102
         // (reboot needed) is routine after a kernel update, so a bare
@@ -1658,8 +1590,7 @@ mod tests {
         for exit in [100, 101, 102, 103, 106] {
             let (t, _h) = sles_target_with_exit("h1", "", exit);
             let mut group = HostsGroup::new(vec![t], false);
-            group.run(Command::All("zypper in".to_owned())).await;
-            let res = install_verdict("install", Role::Install, &group);
+            let res = perform_install(&mut group, &["pkg-a".to_owned()]).await;
             assert!(
                 res.is_ok(),
                 "exit {exit} is informational, not a failure: {res:?}"
@@ -1668,7 +1599,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn install_verdict_falls_back_to_raw_scan_without_a_check_table() {
+    async fn perform_install_falls_back_to_raw_scan_without_a_check_table() {
         // slmicro/YUM keys have no install check registered. They must still get
         // a verdict rather than an unconditional pass.
         let conn = MockConnection::new("h1").with_default(CommandLog::new("t-u", "", "", 1, 0));
@@ -1681,22 +1612,17 @@ mod tests {
             ),
             true,
         );
-        let mut group = HostsGroup::new(vec![t], false);
-        group.run(Command::All("t-u pkg install".to_owned())).await;
-
-        let key = host_key(group.targets().next().expect("one target"));
+        let key = host_key(&t).expect("resolvable key");
         assert!(
             WorkflowRegistry::default()
-                .check(
-                    Role::Install,
-                    &key.clone().expect("key").0,
-                    key.expect("key").1
-                )
+                .check(Role::Install, &key.0, key.1)
                 .is_none(),
             "this test is only meaningful while the key has no check table"
         );
+        let mut group = HostsGroup::new(vec![t], false);
 
-        let err = install_verdict("install", Role::Install, &group)
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
             .expect_err("a non-zero exit must still be reported");
         assert_eq!(err.host.as_deref(), Some("h1"));
         assert_eq!(err.reason, "install command failed");

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -61,6 +61,12 @@ pub enum UpdateFailure {
     /// a rollback is itself a multi-minute downgrade, so rolling back on a
     /// cancel would *extend* the work the caller just asked to stop.
     Cancelled(UpdateError),
+    /// A transactional host rebooted after a successful patch and did not
+    /// reconnect.
+    ///
+    /// Like [`MissingUpdater`](Self::MissingUpdater) this skips the rollback:
+    /// the host is unreachable, so a downgrade cannot run on it.
+    Reboot(UpdateError),
 }
 
 /// Drives [`perform_update`] from a concrete report, reading the package list
@@ -131,6 +137,12 @@ where
             // Anything an earlier `prepare` step installed is left as-is (see
             // `UpdateFailure::Cancelled`).
             info!(reason = %e, "update cancelled");
+            Err(e)
+        }
+        Err(UpdateFailure::Reboot(e)) => {
+            // The patch succeeded but the host never came back: it is
+            // unreachable, so a downgrade cannot run on it either.
+            error!(error = %e, "update failed");
             Err(e)
         }
         Err(UpdateFailure::Check(e)) => {
@@ -395,13 +407,29 @@ async fn perform_operation(
     // The template ran nothing at all — a missing doer, or a host held by
     // another tester. Report it instead of falling through to a verdict that
     // would read stale `last*` values and call it success.
-    if let Err(e) = outcome {
-        return Err(UpdateError::reason_only(describe_start_failure(
-            &e, role, targets,
-        )));
-    }
+    let report = match outcome {
+        Err(e) => {
+            return Err(UpdateError::reason_only(describe_start_failure(
+                &e, role, targets,
+            )));
+        }
+        Ok(report) => report,
+    };
 
-    install_verdict(op, role, targets)
+    // A transactional host that rebooted and never reconnected must fail the
+    // operation by name, alongside any install-check failure `install_verdict`
+    // finds over the other hosts' `last*` snapshots.
+    let mut failures: Vec<UpdateError> = report
+        .reboot_failures
+        .into_iter()
+        .map(|(host, reason)| {
+            UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
+        })
+        .collect();
+    if let Err(e) = install_verdict(op, role, targets) {
+        failures.push(e);
+    }
+    aggregate_failures(op, failures)
 }
 
 /// Turns an [`Operation::run`](mtui_hosts::Operation::run) start failure into a
@@ -521,13 +549,27 @@ pub fn install_verdict(op: &str, role: Role, targets: &HostsGroup) -> Result<(),
     aggregate_failures(op, failures)
 }
 
-/// Reboots the transactional hosts named in `reboot`.
-async fn reboot_transactional(targets: &mut HostsGroup, reboot: BTreeMap<String, String>) {
+/// Reboots the transactional hosts named in `reboot`, returning one
+/// [`UpdateError`] per host that did not reconnect.
+///
+/// A transactional host that rebooted and never came back must fail the flow
+/// by name, not vanish into a discarded `()` — the caller pushes these into
+/// its own failure list before aggregating.
+async fn reboot_transactional(
+    targets: &mut HostsGroup,
+    reboot: BTreeMap<String, String>,
+) -> Vec<UpdateError> {
     if reboot.is_empty() {
-        return;
+        return Vec::new();
     }
     let map: Vec<(String, String)> = reboot.into_iter().collect();
-    OperationGroup::reboot(targets, map).await;
+    OperationGroup::reboot(targets, map)
+        .await
+        .into_iter()
+        .map(|(host, reason)| {
+            UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
+        })
+        .collect()
 }
 
 /// Runs the prepare step: adds/removes the issue repo, then installs
@@ -646,7 +688,7 @@ async fn prepare_body(
         error!(error = %e, "prepare check failed");
         failures.push(e);
     }
-    reboot_transactional(targets, reboot).await;
+    failures.extend(reboot_transactional(targets, reboot).await);
     // A genuine host failure outranks the cancellation: reporting only
     // "cancelled" would bury a broken host the operator must still see.
     if !failures.is_empty() {
@@ -932,7 +974,7 @@ async fn downgrade_body(
         .into_iter()
         .filter(|(h, _)| !dead_probes.contains(h))
         .collect();
-    reboot_transactional(targets, healthy_reboot).await;
+    failures.extend(reboot_transactional(targets, healthy_reboot).await);
 
     let not_downgraded = downgrade_verdict(targets).await;
 
@@ -1169,7 +1211,7 @@ pub async fn perform_update(
             "update did not complete; leaving the test update repositories in place \
              for retry/diagnosis (remove later with `set_repo --remove`)"
         );
-        return Err(UpdateFailure::Check(e));
+        return Err(e);
     }
 
     if newpackage
@@ -1193,19 +1235,22 @@ pub async fn perform_update(
 /// Runs the update commands, checks every host (collecting failures), reboots on
 /// success, and **always** unlocks.
 ///
-/// Returns `Ok(())` when every host's check passed, otherwise `Err` with the
-/// aggregated [`UpdateError`]: a single failure is returned verbatim; more
-/// than one is summarised into `"update failed on {hosts} ({detail})"`.
+/// Returns `Ok(())` when every host's check passed and every transactional
+/// host reconnected; otherwise `Err` with the aggregated failure: a check
+/// failure (packages may be half-applied) is [`UpdateFailure::Check`] and
+/// **suppresses the reboot entirely**; a post-patch reconnect failure is
+/// [`UpdateFailure::Reboot`]. A single failure is returned verbatim; more than
+/// one is summarised into `"update failed on {hosts} ({detail})"`.
 async fn update_run_phase(
     targets: &mut HostsGroup,
     registry: &WorkflowRegistry,
     commands: BTreeMap<String, String>,
     reboot: BTreeMap<String, String>,
     diagnostics: &mut Vec<Diagnostic>,
-) -> Result<(), UpdateError> {
+) -> Result<(), UpdateFailure> {
     targets.run(Command::PerHost(commands)).await;
 
-    let mut failures = run_checks(targets, registry, Role::Update, diagnostics);
+    let failures = run_checks(targets, registry, Role::Update, diagnostics);
     let failed_hosts: std::collections::HashSet<String> =
         failures.iter().filter_map(|e| e.host.clone()).collect();
     let ok_hosts: Vec<String> = targets
@@ -1220,24 +1265,13 @@ async fn update_run_phase(
         error!(error = %e, "update failed");
     }
 
-    let result = if failures.is_empty() {
-        reboot_transactional(targets, reboot).await;
-        Ok(())
-    } else if failures.len() == 1 {
-        // Preserve the exact single-host error the caller used to get.
-        Err(failures.remove(0))
+    // A check failure keeps precedence and suppresses the reboot entirely: a
+    // transactional host whose patch failed must not be rebooted into it.
+    let result = if !failures.is_empty() {
+        aggregate_failures("update", failures).map_err(UpdateFailure::Check)
     } else {
-        let hosts: Vec<String> = {
-            let mut h: Vec<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
-            h.sort();
-            h
-        };
-        let detail: Vec<String> = failures.iter().map(ToString::to_string).collect();
-        Err(UpdateError::reason_only(format!(
-            "update failed on {} ({})",
-            hosts.join(", "),
-            detail.join("; ")
-        )))
+        let reboot_failures = reboot_transactional(targets, reboot).await;
+        aggregate_failures("update", reboot_failures).map_err(UpdateFailure::Reboot)
     };
 
     targets.unlock().await;
@@ -1954,6 +1988,122 @@ mod tests {
             true,
         );
         (t, handle)
+    }
+
+    /// Like [`slmicro_target`] but its reconnect after a reboot always fails,
+    /// modelling a transactional host that never comes back.
+    fn slmicro_target_failing_reconnect(hostname: &str) -> (Target, MockConnection) {
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .failing_reconnect();
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        (t, handle)
+    }
+
+    #[tokio::test]
+    async fn perform_install_reports_a_transactional_host_that_never_reconnects() {
+        // The install itself succeeds (exit 0), but the post-reboot reconnect
+        // never comes back: the whole point of this fix is that mtui must not
+        // report success on a host it lost.
+        let (t, _handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a lost transactional host must not report success");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        assert!(
+            err.reason.contains("reconnect after reboot failed"),
+            "reason: {}",
+            err.reason
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_uninstall_reports_a_transactional_host_that_never_reconnects() {
+        let (t, _handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_uninstall(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a lost transactional host must not report success");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_fails_when_a_transactional_host_does_not_come_back() {
+        let (t, _handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a lost transactional host must not report success");
+        assert!(
+            err.reason.contains("reconnect after reboot failed"),
+            "reason: {}",
+            err.reason
+        );
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[tokio::test]
+    async fn perform_downgrade_fails_when_a_transactional_host_does_not_come_back() {
+        let (t, _handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a lost transactional host must not report success");
+        assert!(
+            err.reason.contains("reconnect after reboot failed"),
+            "reason: {}",
+            err.reason
+        );
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[tokio::test]
+    async fn update_reports_a_host_that_never_came_back_and_skips_the_rollback() {
+        // A successful patch followed by a dead reconnect must fail as
+        // `UpdateFailure::Reboot` and must NOT trigger the rollback downgrade:
+        // the host is unreachable, so a downgrade cannot run on it.
+        let (t, handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let res = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await;
+        let err = res.expect_err("a lost transactional host must not report success");
+        assert!(
+            err.reason.contains("reconnect after reboot failed"),
+            "reason: {}",
+            err.reason
+        );
+
+        // No downgrade (rollback) command was issued.
+        assert!(
+            !handle.commands().iter().any(|c| c.contains("--oldpackage")),
+            "a dead host must not trigger a rollback downgrade: {:?}",
+            handle.commands()
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -312,16 +312,43 @@ impl mtui_hosts::PlanProvider for WorkflowRegistry {
         ))
     }
 
-    fn check(&self, _role: &str, _release: &str, _transactional: bool) -> mtui_hosts::Check {
-        // Deliberately a no-op: the real check needs the command's
-        // stdout/stderr/exit code, which `mtui_hosts::CheckArgs` does not carry
-        // (it holds only the hostname) and which `mtui_hosts::Check` could not
-        // report anyway, since it returns `()`. The install/uninstall verdict is
-        // therefore produced *after* the template returns, by
-        // `update_flow::install_verdict`, which reads each target's `last*`
-        // snapshot and runs this same registry's `CheckFn` over it — the same
-        // path `perform_prepare` / `perform_update` / `perform_downgrade` use.
-        Box::new(|_a: mtui_hosts::CheckArgs<'_>| {})
+    fn check(&self, role: &str, release: &str, transactional: bool) -> mtui_hosts::Check {
+        // An unrecognised role resolves to no check table below, which is
+        // itself a no-op fallback (`op` only labels a raw-exit failure).
+        let op = match Role::from_operation_role(role) {
+            Some(Role::Install) => "install",
+            Some(Role::Uninstall) => "uninstall",
+            _ => "operation",
+        };
+        let check_fn = Role::from_operation_role(role)
+            .and_then(|role| CheckProvider::check(self, role, release, transactional));
+
+        Box::new(move |a: mtui_hosts::CheckArgs<'_>| match &check_fn {
+            Some(check) => {
+                let args = checks::CheckArgs {
+                    hostname: a.hostname,
+                    stdout: a.stdout,
+                    stdin: a.stdin,
+                    stderr: a.stderr,
+                    exitcode: a.exitcode,
+                };
+                match check(args) {
+                    Ok(diagnostics) => {
+                        for d in diagnostics {
+                            tracing::info!("{}", d.text);
+                        }
+                        Ok(())
+                    }
+                    Err(e) => Err(e.reason),
+                }
+            }
+            // No check table for this key (`slmicro`, `YUM`): fall back to the
+            // exit code alone, exactly as `install_verdict` used to. Not "any
+            // stderr is a failure" — `transactional-update` and `yum` both
+            // write progress and warnings to stderr on a successful run.
+            None if a.exitcode != 0 => Err(format!("{op} command failed")),
+            None => Ok(()),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Four independent defects in the host-operation path (install/uninstall/prepare/downgrade/update), fixed as four focused commits per `plans/fix-new-findings.md`:

1. **`fix(hosts): surface transactional reboot failures`** — a transactional (read-only-root) host that rebooted and never reconnected was silently reported as success by every one of install/uninstall/prepare/downgrade/update. `HostsGroup::reboot_transactional` now returns the per-host reconnect outcome instead of discarding it after logging at ERROR; `Operation::run` returns an `OperationReport` naming any lost host; `update` gets a new `UpdateFailure::Reboot` that (like `MissingUpdater`) skips the rollback, since the host is unreachable.

2. **`fix(hosts): check the install verdict before rebooting`** — the install/uninstall template ran `lock → run → check → reboot → unlock`, but its own `check` was a deliberate no-op stub; the real verdict (`install_verdict`) ran *after* `Operation::run` returned, i.e. after the reboot. A transactional host whose install failed was rebooted into that failure before anyone found out. The template's `Check` is now real (reads back each host's post-run output) and gates the reboot per host; `install_verdict` is deleted rather than kept as a second pass.

3. **`fix(testreport): observe cancellation in install/uninstall`** — `perform_operation` (the shared body of install/uninstall) had no cancellation checkpoint, unlike prepare/downgrade/update. It now checks at an entry gate before dispatching any command, mirroring `perform_update`'s own gate.

4. **`fix(testreport): write history after the operation ran`** — `add_op_history` was called before delegating to the actual flow, so a run that never starts (missing doer, host held by another tester, or now a cancel at the entry gate) still left a `/var/log/mtui.log` row. History is now written unconditionally on outcome, from inside each flow, after it has actually dispatched a command.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (all green)
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` and `--all-features` (compile-only feature matrix)
- Patch coverage checked via `cargo llvm-cov`; the added/changed lines are ~98% covered, with the small remainder being defensive/unreachable fallback branches mirroring the removed code's own untested paths.

## Notes

- `Check`, `CheckArgs`, `OperationGroup`, `Operation::run`, and `PlanProvider::check` (all `pub` in `mtui-hosts`) changed shape; every implementer in this workspace (both binaries, all test doubles) is updated in the same commit set.
- `MockConnection::failing_reconnect` is now a public, always-compiled builder (previously `pub(crate)` + `#[cfg(test)]`) so both unit and integration tests can script a dead reconnect.
- CHANGELOG entries cover each user-visible behavior change, including the on-host `/var/log/mtui.log` format's timestamp/row-count change.
