### PR TITLE
fix: detect a transactional reboot that never took effect, and route the rollback on why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `update` specifically reports the new `UpdateFailure::Reboot` and — since
   the host is unreachable — skips the rollback downgrade it runs for a check
   failure.
+- A transactional host that *never rebooted at all* is no longer reported as
+  updated. The reboot outcome above records only whether the host reconnected,
+  which left two failures reading as success: a reboot that was never
+  dispatched — the failed dispatch leaves the SSH session live, so the
+  reconnect that follows returns immediately — and a reboot the host accepted
+  and silently ignored (a masked `rebootmgr`, a systemd inhibitor, a polkit
+  denial), which leaves it up on the old snapshot. The post-operation reboot
+  now takes the same boot-id snapshot and verification the explicit `reboot`
+  command already performed, and records a failed dispatch; the explicit
+  `reboot` command gains the dispatch check it was also missing.
+- `update` now decides on the rollback downgrade from *why* a reboot failed,
+  not merely that one did — refining the `UpdateFailure::Reboot` behaviour
+  described above. The rollback is group-wide, so it runs only when it can
+  actually repair every host that failed: when all of them are still reachable
+  but running an un-activated snapshot (the new `UpdateFailure::RebootNotTaken`)
+  — the split-brain a rollback exists to undo. If any failed host is
+  unreachable the rollback is skipped (`UpdateFailure::Reboot`), because
+  reverting the healthy hosts cannot repair a machine nothing can reach. Every
+  failed host is named either way.
 - `install`/`uninstall`/`downgrade`/`update` now write their
   `/var/log/mtui.log` history row *after* dispatching a command on the host,
   not before. A run that never starts (no doer resolves, the host is held by

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -129,6 +129,7 @@ pub struct MockConnection {
     reconnects: Arc<Mutex<usize>>,
     /// When `true`, [`reconnect`](Connection::reconnect) fails.
     reconnect_fails: bool,
+    fire_and_forget_fails: bool,
     /// The `(retry, backoff)` args of the most recent
     /// [`reconnect`](Connection::reconnect) call, so a test can assert the
     /// caller passed the expected budget (e.g. the reboot lifecycle's
@@ -247,6 +248,7 @@ impl MockConnection {
             close_fails: false,
             reconnects: Arc::new(Mutex::new(0)),
             reconnect_fails: false,
+            fire_and_forget_fails: false,
             last_reconnect_args: Arc::new(Mutex::new(None)),
             fired: Arc::new(Mutex::new(Vec::new())),
             sftp_ops: Arc::new(Mutex::new(Vec::new())),
@@ -452,6 +454,22 @@ impl MockConnection {
     #[must_use]
     pub fn failing_reconnect(mut self) -> Self {
         self.reconnect_fails = true;
+        self
+    }
+
+    /// Scripts [`fire_and_forget`](Connection::fire_and_forget) to fail,
+    /// **without** tearing the link down.
+    ///
+    /// That combination is the point: the real
+    /// `SshConnection::fire_and_forget` closes the local link only as its last
+    /// statement, after the channel open and `exec` have both succeeded, so a
+    /// failed dispatch leaves the session active — and the reconnect that
+    /// follows returns `Ok(())` immediately off `is_active()`. A double that
+    /// closed the link here would make the reconnect do real work and hide the
+    /// very bug this reproduces.
+    #[must_use]
+    pub fn failing_fire_and_forget(mut self) -> Self {
+        self.fire_and_forget_fails = true;
         self
     }
 
@@ -840,6 +858,13 @@ impl Connection for MockConnection {
     }
 
     async fn fire_and_forget(&mut self, command: &str) -> Result<()> {
+        if self.fire_and_forget_fails {
+            // Deliberately leaves `active` set — see `failing_fire_and_forget`.
+            return Err(HostError::Transport {
+                host: self.hostname.clone(),
+                reason: "channel open failed".to_owned(),
+            });
+        }
         self.fired
             .lock()
             .expect("mock fired lock")

--- a/crates/mtui-hosts/src/error.rs
+++ b/crates/mtui-hosts/src/error.rs
@@ -63,6 +63,36 @@ pub enum HostError {
         host: String,
     },
 
+    /// A reboot command could not be handed to the host at all.
+    ///
+    /// Distinct from [`ReconnectFailed`](Self::ReconnectFailed) because the
+    /// host is still **reachable**: `Connection::fire_and_forget` tears the
+    /// local link down only after the channel open *and* `exec` both succeed,
+    /// and `Connection::reconnect` returns early while the session is still
+    /// active. A failed dispatch therefore leaves a live session behind and the
+    /// reconnect that follows succeeds trivially — which is exactly how this
+    /// used to read as a successful reboot.
+    #[error("failed to dispatch the reboot to {host}: {reason}")]
+    RebootNotDispatched {
+        /// The host the reboot never reached.
+        host: String,
+        /// What went wrong, rendered from the underlying transport error.
+        reason: String,
+    },
+
+    /// The host answered after its reboot with an unchanged boot id.
+    ///
+    /// `/proc/sys/kernel/random/boot_id` is regenerated on every boot, so an
+    /// unchanged value means the machine never went down — the reboot was
+    /// accepted and silently did nothing (a masked `rebootmgr`, a systemd
+    /// inhibitor, a polkit denial). On a transactional host that leaves the
+    /// new snapshot **un-activated** while the host stays up on the old one.
+    #[error("{host} did not reboot: its boot id is unchanged")]
+    RebootDidNotHappen {
+        /// The host that never went down.
+        host: String,
+    },
+
     /// A channel/transport-level SSH error occurred while running a command
     /// (channel open/exec failure, unexpected EOF, protocol error).
     #[error("transport error on {host}: {reason}")]

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -36,7 +36,8 @@ pub(crate) use target::POOL_LOCK_PATH;
 pub use target::{
     Check, CheckArgs, Clock, Command, Doer, HostArbiter, HostOutput, HostPlan, HostsGroup,
     InstallOperation, LockOutcome, Operation, OperationGroup, OperationReport, Owner,
-    PackageQuerier, PlanProvider, PoolLock, RemoteLock, RepoManager, RepoOp, SetRepo, Sink,
-    SpinnerGuard, Suspend, SystemClock, TARGET_LOCK_PATH, Target, TargetLock, TtySpinner,
-    UninstallOperation, get_arbiter, parse_system, set_test_sink, spinner, suspend,
+    PackageQuerier, PlanProvider, PoolLock, RebootFailure, RebootFailureCause, RemoteLock,
+    RepoManager, RepoOp, SetRepo, Sink, SpinnerGuard, Suspend, SystemClock, TARGET_LOCK_PATH,
+    Target, TargetLock, TtySpinner, UninstallOperation, get_arbiter, parse_system, set_test_sink,
+    spinner, suspend,
 };

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -46,7 +46,9 @@ use crate::error::{HostError, Result};
 use mtui_types::system::System;
 
 use super::actions::{self, Command, RunCommand};
-use super::operation::{HostCommandMap, HostPlan, OperationGroup, PlanProvider};
+use super::operation::{
+    HostCommandMap, HostPlan, OperationGroup, PlanProvider, RebootFailure, RebootFailureCause,
+};
 use super::repo_manager::{RepoOp, SetRepo};
 use super::{LockRow, Target};
 
@@ -1097,7 +1099,18 @@ impl HostsGroup {
         .await;
         let old_boot_ids = old_boot_ids.into_inner().unwrap();
 
-        // Phase 2: fire the reboot on every host (it drops the connection).
+        // Per-host outcome, collected across the dispatch + reconnect + verify
+        // phases so the returned map is deterministic regardless of completion
+        // order (as in `close`). Earliest phase wins: a reboot that could not be
+        // dispatched takes precedence over a reconnect failure, which in turn
+        // takes precedence over the verify phase — each later verdict is a
+        // consequence of the earlier failure rather than an independent one.
+        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
+
+        // Phase 2: fire the reboot on every host (it drops the connection). A
+        // dispatch that fails leaves the session live, so phase 3's reconnect
+        // would succeed trivially and the host would report a clean reboot it
+        // never received.
         actions::run_fanout(
             &mut self.data,
             is_repl,
@@ -1106,16 +1119,18 @@ impl HostsGroup {
             &select,
             |t| {
                 let command = command.to_owned();
-                Box::pin(async move { t.reboot(&command).await }) as actions::BoxTargetFut<'_>
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    if let Err(e) = t.reboot(&command).await {
+                        outcomes
+                            .lock()
+                            .unwrap()
+                            .insert(t.hostname().to_owned(), Err(e));
+                    }
+                }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
-
-        // Per-host outcome, collected across the reconnect + verify phases so the
-        // returned map is deterministic regardless of completion order (as in
-        // `close`). A reconnect failure is recorded first and takes precedence;
-        // the verify phase only downgrades a host that reconnected cleanly.
-        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
 
         // Phase 3: reconnect every host (concurrently) with retry + backoff.
         actions::run_fanout(
@@ -1139,7 +1154,12 @@ impl HostsGroup {
                             Err(e)
                         }
                     };
-                    outcomes.lock().unwrap().insert(hostname, outcome);
+                    let mut map = outcomes.lock().unwrap();
+                    // Preserve a dispatch failure from phase 2 — that host was
+                    // never sent a reboot in the first place.
+                    if !matches!(map.get(&hostname), Some(Err(_))) {
+                        map.insert(hostname, outcome);
+                    }
                 }) as actions::BoxTargetFut<'_>
             },
         )
@@ -1193,11 +1213,26 @@ impl HostsGroup {
     /// snapshot / verification, and is a no-op
     /// when the map is empty.
     ///
-    /// Returns each named host's reconnect outcome, mirroring
-    /// [`reboot_where`](Self::reboot_where): `Ok(())` when the host reconnected,
-    /// `Err(HostError)` when it did not come back. A caller that discards this
-    /// map cannot tell a transactional host that rebooted into an unreachable
-    /// state from one that came back healthy.
+    /// Returns each named host's outcome, mirroring
+    /// [`reboot_where`](Self::reboot_where): `Ok(())` when the reboot demonstrably
+    /// took effect, `Err(HostError)` otherwise. A caller that discards this map
+    /// cannot tell a transactional host whose snapshot never activated from one
+    /// that came back healthy.
+    ///
+    /// Three distinct failures are recorded, and the *cause* matters to the
+    /// caller because only two of them leave a repairable host:
+    ///
+    /// * [`RebootNotDispatched`](HostError::RebootNotDispatched) — the command
+    ///   never reached the host. It is still up, on the old snapshot.
+    /// * [`RebootDidNotHappen`](HostError::RebootDidNotHappen) — it answered
+    ///   with an unchanged boot id, so it never went down. Still up, new
+    ///   snapshot inert.
+    /// * [`ReconnectFailed`](HostError::ReconnectFailed) — it went away and did
+    ///   not come back. Unreachable.
+    ///
+    /// Earliest phase wins: a host that could not be sent the reboot is
+    /// reported as such rather than as whatever the later phases make of it,
+    /// since those verdicts are consequences of the first failure.
     async fn reboot_transactional(
         &mut self,
         reboot: &BTreeMap<String, String>,
@@ -1215,10 +1250,36 @@ impl HostsGroup {
         );
         let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
 
-        // Fire the reboot on every named host first (it drops the connection),
-        // then reconnect each once it is back up — both phases fan out
-        // concurrently via the shared primitive. `should_run` restricts the
-        // fan-out to the named (transactional) hosts.
+        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
+
+        // Phase 1: record each host's boot id before rebooting, so phase 4 can
+        // tell a real reboot from one that was accepted and silently did
+        // nothing. Mirrors `reboot`, which has always done this.
+        let old_boot_ids: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
+        actions::run_fanout(
+            &mut self.data,
+            is_repl,
+            max_parallel,
+            Some("boot_id"),
+            |t| reboot.contains_key(t.hostname()),
+            |t| {
+                let old_boot_ids = &old_boot_ids;
+                Box::pin(async move {
+                    let id = t.boot_id().await;
+                    old_boot_ids
+                        .lock()
+                        .unwrap()
+                        .insert(t.hostname().to_owned(), id);
+                }) as actions::BoxTargetFut<'_>
+            },
+        )
+        .await;
+        let old_boot_ids = old_boot_ids.into_inner().unwrap();
+
+        // Phase 2: fire the reboot on every named host (it drops the
+        // connection). A dispatch that fails is recorded here: it leaves the
+        // session live, so phase 3's reconnect would otherwise succeed
+        // trivially and the host would report a clean reboot it never got.
         actions::run_fanout(
             &mut self.data,
             is_repl,
@@ -1227,12 +1288,20 @@ impl HostsGroup {
             |t| reboot.contains_key(t.hostname()),
             |t| {
                 let command = reboot.get(t.hostname()).cloned().unwrap_or_default();
-                Box::pin(async move { t.reboot(&command).await }) as actions::BoxTargetFut<'_>
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    if let Err(e) = t.reboot(&command).await {
+                        outcomes
+                            .lock()
+                            .unwrap()
+                            .insert(t.hostname().to_owned(), Err(e));
+                    }
+                }) as actions::BoxTargetFut<'_>
             },
         )
         .await;
 
-        let outcomes: Mutex<BTreeMap<String, Result<()>>> = Mutex::new(BTreeMap::new());
+        // Phase 3: reconnect each host once it is back up.
         actions::run_fanout(
             &mut self.data,
             is_repl,
@@ -1254,7 +1323,42 @@ impl HostsGroup {
                             Err(e)
                         }
                     };
-                    outcomes.lock().unwrap().insert(hostname, outcome);
+                    let mut map = outcomes.lock().unwrap();
+                    // Preserve a dispatch failure from phase 2: this host was
+                    // never sent a reboot, so whatever the reconnect made of it
+                    // is a consequence, not the cause.
+                    if !matches!(map.get(&hostname), Some(Err(_))) {
+                        map.insert(hostname, outcome);
+                    }
+                }) as actions::BoxTargetFut<'_>
+            },
+        )
+        .await;
+
+        // Phase 4: confirm each host's boot id actually changed. Only a host
+        // that got this far cleanly can be downgraded here — an earlier failure
+        // is the more fundamental one and is preserved.
+        actions::run_fanout(
+            &mut self.data,
+            is_repl,
+            max_parallel,
+            Some("verify_reboot"),
+            |t| reboot.contains_key(t.hostname()),
+            |t| {
+                let old = old_boot_ids.get(t.hostname()).cloned().unwrap_or_default();
+                let outcomes = &outcomes;
+                Box::pin(async move {
+                    let hostname = t.hostname().to_owned();
+                    let new_boot_id = t.boot_id().await;
+                    if Self::verify_boot_id(&hostname, &old, &new_boot_id).is_err() {
+                        let mut map = outcomes.lock().unwrap();
+                        if !matches!(map.get(&hostname), Some(Err(_))) {
+                            map.insert(
+                                hostname.clone(),
+                                Err(HostError::RebootDidNotHappen { host: hostname }),
+                            );
+                        }
+                    }
                 }) as actions::BoxTargetFut<'_>
             },
         )
@@ -1295,6 +1399,21 @@ impl HostsGroup {
         } else {
             Ok(())
         }
+    }
+}
+
+/// Classifies a reboot failure for the [`OperationGroup`] seam.
+///
+/// An unrecognised error is reported as
+/// [`Unreachable`](RebootFailureCause::Unreachable) deliberately: that is the
+/// arm that *suppresses* the automatic rollback, and a group-wide downgrade is
+/// destructive enough that it should not be triggered by an error nobody has
+/// classified. The host is still named in the failure either way.
+fn reboot_failure_cause(err: &HostError) -> RebootFailureCause {
+    match err {
+        HostError::RebootNotDispatched { .. } => RebootFailureCause::NotDispatched,
+        HostError::RebootDidNotHappen { .. } => RebootFailureCause::NotRebooted,
+        _ => RebootFailureCause::Unreachable,
     }
 }
 
