### PR TITLE
ci(release): pick the release-notes base tag explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,13 +102,53 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      # Needed only for the tag list that picks the release-notes base below.
+      # `fetch-depth: 0` because a shallow clone carries no tags.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          path: repo
+          persist-credentials: false
+
+      # Pick the previous release tag explicitly.
+      #
+      # `--generate-notes` alone asks GitHub to guess the base, and it guesses
+      # wrong here: releases are cut on per-minor branches (26.0.x, 26.1.x)
+      # that fork from main and are never merged back, so consecutive release
+      # tags are *siblings* rather than ancestors. Finding no previous release
+      # in the tag's own ancestry, GitHub falls back to the start of the
+      # repository — which is why 26.1.1's notes re-listed the entire Python
+      # era back to PR #72.
+      #
+      # Ordering by version rather than by ancestry is what makes this work
+      # across sibling branches. An empty result means this is the first
+      # release, and generating from the repository root is then correct.
+      - name: Resolve the release-notes base tag
+        working-directory: repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          # An explicit walk rather than `grep -B1`: the step runs under
+          # `bash -e`, where a grep that matches nothing exits 1 and would fail
+          # the release. This cannot fail, and yields an empty base for the
+          # oldest tag — the first-release case, where generating from the
+          # repository root is correct.
+          prev=""
+          while read -r tag; do
+            [ "$tag" = "$GITHUB_REF_NAME" ] && break
+            prev="$tag"
+          done < <(git tag --list '[0-9]*.[0-9]*.[0-9]*' | sort -V)
+          echo "NOTES_START_TAG=$prev" >> "$GITHUB_ENV"
+          echo "release-notes base: ${prev:-<repository root: first release>}"
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          # No checkout in this job, so tell gh which repo to act on.
           GH_REPO: ${{ github.repository }}
-        run: >-
-          gh release create "$GITHUB_REF_NAME"
-          --title "$GITHUB_REF_NAME"
-          --generate-notes
-          dist/*
+        run: |
+          args=(--title "$GITHUB_REF_NAME" --generate-notes)
+          if [ -n "$NOTES_START_TAG" ]; then
+            args+=(--notes-start-tag "$NOTES_START_TAG")
+          fi
+          gh release create "$GITHUB_REF_NAME" "${args[@]}" dist/*


### PR DESCRIPTION
## The symptom

[26.1.1's release notes](https://github.com/openSUSE/mtui/releases/tag/26.1.1)
re-list the whole history back to PR #72 — Python-era changes released long
before, and shipped again under a Rust release.

## Why

`gh release create --generate-notes` with no `--notes-start-tag` asks GitHub to
guess the base tag. The guess fails here because of how releases are branched:

```
26.0.1  26.0.2  26.0.3   ← cut on 26.0.x
26.1.1                   ← cut on 26.1.x, two commits past main
```

Release branches fork from `main` and are never merged back, so consecutive
release tags are **siblings, not ancestors**. Verified:

```console
$ for t in 26.0.1 26.0.2 26.0.3; do
    git merge-base --is-ancestor $t 26.1.1 && echo "$t YES" || echo "$t NO"; done
26.0.1 NO
26.0.2 NO
26.0.3 NO
```

Finding no previous release in the tag's own ancestry, GitHub falls back to the
start of the repository.

## The fix

Order tags by **version** rather than by ancestry, and pass the predecessor
explicitly as `--notes-start-tag`. Version order is what remains meaningful
across sibling branches.

Checked against every existing tag:

| tag | base picked | commits in the diff |
|---|---|---|
| `26.1.1` | `26.0.3` | 53 |
| `26.0.3` | `26.0.2` | 5 |
| `26.0.1` | `19.0.1` | 333 (the Rust rewrite — genuinely that large) |
| oldest tag | *(none)* | repository root, correct for a first release |

## Notes

- The resolver walks the sorted tag list instead of using `grep -B1`. The step
  runs under `bash -e`, where a `grep` that matches nothing exits 1 — that
  would fail the release job on the very first release. Tested under `bash -e`
  for all four cases above plus an unknown tag; all exit 0.
- The release job needs a checkout for the tag list: `fetch-depth: 0` (a
  shallow clone carries no tags), `path: repo` so the downloaded `dist/`
  artifacts are untouched, and `persist-credentials: false` since nothing here
  pushes.
- Only affects *future* releases. 26.1.1's existing notes can be regenerated
  separately if you want — happy to do that.
- No CHANGELOG entry: this is release tooling, not tool behaviour.
- yamllint reports the same 8 pre-existing line-length errors before and after;
  none added.

### Worth considering separately

The CHANGELOG has a `[26.0.1]` section but none for `26.0.2`, `26.0.3` or
`26.1.1` — their entries are still under `[Unreleased]`. If the release process
also cut `[Unreleased]` into a versioned section, `--notes-file` on that section
would give curated notes and make the base-tag question moot. That is a process
change, so I have left it alone here.
