### PR TITLE
docs: record that a green suite without a reachable red is not evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,9 @@ next actionable task before working on a subsystem.
   an early timeout as a failure.
 - **"Done" means CI observed green, not predicted green.** Report status from the
   actual run.
+- **A regression test must be observed failing** against the unfixed code before
+  the fix is claimed done. Revert the fix (or hand-break the line), run that one
+  test, see red, restore. A pinning test that was never red pins nothing.
 - New/changed code needs **>=80% patch coverage**. If a line is genuinely
   un-coverable (best-effort network/error paths), add a focused test or a
   justified allow — never leave coverage silently red.
@@ -268,6 +271,21 @@ The `tests/` fixtures are the authority for these formats; treat them as golden.
   lands with that prefix automatically; don't hand-name it otherwise.
 - **Gate real hosts/containers** behind `#[ignore]` + a CI env flag (sshd
   integration fixture); unit tests must run offline and fast.
+- **A test that cannot fail is not evidence.** Twice a real regression has sailed
+  through a green workspace run: once because the fixture disarmed the assertion
+  (a `MockConnection` answering empty stdout builds no downgrade command, so
+  "assert no `--oldpackage`" could not fail; a fresh report "clears" a field that
+  was already `None`), once because the fix landed one layer too low
+  (`Target::reboot` gated on `TargetState`) — which half-gated the lifecycle and
+  silently broke the `reboot` command while every test stayed green. Green CI is
+  a claim about the suite, not a proof about the code. For each new assertion,
+  name the mutation it must catch and check the fixture can express it: a
+  *changing* boot id passes the disabled-host test even when only the dispatch is
+  skipped, so that test pins a *fixed* one. Then break the code and watch it go
+  red. Apply the same scepticism to the fix — when the leaf you are gating has
+  other callers (`Target::reboot` is also reached by `close` and by the explicit
+  `reboot` command), gate on the layer that owns the state and probe the sibling
+  paths before believing the gate landed where you meant it.
 
 ## Style & error handling
 - Edition 2024, MSRV 1.96. `rustfmt` defaults; `clippy` clean with

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -175,6 +175,15 @@ display) passed into each call. There are no hidden globals.
 - **Snapshot text contracts** with `insta` (testreport/export rendering, metadata
   parsing, MCP schemas, the lock wire format, display output). Review new
   snapshots with `cargo insta review`.
+- **Make sure the test can fail.** A green run means something only if red was
+  reachable. Watch for fixtures that quietly disarm the assertion: a
+  `MockConnection` answering empty stdout builds no downgrade command, so an
+  "assert no `--oldpackage`" passes vacuously; a `with_changing_boot_id()` mock
+  passes a skip-the-reboot test even when only the dispatch was skipped. For a
+  test written to pin a bug, revert the fix, watch it go red, then restore. The
+  same applies to the fix itself — when the leaf you are gating has other callers
+  (`Target::reboot` is reached by `close` and the `reboot` command, not just the
+  fan-out), gate on the layer that owns the state and probe the sibling paths.
 
 ### The one-`it.rs`-per-crate rule
 


### PR DESCRIPTION
## Why

Two real regressions passed a green workspace run in the same thread:

1. A `MockConnection` returning empty stdout made "assert no `--oldpackage`"
   unfalsifiable — no downgrade command was ever built to assert against. The
   same shape appeared in `metadata_parsers.rs`, clearing a field on a fresh
   report that was already `None`.
2. The first disabled-host fix gated `Target::reboot` on `TargetState` one
   layer too low, half-gating the lifecycle and silently breaking the
   explicit `reboot` command — while every test stayed green.

Both incidents are already documented at their sites (`9067b5f2`'s commit
body, inline comments in `update_flow.rs` and `metadata_parsers.rs`). This
generalises the lesson so the next test is written with the mutation it
must catch in mind, and the next fix is probed against sibling callers
before being trusted.

## What

- `AGENTS.md` § Testing conventions: fused rule ("a test that cannot fail is
  not evidence") covering both incidents.
- `AGENTS.md` § Definition of Done: regression tests must be observed
  failing against the unfixed code before the fix is claimed done.
- `docs/src/developer.md` § Testing conventions: mirrored bullet in that
  file's shorter voice.

Docs-only; no source changes, no CHANGELOG entry (not user-visible).

## Verification

- `mdbook build docs` succeeds.
- All named identifiers (`Target::reboot`, `TargetState`, `MockConnection`,
  `--oldpackage`, `close`, `with_changing_boot_id`) resolve in the tree.
- `git diff --stat` against `main` touches exactly `AGENTS.md` and
  `docs/src/developer.md`.

Plan: `plans/testing-evidence-rule.md`