### PR TITLE
fix: stop an idle link or a disabled host from rolling back the whole group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A post-operation reboot whose SSH link had gone idle during the (multi-
+  minute) package transaction now reconnects before dispatching, as ordinary
+  commands already did. Without it the reboot failed to dispatch against a
+  perfectly healthy host — and since a failed dispatch followed by a
+  *successful* reconnect is exactly the signature of "the host is up but never
+  got the command", `update` routed its group-wide rollback on it: an idle TCP
+  session could downgrade every host in the group.
+- A **disabled** host is no longer rebooted by the post-operation reboot, nor
+  probed by it, nor reported by it. It is excluded from the command fan-out,
+  so it stages no snapshot and has nothing to activate; rebooting it restarted
+  a machine the operator had deliberately taken out of the run. Left
+  unreported it also read as "never rebooted" — which `update` treats as
+  still-reachable, rolling the whole group back on behalf of a host that was
+  never in it. The `reboot` command and `quit --reboot`/`--poweroff` are
+  unchanged: they reboot whichever hosts the operator named.
 - `install`/`uninstall` now check whether a host's install/uninstall command
   actually succeeded *before* rebooting its transactional (read-only-root)
   snapshot into it. The install/uninstall template used to reboot first and

--- a/crates/mtui-hosts/src/connection/ssh.rs
+++ b/crates/mtui-hosts/src/connection/ssh.rs
@@ -1171,6 +1171,19 @@ impl Connection for SshConnection {
     }
 
     async fn fire_and_forget(&mut self, command: &str) -> Result<()> {
+        // Revive an idle-dropped link before dispatching, as [`run`] does.
+        //
+        // The only caller is the post-operation reboot, which fires after a
+        // `transactional-update` that can run for minutes — long enough for the
+        // server to have closed an idle session. Without this, that reboot
+        // fails to dispatch against a perfectly healthy host, and because a
+        // failed dispatch with a *successful* reconnect is precisely the
+        // signature of "host is up but never got the command", `update` routes
+        // its group-wide rollback on it: an idle TCP session would downgrade
+        // every host in the group. One reconnect removes the trigger.
+        if !self.is_active() {
+            self.reconnect(0, false).await?;
+        }
         let channel = self
             .handle()?
             .channel_open_session()

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1254,6 +1254,21 @@ impl HostsGroup {
         if reboot.is_empty() {
             return BTreeMap::new();
         }
+        // The single predicate every phase below shares. A **disabled** host is
+        // skipped by all of them: `plans()` resolves a plan per target
+        // regardless of state, so a disabled transactional host reaches this
+        // map -- but it was excluded from the command fan-out, so it staged no
+        // snapshot and there is nothing to activate. Rebooting it anyway
+        // restarts a machine the operator deliberately took out of the run.
+        //
+        // Skipping it in only *some* phases would be worse than not skipping it
+        // at all: the boot-id probes would then read the same id twice and
+        // report a host that "never rebooted" -- which `update` reads as still
+        // reachable, and routes a group-wide rollback on.
+        let selected = |t: &Target| {
+            reboot.contains_key(t.hostname())
+                && t.state() != mtui_types::enums::TargetState::Disabled
+        };
         let mut names: Vec<&String> = reboot.keys().collect();
         names.sort();
         tracing::info!(
@@ -1273,7 +1288,7 @@ impl HostsGroup {
             is_repl,
             max_parallel,
             Some("boot_id"),
-            |t| reboot.contains_key(t.hostname()),
+            &selected,
             |t| {
                 let old_boot_ids = &old_boot_ids;
                 Box::pin(async move {
@@ -1297,7 +1312,7 @@ impl HostsGroup {
             is_repl,
             max_parallel,
             Some("reboot"),
-            |t| reboot.contains_key(t.hostname()),
+            &selected,
             |t| {
                 let command = reboot.get(t.hostname()).cloned().unwrap_or_default();
                 let outcomes = &outcomes;
@@ -1319,7 +1334,7 @@ impl HostsGroup {
             is_repl,
             max_parallel,
             Some("reconnect"),
-            |t| reboot.contains_key(t.hostname()),
+            &selected,
             |t| {
                 let outcomes = &outcomes;
                 Box::pin(async move {
@@ -1369,7 +1384,7 @@ impl HostsGroup {
             is_repl,
             max_parallel,
             Some("verify_reboot"),
-            |t| reboot.contains_key(t.hostname()),
+            &selected,
             |t| {
                 let old = old_boot_ids.get(t.hostname()).cloned().unwrap_or_default();
                 let outcomes = &outcomes;
@@ -2297,6 +2312,78 @@ mod tests {
         assert!(h1.fired_commands().is_empty());
         assert_eq!(h1.reconnect_count(), 0);
         assert!(failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_skips_a_disabled_host_in_every_phase() {
+        // A disabled host is excluded from the command fan-out, so it staged no
+        // snapshot and has nothing to activate. `plans()` still resolves a plan
+        // for it, so it reaches the reboot map and must be skipped here --
+        // rebooting it restarts a machine the operator took out of the run.
+        //
+        // Deliberately a *fixed* boot id. With a changing one this test would
+        // pass even if only the dispatch were skipped, because the probes would
+        // report a restart that never happened. A fixed id is what a real
+        // untouched host returns, and it is what catches a phase that forgot
+        // the state check: phase 4 would then record `NotRebooted`, which
+        // `update` reads as still-reachable and routes a group-wide rollback
+        // on -- reverting every healthy host on behalf of a disabled one.
+        let m1 = reboot_mock("h1", "id-1");
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Disabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
+        let failures = OperationGroup::reboot(&mut g, map).await;
+
+        assert!(
+            h1.fired_commands().is_empty(),
+            "a disabled host must not be rebooted: {:?}",
+            h1.fired_commands()
+        );
+        assert!(failures.is_empty(), "skipped, not failed: {failures:?}");
+        // Every phase, not just the dispatch: no boot-id probe, no reconnect.
+        assert!(
+            h1.commands().is_empty(),
+            "a skipped host must cost no SSH reads either: {:?}",
+            h1.commands()
+        );
+        assert_eq!(h1.reconnect_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_still_reboots_an_enabled_host_alongside_a_disabled_one() {
+        // The inertness control for the test above: the state check must skip
+        // the disabled host only, not collapse the whole fan-out.
+        let (m1, m2) = (rebooted_mock("h1"), reboot_mock("h2", "id-2"));
+        let (h1, h2) = (m1.clone(), m2.clone());
+        let mut g = HostsGroup::new(
+            vec![
+                Target::with_connection("h1", TargetState::Enabled, Box::new(m1)),
+                Target::with_connection("h2", TargetState::Disabled, Box::new(m2)),
+            ],
+            false,
+        );
+
+        let map: HostCommandMap = vec![
+            ("h1".to_owned(), "transactional-update reboot".to_owned()),
+            ("h2".to_owned(), "transactional-update reboot".to_owned()),
+        ];
+        let failures = OperationGroup::reboot(&mut g, map).await;
+
+        assert_eq!(
+            h1.fired_commands(),
+            vec!["transactional-update reboot".to_owned()]
+        );
+        assert_eq!(h1.reconnect_count(), 1);
+        assert!(h2.fired_commands().is_empty());
+        assert!(failures.is_empty(), "{failures:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Rewritten.** #388 (`4d1296af` + `92eba4e8`, @plusky) landed while this was open and covers the reboot-verification work this PR originally carried — better than it did: typed `RebootFailureCause` carried to the caller instead of flattened strings, per-cause wording, and rollback routing on the cause, which this PR did not attempt. All of that is dropped here; nothing below overlaps it.

What is left are two defects in the *reboot path around* those commits, both of which make `update` roll the whole group back for a host that never needed it.

## 1. An idle SSH link downgrades the entire group

`Connection::run` reconnects when the link is no longer active before opening its channel. `fire_and_forget` does not. Its only caller is the post-operation reboot — which fires **after** a `transactional-update` that can run for minutes, long enough for the server to have closed an idle session.

That asymmetry was survivable while a failed dispatch was logged and dropped. After `4d1296af` it is not:

```
idle link  →  fire_and_forget fails  →  RebootNotDispatched
           →  reconnect SUCCEEDS (host is fine)
           →  cause NotDispatched  →  host_still_reachable() == true
           →  UpdateFailure::RebootNotTaken  →  group-wide rollback
```

A failed dispatch with a *successful* reconnect is exactly the signature `NotDispatched` is minted for, so the classifier is not wrong — its premise is just repairable before it is ever reached. One reconnect, matching `run`, removes the trigger. That is cheaper and safer than teaching the classifier to tell an idle link from an absent host.

`92eba4e8` already fixed the neighbouring case (link died because the host *went away*): phase 3's reconnect fails, so it correctly reports `Unreachable` and skips the rollback. This is the complement — link died, host is healthy.

## 2. A disabled host is rebooted, and can trigger the rollback

`plans()` resolves a plan for every target regardless of `TargetState`, so a disabled transactional host reaches the reboot map — but it was excluded from the command fan-out, so it staged no snapshot and has nothing to activate. It is rebooted anyway: the operation restarts a machine the operator deliberately took out of the run. (Listed in `AGENTS.md` as deferred; it is no longer only cosmetic.)

Left in, it also lies. Its boot id cannot change across a reboot it never received, so phase 4 records `NotRebooted` → still-reachable → **group-wide rollback**, reverting every host that did everything right on behalf of one that was never in the run.

The state check goes on the predicate all four phases share, **not** on `Target::reboot`:

- skipping only the dispatch leaves the boot-id probes reading the same id twice and reporting exactly the false `NotRebooted` above — half-skipping is worse than not skipping;
- `Target::reboot` is also reached by `close` and by the explicit `reboot` command, neither of which consults fan-out state. Both deliberately keep rebooting whichever hosts they were told to.

Verified against upstream before writing anything — on `92eba4e8`, a connected-but-disabled host in the reboot map yields:

```
fired=["tu reboot"]  reconnects=1
failures=[RebootFailure { host: "hA", cause: NotRebooted, … }]
```

## Tests

The disabled-host test uses a **fixed** boot id deliberately: with a changing one it would pass even if only the dispatch were skipped, because the probes would report a restart that never happened. Confirmed non-vacuous — neutering the predicate fails it with `a disabled host must not be rebooted: ["transactional-update reboot"]`. An inertness control pins that an enabled host alongside a disabled one still reboots, so the check cannot silently collapse the fan-out.

**Not covered:** the `fire_and_forget` reconnect. `MockConnection` implements the trait directly, so the real path is exercised only by the `#[ignore]`d sshd fixture. Stating it rather than claiming coverage that does not exist.

## Gate

`fmt --check` · `clippy --workspace --all-targets -D warnings` (0 findings) · `cargo test --workspace` (2299 passed) · `cargo test -p mtui-mcp -F mcp` (237 passed) · feature matrix (`--no-default-features` + `--all-features`) — all green, and **each of the three commits verified independently green**, not just the tip.
