### PR TITLE
fix: report a transactional host whose reboot did not take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   host has passed its check, so the two cannot arise together. A failed reboot
   on `update` is treated as any other per-host update failure, so it still
   triggers the rollback.
+- A transactional host that never *went down* was also reported as a success.
+  The post-operation reboot is dispatched fire-and-forget, so its exit status
+  is never seen: a `transactional-update reboot` that silently no-ops (a
+  systemd inhibitor, a masked rebootmgr, a polkit denial) leaves the host
+  reachable and its staged snapshot inert, and reconnecting proves only that
+  the host is up. That reboot now snapshots each host's boot id beforehand and
+  re-reads it after, as the `reboot` command already did. A boot id that cannot
+  be read is still not a failure, so an unreadable probe cannot manufacture one.
 - A reboot that could not be *dispatched* at all — an unconnected target, or a
   channel that would not open — was also dropped. Because a failed dispatch
   leaves the SSH session open, the reconnect that follows succeeded trivially

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   error reports only the role and release, and a host whose product never parsed
   has no release, so the message read `Missing Installer for ` — while aborting
   the operation for every host in the group.
+- A transactional host that never came back from its post-operation reboot was
+  not reported. On a read-only-root host (SL Micro) the packages are staged into
+  a snapshot that only the reboot activates, so a host that fails to reconnect
+  has *not* had the operation applied however cleanly its command exited — yet
+  the failed reconnect was logged and dropped. `install`, `uninstall`, `prepare`
+  and `update` reported outright success; `downgrade` reported only a vague
+  "downgrade not completed" from the version re-probe that the dead host then
+  failed. All five now name the host and why it did not return. For `install`,
+  `uninstall`, `prepare` and `downgrade` that appears alongside the per-host
+  verdict rather than instead of it; on `update` the reboot only runs once every
+  host has passed its check, so the two cannot arise together. A failed reboot
+  on `update` is treated as any other per-host update failure, so it still
+  triggers the rollback.
+- A reboot that could not be *dispatched* at all — an unconnected target, or a
+  channel that would not open — was also dropped. Because a failed dispatch
+  leaves the SSH session open, the reconnect that follows succeeded trivially
+  and the host looked rebooted. Both the post-operation reboot and the `reboot`
+  command now report it.
+- `install`/`uninstall` now observe cooperative cancellation (MCP `job_cancel`)
+  at an entry gate, stopping before the group lock is taken instead of running
+  the whole operation to completion, and reporting the stop as a cancellation.
+  This is deliberately the only checkpoint in that flow: every later step is a
+  parallel host fan-out, and skipping one would leave a host's stale state to
+  pass the verdict as success — skipping the reboot in particular would leave a
+  transactional host's snapshot inert while the packages reported installed.
 
 ## [26.0.1] - 2026-07-22
 

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -129,6 +129,10 @@ pub struct MockConnection {
     reconnects: Arc<Mutex<usize>>,
     /// When `true`, [`reconnect`](Connection::reconnect) fails.
     reconnect_fails: bool,
+    /// When `true`, [`fire_and_forget`](Connection::fire_and_forget) fails
+    /// *without* tearing down the local link, modelling a reboot command that
+    /// never reached the host and so left the session live.
+    fire_and_forget_fails: bool,
     /// The `(retry, backoff)` args of the most recent
     /// [`reconnect`](Connection::reconnect) call, so a test can assert the
     /// caller passed the expected budget (e.g. the reboot lifecycle's
@@ -247,6 +251,7 @@ impl MockConnection {
             close_fails: false,
             reconnects: Arc::new(Mutex::new(0)),
             reconnect_fails: false,
+            fire_and_forget_fails: false,
             last_reconnect_args: Arc::new(Mutex::new(None)),
             fired: Arc::new(Mutex::new(Vec::new())),
             sftp_ops: Arc::new(Mutex::new(Vec::new())),
@@ -448,11 +453,24 @@ impl MockConnection {
     }
 
     /// Scripts [`reconnect`](Connection::reconnect) to fail with
-    /// [`HostError::ReconnectFailed`].
-    #[cfg(test)]
+    /// [`HostError::ReconnectFailed`], modelling a host that never comes back
+    /// after a reboot.
+    ///
+    /// `pub` because the flows that must report such a host live in
+    /// `mtui-testreport`, which cannot see this crate's `cfg(test)` items.
     #[must_use]
-    pub(crate) fn failing_reconnect(mut self) -> Self {
+    pub fn failing_reconnect(mut self) -> Self {
         self.reconnect_fails = true;
+        self
+    }
+
+    /// Scripts [`fire_and_forget`](Connection::fire_and_forget) to fail with
+    /// [`HostError::Transport`], leaving the session **active** — the shape a
+    /// reboot takes when its channel cannot be opened, where a following
+    /// `reconnect` then succeeds against the host that never rebooted.
+    #[must_use]
+    pub fn failing_fire_and_forget(mut self) -> Self {
+        self.fire_and_forget_fails = true;
         self
     }
 
@@ -841,6 +859,14 @@ impl Connection for MockConnection {
     }
 
     async fn fire_and_forget(&mut self, command: &str) -> Result<()> {
+        if self.fire_and_forget_fails {
+            // Nothing was dispatched and the link is untouched: the caller
+            // still holds a live session to a host that never got the command.
+            return Err(HostError::Transport {
+                host: self.hostname.clone(),
+                reason: "channel open failed".to_owned(),
+            });
+        }
         self.fired
             .lock()
             .expect("mock fired lock")

--- a/crates/mtui-hosts/src/error.rs
+++ b/crates/mtui-hosts/src/error.rs
@@ -144,6 +144,30 @@ pub enum HostError {
     #[error("{0}")]
     Update(String),
 
+    /// One or more transactional hosts did not come back after the reboot that
+    /// activates the operation's snapshot.
+    ///
+    /// Unlike every other variant an [`Operation`](crate::Operation) returns,
+    /// this one means the operation **did** run: the package-manager command
+    /// was dispatched on every host and only the post-command reboot failed.
+    /// Callers must therefore still consult their per-host verdict rather than
+    /// treating it as a "nothing happened" abort — and must not trust the
+    /// `last*` snapshot of a host named here, which is whatever the host
+    /// reported before it went away.
+    ///
+    /// Carries `(hostname, reason)` per failed host rather than one joined
+    /// string so a caller can fold each host into its own per-host verdict
+    /// instead of re-parsing the message.
+    #[error(
+        "did not come back after the reboot: {}",
+        .hosts.iter().map(|(h, r)| format!("{h} ({r})")).collect::<Vec<_>>().join(", ")
+    )]
+    RebootFailed {
+        /// Each failed host with its own reason. `Operation::run` builds this
+        /// from a `BTreeMap`, so from there it arrives hostname-sorted.
+        hosts: Vec<(String, String)>,
+    },
+
     /// No installer "doer" is defined for the given product release.
     ///
     /// The message is `Missing Installer for

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -36,7 +36,7 @@ pub(crate) use target::POOL_LOCK_PATH;
 pub use target::{
     Check, CheckArgs, Clock, Command, Doer, HostArbiter, HostPlan, HostsGroup, InstallOperation,
     LockOutcome, Operation, OperationGroup, Owner, PackageQuerier, PlanProvider, PoolLock,
-    RemoteLock, RepoManager, RepoOp, SetRepo, Sink, SpinnerGuard, Suspend, SystemClock,
-    TARGET_LOCK_PATH, Target, TargetLock, TtySpinner, UninstallOperation, get_arbiter,
+    RebootOutcomes, RemoteLock, RepoManager, RepoOp, SetRepo, Sink, SpinnerGuard, Suspend,
+    SystemClock, TARGET_LOCK_PATH, Target, TargetLock, TtySpinner, UninstallOperation, get_arbiter,
     parse_system, set_test_sink, spinner, suspend,
 };

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -46,7 +46,7 @@ use crate::error::{HostError, Result};
 use mtui_types::system::System;
 
 use super::actions::{self, Command, RunCommand};
-use super::operation::{HostCommandMap, HostPlan, OperationGroup, PlanProvider};
+use super::operation::{HostCommandMap, HostPlan, OperationGroup, PlanProvider, RebootOutcomes};
 use super::repo_manager::{RepoOp, SetRepo};
 use super::{LockRow, Target};
 
@@ -1097,6 +1097,14 @@ impl HostsGroup {
         .await;
         let old_boot_ids = old_boot_ids.into_inner().unwrap();
 
+        // Per-host outcome, collected across the reboot, reconnect and verify
+        // phases so the returned map is deterministic regardless of completion
+        // order (as in `close`). Precedence runs earliest-phase-first: a reboot
+        // that could not be dispatched beats a reconnect failure, which beats a
+        // boot-id verdict — each later phase can only judge a host the earlier
+        // one actually reached.
+        let outcomes: Mutex<RebootOutcomes> = Mutex::new(BTreeMap::new());
+
         // Phase 2: fire the reboot on every host (it drops the connection).
         actions::run_fanout(
             &mut self.data,
@@ -1106,16 +1114,22 @@ impl HostsGroup {
             &select,
             |t| {
                 let command = command.to_owned();
-                Box::pin(async move { t.reboot(&command).await }) as actions::BoxTargetFut<'_>
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    // A dispatch failure leaves the session live, so the
+                    // reconnect below succeeds trivially; without this the host
+                    // would look rebooted until the boot-id check — which
+                    // passes too when the id cannot be read.
+                    if let Err(e) = t.reboot(&command).await {
+                        outcomes
+                            .lock()
+                            .unwrap()
+                            .insert(t.hostname().to_owned(), Err(e));
+                    }
+                }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
-
-        // Per-host outcome, collected across the reconnect + verify phases so the
-        // returned map is deterministic regardless of completion order (as in
-        // `close`). A reconnect failure is recorded first and takes precedence;
-        // the verify phase only downgrades a host that reconnected cleanly.
-        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
 
         // Phase 3: reconnect every host (concurrently) with retry + backoff.
         actions::run_fanout(
@@ -1184,17 +1198,30 @@ impl HostsGroup {
         outcomes.into_inner().unwrap()
     }
 
-    /// Reboots the *transactional* hosts named in `reboot` and reconnects each.
+    /// Reboots the *transactional* hosts named in `reboot` and reconnects each,
+    /// returning every host's outcome.
     ///
-    /// Transactional hosts contribute a
-    /// per-host reboot command from the operation's doer. Each is dispatched
-    /// fire-and-forget, then reconnected (sorted) with the connection's retry +
-    /// backoff. Unlike [`reboot`](Self::reboot) this path takes no boot-id
-    /// snapshot / verification, and is a no-op
-    /// when the map is empty.
-    async fn reboot_transactional(&mut self, reboot: &BTreeMap<String, String>) {
+    /// Transactional hosts contribute a per-host reboot command from the
+    /// operation's doer. Each is dispatched fire-and-forget, then reconnected
+    /// (sorted) with the connection's retry + backoff. A no-op when the map is
+    /// empty.
+    ///
+    /// Returns `Ok(())` per host that reconnected and `Err(HostError)` for one
+    /// that did not. The reboot is what activates the snapshot a transactional
+    /// host staged its packages into, so a host that never comes back has not
+    /// had the operation applied — reporting that is the caller's only way to
+    /// tell the difference. A host named in `reboot` but absent from the group
+    /// is silently skipped, as everywhere else in the fan-out.
+    ///
+    /// Unlike [`reboot_selected`](Self::reboot_selected) this path takes no
+    /// boot-id snapshot, so it detects a host that did not come *back* but not
+    /// one that never went *down* (a reboot command that silently no-ops leaves
+    /// the connection reconnectable and the snapshot inert).
+    async fn reboot_transactional(&mut self, reboot: &BTreeMap<String, String>) -> RebootOutcomes {
+        use std::sync::Mutex;
+
         if reboot.is_empty() {
-            return;
+            return BTreeMap::new();
         }
         let mut names: Vec<&String> = reboot.keys().collect();
         names.sort();
@@ -1203,6 +1230,12 @@ impl HostsGroup {
             "Rebooting transactional hosts"
         );
         let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
+
+        // Collected through a `Mutex` because the fan-out closure returns `()`
+        // (a host skipped mid-batch must stay indistinguishable from one that
+        // ran), so a per-host result has to leave by a side channel — the same
+        // shape `reboot_where` uses.
+        let outcomes: Mutex<RebootOutcomes> = Mutex::new(BTreeMap::new());
 
         // Fire the reboot on every named host first (it drops the connection),
         // then reconnect each once it is back up — both phases fan out
@@ -1216,7 +1249,19 @@ impl HostsGroup {
             |t| reboot.contains_key(t.hostname()),
             |t| {
                 let command = reboot.get(t.hostname()).cloned().unwrap_or_default();
-                Box::pin(async move { t.reboot(&command).await }) as actions::BoxTargetFut<'_>
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    // A reboot that could not be *dispatched* has to be
+                    // recorded here: it leaves the SSH session live, so the
+                    // reconnect below short-circuits on the still-open handle
+                    // and would otherwise report the host as rebooted.
+                    if let Err(e) = t.reboot(&command).await {
+                        outcomes
+                            .lock()
+                            .unwrap()
+                            .insert(t.hostname().to_owned(), Err(e));
+                    }
+                }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
@@ -1227,17 +1272,33 @@ impl HostsGroup {
             Some("reconnect"),
             |t| reboot.contains_key(t.hostname()),
             |t| {
+                let outcomes = &outcomes;
                 Box::pin(async move {
+                    let hostname = t.hostname().to_owned();
                     let retry = t.reboot_retries();
-                    if let Err(e) = t.reconnect(retry, true).await {
-                        tracing::error!(host = %t.hostname(), error = %e, "reconnect after reboot failed");
-                    } else {
-                        tracing::info!(host = %t.hostname(), "is back up");
+                    let outcome = match t.reconnect(retry, true).await {
+                        Ok(()) => {
+                            tracing::info!(host = %hostname, "is back up");
+                            Ok(())
+                        }
+                        Err(e) => {
+                            tracing::error!(host = %hostname, error = %e, "reconnect after reboot failed");
+                            Err(e)
+                        }
+                    };
+                    // A failed dispatch already recorded above is the more
+                    // fundamental error and wins: a host that never got the
+                    // command cannot be judged on whether it came back.
+                    let mut map = outcomes.lock().unwrap();
+                    if !matches!(map.get(&hostname), Some(Err(_))) {
+                        map.insert(hostname, outcome);
                     }
                 }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
+
+        outcomes.into_inner().unwrap()
     }
 
     /// Decides whether `hostname`'s boot id confirms a reboot, logging as before.
@@ -1348,12 +1409,12 @@ impl OperationGroup for HostsGroup {
         HostsGroup::run(self, Command::PerHost(map)).await;
     }
 
-    async fn reboot(&mut self, reboot: HostCommandMap) {
-        // Only transactional hosts contribute reboot entries; the reboot is
-        // fired fire-and-forget on each, then each is reconnected
-        // (sorted) with the connection's retry + backoff.
+    async fn reboot(&mut self, reboot: HostCommandMap) -> RebootOutcomes {
+        // Only transactional hosts contribute reboot entries: the reboot is
+        // fired fire-and-forget on each (it drops the connection), then each is
+        // reconnected (sorted) with the connection's retry + backoff.
         let map: BTreeMap<String, String> = reboot.into_iter().collect();
-        HostsGroup::reboot_transactional(self, &map).await;
+        HostsGroup::reboot_transactional(self, &map).await
     }
 
     async fn unlock(&mut self) {
@@ -1980,7 +2041,7 @@ mod tests {
 
         // Only h1 is transactional -> only it appears in the reboot map.
         let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
-        OperationGroup::reboot(&mut g, map).await;
+        let outcomes = OperationGroup::reboot(&mut g, map).await;
 
         assert_eq!(
             h1.fired_commands(),
@@ -1989,9 +2050,76 @@ mod tests {
         assert_eq!(h1.reconnect_count(), 1);
         // The transactional reboot path also grants the boot-aware budget.
         assert_eq!(h1.last_reconnect_args(), Some((10, true)));
-        // h2 was not in the map: untouched.
+        // h2 was not in the map: untouched, and absent from the outcomes.
         assert!(h2.fired_commands().is_empty());
         assert_eq!(h2.reconnect_count(), 0);
+        assert_eq!(outcomes.keys().collect::<Vec<_>>(), vec!["h1"]);
+        assert!(outcomes["h1"].is_ok(), "{:?}", outcomes["h1"]);
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_records_a_host_that_never_came_back() {
+        // The regression behind the install/uninstall false success: this
+        // reconnect failure used to be logged at ERROR and dropped, leaving the
+        // caller no way to tell an activated snapshot from an inert one.
+        let m1 = reboot_mock("h1", "id-1").failing_reconnect();
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
+        let outcomes = OperationGroup::reboot(&mut g, map).await;
+
+        // The reboot was still dispatched and the reconnect still attempted —
+        // only the verdict changed.
+        assert_eq!(
+            h1.fired_commands(),
+            vec!["transactional-update reboot".to_owned()]
+        );
+        assert_eq!(h1.reconnect_count(), 1);
+        assert!(
+            matches!(&outcomes["h1"], Err(HostError::ReconnectFailed { host }) if host == "h1"),
+            "reconnect failure must be recorded, got {:?}",
+            outcomes["h1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_records_a_reboot_it_could_not_dispatch() {
+        // A reboot that never left the client is the nastier case: the failed
+        // dispatch leaves the SSH session open, so the reconnect that follows
+        // succeeds against the still-live host and the outcome would otherwise
+        // read as a clean reboot.
+        let m1 = reboot_mock("h1", "id-1").failing_fire_and_forget();
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
+        let outcomes = OperationGroup::reboot(&mut g, map).await;
+
+        assert!(
+            h1.fired_commands().is_empty(),
+            "the command never reached the host: {:?}",
+            h1.fired_commands()
+        );
+        assert!(
+            outcomes["h1"].is_err(),
+            "an undispatched reboot must not read as a completed one: {:?}",
+            outcomes["h1"]
+        );
     }
 
     #[tokio::test]
@@ -2006,9 +2134,10 @@ mod tests {
             )],
             false,
         );
-        OperationGroup::reboot(&mut g, Vec::new()).await;
+        let outcomes = OperationGroup::reboot(&mut g, Vec::new()).await;
         assert!(h1.fired_commands().is_empty());
         assert_eq!(h1.reconnect_count(), 0);
+        assert!(outcomes.is_empty(), "no host, no outcome: {outcomes:?}");
     }
 
     // --- update_lock / lock / unlock fan-out (P2.9) -------------------------

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1213,10 +1213,13 @@ impl HostsGroup {
     /// tell the difference. A host named in `reboot` but absent from the group
     /// is silently skipped, as everywhere else in the fan-out.
     ///
-    /// Unlike [`reboot_selected`](Self::reboot_selected) this path takes no
-    /// boot-id snapshot, so it detects a host that did not come *back* but not
-    /// one that never went *down* (a reboot command that silently no-ops leaves
-    /// the connection reconnectable and the snapshot inert).
+    /// Each host's boot id is snapshotted before the reboot and re-read after,
+    /// as in [`reboot_selected`](Self::reboot_selected). "Never went down" is at
+    /// least as likely here as "never came back": the reboot is dispatched
+    /// fire-and-forget, so its exit status is never seen, and a
+    /// `transactional-update reboot` that silently no-ops leaves the host
+    /// reconnectable with the snapshot inert. Reconnecting proves only that the
+    /// host is reachable, not that it restarted.
     async fn reboot_transactional(&mut self, reboot: &BTreeMap<String, String>) -> RebootOutcomes {
         use std::sync::Mutex;
 
@@ -1236,6 +1239,29 @@ impl HostsGroup {
         // ran), so a per-host result has to leave by a side channel — the same
         // shape `reboot_where` uses.
         let outcomes: Mutex<RebootOutcomes> = Mutex::new(BTreeMap::new());
+
+        // Record each host's boot id before rebooting, so a host that comes
+        // back without having restarted can be told apart from one that did.
+        let old_boot_ids: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
+        actions::run_fanout(
+            &mut self.data,
+            is_repl,
+            max_parallel,
+            Some("boot_id"),
+            |t| reboot.contains_key(t.hostname()),
+            |t| {
+                let old_boot_ids = &old_boot_ids;
+                Box::pin(async move {
+                    let id = t.boot_id().await;
+                    old_boot_ids
+                        .lock()
+                        .unwrap()
+                        .insert(t.hostname().to_owned(), id);
+                }) as actions::BoxTargetFut<'_>
+            },
+        )
+        .await;
+        let old_boot_ids = old_boot_ids.into_inner().unwrap();
 
         // Fire the reboot on every named host first (it drops the connection),
         // then reconnect each once it is back up — both phases fan out
@@ -1292,6 +1318,34 @@ impl HostsGroup {
                     let mut map = outcomes.lock().unwrap();
                     if !matches!(map.get(&hostname), Some(Err(_))) {
                         map.insert(hostname, outcome);
+                    }
+                }) as actions::BoxTargetFut<'_>
+            },
+        )
+        .await;
+
+        // Verify each host's boot id actually changed. Only a host that got
+        // this far cleanly can be downgraded here — an earlier failure is the
+        // more fundamental one. An unreadable id is not a failure (it is
+        // logged), so this can only ever catch a host that provably did not
+        // restart, never one it merely could not confirm.
+        actions::run_fanout(
+            &mut self.data,
+            is_repl,
+            max_parallel,
+            Some("verify_reboot"),
+            |t| reboot.contains_key(t.hostname()),
+            |t| {
+                let old = old_boot_ids.get(t.hostname()).cloned().unwrap_or_default();
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    let hostname = t.hostname().to_owned();
+                    let new_boot_id = t.boot_id().await;
+                    if let Err(reason) = Self::verify_boot_id(&hostname, &old, &new_boot_id) {
+                        let mut map = outcomes.lock().unwrap();
+                        if !matches!(map.get(&hostname), Some(Err(_))) {
+                            map.insert(hostname, Err(HostError::Update(reason)));
+                        }
                     }
                 }) as actions::BoxTargetFut<'_>
             },
@@ -2029,7 +2083,10 @@ mod tests {
 
     #[tokio::test]
     async fn operation_reboot_fires_and_reconnects_named_hosts() {
-        let (m1, m2) = (reboot_mock("h1", "id-1"), reboot_mock("h2", "id-2"));
+        // `rebooted_mock`: a fresh boot id on every read, i.e. a host that
+        // really restarted. `reboot_mock` returns a fixed id, which now
+        // (correctly) reads as "this host never went down".
+        let (m1, m2) = (rebooted_mock("h1"), rebooted_mock("h2"));
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
@@ -2086,6 +2143,64 @@ mod tests {
         assert!(
             matches!(&outcomes["h1"], Err(HostError::ReconnectFailed { host }) if host == "h1"),
             "reconnect failure must be recorded, got {:?}",
+            outcomes["h1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_records_a_host_that_never_went_down() {
+        // The reboot is dispatched fire-and-forget, so its exit status is never
+        // seen. A `transactional-update reboot` that silently no-ops leaves the
+        // host reachable and its staged snapshot inert — reconnecting proves
+        // only that the host is up, not that it restarted. The unchanged boot
+        // id is the only evidence.
+        let m1 = reboot_mock("h1", "id-1");
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
+        let outcomes = OperationGroup::reboot(&mut g, map).await;
+
+        // It reconnected fine — that is exactly what makes this case sneaky.
+        assert_eq!(h1.reconnect_count(), 1);
+        assert!(
+            outcomes["h1"].is_err(),
+            "an unchanged boot id means the host never rebooted: {:?}",
+            outcomes["h1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_unreadable_boot_id_is_not_a_failure() {
+        // The boot-id probe is best-effort: `Target::boot_id` returns "" on any
+        // error. An unconfirmed reboot must not be reported as a failed one, or
+        // every host whose probe hiccups fails its install.
+        let m1 = MockConnection::new("h1").with_default(CommandLog::new("", "", "", 0, 0));
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
+        let outcomes = OperationGroup::reboot(&mut g, map).await;
+
+        assert_eq!(h1.reconnect_count(), 1);
+        assert!(
+            outcomes["h1"].is_ok(),
+            "an unreadable boot id cannot confirm or deny the reboot, so it \
+             must not manufacture a failure: {:?}",
             outcomes["h1"]
         );
     }

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use locks::POOL_LOCK_PATH;
 pub use locks::{Clock, LockRow, PoolLock, RemoteLock, SystemClock, TARGET_LOCK_PATH, TargetLock};
 pub use operation::{
     Check, CheckArgs, Doer, HostPlan, InstallOperation, Operation, OperationGroup, PlanProvider,
-    UninstallOperation,
+    RebootOutcomes, UninstallOperation,
 };
 pub use package_querier::PackageQuerier;
 pub use parsers::parse_system;
@@ -574,16 +574,27 @@ impl Target {
     /// Dispatches via
     /// [`Connection::fire_and_forget`]. The command is expected to drop the SSH
     /// connection, so callers follow up with [`reconnect`](Self::reconnect). A
-    /// no-op (logged) when the target is not connected; a dispatch error is
-    /// logged, not propagated, since a link dropped by the reboot is expected.
-    async fn reboot(&mut self, command: &str) {
+    /// Returns `Err` when the command could not be *dispatched* — the target is
+    /// not connected, or the channel could not be opened. That is not the same
+    /// as the link dropping afterwards, which is the expected outcome and is
+    /// reported as success: `fire_and_forget` never waits for an exit status,
+    /// so this can only fail before the host has seen the command at all.
+    ///
+    /// A caller must not treat a dispatch failure as "the host is rebooting".
+    /// A failed dispatch leaves the SSH handle open, so a following
+    /// [`reconnect`](Self::reconnect) short-circuits on the still-live session
+    /// and returns `Ok` — making an undispatched reboot otherwise
+    /// indistinguishable from a completed one.
+    async fn reboot(&mut self, command: &str) -> Result<()> {
         let Some(conn) = self.connection.as_mut() else {
             tracing::error!(host = %self.hostname, "reboot on unconnected target");
-            return;
+            return Err(HostError::NotConnected {
+                host: self.hostname.clone(),
+            });
         };
-        if let Err(e) = conn.fire_and_forget(command).await {
+        conn.fire_and_forget(command).await.inspect_err(|e| {
             tracing::error!(host = %self.hostname, error = %e, "failed to dispatch reboot");
-        }
+        })
     }
 
     /// The post-reboot reconnect attempt budget (`[connection]
@@ -649,13 +660,16 @@ impl Target {
         }
 
         match action {
+            // A dispatch failure on the way out is logged by `reboot` itself
+            // and deliberately not folded into the shutdown outcome, which
+            // reports whether the *connection* closed cleanly.
             Some("reboot") => {
                 tracing::info!(host = %self.hostname, "rebooting");
-                self.reboot("reboot").await;
+                let _ = self.reboot("reboot").await;
             }
             Some("poweroff") => {
                 tracing::info!(host = %self.hostname, "powering off");
-                self.reboot("halt").await;
+                let _ = self.reboot("halt").await;
             }
             _ => {
                 tracing::info!(host = %self.hostname, "closing connection");
@@ -1817,15 +1831,26 @@ mod tests {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
         let mut t = enabled_with(conn);
-        t.reboot("systemctl reboot").await;
+        t.reboot("systemctl reboot")
+            .await
+            .expect("a dispatched reboot is a success even though it drops the link");
         assert_eq!(handle.fired_commands(), vec!["systemctl reboot".to_owned()]);
     }
 
     #[tokio::test]
-    async fn reboot_on_unconnected_is_noop() {
+    async fn reboot_on_unconnected_target_is_reported() {
         let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
-        // Must not panic; nothing to assert beyond the no-op completing.
-        t.reboot("systemctl reboot").await;
+        // Not a no-op verdict: nothing was dispatched, so the caller must not
+        // go on to treat the host as rebooting. `reconnect` would report `Ok`
+        // for this same target, so this is the only place it can be caught.
+        let err = t
+            .reboot("systemctl reboot")
+            .await
+            .expect_err("a reboot that was never dispatched is not a success");
+        assert!(
+            matches!(err, HostError::NotConnected { ref host } if host == "h1"),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -15,7 +15,8 @@
 //! 2. `group.update_lock()`,
 //! 3. in a fallible section: `group.run(commands)` → per-host `check(...)` →
 //!    `group.reboot(reboot)`,
-//! 4. **always** `group.unlock()` afterwards.
+//! 4. **always** `group.unlock()` afterwards, and only then report a host that
+//!    failed to come back from its reboot.
 //!
 //! ## Scope: template + seams
 //!
@@ -46,6 +47,18 @@ use crate::error::HostError;
 /// An ordered `(hostname, command)` command/reboot map, kept as
 /// an ordered `Vec` so fan-out order is deterministic (sorted iteration).
 pub type HostCommandMap = Vec<(String, String)>;
+
+/// Per-host outcome of the post-operation reboot, keyed by hostname.
+///
+/// `Ok(())` means the host rebooted and reconnected; `Err` names why it did
+/// not. Only transactional hosts appear — they are the only ones that
+/// contribute a reboot entry (see [`Operation::collect`]).
+///
+/// The reboot is what activates the snapshot a transactional host staged the
+/// packages into, so a host that never comes back has *not* had the operation
+/// applied, however cleanly its command exited. Returning the outcome per host
+/// rather than logging it is what lets the caller say so.
+pub type RebootOutcomes = std::collections::BTreeMap<String, Result<(), HostError>>;
 
 /// A resolved *doer*: the command and (transactional) reboot templates for one
 /// target
@@ -162,8 +175,13 @@ pub trait OperationGroup: Send {
     /// Runs the per-host command map.
     async fn run(&mut self, commands: HostCommandMap);
 
-    /// Reboots the transactional hosts named in `reboot`.
-    async fn reboot(&mut self, reboot: HostCommandMap);
+    /// Reboots the transactional hosts named in `reboot`, returning each
+    /// host's outcome.
+    ///
+    /// A host that does not come back is reported, not logged and dropped:
+    /// its staged snapshot never activated, so the operation did not take
+    /// effect there no matter what its command printed.
+    async fn reboot(&mut self, reboot: HostCommandMap) -> RebootOutcomes;
 
     /// Releases the shared operation lock.
     async fn unlock(&mut self);
@@ -231,6 +249,12 @@ pub trait Operation: Send + Sync {
     /// from "could not even start" will print success for an update that never
     /// touched a host — the same reasoning that makes
     /// `UpdateFailure::MissingUpdater` a hard failure in the update flow.
+    ///
+    /// Returns [`HostError::RebootFailed`] when a transactional host did not
+    /// come back. **This one means the opposite**: the command ran everywhere,
+    /// and only the reboot that activates the snapshot failed. A caller that
+    /// computes a per-host verdict must still compute it — see
+    /// `update_flow::perform_operation`, which routes the two apart.
     async fn run(&self, group: &mut dyn OperationGroup) -> Result<(), HostError> {
         let plans = group.plans(self.role())?;
 
@@ -243,20 +267,51 @@ pub trait Operation: Send + Sync {
         group.update_lock().await?;
 
         // Everything past the lock must reach `unlock()`, so this section stays
-        // free of `?`. It is infallible over the group seam today (run/reboot
-        // return `()`); a future fallible step must capture its error and fall
-        // through to the unlock rather than returning early.
+        // free of `?`: the reboot's verdict is *captured* here and returned
+        // only after the unlock below, never propagated with `?`. Anything
+        // fallible added here must follow the same shape — an early return
+        // would strand `/var/lock/mtui.lock` on every host in the group.
         group.run(commands).await;
         for plan in &mut plans {
             (plan.check)(CheckArgs {
                 hostname: &plan.hostname,
             });
         }
-        group.reboot(reboot).await;
+        let reboot_outcomes = group.reboot(reboot).await;
 
         group.unlock().await;
+
+        // Reported after the unlock, and deliberately *not* as a "could not
+        // start" error: the command ran on every host, and only the reboot
+        // that activates a transactional host's snapshot failed.
+        if let Some(err) = reboot_failure(&reboot_outcomes) {
+            return Err(err);
+        }
         Ok(())
     }
+}
+
+/// Folds a [`RebootOutcomes`] map into one [`HostError::RebootFailed`], or
+/// `None` when every host came back.
+///
+/// Each failed host is named with its own reason rather than collapsed into a
+/// count: "h1 did not come back" and "h1 refused the connection" send an
+/// operator to different places. The map is a `BTreeMap`, so the order is
+/// hostname-sorted and the message is stable across runs.
+fn reboot_failure(outcomes: &RebootOutcomes) -> Option<HostError> {
+    let hosts: Vec<(String, String)> = outcomes
+        .iter()
+        .filter_map(|(host, outcome)| {
+            outcome
+                .as_ref()
+                .err()
+                .map(|e| (host.clone(), e.to_string()))
+        })
+        .collect();
+    if hosts.is_empty() {
+        return None;
+    }
+    Some(HostError::RebootFailed { hosts })
 }
 
 /// Install `packages` on every target in the group.
@@ -440,6 +495,9 @@ mod tests {
         /// When `true`, `update_lock` records its event then returns
         /// [`HostError::Update`] to model a foreign-locked host.
         fail_update_lock: bool,
+        /// Hosts whose post-operation reboot reports a failed reconnect,
+        /// modelling a transactional host that never came back.
+        failing_reboot_hosts: Vec<String>,
     }
 
     impl MockGroup {
@@ -459,12 +517,20 @@ mod tests {
                 roles_seen: Arc::new(Mutex::new(Vec::new())),
                 events,
                 fail_update_lock: false,
+                failing_reboot_hosts: Vec::new(),
             }
         }
 
         /// Marks `update_lock` to fail, modelling a foreign-locked host.
         fn failing_update_lock(mut self) -> Self {
             self.fail_update_lock = true;
+            self
+        }
+
+        /// Marks `hostname`'s post-operation reboot to fail its reconnect,
+        /// modelling a transactional host that never came back up.
+        fn failing_reboot(mut self, hostname: &str) -> Self {
+            self.failing_reboot_hosts.push(hostname.to_owned());
             self
         }
 
@@ -498,8 +564,20 @@ mod tests {
             self.events.lock().unwrap().push(Event::Run(commands));
         }
 
-        async fn reboot(&mut self, reboot: HostCommandMap) {
+        async fn reboot(&mut self, reboot: HostCommandMap) -> RebootOutcomes {
+            let outcomes: RebootOutcomes = reboot
+                .iter()
+                .map(|(host, _)| {
+                    let outcome = if self.failing_reboot_hosts.contains(host) {
+                        Err(HostError::ReconnectFailed { host: host.clone() })
+                    } else {
+                        Ok(())
+                    };
+                    (host.clone(), outcome)
+                })
+                .collect();
             self.events.lock().unwrap().push(Event::Reboot(reboot));
+            outcomes
         }
 
         async fn unlock(&mut self) {
@@ -641,9 +719,9 @@ mod tests {
     }
 
     // --- run(): unlock always happens after run -----------------------------
-    // The Rust template's run→check→reboot section is infallible over the group
-    // seam today, so we assert the *ordering contract*: unlock is the final
-    // event and always follows update_lock+run.
+    // Unlock is the final event and always follows update_lock+run. The reboot
+    // step is fallible, so the second test drives the case that contract exists
+    // for — a failing step must still reach the unlock before it reports.
 
     #[tokio::test]
     async fn run_always_unlocks_after_running() {
@@ -668,6 +746,75 @@ mod tests {
             1
         );
         assert_eq!(events.iter().filter(|e| **e == Event::Unlock).count(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_reports_a_host_that_never_came_back_and_still_unlocks() {
+        // The regression: a transactional host whose post-install reboot never
+        // reconnected was logged at ERROR and dropped, so `install` reported
+        // success on a host whose snapshot never activated.
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![
+            plan_with_recording_check(
+                "h1",
+                true,
+                Doer::new("in $packages", "systemctl reboot"),
+                sink.clone(),
+            ),
+            plan_with_recording_check(
+                "h2",
+                true,
+                Doer::new("in $packages", "systemctl reboot"),
+                sink,
+            ),
+        ];
+        let mut group = MockGroup::new(Ok(plans)).failing_reboot("h2");
+
+        let err = InstallOperation::new(strs(&["pkg-a"]))
+            .run(&mut group)
+            .await
+            .expect_err("a host that never came back is reported, not swallowed");
+
+        // Named as a reboot failure, not as a start failure: the command *did*
+        // run, so a caller must still consult its per-host verdict.
+        assert!(matches!(err, HostError::RebootFailed { .. }), "{err:?}");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("h2"),
+            "names the host that did not return: {msg}"
+        );
+        assert!(
+            !msg.contains("h1"),
+            "must not implicate the host that came back fine: {msg}"
+        );
+
+        // The lock is still released — the failure is reported *after* the
+        // unlock, never propagated with `?` from inside the section.
+        let events = group.events();
+        assert_eq!(
+            events.last(),
+            Some(&Event::Unlock),
+            "a failing reboot must still reach the unlock: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_succeeds_when_every_transactional_host_comes_back() {
+        // The inertness control for the test above: the same transactional
+        // shape, nothing scripted to fail, must stay `Ok`.
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![plan_with_recording_check(
+            "h1",
+            true,
+            Doer::new("in $packages", "systemctl reboot"),
+            sink,
+        )];
+        let mut group = MockGroup::new(Ok(plans));
+
+        InstallOperation::new(strs(&["pkg-a"]))
+            .run(&mut group)
+            .await
+            .expect("a reboot that reconnects is not a failure");
     }
 
     // --- run(): update_lock failure aborts before run/unlock ----------------

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -76,8 +76,12 @@ fn target(
     version: &str,
     transactional: bool,
 ) -> (Target, mtui_hosts::MockConnection) {
+    // `with_changing_boot_id`: a fresh boot id on every read, modelling a host
+    // that really restarted. Without it both boot-id probes return the
+    // `with_default` stdout and the reboot reads as "never went down".
     let conn = mtui_hosts::MockConnection::new(hostname)
-        .with_default(CommandLog::new("", "done", "", 0, 1));
+        .with_default(CommandLog::new("", "done", "", 0, 1))
+        .with_changing_boot_id();
     let handle = conn.clone();
     let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
     let system = System::new(
@@ -87,6 +91,15 @@ fn target(
     );
     t.set_system(system, transactional);
     (t, handle)
+}
+
+/// The commands a mock was asked to run, minus the reboot lifecycle's own
+/// boot-id probes — those are bookkeeping, not the operation's work.
+fn package_commands(conn: &mtui_hosts::MockConnection) -> Vec<String> {
+    conn.commands()
+        .into_iter()
+        .filter(|c| !c.contains("/proc/sys/kernel/random/boot_id"))
+        .collect()
 }
 
 #[tokio::test]
@@ -125,9 +138,11 @@ async fn install_drives_doer_and_reboots_only_transactional() {
 
     // The transactional host ran only the install as a normal command; the
     // reboot is dispatched fire-and-forget (the reboot drops the connection),
-    // then the host is reconnected — the P2.9 `_reboot` lifecycle.
+    // then the host is reconnected and its boot id re-read to confirm it
+    // really restarted. The boot-id probes are part of that lifecycle rather
+    // than work the operation asked for, so they are filtered out here.
     assert_eq!(
-        m2.commands(),
+        package_commands(&m2),
         vec!["zypper -n in -y -l pkg-a pkg-b".to_owned()]
     );
     assert_eq!(m2.fired_commands(), vec!["systemctl reboot".to_owned()]);

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -106,8 +106,10 @@ where
 /// error.
 ///
 /// A `MissingUpdater` failure installed nothing, so it re-surfaces without a
-/// rollback attempt. The rollback is best-effort ([`perform_downgrade`] returns
-/// `()`), so it can never bury the original update error.
+/// rollback attempt. The rollback is best-effort: [`perform_downgrade`] does
+/// return a `Result` — including, on a transactional host, "did not come back
+/// after the reboot" — but its error is logged rather than returned, so it can
+/// never bury the original update error the operator actually needs.
 pub async fn perform_update_with_rollback<R>(
     report: &R,
     targets: &mut HostsGroup,
@@ -147,8 +149,12 @@ where
             let token = targets.suspend_cancellation();
             // Rollback is best-effort; a failed downgrade must never bury the
             // original update error, so its result is logged, not returned.
+            // ERROR, not WARN: this is not "the recovery was untidy", it is
+            // "the fleet is still on the bad update" — and on a transactional
+            // host the failure may be that it never came back, so the operator
+            // has a machine to attend to that the returned error does not name.
             if let Err(de) = perform_downgrade(targets, report, &pkgs).await {
-                warn!(error = %de, "rollback downgrade failed");
+                error!(error = %de, "rollback downgrade failed -- these hosts are still on the failed update");
             }
             targets.set_cancel_token(token);
             Err(e)
@@ -367,23 +373,17 @@ async fn perform_operation(
     role: Role,
     packages: &[String],
 ) -> Result<(), UpdateError> {
-    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
-
     // Matched exhaustively on purpose: a `_ =>` arm defaulting to install would
     // quietly run the wrong package-manager command if a role were ever added,
     // which is the same shape of silent-wrong-default this function exists to
     // fix. Only the two template roles reach here.
-    let (op, outcome) = match role {
-        Role::Install => (
-            "install",
-            InstallOperation::new(packages.to_vec()).run(targets).await,
-        ),
-        Role::Uninstall => (
-            "uninstall",
-            UninstallOperation::new(packages.to_vec())
-                .run(targets)
-                .await,
-        ),
+    //
+    // `op` is the command verb the operator typed (`install`), not the doer
+    // table's role key (`installer`) — it labels every message this function
+    // produces, and those are read by a human or an MCP client.
+    let op = match role {
+        Role::Install => "install",
+        Role::Uninstall => "uninstall",
         Role::Update | Role::Prepare | Role::Downgrade => {
             return Err(UpdateError::reason_only(format!(
                 "{} is not driven by the install/uninstall template",
@@ -392,16 +392,74 @@ async fn perform_operation(
         }
     };
 
-    // The template ran nothing at all — a missing doer, or a host held by
-    // another tester. Report it instead of falling through to a verdict that
-    // would read stale `last*` values and call it success.
-    if let Err(e) = outcome {
-        return Err(UpdateError::reason_only(describe_start_failure(
-            &e, role, targets,
+    // Entry gate: no package-manager command has run yet, so a cancel here
+    // leaves no host half-changed. It is the last checkpoint this flow gets —
+    // every step below is a parallel fan-out, and a fan-out is never
+    // interrupted part-way: a host skipped mid-batch would leave its stale
+    // `last*` snapshot to sail through the verdict as a success. Skipping the
+    // reboot in particular would leave a transactional host's snapshot inert
+    // while the packages reported installed.
+    //
+    // The caller has already dispatched a history line to each host
+    // (`add_op_history`), so this is not quite "nothing happened" — say so
+    // rather than let the operator infer a clean slate. "Dispatched", not
+    // "written": `Target::add_history` is best-effort and logs rather than
+    // fails, so a host that was unreachable has no entry.
+    if targets.cancel_requested() {
+        return Err(UpdateError::cancelled(format!(
+            "cancelled before the {op} ran; no host was touched beyond the \
+             history entry already dispatched for it"
         )));
     }
 
-    install_verdict(op, role, targets)
+    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
+
+    // Exhaustive, with no `_ =>` arm: a wildcard defaulting to install would
+    // quietly run the wrong package-manager command if a role were ever added.
+    // The last arm is unreachable — `op` above already returned for those
+    // roles — but it is spelled out rather than left to a wildcard so adding a
+    // role is a compile error here, not a silent mis-dispatch.
+    let outcome = match role {
+        Role::Install => InstallOperation::new(packages.to_vec()).run(targets).await,
+        Role::Uninstall => {
+            UninstallOperation::new(packages.to_vec())
+                .run(targets)
+                .await
+        }
+        Role::Update | Role::Prepare | Role::Downgrade => {
+            return Err(UpdateError::reason_only(format!(
+                "{} is not driven by the install/uninstall template",
+                role.as_operation_role()
+            )));
+        }
+    };
+
+    match outcome {
+        Ok(()) => install_verdict(op, role, targets),
+
+        // The command ran on every host and only the post-command reboot
+        // failed, so the per-host verdict still applies and is still computed —
+        // the reboot failures are folded in alongside it. Treating this like a
+        // start failure would throw the verdict away.
+        Err(HostError::RebootFailed { hosts }) => {
+            let mut failures = install_failures(op, role, targets);
+            for (host, reason) in hosts {
+                error!(host = %host, reason = %reason, "host did not come back after the reboot");
+                failures.push(UpdateError::new(
+                    format!("did not come back after the reboot ({reason})"),
+                    host,
+                ));
+            }
+            aggregate_failures(op, failures)
+        }
+
+        // The template ran nothing at all — a missing doer, or a host held by
+        // another tester. Report it instead of falling through to a verdict
+        // that would read stale `last*` values and call it success.
+        Err(e) => Err(UpdateError::reason_only(describe_start_failure(
+            &e, role, targets,
+        ))),
+    }
 }
 
 /// Turns an [`Operation::run`](mtui_hosts::Operation::run) start failure into a
@@ -474,6 +532,16 @@ fn describe_start_failure(err: &HostError, role: Role, targets: &HostsGroup) -> 
 ///
 /// Returns the aggregated [`UpdateError`] when any host failed.
 pub fn install_verdict(op: &str, role: Role, targets: &HostsGroup) -> Result<(), UpdateError> {
+    aggregate_failures(op, install_failures(op, role, targets))
+}
+
+/// The per-host half of [`install_verdict`], before aggregation.
+///
+/// Split out so a caller that has *additional* per-host failures to report —
+/// `perform_operation`, when a transactional host did not come back from its
+/// reboot — can merge both sets into one aggregate. Aggregating twice would
+/// either drop one set or emit two errors for one operation.
+fn install_failures(op: &str, role: Role, targets: &HostsGroup) -> Vec<UpdateError> {
     let registry = WorkflowRegistry::default();
     let reason = format!("{op} command failed");
     let mut failures = Vec::new();
@@ -518,16 +586,30 @@ pub fn install_verdict(op: &str, role: Role, targets: &HostsGroup) -> Result<(),
         }
     }
 
-    aggregate_failures(op, failures)
+    failures
 }
 
 /// Reboots the transactional hosts named in `reboot`.
-async fn reboot_transactional(targets: &mut HostsGroup, reboot: BTreeMap<String, String>) {
+async fn reboot_transactional(
+    targets: &mut HostsGroup,
+    reboot: BTreeMap<String, String>,
+) -> Vec<UpdateError> {
     if reboot.is_empty() {
-        return;
+        return Vec::new();
     }
     let map: Vec<(String, String)> = reboot.into_iter().collect();
-    OperationGroup::reboot(targets, map).await;
+    OperationGroup::reboot(targets, map)
+        .await
+        .into_iter()
+        .filter_map(|(host, outcome)| {
+            let err = outcome.err()?;
+            error!(host = %host, error = %err, "host did not come back after the reboot");
+            Some(UpdateError::new(
+                format!("did not come back after the reboot ({err})"),
+                host,
+            ))
+        })
+        .collect()
 }
 
 /// Runs the prepare step: adds/removes the issue repo, then installs
@@ -562,7 +644,7 @@ pub async fn perform_prepare(
     };
 
     if let Err(e) = targets.update_lock().await {
-        return Err(UpdateError::reason_only(e.to_string()));
+        return Err(e.into());
     }
 
     // The body runs, then we always unlock, matching a try/finally.
@@ -646,7 +728,10 @@ async fn prepare_body(
         error!(error = %e, "prepare check failed");
         failures.push(e);
     }
-    reboot_transactional(targets, reboot).await;
+    // A host that never came back is a prepare failure like any other: its
+    // staged snapshot never activated, so the packages are not in place however
+    // cleanly the command exited.
+    failures.extend(reboot_transactional(targets, reboot).await);
     // A genuine host failure outranks the cancellation: reporting only
     // "cancelled" would bury a broken host the operator must still see.
     if !failures.is_empty() {
@@ -727,7 +812,7 @@ pub async fn perform_downgrade(
     };
 
     if let Err(e) = targets.update_lock().await {
-        return Err(UpdateError::reason_only(e.to_string()));
+        return Err(e.into());
     }
 
     let result = downgrade_body(targets, &registry, report, packages, reboot).await;
@@ -932,7 +1017,10 @@ async fn downgrade_body(
         .into_iter()
         .filter(|(h, _)| !dead_probes.contains(h))
         .collect();
-    reboot_transactional(targets, healthy_reboot).await;
+    // Collected before `downgrade_verdict` re-queries every host: a host that
+    // never came back would otherwise only surface as a vague "downgrade not
+    // completed" from its failed version probe.
+    failures.extend(reboot_transactional(targets, healthy_reboot).await);
 
     let not_downgraded = downgrade_verdict(targets).await;
 
@@ -1121,9 +1209,7 @@ pub async fn perform_update(
     targets.package_check(false).await;
 
     if let Err(e) = targets.update_lock().await {
-        return Err(UpdateFailure::Check(UpdateError::reason_only(
-            e.to_string(),
-        )));
+        return Err(UpdateFailure::Check(e.into()));
     }
 
     targets.fanout_set_repo(RepoOp::Add, report).await;
@@ -1172,10 +1258,14 @@ pub async fn perform_update(
         return Err(UpdateFailure::Check(e));
     }
 
+    // The update itself succeeded, so this cannot become the operation's
+    // verdict — but it must not vanish either: `perform_prepare` reports a
+    // transactional host that never came back, and swallowing that would put
+    // the operator back to reading success for a host that is not reachable.
     if newpackage
         && let Err(e) = perform_prepare(targets, report, packages, false, true, false).await
     {
-        warn!(error = %e, "newpackage prepare after update failed");
+        error!(error = %e, "the update succeeded but the --newpackage prepare that follows it did not");
     }
 
     targets.package_check(true).await;
@@ -1220,25 +1310,15 @@ async fn update_run_phase(
         error!(error = %e, "update failed");
     }
 
-    let result = if failures.is_empty() {
-        reboot_transactional(targets, reboot).await;
-        Ok(())
-    } else if failures.len() == 1 {
-        // Preserve the exact single-host error the caller used to get.
-        Err(failures.remove(0))
-    } else {
-        let hosts: Vec<String> = {
-            let mut h: Vec<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
-            h.sort();
-            h
-        };
-        let detail: Vec<String> = failures.iter().map(ToString::to_string).collect();
-        Err(UpdateError::reason_only(format!(
-            "update failed on {} ({})",
-            hosts.join(", "),
-            detail.join("; ")
-        )))
-    };
+    // Only reboot when every host's check passed: a host whose update failed
+    // has nothing worth activating. A host that then fails to come back joins
+    // the same failure set — its snapshot is inert, so the update did not take
+    // effect there. `aggregate_failures` still returns a lone failure verbatim,
+    // so the single-host message is unchanged.
+    if failures.is_empty() {
+        failures.extend(reboot_transactional(targets, reboot).await);
+    }
+    let result = aggregate_failures("update", failures);
 
     targets.unlock().await;
     result
@@ -1577,6 +1657,261 @@ mod tests {
             .await
             .expect("a clean install");
         assert_eq!(handle.commands(), vec!["zypper -n in -y -l pkg-a"]);
+    }
+
+    /// A transactional host that never comes back has an inert snapshot: the
+    /// packages are staged but not live, so the install did not take effect
+    /// there. This used to be logged at ERROR and reported as success.
+    #[tokio::test]
+    async fn perform_install_reports_a_transactional_host_that_never_came_back() {
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .failing_reconnect();
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a host that never came back is not a successful install");
+
+        assert_eq!(err.host.as_deref(), Some("h1"), "{err:?}");
+        assert!(
+            err.reason.contains("did not come back after the reboot"),
+            "names the real failure rather than a generic one: {err:?}"
+        );
+        assert!(
+            err.reason.contains("failed to reconnect to h1"),
+            "carries the underlying reason, not just the category: {err:?}"
+        );
+        assert!(
+            !err.is_cancelled(),
+            "a dead host is a failure, not a cancellation: {err:?}"
+        );
+        // The install itself still ran and the reboot was still dispatched —
+        // only the verdict changed.
+        assert_eq!(
+            handle.commands(),
+            vec!["transactional-update -n pkg install pkg-a"]
+        );
+        assert_eq!(handle.fired_commands(), vec!["systemctl reboot"]);
+    }
+
+    /// A transactional (SL-Micro) host. `alive` controls whether it comes back
+    /// from the reboot that activates its snapshot; `exit` is the exit code its
+    /// commands report.
+    fn slmicro_maybe_dead(
+        hostname: &str,
+        stdout: &str,
+        exit: i16,
+        alive: bool,
+    ) -> (Target, MockConnection) {
+        let conn =
+            MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", exit, 0));
+        let conn = if alive {
+            conn
+        } else {
+            conn.failing_reconnect()
+        };
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        (t, handle)
+    }
+
+    /// A transactional host with a scripted reconnect failure, so the reboot
+    /// that activates its snapshot leaves it unreachable.
+    fn dead_after_reboot_slmicro(hostname: &str, stdout: &str) -> (Target, MockConnection) {
+        slmicro_maybe_dead(hostname, stdout, 0, false)
+    }
+
+    /// Two transactional hosts, only `h2` dead. Without a second, *healthy*
+    /// host every "the dead host is named" assertion is vacuous: in a one-host
+    /// group any hostname the implementation picks is the right one.
+    #[tokio::test]
+    async fn perform_install_names_only_the_host_that_did_not_come_back() {
+        let (t1, m1) = slmicro_maybe_dead("h1", "", 0, true);
+        let (t2, m2) = slmicro_maybe_dead("h2", "", 0, false);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("one dead host fails the install");
+
+        assert_eq!(
+            err.host.as_deref(),
+            Some("h2"),
+            "the failure must be attributed to the host that did not return, \
+             not to whichever host happened to be first: {err:?}"
+        );
+        assert!(
+            err.reason.contains("failed to reconnect to h2"),
+            "carries the underlying reason, not just the category: {err:?}"
+        );
+        assert!(
+            !err.to_string().contains("h1"),
+            "the healthy host must not be implicated: {err}"
+        );
+        // Both hosts really did install and really were rebooted — the healthy
+        // one is not skipped just because its neighbour died.
+        assert_eq!(
+            m1.commands(),
+            vec!["transactional-update -n pkg install pkg-a"]
+        );
+        assert_eq!(m1.fired_commands(), vec!["systemctl reboot"]);
+        assert_eq!(m2.fired_commands(), vec!["systemctl reboot"]);
+    }
+
+    /// The claim this whole change rests on: a reboot failure is reported
+    /// *alongside* the per-host verdict, not instead of it. `h1` fails its
+    /// install command, `h2` installs cleanly but never comes back — both must
+    /// appear.
+    #[tokio::test]
+    async fn perform_install_reports_the_command_failure_and_the_dead_host_together() {
+        // Exit 1 is a genuine failure for the slmicro key, which has no check
+        // table and is judged on the exit code alone.
+        let (t1, _m1) = slmicro_maybe_dead("h1", "", 1, true);
+        let (t2, _m2) = slmicro_maybe_dead("h2", "", 0, false);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("both a failed command and a dead host fail the install");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("install command failed"),
+            "the per-host verdict must survive the reboot failure: {msg}"
+        );
+        assert!(
+            msg.contains("did not come back after the reboot"),
+            "the reboot failure must survive the per-host verdict: {msg}"
+        );
+        assert!(
+            msg.contains("h1") && msg.contains("h2"),
+            "names both: {msg}"
+        );
+    }
+
+    /// `prepare` stages packages into a snapshot that only the reboot
+    /// activates, so a host that never comes back has not been prepared.
+    #[tokio::test]
+    async fn perform_prepare_reports_a_transactional_host_that_never_came_back() {
+        let (t, handle) = dead_after_reboot_slmicro("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a host that never came back is not a successful prepare");
+
+        assert_eq!(err.host.as_deref(), Some("h1"), "{err:?}");
+        assert!(
+            err.reason.contains("did not come back after the reboot"),
+            "names the real failure: {err:?}"
+        );
+        assert!(
+            err.reason.contains("failed to reconnect to h1"),
+            "carries the underlying reason, not just the category: {err:?}"
+        );
+        assert_eq!(handle.fired_commands(), vec!["systemctl reboot"]);
+    }
+
+    /// Same for `downgrade`: the rollback only takes effect once the host
+    /// reboots into the restored snapshot.
+    #[tokio::test]
+    async fn perform_downgrade_reports_a_transactional_host_that_never_came_back() {
+        let (t, handle) = dead_after_reboot_slmicro("h1", "pkg-a = 1.0-1\n");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a host that never came back is not a successful downgrade");
+
+        assert_eq!(err.host.as_deref(), Some("h1"), "{err:?}");
+        assert!(
+            err.reason.contains("did not come back after the reboot"),
+            "the dead host must be named as such, not left to surface as a \
+             vague \"downgrade not completed\" from its failed re-probe: {err:?}"
+        );
+        assert_eq!(handle.fired_commands(), vec!["systemctl reboot"]);
+    }
+
+    /// The install entry gate: a cancel observed before anything runs stops the
+    /// flow without taking the group lock, and reports a cancellation rather
+    /// than a generic failure.
+    #[tokio::test]
+    async fn perform_install_entry_gate_reports_cancelled_and_runs_nothing() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+
+        let err = perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a cancelled install reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        assert!(
+            err.reason.contains("install"),
+            "names the command verb the operator typed, not the doer table's \
+             role key (`installer`): {err:?}"
+        );
+        assert!(
+            handle.commands().is_empty(),
+            "entry gate must run no host command: {:?}",
+            handle.commands()
+        );
+        // The group lock is taken over SFTP, not `run`, so an empty command log
+        // says nothing about it. This is what pins "before the group lock".
+        assert!(
+            handle.sftp_ops().is_empty(),
+            "entry gate must not take the group lock: {:?}",
+            handle.sftp_ops()
+        );
+    }
+
+    /// Same gate, on the uninstall role — the two share `perform_operation`,
+    /// so this pins that the message names the role that was actually asked
+    /// for rather than hard-coding "install".
+    #[tokio::test]
+    async fn perform_uninstall_entry_gate_names_the_uninstall_role() {
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+
+        let err = perform_uninstall(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a cancelled uninstall reports an error");
+
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        assert!(
+            err.reason.contains("uninstall") && !err.reason.contains("uninstaller"),
+            "names the verb `uninstall`, not the role key `uninstaller` -- a \
+             bare contains(\"uninstall\") also matches `uninstaller`: {err:?}"
+        );
+        assert!(handle.commands().is_empty(), "{:?}", handle.commands());
+        assert!(handle.sftp_ops().is_empty(), "{:?}", handle.sftp_ops());
     }
 
     #[tokio::test]
@@ -1986,6 +2321,67 @@ mod tests {
         );
     }
 
+    /// The twin of the test above: every check passed, so the update looked
+    /// clean, but the host never came back from the reboot that activates it.
+    /// This path used to return `Ok(())` unconditionally after the reboot.
+    #[tokio::test]
+    async fn perform_update_reports_a_transactional_host_that_never_came_back() {
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .failing_reconnect();
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+
+        let err = perform_update(
+            &mut group,
+            &report,
+            &packages,
+            "42",
+            "7",
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await
+        .expect_err("a host that never came back is not a successful update");
+
+        // A `Check` failure, so `perform_update_with_rollback` treats it like
+        // any other per-host update failure and rolls back — deliberate: the
+        // update is not live on that host, and a partially-applied fleet is
+        // exactly what the rollback exists for.
+        let UpdateFailure::Check(err) = err else {
+            panic!("expected a check failure, got {err:?}");
+        };
+        assert_eq!(err.host.as_deref(), Some("h1"), "{err:?}");
+        assert!(
+            err.reason.contains("did not come back after the reboot"),
+            "names the real failure: {err:?}"
+        );
+        assert!(
+            err.reason.contains("failed to reconnect to h1"),
+            "carries the underlying reason, not just the category: {err:?}"
+        );
+        assert!(
+            handle
+                .fired_commands()
+                .iter()
+                .any(|c| c.contains("systemctl reboot")),
+            "the reboot must still be dispatched: {:?}",
+            handle.fired_commands()
+        );
+    }
+
     #[tokio::test]
     async fn perform_update_keeps_repos_on_check_failure() {
         // exit 104 on the updater command ⇒ the update check flags "package not
@@ -2299,7 +2695,11 @@ mod tests {
     /// transactional host inert.
     #[tokio::test]
     async fn prepare_cancel_mid_loop_still_reaches_the_reboot_fallthrough() {
-        let (t, handle) = sles_target("h1", "");
+        // A *transactional* host: with a non-transactional one the reboot map
+        // is empty and `reboot_transactional` returns before touching the
+        // group, so the fall-through this test is named for never runs and the
+        // assertions below hold vacuously.
+        let (t, handle) = slmicro_maybe_dead("h1", "", 0, true);
         let mut group = HostsGroup::new(vec![t], false);
         let report = crate::reports::PiReport::new(Config::default());
         let packages = vec!["pkg-a".to_owned(), "pkg-b".to_owned()];
@@ -2325,6 +2725,14 @@ mod tests {
             handle.commands().is_empty(),
             "cancelled at package 0, so no package command may run: {:?}",
             handle.commands()
+        );
+        // ...but the reboot still fired. This is the whole point of `break`
+        // rather than an early return: the snapshot must be activated even
+        // though the operator asked to stop.
+        assert_eq!(
+            handle.fired_commands(),
+            vec!["systemctl reboot"],
+            "the cancelled prepare must still reach the reboot fall-through"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1699,7 +1699,7 @@ mod tests {
         // The install itself still ran and the reboot was still dispatched —
         // only the verdict changed.
         assert_eq!(
-            handle.commands(),
+            package_commands(&handle),
             vec!["transactional-update -n pkg install pkg-a"]
         );
         assert_eq!(handle.fired_commands(), vec!["systemctl reboot"]);
@@ -1714,8 +1714,12 @@ mod tests {
         exit: i16,
         alive: bool,
     ) -> (Target, MockConnection) {
-        let conn =
-            MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", exit, 0));
+        // `with_changing_boot_id` models a host that really restarted; without
+        // it both boot-id probes return `stdout` and the reboot is correctly
+        // judged never to have happened.
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", stdout, "", exit, 0))
+            .with_changing_boot_id();
         let conn = if alive {
             conn
         } else {
@@ -1732,6 +1736,15 @@ mod tests {
             true,
         );
         (t, handle)
+    }
+
+    /// The commands a mock was asked to run, minus the reboot lifecycle's own
+    /// boot-id probes — those are bookkeeping, not the operation's work.
+    fn package_commands(conn: &MockConnection) -> Vec<String> {
+        conn.commands()
+            .into_iter()
+            .filter(|c| !c.contains("/proc/sys/kernel/random/boot_id"))
+            .collect()
     }
 
     /// A transactional host with a scripted reconnect failure, so the reboot
@@ -1770,7 +1783,7 @@ mod tests {
         // Both hosts really did install and really were rebooted — the healthy
         // one is not skipped just because its neighbour died.
         assert_eq!(
-            m1.commands(),
+            package_commands(&m1),
             vec!["transactional-update -n pkg install pkg-a"]
         );
         assert_eq!(m1.fired_commands(), vec!["systemctl reboot"]);
@@ -2276,8 +2289,12 @@ mod tests {
     /// Builds an enabled SL Micro (transactional) target on a mock returning
     /// `stdout` with `exit` for every command.
     fn slmicro_target(hostname: &str, stdout: &str, exit: i16) -> (Target, MockConnection) {
-        let conn =
-            MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", exit, 0));
+        // `with_changing_boot_id` models a host that really restarted; without
+        // it both boot-id probes return `stdout` and the reboot is correctly
+        // judged never to have happened.
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", stdout, "", exit, 0))
+            .with_changing_boot_id();
         let handle = conn.clone();
         let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
@@ -2722,9 +2739,9 @@ mod tests {
         // No package command was dispatched (cancelled at index 0), proving
         // the loop stopped rather than running to completion.
         assert!(
-            handle.commands().is_empty(),
+            package_commands(&handle).is_empty(),
             "cancelled at package 0, so no package command may run: {:?}",
-            handle.commands()
+            package_commands(&handle)
         );
         // ...but the reboot still fired. This is the whole point of `break`
         // rather than an early return: the snapshot must be activated even

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -103,6 +103,38 @@ impl UpdateError {
     }
 }
 
+impl From<HostError> for UpdateError {
+    /// Lifts a host-layer error into the flow's error type.
+    ///
+    /// This is the **default** lifting, and the point of it is that `cancelled`
+    /// is decided in one place rather than at each call site, where a
+    /// `reason_only(e.to_string())` silently hard-codes `false`. The command
+    /// layer reads nothing but that flag to choose `CommandError::Cancelled`
+    /// over `CommandError::Other`, so a call site that guesses wrong reports a
+    /// cancelled flow as a generic failure. A caller with better per-host
+    /// structure still builds its own error — `perform_operation` does, to name
+    /// each host that did not come back.
+    ///
+    /// No [`HostError`] variant represents a cancellation today — the flows
+    /// stop at their own checkpoints and build the error with
+    /// [`UpdateError::cancelled`] directly, so a cancel never arrives through
+    /// here. `HostError` is `#[non_exhaustive]`; a future cancellation variant
+    /// gets its mapping added here and nowhere else.
+    ///
+    /// The host is left unset: every `HostError` that names a host already
+    /// interpolates it into its own `Display`, so setting it too would render
+    /// as `h1: failed to reconnect to h1`. A caller with better per-host
+    /// structure (`update_flow::perform_operation`) builds its own errors
+    /// instead of routing through this.
+    fn from(err: HostError) -> Self {
+        Self {
+            reason: err.to_string(),
+            host: None,
+            cancelled: false,
+        }
+    }
+}
+
 impl std::fmt::Display for UpdateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.host {
@@ -339,6 +371,68 @@ mod tests {
     fn update_error_display_without_host_is_reason_only() {
         let e = UpdateError::reason_only("RPM Error");
         assert_eq!(e.to_string(), "RPM Error");
+    }
+
+    #[test]
+    fn host_error_converts_preserving_its_message() {
+        let e: UpdateError = HostError::Update("Hosts locked".to_owned()).into();
+        assert_eq!(e.to_string(), "Hosts locked");
+
+        // A host-naming variant keeps its own rendering rather than being
+        // re-prefixed into `h1: failed to reconnect to h1`.
+        let e: UpdateError = HostError::ReconnectFailed {
+            host: "h1".to_owned(),
+        }
+        .into();
+        assert_eq!(e.to_string(), "failed to reconnect to h1");
+    }
+
+    #[test]
+    fn reboot_failure_names_every_host_with_its_own_reason() {
+        // Rendered with two hosts on purpose: with one, a Display that dropped
+        // the join, truncated to the first entry, or omitted the reason would
+        // read identically.
+        let e = HostError::RebootFailed {
+            hosts: vec![
+                ("h1".to_owned(), "failed to reconnect to h1".to_owned()),
+                ("h2".to_owned(), "host h2 is not connected".to_owned()),
+            ],
+        };
+        assert_eq!(
+            e.to_string(),
+            "did not come back after the reboot: h1 (failed to reconnect to h1), \
+             h2 (host h2 is not connected)"
+        );
+    }
+
+    #[test]
+    fn host_error_never_converts_into_a_cancellation() {
+        // The command layer reads nothing but this flag to choose
+        // `CommandError::Cancelled` over `CommandError::Other`. No host-layer
+        // error means "the operator asked to stop" — cancellations are built by
+        // the flows' own checkpoints with `UpdateError::cancelled`. If a
+        // `HostError::Cancelled`-style variant is ever added, its mapping
+        // belongs in the `From` impl, and this assertion is what will catch it
+        // being forgotten.
+        for err in [
+            HostError::Update("Hosts locked".to_owned()),
+            HostError::ReconnectFailed {
+                host: "h1".to_owned(),
+            },
+            HostError::NoPlanProvider,
+            HostError::MissingInstaller {
+                release: "15".to_owned(),
+            },
+            HostError::RebootFailed {
+                hosts: vec![("h1".to_owned(), "failed to reconnect to h1".to_owned())],
+            },
+        ] {
+            let converted: UpdateError = err.into();
+            assert!(
+                !converted.is_cancelled(),
+                "a host failure must never masquerade as a cancel: {converted:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -60,7 +60,7 @@ Defaults below are the built-in values.
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
 | `connection_timeout` | seconds (>0) | `300` | SSH connect + command timeout. |
-| `reboot_timeout` | seconds (>0) | `10` | Backoff base for reconnecting after a reboot (`prepare`/`reboot`/`update`). Sleeps grow as `2*(reboot_timeout + 5*count)` across attempts. |
+| `reboot_timeout` | seconds (>0) | `10` | Backoff base for reconnecting after a reboot. Applies to the `reboot` command and to the post-operation reboot of a transactional host, which `install`, `uninstall`, `prepare`, `update` and `downgrade` all perform. Sleeps grow as `2*(reboot_timeout + 5*count)` across attempts. |
 | `reboot_retries` | int (>0) | `10` | Number of post-reboot reconnect attempts beyond the first. With the defaults this gives a rebooting host up to ~12.7 minutes to come back. |
 | `max_parallel` | int (>0) | `50` | Max hosts to fan out to concurrently (SSH/SFTP/lock/connect batches). |
 | `max_oqa_parallel` | int (>0) | `8` | Max concurrent openQA/QAM HTTP requests in the overview search (kept low to be polite to shared hosts). |


### PR DESCRIPTION
## The bug

On a read-only-root host (SL Micro) the packages an operation installs are staged into a snapshot that **only the reboot activates**. A host that fails to come back has therefore not had the operation applied, however cleanly its command exited — but the failed reconnect was logged at ERROR and dropped, so `install` printed `install completed on <hosts>` for a machine that was no longer reachable.

This is the same shape as #383 (install/uninstall ran nothing while reporting success), one layer further along.

Three distinct ways a transactional reboot could lie, all now reported:

| | before | now |
|---|---|---|
| host never came **back** | logged at ERROR, dropped | named, with its reason |
| host never went **down** (reboot silently no-ops) | invisible — reconnect succeeds against the still-live host | caught by the boot-id check |
| reboot never **dispatched** | invisible — the failed dispatch leaves the session open, so the reconnect succeeds trivially | recorded, and outranks any later verdict |

All five flows that reboot a transactional host were affected. `install`, `uninstall`, `prepare` and `update` reported outright success; `downgrade` reported only a vague "downgrade not completed" from the version re-probe the dead host then failed.

## What changed

`reboot_transactional` returns a per-host outcome map instead of `()`, collected through a side channel because the fan-out closure must keep returning `()` — a host skipped mid-batch has to stay indistinguishable from one that ran. `Operation::run` folds it into a new `HostError::RebootFailed`, reported **after** the unlock and never propagated with `?`, so the group lock is still released on every host.

That variant deliberately means the opposite of every other error the template returns: the command ran everywhere and only the reboot failed, so `perform_operation` routes the two apart and still computes the per-host verdict — the dead host is named *alongside* it, not instead of it.

`update_run_phase`'s hand-rolled aggregation was a copy of `aggregate_failures`, so it now calls it; the rendered message is byte-identical for the pre-existing single- and multi-host cases.

Also here, because they are the same seam:

- **`install`/`uninstall` observe cancellation** (they were the only long-running flows with no checkpoint at all — a `job_cancel` let the whole thing run to completion). Deliberately one gate, on entry: every later step is a parallel fan-out, and skipping the reboot would leave a snapshot inert while the packages reported installed. The message says a history line was already *dispatched* rather than implying a clean slate.
- **`From<HostError> for UpdateError`**, so host failures are lifted in one place instead of a `reason_only(e.to_string())` at each call site that silently hard-codes `cancelled: false`. No variant represents a cancellation today; a test pins that, so a future `#[non_exhaustive]` variant cannot quietly acquire the wrong flag.

A failed reboot on `update` stays an `UpdateFailure::Check`, so it still triggers the rollback. That is intended: the host is on the pre-update packages while the rest of the group is on the post-update ones, and a split-brain group is worse than a uniform pre-update one.

## Review

Adversarial review before committing, four reviewers on distinct lenses (remaining false-success paths / cancellation contract / test quality / contracts + both surfaces). It changed the work:

- the cancellation message claimed history "was already recorded on each host" — `add_op_history` is best-effort, so that was false for an unreachable host;
- the message used `as_operation_role()`, which renders **`installer`**, not the verb the operator typed — and the test's `contains("uninstall")` passed vacuously against `uninstaller`;
- `Target::reboot` swallowed its dispatch error — the third row of the table above, found by the reviewer, not by me;
- `docs/src/configuration.md` scoped `reboot_timeout` to `prepare`/`reboot`/`update`; this change is what made the omission user-visible;
- two CHANGELOG claims were wrong (`downgrade` never reported success; on `update` a reboot failure and a per-host verdict cannot co-occur).

Mutation-verified: 13 mutants, all killed. One survived the first pass — nothing tested that `prepare` propagated a reboot failure — which is why the prepare and downgrade tests exist. The tree was restored byte-identically (`git diff | sha256sum`) after every mutation.

Deferred to their own issues rather than smuggled in here: `update` has no verdict at all on slmicro/YUM hosts (no check table *and* no exit-code fallback), disabled transactional hosts are rebooted and reported installed, and a cancelled template is reported as a fan-out failure.

## Gate

`fmt` · `clippy -D warnings` · `cargo test --workspace` · `cargo test -p mtui-mcp -F mcp` · feature matrix (`--no-default-features` + `--all-features`) · `typos` — all green locally.