@@ -1380,7 +1499,7 @@ impl OperationGroup for HostsGroup {
         })
     }
 
-    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
+    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<RebootFailure> {
         // Only transactional hosts contribute reboot entries; the reboot is
         // fired fire-and-forget on each, then each is reconnected
         // (sorted) with the connection's retry + backoff.
@@ -1388,7 +1507,14 @@ impl OperationGroup for HostsGroup {
         HostsGroup::reboot_transactional(self, &map)
             .await
             .into_iter()
-            .filter_map(|(host, outcome)| outcome.err().map(|e| (host, e.to_string())))
+            .filter_map(|(host, outcome)| {
+                let e = outcome.err()?;
+                Some(RebootFailure {
+                    host,
+                    cause: reboot_failure_cause(&e),
+                    reason: e.to_string(),
+                })
+            })
             .collect()
     }
 
@@ -2070,7 +2196,11 @@ mod tests {
 
         assert_eq!(h1.reconnect_count(), 1);
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].0, "h1");
+        assert_eq!(failures[0].host, "h1");
+        // The cause, not just the fact: a host that went away and never came
+        // back is the one case the rollback must NOT be run for.
+        assert_eq!(failures[0].cause, RebootFailureCause::Unreachable);
+        assert!(!failures[0].cause.host_still_reachable());
     }
 
     // --- update_lock / lock / unlock fan-out (P2.9) -------------------------

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1155,10 +1155,16 @@ impl HostsGroup {
                         }
                     };
                     let mut map = outcomes.lock().unwrap();
-                    // Preserve a dispatch failure from phase 2 — that host was
-                    // never sent a reboot in the first place.
-                    if !matches!(map.get(&hostname), Some(Err(_))) {
-                        map.insert(hostname, outcome);
+                    // As in `reboot_transactional`: a failed reconnect is the
+                    // only direct evidence about reachability and outranks
+                    // phase 2's dispatch diagnosis, but a *successful* one must
+                    // not erase a dispatch failure — that reconnect succeeded
+                    // only because the session was never torn down.
+                    match (&outcome, map.get(&hostname)) {
+                        (Err(_), _) | (Ok(()), None) => {
+                            map.insert(hostname, outcome);
+                        }
+                        (Ok(()), Some(_)) => {}
                     }
                 }) as actions::BoxTargetFut<'_>
             },
