### PR TITLE
chore(release): open the 26.2.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [26.1.1] - 2026-07-27
+
 ### Added
 
 - Fuzzing: a `cargo-fuzz` harness (`fuzz/`, detached from the workspace) over

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-cli"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-config"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "directories",
  "mtui-types",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-core"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-datasources"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-hosts"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-mcp"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-testreport"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-types"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "insta",
  "sandogasa-rpmvercmp",
@@ -5320,7 +5320,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "26.1.0"
+version = "26.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "xtask"]
 
 [workspace.package]
-version = "26.1.0"
+version = "26.2.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-or-later"   # intentional deviation from upstream mtui (GPL-2.0-only); see LICENSE

--- a/dist/man/mtui-mcp.1
+++ b/dist/man/mtui-mcp.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui-mcp 1  "mtui-mcp 26.1.0" 
+.TH mtui-mcp 1  "mtui-mcp 26.2.0" 
 .SH NAME
 mtui\-mcp \- MCP server for mtui (tools synthesised from the command registry)
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.1.0
+v26.2.0

--- a/dist/man/mtui.1
+++ b/dist/man/mtui.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui 1  "mtui 26.1.0" 
+.TH mtui 1  "mtui 26.2.0" 
 .SH NAME
 mtui \- Maintenance Test Update Installer
 .SH SYNOPSIS
@@ -63,4 +63,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.1.0
+v26.2.0


### PR DESCRIPTION
## Why

`26.1.x` forked from `d1d87f0d` and owns the patch line (it has already cut
`26.1.1`). The main line therefore opens its next development cycle at
**26.2.0**, and needs the changelog reconciled with what the release branch
actually shipped.

## What

- **`chore(release): bump version to 26.2.0`** — `[workspace.package] version`
  in `Cargo.toml` (the single source; every crate inherits it), the 9
  workspace-member entries in `Cargo.lock` via `cargo update --workspace` (no
  third-party churn), and `dist/man/{mtui,mtui-mcp}.1` regenerated with
  `cargo xtask gen`. Completions carry no version literal and are unchanged;
  `mtui.spec` keeps `Version: 0`, which the OBS `set_version` service fills at
  release time.
- **`chore(release): cut 26.1.1`** — cherry-picked with `-x` from `002293fd` on
  `26.1.x`, so `CHANGELOG.md` is byte-identical across the two branches and
  `[Unreleased]` opens empty for 26.2.0 work.

No tag and no packaging change: this is a development-version bump, not a
release.

## Verification

Full gate, observed green locally:

| check | result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace` | 0 failed |
| `cargo test -p mtui-mcp -F mcp` | 237 passed, 0 failed |
| `cargo build --workspace --no-default-features` | ok |
| `cargo build --workspace --all-features` | ok |

The version literal is asserted in `crates/mtui-core/tests/args.rs` and
`xtask/tests/generate.rs`, so a stale man page or lockfile would have failed the
run. Additionally: `mtui --version` prints `mtui 26.2.0 (...)`, no `26.1.0`
literal remains outside `Cargo.lock` history, and `git diff 26.1.x -- CHANGELOG.md`
is empty.

## Changelog

None. Per `CONTRIBUTING.md` a version bump is not a user-visible change; the
only `CHANGELOG.md` edit here is the 26.1.1 reconciliation itself.