@@ -1180,12 +1186,15 @@ impl HostsGroup {
                 Box::pin(async move {
                     let hostname = t.hostname().to_owned();
                     let new_boot_id = t.boot_id().await;
-                    if let Err(reason) = Self::verify_boot_id(&hostname, &old, &new_boot_id) {
+                    if Self::verify_boot_id(&hostname, &old, &new_boot_id).is_err() {
                         let mut map = outcomes.lock().unwrap();
-                        // Preserve a reconnect failure; only mark a cleanly
-                        // reconnected host as failed for an unchanged boot id.
+                        // Preserve an earlier failure; only mark a host that got
+                        // this far cleanly as never having rebooted.
                         if !matches!(map.get(&hostname), Some(Err(_))) {
-                            map.insert(hostname, Err(HostError::Update(reason)));
+                            map.insert(
+                                hostname.clone(),
+                                Err(HostError::RebootDidNotHappen { host: hostname }),
+                            );
                         }
                     }
                 }) as actions::BoxTargetFut<'_>
@@ -1209,13 +1218,16 @@ impl HostsGroup {
     /// Transactional hosts contribute a
     /// per-host reboot command from the operation's doer. Each is dispatched
     /// fire-and-forget, then reconnected (sorted) with the connection's retry +
-    /// backoff. Unlike [`reboot`](Self::reboot) this path takes no boot-id
-    /// snapshot / verification, and is a no-op
-    /// when the map is empty.
+    /// backoff, with the same boot-id snapshot and verification
+    /// [`reboot`](Self::reboot) performs. A no-op when the map is empty.
     ///
     /// Returns each named host's outcome, mirroring
-    /// [`reboot_where`](Self::reboot_where): `Ok(())` when the reboot demonstrably
-    /// took effect, `Err(HostError)` otherwise. A caller that discards this map
+    /// [`reboot_where`](Self::reboot_where): `Err(HostError)` when the reboot is
+    /// known to have failed, `Ok(())` otherwise. Note `Ok(())` is "nothing
+    /// contradicted it", not proof: an unreadable boot id (see
+    /// [`verify_boot_id`](Self::verify_boot_id)) leaves the host unverified and
+    /// passing, logged at WARN — failing open here beats reverting a fleet on a
+    /// probe that timed out. A caller that discards this map
     /// cannot tell a transactional host whose snapshot never activated from one
     /// that came back healthy.
     ///
@@ -1324,11 +1336,25 @@ impl HostsGroup {
                         }
                     };
                     let mut map = outcomes.lock().unwrap();
-                    // Preserve a dispatch failure from phase 2: this host was
-                    // never sent a reboot, so whatever the reconnect made of it
-                    // is a consequence, not the cause.
-                    if !matches!(map.get(&hostname), Some(Err(_))) {
-                        map.insert(hostname, outcome);
+                    // Precedence is deliberately *not* plain earliest-wins.
+                    //
+                    // A failed reconnect is the only direct evidence anyone
+                    // gathers about reachability, and reachability is what
+                    // decides whether the caller runs a destructive group-wide
+                    // rollback. So it outranks phase 2's dispatch diagnosis: a
+                    // link that died before the dispatch produces a `Transport`
+                    // error there, which would otherwise claim the host is
+                    // still up and send the whole group into a rollback on
+                    // behalf of a machine nothing can reach.
+                    //
+                    // A *successful* reconnect must not overwrite a dispatch
+                    // failure, though — that is the trivially-succeeding
+                    // reconnect this whole change exists to catch.
+                    match (&outcome, map.get(&hostname)) {
+                        (Err(_), _) | (Ok(()), None) => {
+                            map.insert(hostname, outcome);
+                        }
+                        (Ok(()), Some(_)) => {}
                     }
                 }) as actions::BoxTargetFut<'_>
             },
@@ -2066,7 +2092,7 @@ mod tests {
         assert_eq!(h1.reconnect_count(), 1);
         // Reconnect succeeded but the boot id was unchanged -> recorded failure.
         assert!(
-            matches!(&outcomes["h1"], Err(HostError::Update(msg)) if msg.contains("boot id unchanged")),
+            matches!(&outcomes["h1"], Err(HostError::RebootDidNotHappen { host }) if host == "h1"),
             "unchanged boot id must be recorded as a failure, got {:?}",
             outcomes["h1"]
         );
@@ -2130,7 +2156,7 @@ mod tests {
 
     #[tokio::test]
     async fn operation_reboot_fires_and_reconnects_named_hosts() {
-        let (m1, m2) = (reboot_mock("h1", "id-1"), reboot_mock("h2", "id-2"));
+        let (m1, m2) = (rebooted_mock("h1"), rebooted_mock("h2"));
         let (h1, h2) = (m1.clone(), m2.clone());
         let mut g = HostsGroup::new(
             vec![
@@ -2142,8 +2168,13 @@ mod tests {
 
         // Only h1 is transactional -> only it appears in the reboot map.
         let map: HostCommandMap = vec![("h1".to_owned(), "transactional-update reboot".to_owned())];
-        OperationGroup::reboot(&mut g, map).await;
+        let failures = OperationGroup::reboot(&mut g, map).await;
 
+        // The healthy path, which nothing else asserts: a transactional host
+        // that really rebooted must produce **no** failure. Discarding this
+        // `Vec` is what let the fixture drift to a fixed boot id — modelling a
+        // host that never went down — without any test noticing.
+        assert!(failures.is_empty(), "{failures:?}");
         assert_eq!(
             h1.fired_commands(),
             vec!["transactional-update reboot".to_owned()]
@@ -2154,6 +2185,100 @@ mod tests {
         // h2 was not in the map: untouched.
         assert!(h2.fired_commands().is_empty());
         assert_eq!(h2.reconnect_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_a_dead_link_is_unreachable_not_undispatched() {
+        // The regression this guards: a link that dies *before* the dispatch
+        // makes `fire_and_forget` fail, which phase 2 records as
+        // `RebootNotDispatched` — a variant that asserts the host is still
+        // reachable. If phase 2 simply won, that claim would stand unchallenged
+        // and `update` would revert the whole group on behalf of a machine
+        // nothing can talk to. Phase 3 actually probes reachability, so its
+        // failure has to outrank the phase-2 diagnosis.
+        let m1 = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "ok", "", 0, 0))
+            .failing_fire_and_forget()
+            .failing_reconnect();
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "systemctl reboot".to_owned())];
+        let failures = OperationGroup::reboot(&mut g, map).await;
+
+        assert_eq!(h1.reconnect_count(), 1);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert_eq!(
+            failures[0].cause,
+            RebootFailureCause::Unreachable,
+            "a host that failed BOTH dispatch and reconnect is unreachable"
+        );
+        assert!(
+            !failures[0].cause.host_still_reachable(),
+            "must not claim reachability that would trigger a rollback"
+        );
+    }
+
+    #[tokio::test]
+    async fn operation_reboot_undispatched_but_alive_stays_repairable() {
+        // The complement: dispatch fails and the reconnect *succeeds* (the
+        // session was never torn down). Here the host really is up, so the
+        // phase-2 verdict must survive rather than be erased by the Ok.
+        let m1 = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "ok", "", 0, 0))
+            .with_changing_boot_id()
+            .failing_fire_and_forget();
+        let h1 = m1.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let map: HostCommandMap = vec![("h1".to_owned(), "systemctl reboot".to_owned())];
+        let failures = OperationGroup::reboot(&mut g, map).await;
+
+        assert_eq!(h1.reconnect_count(), 1);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert_eq!(failures[0].cause, RebootFailureCause::NotDispatched);
+        assert!(failures[0].cause.host_still_reachable());
+    }
+
+    #[tokio::test]
+    async fn reboot_selected_reports_a_reboot_it_could_not_dispatch() {
+        // The explicit `reboot` command had the same hole as the operation
+        // path: a failed dispatch left the session live, so the reconnect
+        // succeeded and the host was reported as rebooted.
+        let m1 = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "ok", "", 0, 0))
+            .with_changing_boot_id()
+            .failing_fire_and_forget();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(m1),
+            )],
+            false,
+        );
+
+        let only_h1: std::collections::BTreeSet<String> = ["h1".to_owned()].into_iter().collect();
+        let outcomes = g.reboot_selected("systemctl reboot", "", &only_h1).await;
+        assert!(
+            matches!(&outcomes["h1"], Err(HostError::RebootNotDispatched { .. })),
+            "{:?}",
+            outcomes["h1"]
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -573,15 +573,24 @@ impl Target {
     ///
     /// Dispatches via
     /// [`Connection::fire_and_forget`]. The command is expected to drop the SSH
-    /// connection, so callers follow up with [`reconnect`](Self::reconnect). A
-    /// no-op (logged) when the target is not connected; a dispatch error is
-    /// logged, not propagated, since a link dropped by the reboot is expected.
+    /// connection, so callers follow up with [`reconnect`](Self::reconnect).
+    ///
+    /// A dispatch failure is logged **and returned**: the link is torn down
+    /// only after the dispatch succeeds, so a failure leaves the session live
+    /// and the reconnect that follows returns immediately — which is precisely
+    /// how a reboot that never happened used to read as one that did. An
+    /// unconnected target reports [`ReconnectFailed`](HostError::ReconnectFailed),
+    /// not [`RebootNotDispatched`](HostError::RebootNotDispatched), because the
+    /// latter asserts the host is still reachable.
     async fn reboot(&mut self, command: &str) -> Result<()> {
         let Some(conn) = self.connection.as_mut() else {
             tracing::error!(host = %self.hostname, "reboot on unconnected target");
-            return Err(HostError::RebootNotDispatched {
+            // Deliberately *not* `RebootNotDispatched`: that variant asserts
+            // the host is still reachable, and a target with no connection at
+            // all is the least reachable state there is. Claiming otherwise
+            // would route a group-wide rollback at a host nothing can talk to.
+            return Err(HostError::ReconnectFailed {
                 host: self.hostname.clone(),
-                reason: "the target has no live connection".to_owned(),
             });
         };
         conn.fire_and_forget(command).await.map_err(|e| {
@@ -1843,8 +1852,12 @@ mod tests {
             .reboot("systemctl reboot")
             .await
             .expect_err("an unconnected target cannot be rebooted");
+        // `ReconnectFailed`, deliberately, and NOT `RebootNotDispatched`: the
+        // latter asserts the host is still reachable, which routes a
+        // destructive group-wide rollback at it. A target with no connection
+        // is the least reachable state there is.
         assert!(
-            matches!(&err, HostError::RebootNotDispatched { host, .. } if host == "h1"),
+            matches!(&err, HostError::ReconnectFailed { host } if host == "h1"),
             "{err:?}"
         );
     }
@@ -1864,13 +1877,27 @@ mod tests {
             matches!(&err, HostError::RebootNotDispatched { .. }),
             "{err:?}"
         );
-        // The mock deliberately leaves the session active on a failed dispatch,
-        // exactly as the real connection does — which is what made the
-        // following reconnect succeed and hide this.
+        // The link must survive the failed dispatch, exactly as the real
+        // connection's does — that is what makes the following reconnect
+        // succeed trivially and hides the lost reboot.
+        //
+        // Asserted through `is_closed()`, which reads the `Arc`-shared flag.
+        // `is_active()` would be vacuous here: `active` is a plain `bool` and
+        // `handle` is a clone, so it reports the value it was cloned with no
+        // matter what the connection does.
         assert!(
-            handle.is_active(),
-            "a failed dispatch must not close the link"
+            !handle.is_closed(),
+            "a failed dispatch must not tear the link down"
         );
+        // And the behavioural consequence, which is the actual trap: the
+        // reconnect that follows a lost dispatch still succeeds, so it can
+        // never be the signal — the dispatch result is the only evidence.
+        // (The real connection short-circuits on `is_active()`; this double
+        // simply succeeds. Different mechanism, same observable outcome, which
+        // is the part the caller depends on.)
+        t.reconnect(1, false)
+            .await
+            .expect("a reconnect after a lost dispatch still reports success");
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use locks::POOL_LOCK_PATH;
 pub use locks::{Clock, LockRow, PoolLock, RemoteLock, SystemClock, TARGET_LOCK_PATH, TargetLock};
 pub use operation::{
     Check, CheckArgs, Doer, HostOutput, HostPlan, InstallOperation, Operation, OperationGroup,
-    OperationReport, PlanProvider, UninstallOperation,
+    OperationReport, PlanProvider, RebootFailure, RebootFailureCause, UninstallOperation,
 };
 pub use package_querier::PackageQuerier;
 pub use parsers::parse_system;
@@ -576,14 +576,21 @@ impl Target {
     /// connection, so callers follow up with [`reconnect`](Self::reconnect). A
     /// no-op (logged) when the target is not connected; a dispatch error is
     /// logged, not propagated, since a link dropped by the reboot is expected.
-    async fn reboot(&mut self, command: &str) {
+    async fn reboot(&mut self, command: &str) -> Result<()> {
         let Some(conn) = self.connection.as_mut() else {
             tracing::error!(host = %self.hostname, "reboot on unconnected target");
-            return;
+            return Err(HostError::RebootNotDispatched {
+                host: self.hostname.clone(),
+                reason: "the target has no live connection".to_owned(),
+            });
         };
-        if let Err(e) = conn.fire_and_forget(command).await {
+        conn.fire_and_forget(command).await.map_err(|e| {
             tracing::error!(host = %self.hostname, error = %e, "failed to dispatch reboot");
-        }
+            HostError::RebootNotDispatched {
+                host: self.hostname.clone(),
+                reason: e.to_string(),
+            }
+        })
     }
 
     /// The post-reboot reconnect attempt budget (`[connection]
@@ -648,14 +655,19 @@ impl Target {
             tracing::debug!(host = %self.hostname, "close: not connected");
         }
 
+        // Session teardown: the dispatch result is deliberately discarded here.
+        // `close` has already released the locks and there is no reconnect to
+        // follow, so there is nothing left to verify or to repair — unlike the
+        // operation paths, where a lost reboot silently invalidates the verdict.
+        // `reboot` logs the failure at ERROR either way.
         match action {
             Some("reboot") => {
                 tracing::info!(host = %self.hostname, "rebooting");
-                self.reboot("reboot").await;
+                let _ = self.reboot("reboot").await;
             }
             Some("poweroff") => {
                 tracing::info!(host = %self.hostname, "powering off");
-                self.reboot("halt").await;
+                let _ = self.reboot("halt").await;
             }
             _ => {
                 tracing::info!(host = %self.hostname, "closing connection");
@@ -1817,15 +1829,48 @@ mod tests {
         let conn = MockConnection::new("h1");
         let handle = conn.clone();
         let mut t = enabled_with(conn);
-        t.reboot("systemctl reboot").await;
+        t.reboot("systemctl reboot").await.expect("dispatch ok");
         assert_eq!(handle.fired_commands(), vec!["systemctl reboot".to_owned()]);
     }
 
     #[tokio::test]
-    async fn reboot_on_unconnected_is_noop() {
+    async fn reboot_on_unconnected_target_is_reported() {
         let mut t = Target::new(&cfg(), "h1", TargetState::Enabled);
-        // Must not panic; nothing to assert beyond the no-op completing.
-        t.reboot("systemctl reboot").await;
+        // A silent no-op here is what let an undispatched reboot read as a
+        // successful one: the following reconnect short-circuits on the still
+        // "active" session and returns Ok.
+        let err = t
+            .reboot("systemctl reboot")
+            .await
+            .expect_err("an unconnected target cannot be rebooted");
+        assert!(
+            matches!(&err, HostError::RebootNotDispatched { host, .. } if host == "h1"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reboot_reports_a_dispatch_failure() {
+        let conn = MockConnection::new("h1").failing_fire_and_forget();
+        let handle = conn.clone();
+        let mut t = enabled_with(conn);
+        let err = t
+            .reboot("systemctl reboot")
+            .await
+            .expect_err("a failed dispatch must be reported");
+        // Not `ReconnectFailed`: the two are routed differently downstream,
+        // because this host is still up and therefore still repairable.
+        assert!(
+            matches!(&err, HostError::RebootNotDispatched { .. }),
+            "{err:?}"
+        );
+        // The mock deliberately leaves the session active on a failed dispatch,
+        // exactly as the real connection does — which is what made the
+        // following reconnect succeed and hide this.
+        assert!(
+            handle.is_active(),
+            "a failed dispatch must not close the link"
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -199,7 +199,7 @@ pub trait OperationGroup: Send {
     /// Returns `(hostname, reason)` for every host that did not reconnect —
     /// a transactional host that rebooted and never came back must fail the
     /// operation, not report success on a host it lost.
-    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)>;
+    async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<RebootFailure>;
 
     /// Releases the shared operation lock.
     async fn unlock(&mut self);
@@ -212,14 +212,57 @@ pub trait OperationGroup: Send {
 /// `Err` from [`Operation::run`] keeps meaning "never started" (no plans, or a
 /// foreign lock); `Ok(report)` means it ran, and the two failure lists name any
 /// host that failed its check or was left unreachable by its reboot.
+#[must_use = "the report names the hosts that failed; dropping it silently \
+              reports a failed operation as a clean one"]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OperationReport {
     /// `(hostname, reason)` for every host whose post-run [`Check`] failed.
     pub check_failures: Vec<(String, String)>,
-    /// `(hostname, reason)` for every transactional host that rebooted and did
-    /// not reconnect. A host whose check already failed is excluded — its
-    /// reboot was skipped, not attempted and lost.
-    pub reboot_failures: Vec<(String, String)>,
+    /// Every transactional host whose reboot did not demonstrably take effect.
+    /// A host whose check already failed is excluded — its reboot was skipped,
+    /// not attempted and lost.
+    pub reboot_failures: Vec<RebootFailure>,
+}
+
+/// Why a transactional host's post-operation reboot did not take effect.
+///
+/// The distinction is load-bearing rather than cosmetic: it decides whether the
+/// host can still be repaired. Two of the three leave it **up**, running the
+/// old snapshot while the rest of the group moved on — which is the
+/// split-brain a rollback exists to undo. The third leaves nothing to talk to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebootFailureCause {
+    /// The reboot was dispatched, the host went away and never came back.
+    /// **Unreachable** — a rollback cannot run on it.
+    Unreachable,
+    /// The reboot command never reached the host. It is **still up**, on the
+    /// old snapshot.
+    NotDispatched,
+    /// The host answered with an unchanged boot id: it never went down. It is
+    /// **still up**, with the new snapshot inert.
+    NotRebooted,
+}
+
+impl RebootFailureCause {
+    /// Whether the host is still reachable, and so still repairable.
+    #[must_use]
+    pub fn host_still_reachable(self) -> bool {
+        match self {
+            Self::NotDispatched | Self::NotRebooted => true,
+            Self::Unreachable => false,
+        }
+    }
+}
+
+/// One transactional host whose reboot did not take effect, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebootFailure {
+    /// The host that did not come through its reboot.
+    pub host: String,
+    /// Which of the three ways it failed — see [`RebootFailureCause`].
+    pub cause: RebootFailureCause,
+    /// The rendered underlying error, for the operator-facing message.
+    pub reason: String,
 }
 
 /// The install/uninstall template method.
@@ -537,7 +580,7 @@ mod tests {
         fail_update_lock: bool,
         /// What `reboot` should report as failed, modelling a transactional
         /// host that rebooted and did not reconnect.
-        reboot_failures: Vec<(String, String)>,
+        reboot_failures: Vec<RebootFailure>,
     }
 
     impl MockGroup {
@@ -569,7 +612,7 @@ mod tests {
 
         /// Scripts `reboot` to report `failures`, modelling a transactional
         /// host whose post-reboot reconnect never came back.
-        fn with_reboot_failures(mut self, failures: Vec<(String, String)>) -> Self {
+        fn with_reboot_failures(mut self, failures: Vec<RebootFailure>) -> Self {
             self.reboot_failures = failures;
             self
         }
@@ -610,7 +653,7 @@ mod tests {
             Some(HostOutput::default())
         }
 
-        async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<(String, String)> {
+        async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<RebootFailure> {
             self.events.lock().unwrap().push(Event::Reboot(reboot));
             self.reboot_failures.clone()
         }
@@ -784,7 +827,8 @@ mod tests {
         let mut group = MockGroup::new(Ok(plans));
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await.expect("a clean run succeeds");
+        // This test asserts on the recorded events, not the report.
+        let _ = op.run(&mut group).await.expect("a clean run succeeds");
 
         let events = group.events();
         assert_eq!(events.first(), Some(&Event::UpdateLock));
@@ -837,7 +881,8 @@ mod tests {
         let mut group = MockGroup::new(Ok(plans));
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
-        op.run(&mut group).await.expect("a clean run succeeds");
+        // This test asserts on the recorded events, not the report.
+        let _ = op.run(&mut group).await.expect("a clean run succeeds");
 
         let checks: Vec<Event> = sink.lock().unwrap().clone();
         assert_eq!(
@@ -865,7 +910,7 @@ mod tests {
         )];
         let mut group = MockGroup::with_event_log(Ok(plans), log);
 
-        InstallOperation::new(strs(&["pkg-a"]))
+        let _ = InstallOperation::new(strs(&["pkg-a"]))
             .run(&mut group)
             .await
             .expect("a clean run succeeds");
@@ -894,8 +939,11 @@ mod tests {
             Doer::new("in $packages", "systemctl reboot"),
             sink,
         )];
-        let mut group = MockGroup::new(Ok(plans))
-            .with_reboot_failures(vec![("h1".to_owned(), "reconnect failed".to_owned())]);
+        let mut group = MockGroup::new(Ok(plans)).with_reboot_failures(vec![RebootFailure {
+            host: "h1".to_owned(),
+            cause: RebootFailureCause::Unreachable,
+            reason: "reconnect failed".to_owned(),
+        }]);
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
         let report = op
@@ -905,7 +953,11 @@ mod tests {
 
         assert_eq!(
             report.reboot_failures,
-            vec![("h1".to_owned(), "reconnect failed".to_owned())]
+            vec![RebootFailure {
+                host: "h1".to_owned(),
+                cause: RebootFailureCause::Unreachable,
+                reason: "reconnect failed".to_owned(),
+            }]
         );
         // Unlock must still be the last event: a lost host does not skip
         // releasing the operation lock.
@@ -1010,7 +1062,7 @@ mod tests {
         )];
         let mut group = MockGroup::new(Ok(plans));
 
-        UninstallOperation::new(strs(&["pkg"]))
+        let _ = UninstallOperation::new(strs(&["pkg"]))
             .run(&mut group)
             .await
             .expect("a clean run succeeds");

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -196,9 +196,10 @@ pub trait OperationGroup: Send {
 
     /// Reboots the transactional hosts named in `reboot`.
     ///
-    /// Returns `(hostname, reason)` for every host that did not reconnect —
-    /// a transactional host that rebooted and never came back must fail the
-    /// operation, not report success on a host it lost.
+    /// Returns one [`RebootFailure`] for every host whose reboot did not take
+    /// effect, carrying *why* — a transactional host whose snapshot never
+    /// activated must fail the operation, not report success, and the caller
+    /// routes its recovery on the cause.
     async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<RebootFailure>;
 
     /// Releases the shared operation lock.
@@ -211,7 +212,7 @@ pub trait OperationGroup: Send {
 ///
 /// `Err` from [`Operation::run`] keeps meaning "never started" (no plans, or a
 /// foreign lock); `Ok(report)` means it ran, and the two failure lists name any
-/// host that failed its check or was left unreachable by its reboot.
+/// host that failed its check or whose reboot did not take effect.
 #[must_use = "the report names the hosts that failed; dropping it silently \
               reports a failed operation as a clean one"]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -319,9 +320,9 @@ pub trait Operation: Send + Sync {
     /// activates; a host left inert by a failed check is named at WARN.
     ///
     /// Returns the started run's [`OperationReport`], which names any host
-    /// that failed its check and any transactional host that rebooted and did
-    /// not reconnect — a caller that discards it cannot tell either apart from
-    /// a host that came back healthy.
+    /// that failed its check and any transactional host whose reboot did not
+    /// take effect — a caller that discards it cannot tell either apart from a
+    /// host that came back healthy.
     ///
     /// # Errors
     ///

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -95,13 +95,27 @@ fn target(
     (t, handle)
 }
 
-/// The commands a test actually cares about: the operation's own, with the
-/// reboot lifecycle's boot-id probes filtered out.
-fn package_commands(conn: &mtui_hosts::MockConnection) -> Vec<String> {
+/// Splits a host's issued commands into the operation's own and the reboot
+/// lifecycle's boot-id probes.
+///
+/// The probes are returned rather than discarded so a caller can pin how many
+/// there were: filtering them away silently would make "two probes" (the
+/// snapshot plus the verification) indistinguishable from one, or from none at
+/// all — i.e. it would hide the deletion of either boot-id phase.
+fn split_commands(conn: &mtui_hosts::MockConnection) -> (Vec<String>, Vec<String>) {
     conn.commands()
         .into_iter()
-        .filter(|c| c != "cat /proc/sys/kernel/random/boot_id")
-        .collect()
+        .partition(|c| c != "cat /proc/sys/kernel/random/boot_id")
+}
+
+/// Just the operation's own commands.
+fn package_commands(conn: &mtui_hosts::MockConnection) -> Vec<String> {
+    split_commands(conn).0
+}
+
+/// How many boot-id probes a host saw.
+fn probe_count(conn: &mtui_hosts::MockConnection) -> usize {
+    split_commands(conn).1.len()
 }
 
 #[tokio::test]
@@ -112,10 +126,14 @@ async fn install_drives_doer_and_reboots_only_transactional() {
     let (h2, m2) = target("h2", "SL-Micro", "6.0", true);
     let mut group = HostsGroup::new(vec![h1, h2], false).with_plan_provider(Arc::new(provider));
 
-    let _ = InstallOperation::new(vec!["pkg-a".to_owned(), "pkg-b".to_owned()])
+    let report = InstallOperation::new(vec!["pkg-a".to_owned(), "pkg-b".to_owned()])
         .run(&mut group)
         .await
         .expect("a wired group installs");
+    // Asserted, not discarded: this is the end-to-end healthy-reboot case, and
+    // it is what makes the fixture's changing boot id load-bearing.
+    assert!(report.reboot_failures.is_empty(), "{report:?}");
+    assert!(report.check_failures.is_empty(), "{report:?}");
 
     // The provider was consulted for each host with the release derived from
     // its parsed system: SLES 15.5 -> "15", SL-Micro -> "slmicro".
@@ -134,9 +152,15 @@ async fn install_drives_doer_and_reboots_only_transactional() {
         package_commands(&m1),
         vec!["zypper -n in -y -l pkg-a pkg-b".to_owned()]
     );
-    // The non-transactional host was never rebooted.
+    // The non-transactional host was never rebooted — and never probed, which
+    // the old exact-command-list assertion used to enforce.
     assert!(m1.fired_commands().is_empty());
     assert_eq!(m1.reconnect_count(), 0);
+    assert_eq!(
+        probe_count(&m1),
+        0,
+        "a non-transactional host is not probed"
+    );
 
     // The transactional host ran only the install as a normal command; the
     // reboot is dispatched fire-and-forget (the reboot drops the connection),
@@ -147,6 +171,9 @@ async fn install_drives_doer_and_reboots_only_transactional() {
     );
     assert_eq!(m2.fired_commands(), vec!["systemctl reboot".to_owned()]);
     assert_eq!(m2.reconnect_count(), 1);
+    // Exactly two: the pre-reboot snapshot and the post-reboot verification.
+    // Deleting either phase drops this to one.
+    assert_eq!(probe_count(&m2), 2, "snapshot + verify");
 
     // The check fired once per host.
     let mut who = checked.lock().unwrap().clone();

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use mtui_hosts::{
     Check, CheckArgs, Doer, HostError, HostsGroup, InstallOperation, Operation, OperationGroup,
-    PlanProvider, Target, UninstallOperation,
+    PlanProvider, RebootFailure, RebootFailureCause, Target, UninstallOperation,
 };
 use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
@@ -77,8 +77,13 @@ fn target(
     version: &str,
     transactional: bool,
 ) -> (Target, mtui_hosts::MockConnection) {
+    // A *fresh* boot id on every read models a host that really rebooted. A
+    // fixture built with `with_default` alone answers both probes identically,
+    // which the reboot lifecycle now correctly reads as "this host never went
+    // down" — right for a test about that, wrong for every other test here.
     let conn = mtui_hosts::MockConnection::new(hostname)
-        .with_default(CommandLog::new("", "done", "", 0, 1));
+        .with_default(CommandLog::new("", "done", "", 0, 1))
+        .with_changing_boot_id();
     let handle = conn.clone();
     let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
     let system = System::new(
@@ -90,6 +95,15 @@ fn target(
     (t, handle)
 }
 
+/// The commands a test actually cares about: the operation's own, with the
+/// reboot lifecycle's boot-id probes filtered out.
+fn package_commands(conn: &mtui_hosts::MockConnection) -> Vec<String> {
+    conn.commands()
+        .into_iter()
+        .filter(|c| c != "cat /proc/sys/kernel/random/boot_id")
+        .collect()
+}
+
 #[tokio::test]
 async fn install_drives_doer_and_reboots_only_transactional() {
     let (provider, lookups, checked) = RecordingProvider::new();
@@ -98,7 +112,7 @@ async fn install_drives_doer_and_reboots_only_transactional() {
     let (h2, m2) = target("h2", "SL-Micro", "6.0", true);
     let mut group = HostsGroup::new(vec![h1, h2], false).with_plan_provider(Arc::new(provider));
 
-    InstallOperation::new(vec!["pkg-a".to_owned(), "pkg-b".to_owned()])
+    let _ = InstallOperation::new(vec!["pkg-a".to_owned(), "pkg-b".to_owned()])
         .run(&mut group)
         .await
         .expect("a wired group installs");
@@ -117,7 +131,7 @@ async fn install_drives_doer_and_reboots_only_transactional() {
 
     // The install command ran on both hosts with $packages substituted.
     assert_eq!(
-        m1.commands(),
+        package_commands(&m1),
         vec!["zypper -n in -y -l pkg-a pkg-b".to_owned()]
     );
     // The non-transactional host was never rebooted.
@@ -128,7 +142,7 @@ async fn install_drives_doer_and_reboots_only_transactional() {
     // reboot is dispatched fire-and-forget (the reboot drops the connection),
     // then the host is reconnected — the P2.9 `_reboot` lifecycle.
     assert_eq!(
-        m2.commands(),
+        package_commands(&m2),
         vec!["zypper -n in -y -l pkg-a pkg-b".to_owned()]
     );
     assert_eq!(m2.fired_commands(), vec!["systemctl reboot".to_owned()]);
@@ -183,7 +197,7 @@ async fn install_check_sees_the_hosts_post_run_output() {
     let (h1, _m1) = target("h1", "SLES", "15.5", false);
     let mut group = HostsGroup::new(vec![h1], false).with_plan_provider(Arc::new(provider));
 
-    InstallOperation::new(vec!["pkg-a".to_owned()])
+    let _ = InstallOperation::new(vec!["pkg-a".to_owned()])
         .run(&mut group)
         .await
         .expect("a wired group installs");
@@ -228,7 +242,11 @@ async fn install_reports_a_transactional_host_that_never_reconnects() {
 
     assert_eq!(
         report.reboot_failures,
-        vec![("h1".to_owned(), "failed to reconnect to h1".to_owned())]
+        vec![RebootFailure {
+            host: "h1".to_owned(),
+            cause: RebootFailureCause::Unreachable,
+            reason: "failed to reconnect to h1".to_owned(),
+        }]
     );
     assert_eq!(handle.reconnect_count(), 1);
 }
@@ -242,12 +260,15 @@ async fn install_shell_quotes_malicious_package_name_end_to_end() {
     let (h1, m1) = target("h1", "SLES", "15.5", false);
     let mut group = HostsGroup::new(vec![h1], false).with_plan_provider(Arc::new(provider));
 
-    InstallOperation::new(vec!["foo; rm -rf /".to_owned()])
+    let _ = InstallOperation::new(vec!["foo; rm -rf /".to_owned()])
         .run(&mut group)
         .await
         .expect("a wired group installs");
 
-    let cmd = m1.commands().into_iter().next().expect("one command ran");
+    let cmd = package_commands(&m1)
+        .into_iter()
+        .next()
+        .expect("one command ran");
     assert!(
         !cmd.ends_with("foo; rm -rf /"),
         "metacharacters leaked unquoted: {cmd:?}"
@@ -274,7 +295,7 @@ async fn uninstall_uses_uninstaller_role() {
     let (h1, _m1) = target("h1", "SLES", "15.5", false);
     let mut group = HostsGroup::new(vec![h1], false).with_plan_provider(Arc::new(provider));
 
-    UninstallOperation::new(vec!["pkg".to_owned()])
+    let _ = UninstallOperation::new(vec!["pkg".to_owned()])
         .run(&mut group)
         .await
         .expect("a wired group uninstalls");
@@ -322,7 +343,7 @@ async fn select_preserves_injected_provider() {
     // Selecting a subset must carry the provider through so the sub-group can
     // still drive an operation.
     let mut sub = group.select(Some(&["h1".to_owned()]), false).unwrap();
-    InstallOperation::new(vec!["pkg".to_owned()])
+    let _ = InstallOperation::new(vec!["pkg".to_owned()])
         .run(&mut sub)
         .await
         .expect("a wired group installs");

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -120,9 +120,11 @@ where
     .await
 }
 
-/// Drives [`perform_update_from_report`] and, on a *check* failure, rolls the
-/// packages back via [`perform_downgrade`] before re-surfacing the original
-/// error.
+/// Drives [`perform_update_from_report`] and rolls the packages back via
+/// [`perform_downgrade`], before re-surfacing the original error, on the two
+/// failures that leave the group repairable: a *check* failure, and a reboot
+/// that did not take effect on a host still reachable
+/// ([`UpdateFailure::RebootNotTaken`]).
 ///
 /// A `MissingUpdater` failure installed nothing, so it re-surfaces without a
 /// rollback attempt. The rollback is best-effort ([`perform_downgrade`] returns
@@ -1228,10 +1230,13 @@ pub async fn perform_update(
 /// success, and **always** unlocks.
 ///
 /// Returns `Ok(())` when every host's check passed and every transactional
-/// host reconnected; otherwise `Err` with the aggregated failure: a check
-/// failure (packages may be half-applied) is [`UpdateFailure::Check`] and
-/// **suppresses the reboot entirely**; a post-patch reconnect failure is
-/// [`UpdateFailure::Reboot`]. A single failure is returned verbatim; more than
+/// host's reboot took effect — reconnecting is not sufficient, since a host can
+/// answer without ever having gone down. Otherwise `Err` with the aggregated
+/// failure: a check failure (packages may be half-applied) is
+/// [`UpdateFailure::Check`] and **suppresses the reboot entirely**; a reboot
+/// failure is [`UpdateFailure::Reboot`] when the host is unreachable and
+/// [`UpdateFailure::RebootNotTaken`] when every failed host is still reachable,
+/// which is what decides whether the group-wide rollback runs. A single failure is returned verbatim; more than
 /// one is summarised into `"update failed on {hosts} ({detail})"`.
 async fn update_run_phase(
     targets: &mut HostsGroup,
@@ -1269,11 +1274,18 @@ async fn update_run_phase(
         // behalf of one this flow cannot reach. A host that is still up, on the
         // other hand, is running the un-activated snapshot while the rest of the
         // group moved on, and that is precisely the split-brain the rollback
-        // undoes. Mixed causes take the repairable route: the reachable host is
-        // the one that can still be put right.
-        let repairable = reboot_failures
-            .iter()
-            .any(|f| f.cause.host_still_reachable());
+        // undoes.
+        //
+        // Mixed causes take the *conservative* route. `all`, not `any`: the
+        // rollback reverts the whole group, so it is only worth running when
+        // every failed host can actually be repaired by it. With one host
+        // unreachable and one merely inert, rolling back cannot reach the
+        // first, leaves the second needing manual work anyway, and reverts the
+        // hosts that did everything right. Both are still named in the error.
+        let repairable = !reboot_failures.is_empty()
+            && reboot_failures
+                .iter()
+                .all(|f| f.cause.host_still_reachable());
         let wrap: fn(UpdateError) -> UpdateFailure = if repairable {
             UpdateFailure::RebootNotTaken
         } else {
@@ -2366,6 +2378,33 @@ mod tests {
             "a reachable host on an inactive snapshot must be rolled back: {:?}",
             handle.commands()
         );
+    }
+
+    #[tokio::test]
+    async fn update_skips_the_rollback_when_any_failed_host_is_unreachable() {
+        // Mixed causes: h1 is gone, h2 is up but never rebooted. The rollback
+        // is group-wide, so running it could not repair h1, would leave h2
+        // needing manual work anyway, and would revert every healthy host in
+        // the group. `all`, not `any` — and both hosts are still named.
+        let (t1, h1) = slmicro_reboot_failure("h1", RebootFault::Unreachable);
+        let (t2, h2) = slmicro_reboot_failure("h2", RebootFault::WentNowhere);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("two failed reboots must not report success");
+        assert!(err.reason.contains("h1"), "reason: {}", err.reason);
+        assert!(err.reason.contains("h2"), "reason: {}", err.reason);
+        for (name, handle) in [("h1", &h1), ("h2", &h2)] {
+            assert!(
+                !handle.commands().iter().any(|c| c.contains("--oldpackage")),
+                "{name} must not be rolled back when a peer is unreachable: {:?}",
+                handle.commands()
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -25,8 +25,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use mtui_hosts::{
-    Command, HostError, HostsGroup, InstallOperation, Operation, OperationGroup, RepoOp, SetRepo,
-    UninstallOperation,
+    Command, HostError, HostsGroup, InstallOperation, Operation, OperationGroup, RebootFailure,
+    RebootFailureCause, RepoOp, SetRepo, UninstallOperation,
 };
 use mtui_types::shellquote::quote_args;
 use tracing::{debug, error, info, warn};
@@ -65,8 +65,19 @@ pub enum UpdateFailure {
     /// reconnect.
     ///
     /// Like [`MissingUpdater`](Self::MissingUpdater) this skips the rollback:
-    /// the host is unreachable, so a downgrade cannot run on it.
+    /// the host is unreachable, so a downgrade cannot run on it — and the
+    /// rollback is group-wide, so running it would revert the *healthy* hosts
+    /// on behalf of one that cannot be reached either way.
     Reboot(UpdateError),
+    /// A transactional host was patched but its reboot never took effect, and
+    /// the host is **still reachable**: the command was never dispatched, or
+    /// the host answered with an unchanged boot id.
+    ///
+    /// Unlike [`Reboot`](Self::Reboot) this *does* roll back. The host is up,
+    /// serving from the old snapshot while the rest of the group runs the new
+    /// packages — the split-brain the rollback exists to undo — and, being
+    /// reachable, it is a host the downgrade can actually reach.
+    RebootNotTaken(UpdateError),
 }
 
 /// Drives [`perform_update`] from a concrete report, reading the package list
@@ -147,7 +158,7 @@ where
             error!(error = %e, "update failed");
             Err(e)
         }
-        Err(UpdateFailure::Check(e)) => {
+        Err(UpdateFailure::Check(e) | UpdateFailure::RebootNotTaken(e)) => {
             error!("Update failed");
             warn!("Error while updating. Rolling back changes");
             let pkgs = report.get_package_list();
@@ -443,10 +454,24 @@ async fn perform_operation(
         .into_iter()
         .map(|(host, reason)| UpdateError::new(reason, host))
         .collect();
-    failures.extend(report.reboot_failures.into_iter().map(|(host, reason)| {
-        UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
-    }));
+    failures.extend(report.reboot_failures.into_iter().map(reboot_error));
     aggregate_failures(op, failures)
+}
+
+/// Renders a [`RebootFailure`] as the operator-facing per-host error.
+///
+/// The three causes deliberately read differently: they send an operator to
+/// opposite places. "Did not come back" means go find the machine; "never
+/// rebooted" means it is right there, still serving, with an inert snapshot.
+/// A single "reconnect after reboot failed" message was accurate for only one
+/// of the three.
+fn reboot_error(failure: RebootFailure) -> UpdateError {
+    let what = match failure.cause {
+        RebootFailureCause::Unreachable => "did not come back after the reboot",
+        RebootFailureCause::NotDispatched => "never received the reboot",
+        RebootFailureCause::NotRebooted => "never rebooted, so its snapshot is still inactive",
+    };
+    UpdateError::new(format!("{what} ({})", failure.reason), failure.host)
 }
 
 /// Turns an [`Operation::run`](mtui_hosts::Operation::run) start failure into a
@@ -495,26 +520,21 @@ fn describe_start_failure(err: &HostError, role: Role, targets: &HostsGroup) -> 
 }
 
 /// Reboots the transactional hosts named in `reboot`, returning one
-/// [`UpdateError`] per host that did not reconnect.
+/// [`RebootFailure`] per host whose reboot did not demonstrably take effect.
 ///
-/// A transactional host that rebooted and never came back must fail the flow
-/// by name, not vanish into a discarded `()` — the caller pushes these into
-/// its own failure list before aggregating.
+/// Such a host must fail the flow by name, not vanish into a discarded `()` —
+/// the caller renders these through [`reboot_error`] into its own failure list
+/// before aggregating. The cause is carried rather than flattened to a string
+/// because `update` routes its rollback on it.
 async fn reboot_transactional(
     targets: &mut HostsGroup,
     reboot: BTreeMap<String, String>,
-) -> Vec<UpdateError> {
+) -> Vec<RebootFailure> {
     if reboot.is_empty() {
         return Vec::new();
     }
     let map: Vec<(String, String)> = reboot.into_iter().collect();
-    OperationGroup::reboot(targets, map)
-        .await
-        .into_iter()
-        .map(|(host, reason)| {
-            UpdateError::new(format!("reconnect after reboot failed: {reason}"), host)
-        })
-        .collect()
+    OperationGroup::reboot(targets, map).await
 }
 
 /// Runs the prepare step: adds/removes the issue repo, then installs
@@ -633,7 +653,12 @@ async fn prepare_body(
         error!(error = %e, "prepare check failed");
         failures.push(e);
     }
-    failures.extend(reboot_transactional(targets, reboot).await);
+    failures.extend(
+        reboot_transactional(targets, reboot)
+            .await
+            .into_iter()
+            .map(reboot_error),
+    );
     // A genuine host failure outranks the cancellation: reporting only
     // "cancelled" would bury a broken host the operator must still see.
     if !failures.is_empty() {
@@ -924,7 +949,12 @@ async fn downgrade_body(
         .into_iter()
         .filter(|(h, _)| !dead_probes.contains(h))
         .collect();
-    failures.extend(reboot_transactional(targets, healthy_reboot).await);
+    failures.extend(
+        reboot_transactional(targets, healthy_reboot)
+            .await
+            .into_iter()
+            .map(reboot_error),
+    );
 
     // The downgrade commands have now dispatched, whatever the verdict:
     // record the history row here, not before the run started.
@@ -1233,7 +1263,27 @@ async fn update_run_phase(
         aggregate_failures("update", failures).map_err(UpdateFailure::Check)
     } else {
         let reboot_failures = reboot_transactional(targets, reboot).await;
-        aggregate_failures("update", reboot_failures).map_err(UpdateFailure::Reboot)
+        // Route the rollback on *why* the reboot failed, not on the fact that
+        // it did. A host that never came back cannot be downgraded, and the
+        // rollback is group-wide — running it would revert the healthy hosts on
+        // behalf of one this flow cannot reach. A host that is still up, on the
+        // other hand, is running the un-activated snapshot while the rest of the
+        // group moved on, and that is precisely the split-brain the rollback
+        // undoes. Mixed causes take the repairable route: the reachable host is
+        // the one that can still be put right.
+        let repairable = reboot_failures
+            .iter()
+            .any(|f| f.cause.host_still_reachable());
+        let wrap: fn(UpdateError) -> UpdateFailure = if repairable {
+            UpdateFailure::RebootNotTaken
+        } else {
+            UpdateFailure::Reboot
+        };
+        aggregate_failures(
+            "update",
+            reboot_failures.into_iter().map(reboot_error).collect(),
+        )
+        .map_err(wrap)
     };
 
     targets.unlock().await;
@@ -2084,8 +2134,58 @@ mod tests {
     /// Builds an enabled SL Micro (transactional) target on a mock returning
     /// `stdout` with `exit` for every command.
     fn slmicro_target(hostname: &str, stdout: &str, exit: i16) -> (Target, MockConnection) {
-        let conn =
-            MockConnection::new(hostname).with_default(CommandLog::new("", stdout, "", exit, 0));
+        // A changing boot id models a host that really rebooted. Without it
+        // both probes read the same and the lifecycle correctly concludes the
+        // host never went down — see `RebootFault::WentNowhere` for that.
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", stdout, "", exit, 0))
+            .with_changing_boot_id();
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        (t, handle)
+    }
+
+    /// Which of the three reboot failure modes a fixture should exhibit.
+    #[derive(Debug, Clone, Copy)]
+    enum RebootFault {
+        /// Went away and never came back. Unreachable.
+        Unreachable,
+        /// Answers afterwards with the same boot id: it never went down.
+        WentNowhere,
+        /// The dispatch itself failed, leaving the session live so the
+        /// following reconnect succeeds trivially.
+        Undispatched,
+    }
+
+    /// A transactional SL-Micro target whose reboot fails in one of the three
+    /// distinguishable ways, wired so a rollback *would* render if one ran.
+    ///
+    /// The stdout matters: a mock answering `""` makes the downgrade version
+    /// probe yield nothing, so `combined` stays empty and **no downgrade
+    /// command is ever built** — which silently turns any "assert no
+    /// `--oldpackage`" into a test that cannot fail. Answering with a parseable
+    /// `pkg = version` line is what makes those assertions real.
+    fn slmicro_reboot_failure(hostname: &str, how: RebootFault) -> (Target, MockConnection) {
+        let conn = MockConnection::new(hostname).with_default(CommandLog::new(
+            "",
+            "pkg-a = 1.0-1\n",
+            "",
+            0,
+            0,
+        ));
+        let conn = match how {
+            RebootFault::Unreachable => conn.with_changing_boot_id().failing_reconnect(),
+            RebootFault::WentNowhere => conn,
+            RebootFault::Undispatched => conn.with_changing_boot_id().failing_fire_and_forget(),
+        };
         let handle = conn.clone();
         let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
         t.set_system(
@@ -2102,20 +2202,7 @@ mod tests {
     /// Like [`slmicro_target`] but its reconnect after a reboot always fails,
     /// modelling a transactional host that never comes back.
     fn slmicro_target_failing_reconnect(hostname: &str) -> (Target, MockConnection) {
-        let conn = MockConnection::new(hostname)
-            .with_default(CommandLog::new("", "", "", 0, 0))
-            .failing_reconnect();
-        let handle = conn.clone();
-        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
-        t.set_system(
-            System::new(
-                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
-                BTreeSet::new(),
-                true,
-            ),
-            true,
-        );
-        (t, handle)
+        slmicro_reboot_failure(hostname, RebootFault::Unreachable)
     }
 
     #[tokio::test]
@@ -2131,7 +2218,14 @@ mod tests {
             .expect_err("a lost transactional host must not report success");
         assert_eq!(err.host.as_deref(), Some("h1"));
         assert!(
-            err.reason.contains("reconnect after reboot failed"),
+            err.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: the two reachable causes must not be claimed for a
+        // host that genuinely went away — they route the rollback differently.
+        assert!(
+            !err.reason.contains("never rebooted") && !err.reason.contains("never received"),
             "reason: {}",
             err.reason
         );
@@ -2164,7 +2258,14 @@ mod tests {
         .await
         .expect_err("a lost transactional host must not report success");
         assert!(
-            err.reason.contains("reconnect after reboot failed"),
+            err.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: the two reachable causes must not be claimed for a
+        // host that genuinely went away — they route the rollback differently.
+        assert!(
+            !err.reason.contains("never rebooted") && !err.reason.contains("never received"),
             "reason: {}",
             err.reason
         );
@@ -2180,7 +2281,14 @@ mod tests {
             .await
             .expect_err("a lost transactional host must not report success");
         assert!(
-            err.reason.contains("reconnect after reboot failed"),
+            err.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: the two reachable causes must not be claimed for a
+        // host that genuinely went away — they route the rollback differently.
+        assert!(
+            !err.reason.contains("never rebooted") && !err.reason.contains("never received"),
             "reason: {}",
             err.reason
         );
@@ -2202,15 +2310,86 @@ mod tests {
             .await;
         let err = res.expect_err("a lost transactional host must not report success");
         assert!(
-            err.reason.contains("reconnect after reboot failed"),
+            err.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: the two reachable causes must not be claimed for a
+        // host that genuinely went away — they route the rollback differently.
+        assert!(
+            !err.reason.contains("never rebooted") && !err.reason.contains("never received"),
             "reason: {}",
             err.reason
         );
 
-        // No downgrade (rollback) command was issued.
+        // No downgrade (rollback) command was issued. The fixture answers the
+        // version probe with a parseable line, so a rollback that *did* run
+        // would render `--oldpackage` here — without that, this assertion would
+        // pass no matter how the failure was routed.
         assert!(
             !handle.commands().iter().any(|c| c.contains("--oldpackage")),
             "a dead host must not trigger a rollback downgrade: {:?}",
+            handle.commands()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_rolls_back_when_the_host_never_went_down() {
+        // The inverse of the test above, and the reason the cause is carried
+        // rather than flattened: this host is *reachable*. Its patch was staged
+        // into a snapshot that never activated, so it is serving the old
+        // packages while the rest of the group moved on — the split-brain the
+        // rollback exists to undo, and a host the downgrade can actually reach.
+        let (t, handle) = slmicro_reboot_failure("h1", RebootFault::WentNowhere);
+        let mut group = HostsGroup::new(vec![t], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("a host that never rebooted must not report success");
+        assert!(
+            err.reason.contains("never rebooted"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: this is NOT the unreachable case, which skips the
+        // rollback. Asserting the positive alone would pass on either routing.
+        assert!(
+            !err.reason.contains("did not come back"),
+            "reason: {}",
+            err.reason
+        );
+        assert!(
+            handle.commands().iter().any(|c| c.contains("--oldpackage")),
+            "a reachable host on an inactive snapshot must be rolled back: {:?}",
+            handle.commands()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_rolls_back_when_the_reboot_was_never_dispatched() {
+        // The subtlest of the three: the dispatch fails, which leaves the SSH
+        // session live, so the reconnect that follows returns Ok immediately.
+        // Before the dispatch result was captured this read as a clean reboot.
+        let (t, handle) = slmicro_reboot_failure("h1", RebootFault::Undispatched);
+        let mut group = HostsGroup::new(vec![t], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("an undispatched reboot must not report success");
+        assert!(
+            err.reason.contains("never received the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        assert!(
+            handle.commands().iter().any(|c| c.contains("--oldpackage")),
+            "a host that never got the reboot is still up and must be rolled back: {:?}",
             handle.commands()
         );
     }


### PR DESCRIPTION
## Summary

Follow-up to #385, keeping only what that PR does not cover. #385 detects a transactional host that rebooted and **never came back**; a post-operation reboot can fail in two more ways, and both still report success on main:

- **The reboot was never dispatched.** `SshConnection::fire_and_forget` tears the local link down only as its last statement, after `channel_open_session` and `exec` have both succeeded, and `reconnect` opens with `if self.is_active() { return Ok(()) }`. So a failed dispatch leaves a live session behind and the reconnect that follows returns `Ok(())` in zero time. `Target::reboot` returned `()` and only logged, so nothing propagated.
- **The host never went down.** A reboot the host accepts and silently ignores (a masked `rebootmgr`, a systemd inhibitor, a polkit denial) leaves it reachable, so the reconnect succeeds against a machine still running the old snapshot. `reboot_transactional`'s own doc comment said it took no boot-id snapshot — the explicit `reboot` command has always taken one.

`Target::reboot` now returns `Result<()>` and `reboot_transactional` gains the snapshot/verify phases. The explicit `reboot`/`reboot_where` path had the same undispatched-reboot hole and is fixed in the same shape.

## The rollback decision

`update`'s rollback now routes on **why** the reboot failed, which is why the cause is carried as `RebootFailure`/`RebootFailureCause` instead of being flattened to a string at the `OperationGroup` seam.

The rollback is group-wide (`perform_downgrade` takes the whole `HostsGroup`), so it runs only when it can actually repair every host that failed — i.e. when all of them are still reachable but sitting on an un-activated snapshot (`UpdateFailure::RebootNotTaken`). That is the split-brain a rollback exists to undo. If **any** failed host is unreachable it is skipped (`UpdateFailure::Reboot`): reverting the healthy hosts cannot repair a machine nothing can reach, and `downgrade_body` reboots the transactional hosts again, so it can turn one lost host into two. Every failed host is named either way.

## Notes for review

- **`OperationGroup::reboot` and `OperationReport.reboot_failures` change shape** (`Vec<(String, String)>` → `Vec<RebootFailure>`). Both implementers (`HostsGroup`, the `MockGroup` double) and the single production consumer are updated. The tuple stringified the error at the seam, which is exactly the information the routing above needs.
- **`OperationReport` gains `#[must_use]`.** To be precise: it catches **no** live drop today — it prevents a future one, which its own doc comment already warned about.
- **An unreadable boot id is not a failure.** `Target::boot_id` returns `""` on any error and an empty id passes with a WARN. Boot-id verification is therefore best-effort, not a guarantee, and the doc now says so — failing open beats reverting a fleet because a probe timed out.
- The second commit fixes a bug the first one introduced; it is kept separate because the reasoning is worth reading. `RebootNotDispatched` asserts the host is still reachable, and an "earliest phase wins" rule discarded the reconnect result — so a link that died *before* the dispatch was reported as reachable and would have sent the whole group into a rollback. A failed reconnect now outranks the phase-2 diagnosis, while a *successful* one still cannot erase it.

## Testing

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, `--no-default-features` and `--all-features` compile-only, `typos`.
- Eight mutants, each killed by the intended test: forcing either rollback route, collapsing the cause classifier, deleting the boot-id verdict, re-swallowing the dispatch error, reverting the precedence rule, `all` back to `any`, and the unconnected-target variant.
- Two fixture traps worth knowing about, both of which silently disarm tests here:
  - A mock built with `with_default` alone answers both boot-id probes identically, which now correctly reads as "this host never went down". Transactional fixtures need `with_changing_boot_id()`.
  - `slmicro_target_failing_reconnect` previously answered the version probe with `""`, so `parse_downgrade_versions` yielded nothing and **no downgrade command was ever built** — which made `assert!(!commands.contains("--oldpackage"))` in `update_reports_a_host_that_never_came_back_and_skips_the_rollback` unfailable. That test passed on main with `UpdateFailure::Reboot` deleted entirely. The fixture now answers with a parseable version line, and the assertion discriminates.
- Also fixed: `operation_reboot_fires_and_reconnects_named_hosts` had drifted to a fixed-boot-id mock and passed only because the returned `Vec` was discarded, so nothing asserted that a *healthy* transactional reboot yields no failures. It does now.

## Not in this PR

Found while reviewing #385, filed separately rather than folded in here:

- `update` still has no verdict at all on SL Micro / YUM hosts. `run_checks` bails via `else { continue }` when the registry has no entry, and the update check table covers only `("11" | "12" | "15" | "16", false)`. #385's exit-code fallback lives in the `PlanProvider::check` adapter, which `run_checks` does not go through — so `update_run_phase`'s new "a check failure suppresses the reboot entirely" comment describes a branch unreachable for transactional hosts.
- `prepare` and `downgrade` still reboot a host into a failed transaction; #385's check-before-reboot landed only in the install/uninstall template.
- A host lost to the reboot now gets **no** `/var/log/mtui.log` row: `add_op_history` moved after the reboot fan-out, and `Target::add_history` writes through a session that has just failed to reconnect, swallowing the failure at WARN.
