### PR TITLE
fix: give update a verdict on SL Micro/YUM, keep history rows, stop rebooting into failed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `update` now reaches a verdict on SL Micro and RHEL/YUM hosts. Both have had
+  an update command since the port but no post-update *check*, so the flow
+  skipped them silently and reported success however the patch went — a locked
+  update stack, an unresolved dependency or an RPM error on those hosts was
+  simply not looked at, and on SL Micro the host was then rebooted into the
+  failed transaction. SL Micro is judged on the command's output markers rather
+  than its exit code: its update template ends with a repo-cleanup loop, so the
+  status the shell reports is that loop's and not the patch's.
+- An `update` that timed out, or whose connection dropped part-way, is no
+  longer reported as successful on **any** host. The update check had no
+  equivalent of the downgrade check's "timed out or failed to run" gate, so a
+  patch that never completed left an empty transcript that matched none of the
+  failure markers and passed.
 - A post-operation reboot whose SSH link had gone idle during the (multi-
   minute) package transaction now reconnects before dispatching, as ordinary
   commands already did. Without it the reboot failed to dispatch against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,58 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- `update` now reaches a verdict on SL Micro and RHEL/YUM hosts. Both have had
+  an update command since the port but no post-update *check*, so the flow
+  skipped them silently and reported success however the patch went — a locked
+  update stack, an unresolved dependency or an RPM error on those hosts was
+  simply not looked at, and on SL Micro the host was then rebooted into the
+  failed transaction. As on every other host, a failed update check on these
+  also drives the group-wide rollback downgrade, which they could not reach
+  before.
+  SL Micro is judged on the command's output markers rather than its exit code:
+  its update template ends with a repo-cleanup loop, so the status the shell
+  reports is that loop's and not the patch's. RHEL/YUM is judged only on
+  whether the command ran: that key covers every RHEL version, `yum` is `dnf`
+  on RHEL 8/9, and mtui passes the whole package list to hosts that carry only
+  a subset — so neither a non-zero exit nor an `Error:` line (the template also
+  runs `yum repolist` in the same shell) reliably means the update failed.
+- An `update` that timed out, or whose connection dropped part-way, is no
+  longer reported as successful on **any** host. The update check had no
+  equivalent of the downgrade check's "timed out or failed to run" gate, so a
+  patch that never completed left an empty transcript that matched none of the
+  failure markers and passed. Such a host fails the command but does **not**
+  trigger the rollback downgrade: the flow could not talk to it, so a
+  group-wide downgrade could not repair it and would only revert the hosts that
+  patched cleanly. A run mixing one lost host with a genuine check failure
+  still rolls back, on behalf of the host the rollback can actually repair.
+- A transactional host is no longer rebooted by `prepare` or `downgrade` when
+  nothing was staged on it — no package resolved to a version to downgrade, or
+  no prepare command was dispatched. The reboot was gratuitous on its own, and
+  when the downgrade is the `update` rollback it activated whatever the failed
+  update had staged, undoing the update flow's own decision not to reboot.
+- `prepare --installed-only` reports a package that failed anywhere in its
+  per-package run, not only in the last one. It installs one package per
+  round-trip but read a single post-run snapshot, and its template exits 0 when
+  a package is absent — so a later no-op masked an earlier failure, and the
+  host was rebooted into it.
+- A transactional host lost to its post-operation reboot keeps its
+  `/var/log/mtui.log` row. The row was written after the reboot, so on the one
+  host an operator most needs to reconstruct — the one that never came back —
+  the append failed and was swallowed at WARN, leaving no record that
+  `install`, `uninstall`, `update` or `downgrade` had run there at all. It is
+  now written between the command dispatch and the reboot: still never for a
+  run that did not start, and still exactly one row per operation.
+- `prepare` and `downgrade` no longer reboot a transactional host whose
+  package transaction failed. Both flows collected the failure and then
+  rebooted every transactional host anyway, activating the very snapshot the
+  failure came from. The gate is per-host, matching `install`/`uninstall`: a
+  healthy host in the same group still reboots so its staged snapshot
+  activates, and every skipped host is named in the log. A failed combined
+  transactional downgrade is now also reported as a per-host failure rather
+  than relying solely on the post-rollback version verdict.
+
 ## [26.1.1] - 2026-07-27
 
 ### Added
@@ -74,34 +126,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- `update` now reaches a verdict on SL Micro and RHEL/YUM hosts. Both have had
-  an update command since the port but no post-update *check*, so the flow
-  skipped them silently and reported success however the patch went — a locked
-  update stack, an unresolved dependency or an RPM error on those hosts was
-  simply not looked at, and on SL Micro the host was then rebooted into the
-  failed transaction. SL Micro is judged on the command's output markers rather
-  than its exit code: its update template ends with a repo-cleanup loop, so the
-  status the shell reports is that loop's and not the patch's.
-- An `update` that timed out, or whose connection dropped part-way, is no
-  longer reported as successful on **any** host. The update check had no
-  equivalent of the downgrade check's "timed out or failed to run" gate, so a
-  patch that never completed left an empty transcript that matched none of the
-  failure markers and passed.
-- A transactional host lost to its post-operation reboot keeps its
-  `/var/log/mtui.log` row. The row was written after the reboot, so on the one
-  host an operator most needs to reconstruct — the one that never came back —
-  the append failed and was swallowed at WARN, leaving no record that
-  `install`, `uninstall`, `update` or `downgrade` had run there at all. It is
-  now written between the command dispatch and the reboot: still never for a
-  run that did not start, and still exactly one row per operation.
-- `prepare` and `downgrade` no longer reboot a transactional host whose
-  package transaction failed. Both flows collected the failure and then
-  rebooted every transactional host anyway, activating the very snapshot the
-  failure came from. The gate is per-host, matching `install`/`uninstall`: a
-  healthy host in the same group still reboots so its staged snapshot
-  activates, and every skipped host is named in the log. A failed combined
-  transactional downgrade is now also reported as a per-host failure rather
-  than relying solely on the post-rollback version verdict.
 - A post-operation reboot whose SSH link had gone idle during the (multi-
   minute) package transaction now reconnects before dispatching, as ordinary
   commands already did. Without it the reboot failed to dispatch against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   equivalent of the downgrade check's "timed out or failed to run" gate, so a
   patch that never completed left an empty transcript that matched none of the
   failure markers and passed.
+- `prepare` and `downgrade` no longer reboot a transactional host whose
+  package transaction failed. Both flows collected the failure and then
+  rebooted every transactional host anyway, activating the very snapshot the
+  failure came from. The gate is per-host, matching `install`/`uninstall`: a
+  healthy host in the same group still reboots so its staged snapshot
+  activates, and every skipped host is named in the log. A failed combined
+  transactional downgrade is now also reported as a per-host failure rather
+  than relying solely on the post-rollback version verdict.
 - A post-operation reboot whose SSH link had gone idle during the (multi-
   minute) package transaction now reconnects before dispatching, as ordinary
   commands already did. Without it the reboot failed to dispatch against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   equivalent of the downgrade check's "timed out or failed to run" gate, so a
   patch that never completed left an empty transcript that matched none of the
   failure markers and passed.
+- A transactional host lost to its post-operation reboot keeps its
+  `/var/log/mtui.log` row. The row was written after the reboot, so on the one
+  host an operator most needs to reconstruct — the one that never came back —
+  the append failed and was swallowed at WARN, leaving no record that
+  `install`, `uninstall`, `update` or `downgrade` had run there at all. It is
+  now written between the command dispatch and the reboot: still never for a
+  run that did not start, and still exactly one row per operation.
 - `prepare` and `downgrade` no longer reboot a transactional host whose
   package transaction failed. Both flows collected the failure and then
   rebooted every transactional host anyway, activating the very snapshot the

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -1024,6 +1024,14 @@ impl Connection for MockConnection {
     }
 
     async fn sftp_append(&mut self, path: &Path, data: &[u8]) -> Result<()> {
+        // Reconnect at entry if inactive, mirroring `sftp_session` and the ssh
+        // impl (whose `sftp()` does exactly this). Without it the mock accepted
+        // an append on a host that had gone away — so a host lost to its reboot
+        // still "wrote" its history row here, and any test for that regression
+        // would pass however the flow ordered the write.
+        if !self.active {
+            self.reconnect(0, false).await?;
+        }
         self.record_sftp(MockSftpOp::Append(path.to_path_buf()));
         if self.sftp_append_errors.contains(path) {
             return Err(HostError::Sftp {

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -1024,6 +1024,10 @@ impl Connection for MockConnection {
     }
 
     async fn sftp_append(&mut self, path: &Path, data: &[u8]) -> Result<()> {
+        // Record the attempt before anything can fail, so the op log keeps
+        // meaning "an append was tried" even when nothing is persisted — the
+        // oracle `add_history_swallows_append_failure` relies on.
+        self.record_sftp(MockSftpOp::Append(path.to_path_buf()));
         // Reconnect at entry if inactive, mirroring `sftp_session` and the ssh
         // impl (whose `sftp()` does exactly this). Without it the mock accepted
         // an append on a host that had gone away — so a host lost to its reboot
@@ -1032,7 +1036,6 @@ impl Connection for MockConnection {
         if !self.active {
             self.reconnect(0, false).await?;
         }
-        self.record_sftp(MockSftpOp::Append(path.to_path_buf()));
         if self.sftp_append_errors.contains(path) {
             return Err(HostError::Sftp {
                 host: self.hostname.clone(),
@@ -1400,6 +1403,49 @@ mod tests {
                 MockSftpOp::Append(PathBuf::from("/log")),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn sftp_append_on_a_dead_link_reconnects_first() {
+        // Mirrors `SshConnection::sftp()`, which reconnects when the link is
+        // inactive. Without this the mock accepts an append on a host that has
+        // gone away — which silently makes the "a host lost to its reboot
+        // still gets its history row" tests in `mtui-testreport` vacuous: they
+        // would pass with the write on either side of the reboot. This test
+        // exists so removing that guard fails *here*, visibly, rather than
+        // quietly disarming tests in another crate.
+        let mut conn = MockConnection::new("h1").failing_reconnect();
+        conn.fire_and_forget("systemctl reboot")
+            .await
+            .expect("dispatch succeeds and tears the link down");
+        assert!(!conn.is_active(), "the reboot dispatch closes the link");
+
+        let err = conn
+            .sftp_append(Path::new("/log"), b"x\n")
+            .await
+            .expect_err("an append on a dead link must not silently succeed");
+        assert!(matches!(err, HostError::ReconnectFailed { .. }), "{err:?}");
+        assert_eq!(conn.reconnect_count(), 1, "it must have tried to reconnect");
+        assert!(
+            conn.file_contents("/log").is_none(),
+            "nothing may be persisted through a dead link"
+        );
+        // The attempt is still recorded, so an "it tried" oracle stays honest.
+        assert_eq!(conn.sftp_ops(), [MockSftpOp::Append(PathBuf::from("/log"))]);
+    }
+
+    #[tokio::test]
+    async fn sftp_append_on_a_dead_link_succeeds_when_the_reconnect_does() {
+        // The complement: a link that comes back must not lose the write.
+        let mut conn = MockConnection::new("h1");
+        conn.fire_and_forget("systemctl reboot")
+            .await
+            .expect("dispatch ok");
+        conn.sftp_append(Path::new("/log"), b"x\n")
+            .await
+            .expect("a recoverable link still appends");
+        assert_eq!(conn.file_contents("/log").as_deref(), Some(&b"x\n"[..]));
+        assert!(conn.is_active(), "the reconnect reactivated the link");
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1530,6 +1530,10 @@ impl OperationGroup for HostsGroup {
         HostsGroup::run(self, Command::PerHost(map)).await;
     }
 
+    async fn add_history(&mut self, fields: &[String]) {
+        HostsGroup::add_history(self, fields).await;
+    }
+
     fn last_output(&self, hostname: &str) -> Option<super::operation::HostOutput> {
         let target = self.data.get(hostname)?;
         Some(super::operation::HostOutput {

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -13,8 +13,8 @@
 //!    transactional-only reboot map (early-return on the configured
 //!    `missing_error`),
 //! 2. `group.update_lock()`,
-//! 3. in a fallible section: `group.run(commands)` → per-host `check(...)` →
-//!    `group.reboot(reboot)`,
+//! 3. in a fallible section: `group.run(commands)` → `group.add_history(...)`
+//!    → per-host `check(...)` → `group.reboot(reboot)`,
 //! 4. **always** `group.unlock()` afterwards.
 //!
 //! ## Scope: template + seams
@@ -187,6 +187,16 @@ pub trait OperationGroup: Send {
     /// Runs the per-host command map.
     async fn run(&mut self, commands: HostCommandMap);
 
+    /// Appends one colon-joined row to every enabled host's remote history
+    /// file.
+    ///
+    /// Called by [`Operation::run`] between the command fan-out and the reboot.
+    /// It is on the group seam rather than left to the caller because the
+    /// reboot happens inside the template: a caller writing the row after
+    /// `run` returns would lose it on exactly the transactional hosts that
+    /// never came back.
+    async fn add_history(&mut self, fields: &[String]);
+
     /// Reads back `hostname`'s post-run output, for the [`Check`] call.
     ///
     /// Returns `None` for a host outside the group (should not happen for a
@@ -277,6 +287,16 @@ pub trait Operation: Send + Sync {
     /// The doer/check dispatch role: `"installer"` or `"uninstaller"`.
     fn role(&self) -> &'static str;
 
+    /// The operation's label in the remote history file: `"install"` or
+    /// `"uninstall"`.
+    ///
+    /// Deliberately **not** derived from [`role`](Self::role): that returns the
+    /// doer-table key (`"installer"`), and `/var/log/mtui.log` is a parsed
+    /// interop contract whose readers match the command verb. A substring
+    /// check for `"uninstall"` would also match `"uninstaller"`, so the wrong
+    /// value here is one a naive assertion cannot catch.
+    fn history_label(&self) -> &'static str;
+
     /// The packages to interpolate into each host's command template.
     fn packages(&self) -> &[String];
 
@@ -354,6 +374,15 @@ pub trait Operation: Send + Sync {
         // through to the unlock rather than returning early.
         group.run(commands).await;
 
+        // The command has now dispatched on every host, whatever the verdict:
+        // record the history row here — after the run started, but *before* the
+        // reboot. A transactional host that never comes back cannot be written
+        // to afterwards, and the row would be lost on exactly the host whose
+        // state an operator most needs to reconstruct.
+        group
+            .add_history(&[self.history_label().to_owned(), self.packages().join(" ")])
+            .await;
+
         let mut check_failures: Vec<(String, String)> = Vec::new();
         for plan in &mut plans {
             let output = group.last_output(&plan.hostname).unwrap_or_default();
@@ -415,6 +444,10 @@ impl Operation for InstallOperation {
         "installer"
     }
 
+    fn history_label(&self) -> &'static str {
+        "install"
+    }
+
     fn packages(&self) -> &[String] {
         &self.packages
     }
@@ -448,6 +481,10 @@ impl UninstallOperation {
 impl Operation for UninstallOperation {
     fn role(&self) -> &'static str {
         "uninstaller"
+    }
+
+    fn history_label(&self) -> &'static str {
+        "uninstall"
     }
 
     fn packages(&self) -> &[String] {
@@ -562,6 +599,8 @@ mod tests {
     enum Event {
         UpdateLock,
         Run(Vec<(String, String)>),
+        /// A remote-history append, carrying the colon-joined fields.
+        AddHistory(Vec<String>),
         Reboot(Vec<(String, String)>),
         Unlock,
         /// A per-host check invocation, carrying the host it ran on.
@@ -646,6 +685,13 @@ mod tests {
 
         async fn run(&mut self, commands: HostCommandMap) {
             self.events.lock().unwrap().push(Event::Run(commands));
+        }
+
+        async fn add_history(&mut self, fields: &[String]) {
+            self.events
+                .lock()
+                .unwrap()
+                .push(Event::AddHistory(fields.to_vec()));
         }
 
         fn last_output(&self, _hostname: &str) -> Option<HostOutput> {
@@ -917,16 +963,57 @@ mod tests {
             .expect("a clean run succeeds");
 
         let events = group.events();
-        // lock → run → check → reboot → unlock.
+        // lock → run → history → check → reboot → unlock.
         assert!(matches!(events[0], Event::UpdateLock));
         assert!(matches!(events[1], Event::Run(_)));
-        assert!(matches!(events[2], Event::Check(..)));
-        assert!(matches!(events[3], Event::Reboot(_)));
-        assert!(matches!(events[4], Event::Unlock));
+        assert!(matches!(events[2], Event::AddHistory(_)));
+        assert!(matches!(events[3], Event::Check(..)));
+        assert!(matches!(events[4], Event::Reboot(_)));
+        assert!(matches!(events[5], Event::Unlock));
+        // The history row must land *after* the command dispatched and
+        // *before* the reboot: written earlier it would claim work that never
+        // started, written later it is lost on a host that never comes back.
+        // Asserting the index alone would not say which side of the reboot it
+        // fell on, so pin both neighbours.
+        if let Event::AddHistory(fields) = &events[2] {
+            // The label is the command verb, not the doer-table role key
+            // (`installer`) — `/var/log/mtui.log` is parsed by other tools.
+            assert_eq!(fields, &vec!["install".to_owned(), "pkg-a".to_owned()]);
+        }
         // The transactional host contributed to the reboot map.
-        if let Event::Reboot(map) = &events[3] {
+        if let Event::Reboot(map) = &events[4] {
             assert_eq!(map, &vec![("h1".to_owned(), "systemctl reboot".to_owned())]);
         }
+    }
+
+    #[tokio::test]
+    async fn uninstall_history_label_is_the_verb_not_the_role_key() {
+        // `role()` returns "uninstaller"; the history label must be
+        // "uninstall". A `contains("uninstall")` assertion cannot tell the two
+        // apart — "uninstaller" contains "uninstall" — so compare exactly.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![plan_with_recording_check(
+            "h1",
+            false,
+            Doer::new("rm $packages", "systemctl reboot"),
+            log.clone(),
+        )];
+        let mut group = MockGroup::with_event_log(Ok(plans), log);
+
+        let _ = UninstallOperation::new(strs(&["pkg-a"]))
+            .run(&mut group)
+            .await
+            .expect("a clean run succeeds");
+
+        let fields = group
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                Event::AddHistory(f) => Some(f),
+                _ => None,
+            })
+            .expect("the uninstall must write a history row");
+        assert_eq!(fields[0], "uninstall");
     }
 
     // --- run(): a reboot failure is reported, not swallowed -----------------

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -2165,6 +2165,29 @@ mod tests {
         (t, handle)
     }
 
+    /// A transactional SL-Micro target whose commands answer with `stderr`.
+    ///
+    /// The update check for `("slmicro", true)` is deliberately judged on the
+    /// output markers rather than the exit code — the slmicro update template
+    /// ends with a repo-cleanup loop that masks the patch's status — so a
+    /// stderr marker is the signal a genuinely failing patch leaves behind.
+    fn slmicro_target_with_stderr(hostname: &str, stderr: &str) -> (Target, MockConnection) {
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", "", stderr, 0, 0))
+            .with_changing_boot_id();
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        (t, handle)
+    }
+
     /// Which of the three reboot failure modes a fixture should exhibit.
     #[derive(Debug, Clone, Copy)]
     enum RebootFault {
@@ -2461,6 +2484,49 @@ mod tests {
         assert!(
             fired.iter().any(|c| c.contains("systemctl reboot")),
             "expected transactional reboot after a successful update: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_update_fails_a_transactional_host_whose_stack_is_locked() {
+        // `("slmicro", true)` had an *updater* but no *check*, so `run_checks`
+        // hit its `else { continue }` and the host contributed no verdict at
+        // all: `update` reported success however the patch went. This is the
+        // end-to-end proof the newly registered check is actually reached —
+        // registering it in the table alone would not show that.
+        let (t, handle) = slmicro_target_with_stderr("h1", "System management is locked");
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+
+        let res = perform_update(
+            &mut group,
+            &report,
+            &packages,
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+
+        let Err(UpdateFailure::Check(e)) = res else {
+            panic!("a locked update stack must fail the update: {res:?}");
+        };
+        assert_eq!(e.reason, "update stack locked");
+        assert_eq!(e.host.as_deref(), Some("h1"));
+
+        // And the check failure must suppress the reboot: activating the new
+        // snapshot would hide the failed patch behind a healthy-looking boot.
+        // Before the check existed this branch was unreachable for a
+        // transactional host, so #385's "a check failure suppresses the reboot
+        // entirely" comment described a path nothing could take.
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a host whose update check failed must not be rebooted: {fired:?}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -21,7 +21,7 @@
 //! `PlanProvider` adapter uses — keyed on `(system.get_release(),
 //! transactional)`.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use mtui_hosts::{
@@ -651,10 +651,44 @@ async fn prepare_body(
     // prepare check's own failures. The prepare check emits no diagnostics; the
     // sink is discarded.
     let mut failures = host_command_failures(targets, "prepare command failed");
-    for e in run_checks(targets, registry, Role::Prepare, &mut Vec::new()) {
+    let check_failures = run_checks(targets, registry, Role::Prepare, &mut Vec::new());
+
+    // A host whose prepare failed must not reboot into the failed transaction,
+    // mirroring the install/uninstall template's per-host gate: activating the
+    // snapshot would hide the failure behind a healthy-looking boot, while a
+    // healthy host in the same group still reboots so its own snapshot
+    // activates. The skip set is built from the check verdicts and non-zero
+    // exit codes only — never from the stderr rule `host_command_failures`
+    // also applies, because `transactional-update` writes progress to stderr
+    // on a *successful* run and skipping such a host's reboot would leave its
+    // healthy staged snapshot silently inert. Unlike update's multi-line
+    // script, the prepare templates are single commands, so the recorded exit
+    // code is genuinely the prepare command's own. (In the per-package
+    // `installed_only` loop the snapshot reflects the last package that ran —
+    // the same window `host_command_failures` reads.)
+    let mut inert: BTreeSet<String> = check_failures
+        .iter()
+        .filter_map(|e| e.host.clone())
+        .collect();
+    for target in targets.targets() {
+        if target.lastexit().is_some_and(|c| c != 0) {
+            inert.insert(target.hostname().to_owned());
+        }
+    }
+    for e in check_failures {
         error!(error = %e, "prepare check failed");
         failures.push(e);
     }
+    let reboot: BTreeMap<String, String> = reboot
+        .into_iter()
+        .filter(|(host, _)| {
+            let ok = !inert.contains(host);
+            if !ok {
+                warn!(host = %host, "prepare failed; skipping reboot");
+            }
+            ok
+        })
+        .collect();
     failures.extend(
         reboot_transactional(targets, reboot)
             .await
@@ -932,6 +966,7 @@ async fn downgrade_body(
             combined.insert(hn.clone(), rendered);
         }
     }
+    let mut failed_downgrade: BTreeSet<String> = BTreeSet::new();
     if !combined.is_empty() {
         targets.run(Command::PerHost(combined.clone())).await;
         // Same scoping as the per-package loop: only check the transactional
@@ -940,16 +975,42 @@ async fn downgrade_body(
             let host = e.host.as_deref().unwrap_or("");
             if combined.contains_key(host) && transactional_hosts.contains(host) {
                 error!(error = %e, "downgrade check failed");
+                failed_downgrade.insert(host.to_owned());
                 failures.push(e);
+            }
+        }
+        // The transactional check only gates "timed out or failed to run"; the
+        // downgrade template is a single command, so a non-zero exit is
+        // genuinely the downgrade's own status and the host must not reboot
+        // into the failed transaction. It is also pushed as a failure — a
+        // skipped reboot behind an `Ok` would be a quiet no-op — but only when
+        // the check did not already report this host (`insert` is `false` for
+        // the `-1` case the check covers). (Scoped to `combined`: hosts
+        // outside it carry a stale record.)
+        for hostname in combined.keys() {
+            let exit = targets.get(hostname).and_then(mtui_hosts::Target::lastexit);
+            if exit.is_some_and(|c| c != 0) && failed_downgrade.insert(hostname.clone()) {
+                failures.push(UpdateError::new(
+                    "downgrade command failed",
+                    hostname.clone(),
+                ));
             }
         }
     }
 
     // Reboot the healthy transactional hosts first (their staged snapshots must
     // still activate), then surface the dead probes as the command's failure.
+    // A host whose combined downgrade failed is skipped too: rebooting it would
+    // activate the snapshot of the failed transaction.
     let healthy_reboot: BTreeMap<String, String> = reboot
         .into_iter()
-        .filter(|(h, _)| !dead_probes.contains(h))
+        .filter(|(h, _)| {
+            if failed_downgrade.contains(h) {
+                warn!(host = %h, "downgrade failed; skipping reboot");
+                return false;
+            }
+            !dead_probes.contains(h)
+        })
         .collect();
     failures.extend(
         reboot_transactional(targets, healthy_reboot)
@@ -2745,6 +2806,122 @@ mod tests {
             cmds.iter()
                 .any(|c| c.contains("pkg-a=1.0-1") && c.contains("pkg-b=2.0-1")),
             "expected a single combined transactional downgrade: {cmds:?}"
+        );
+        // And a clean combined downgrade still reboots: the gate must not
+        // withhold the reboot from a host whose transaction succeeded.
+        let fired = handle.fired_commands();
+        assert!(
+            fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a clean transactional downgrade must still reboot: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_skips_the_reboot_of_a_host_whose_prepare_failed() {
+        // The per-host reboot gate (mirrors the install/uninstall template):
+        // h1's prepare command exits non-zero, h2's succeeds. h1 must not be
+        // rebooted into the failed transaction, while h2 — a healthy host in
+        // the same group — still must, or its staged snapshot stays inert.
+        let (t1, h1) = slmicro_target("h1", "", 1);
+        let (t2, h2) = slmicro_target("h2", "", 0);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a failed prepare must not report success");
+        assert!(err.to_string().contains("h1"), "err: {err}");
+
+        let fired1 = h1.fired_commands();
+        assert!(
+            !fired1.iter().any(|c| c.contains("systemctl reboot")),
+            "h1 failed its prepare and must not be rebooted: {fired1:?}"
+        );
+        let fired2 = h2.fired_commands();
+        assert!(
+            fired2.iter().any(|c| c.contains("systemctl reboot")),
+            "healthy h2 must still reboot so its snapshot activates: {fired2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_still_reboots_a_host_that_only_wrote_to_stderr() {
+        // `transactional-update` writes progress and warnings to stderr on a
+        // *successful* run, so stderr alone must not gate the reboot — the
+        // staged snapshot is healthy and leaving it inert would reintroduce
+        // the quiet-no-op bug from the other direction. (The stderr rule still
+        // fails the verdict via `host_command_failures`; that is pre-existing
+        // and separate from the action taken here.)
+        let (t, handle) = slmicro_target_with_stderr("h1", "1 issue found. see the log");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await;
+        assert!(res.is_err(), "the stderr verdict is unchanged: {res:?}");
+        let fired = handle.fired_commands();
+        assert!(
+            fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a stderr-only host keeps its reboot: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_downgrade_skips_the_reboot_of_a_failed_transactional_downgrade() {
+        // The combined transactional downgrade exits non-zero — which the
+        // `("slmicro", true)` check deliberately does not gate (it catches
+        // only `-1`) — so this exercises the exit-code half of the gate: no
+        // reboot into the failed transaction, and the failure is reported
+        // rather than leaving a skipped reboot behind an `Ok`.
+        let combined_cmd = format!(
+            "transactional-update -n pkg in --force-resolution --oldpackage -y {}",
+            quote_args(&["pkg-a=1.0-1"])
+        );
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "pkg-a = 1.0-1\n", "", 0, 0))
+            .with_response(
+                combined_cmd.clone(),
+                CommandLog::new(&combined_cmd, "", "", 1, 0),
+            )
+            .with_changing_boot_id();
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None)
+            .await
+            .expect_err("a failed combined downgrade must not report success");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        assert!(
+            err.reason.contains("downgrade command failed"),
+            "reason: {}",
+            err.reason
+        );
+
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a host whose downgrade failed must not be rebooted: {fired:?}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -78,6 +78,21 @@ pub enum UpdateFailure {
     /// packages — the split-brain the rollback exists to undo — and, being
     /// reachable, it is a host the downgrade can actually reach.
     RebootNotTaken(UpdateError),
+    /// The update command never ran to completion on any host that failed —
+    /// it timed out, or the connection dropped part-way (`Target::run`'s `-1`).
+    ///
+    /// Like [`Reboot`](Self::Reboot) this skips the rollback, and for the same
+    /// reason: `-1` says the flow could not talk to the host, so a group-wide
+    /// downgrade would revert the *healthy* hosts on behalf of one it cannot
+    /// reach either way. It is a distinct variant rather than a
+    /// [`Check`](Self::Check) because a check failure means "the patch ran and
+    /// went wrong" — a half-applied state the rollback repairs — whereas this
+    /// means the patch may never have started.
+    ///
+    /// Only used when **every** failed host is in that state; a run mixing a
+    /// real check failure with a lost host still rolls back, on behalf of the
+    /// host the rollback can genuinely repair.
+    NotRun(UpdateError),
 }
 
 /// Drives [`perform_update`] from a concrete report, reading the package list
@@ -154,9 +169,12 @@ where
             info!(reason = %e, "update cancelled");
             Err(e)
         }
-        Err(UpdateFailure::Reboot(e)) => {
-            // The patch succeeded but the host never came back: it is
-            // unreachable, so a downgrade cannot run on it either.
+        Err(UpdateFailure::Reboot(e) | UpdateFailure::NotRun(e)) => {
+            // Either the patch succeeded and the host never came back, or the
+            // command never ran to completion in the first place. Both mean
+            // the flow lost contact with every host that failed, so a
+            // group-wide downgrade cannot repair them and would only revert
+            // the healthy ones.
             error!(error = %e, "update failed");
             Err(e)
         }
@@ -623,6 +641,15 @@ async fn prepare_body(
         return aggregate_failures("prepare", repo_failures);
     }
 
+    // Every host that actually received a prepare command, and the hosts a
+    // package failed on. Both are accumulated *inside* the loop below: it runs
+    // one fan-out per package, so a single post-loop read of `lastexit()` sees
+    // only the last package — and under `--installed-only` the last package is
+    // very often a no-op `if rpm -q ...` that exits 0, which would mask an
+    // earlier failure and let the host reboot into it.
+    let mut dispatched: BTreeSet<String> = BTreeSet::new();
+    let mut inert: BTreeSet<String> = BTreeSet::new();
+
     let mut cancelled_at: Option<usize> = None;
     if installed_only {
         // Conditional per-package install — inherently one package at a time.
@@ -641,14 +668,16 @@ async fn prepare_body(
             }
             let quoted = quote_args(std::slice::from_ref(pkg));
             let cmd = build_prepare_map(targets, registry, Some(&quoted), true);
-            targets.run(Command::PerHost(cmd)).await;
+            targets.run(Command::PerHost(cmd.clone())).await;
+            note_dispatch(targets, &cmd, &mut dispatched, &mut inert);
         }
     } else if !pkgs.is_empty() {
         // Install every package in a SINGLE transaction (one snapshot for
         // transactional hosts). Quote each name for the root command line.
         let joined = quote_args(pkgs);
         let cmd = build_prepare_map(targets, registry, Some(&joined), false);
-        targets.run(Command::PerHost(cmd)).await;
+        targets.run(Command::PerHost(cmd.clone())).await;
+        note_dispatch(targets, &cmd, &mut dispatched, &mut inert);
     }
 
     // Surface any per-host command failure from the install fan-out plus the
@@ -667,25 +696,41 @@ async fn prepare_body(
     // on a *successful* run and skipping such a host's reboot would leave its
     // healthy staged snapshot silently inert. Unlike update's multi-line
     // script, the prepare templates are single commands, so the recorded exit
-    // code is genuinely the prepare command's own. (In the per-package
-    // `installed_only` loop the snapshot reflects the last package that ran —
-    // the same window `host_command_failures` reads.)
-    let mut inert: BTreeSet<String> = check_failures
-        .iter()
-        .filter_map(|e| e.host.clone())
-        .collect();
-    for target in targets.targets() {
-        if target.lastexit().is_some_and(|c| c != 0) {
-            inert.insert(target.hostname().to_owned());
-        }
-    }
+    // code is genuinely the prepare command's own.
+    //
+    // The check verdicts are seeded too, but they are inert for the hosts that
+    // matter today: `prepare_check` has no ("slmicro", true) entry, and only
+    // transactional hosts are ever in `reboot`. Kept so the gate is already
+    // right when that check is registered, not because it fires now.
+    inert.extend(check_failures.iter().filter_map(|e| e.host.clone()));
     for e in check_failures {
         error!(error = %e, "prepare check failed");
         failures.push(e);
     }
+
+    // `host_command_failures` reads one post-loop snapshot, so on the
+    // per-package path it only ever sees the last package. Name every host a
+    // package failed on, deduped against the hosts already reported — a second
+    // entry for one host would push `aggregate_failures` out of its
+    // single-failure verbatim branch into the summary, which drops `host` to
+    // `None` and breaks callers that read it.
+    let named: BTreeSet<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
+    for host in &inert {
+        if !named.contains(host) {
+            failures.push(UpdateError::new("prepare command failed", host.clone()));
+        }
+    }
     let reboot: BTreeMap<String, String> = reboot
         .into_iter()
         .filter(|(host, _)| {
+            // A host nothing was dispatched to staged nothing, so there is no
+            // snapshot to activate and the reboot would be gratuitous — and in
+            // the `update` rollback path it would activate whatever the failed
+            // update left staged.
+            if !dispatched.contains(host) {
+                warn!(host = %host, "no prepare command was staged; skipping reboot");
+                return false;
+            }
             let ok = !inert.contains(host);
             if !ok {
                 warn!(host = %host, "prepare failed; skipping reboot");
@@ -721,6 +766,31 @@ async fn prepare_body(
         )));
     }
     aggregate_failures("prepare", failures)
+}
+
+/// Records which hosts a prepare fan-out reached, and which of them it failed
+/// on, into the two sets the reboot gate consults.
+///
+/// Called after *every* fan-out rather than once at the end, because the
+/// per-package `--installed-only` loop runs one fan-out per package and
+/// `lastexit()` keeps only the last. Scoped to `cmd`'s keys so a host outside
+/// this fan-out is never judged on another phase's record.
+fn note_dispatch(
+    targets: &HostsGroup,
+    cmd: &BTreeMap<String, String>,
+    dispatched: &mut BTreeSet<String>,
+    inert: &mut BTreeSet<String>,
+) {
+    for hostname in cmd.keys() {
+        dispatched.insert(hostname.clone());
+        if targets
+            .get(hostname)
+            .and_then(mtui_hosts::Target::lastexit)
+            .is_some_and(|c| c != 0)
+        {
+            inert.insert(hostname.clone());
+        }
+    }
 }
 
 /// Builds the per-host prepare command map. `package` fills the `$package`
@@ -1009,6 +1079,18 @@ async fn downgrade_body(
     let healthy_reboot: BTreeMap<String, String> = reboot
         .into_iter()
         .filter(|(h, _)| {
+            // Nothing staged, nothing to activate. A transactional host drops
+            // out of `combined` when the version probe resolved no versions
+            // for it (a `versions` miss, or every spec filtered out) — both
+            // reachable with an exit-0 probe, so `dead_probes` does not cover
+            // them. Rebooting anyway is not merely gratuitous: when this
+            // downgrade *is* the `update` rollback, the host would boot into
+            // the snapshot the failed update left staged, which is exactly
+            // what suppressing the update's own reboot had avoided.
+            if !combined.contains_key(h) {
+                warn!(host = %h, "no downgrade was staged; skipping reboot");
+                return false;
+            }
             if failed_downgrade.contains(h) {
                 warn!(host = %h, "downgrade failed; skipping reboot");
                 return false;
@@ -1348,7 +1430,29 @@ async fn update_run_phase(
     // A check failure keeps precedence and suppresses the reboot entirely: a
     // transactional host whose patch failed must not be rebooted into it.
     let result = if !failures.is_empty() {
-        aggregate_failures("update", failures).map_err(UpdateFailure::Check)
+        // Route on *why* the check failed, exactly as the reboot arm below
+        // routes on why the reboot failed. `Target::run` records `-1` when a
+        // command timed out, lost its connection, or was dispatched to an
+        // unconnected target — i.e. the flow could not talk to the host, so it
+        // does not know whether the patch ran. A group-wide rollback cannot
+        // repair such a host and would revert every healthy one on its behalf.
+        //
+        // `all`, not `any`, for the same reason as the reboot arm: a run that
+        // mixes a lost host with a genuine check failure still rolls back, on
+        // behalf of the host the rollback can actually repair.
+        let never_ran = failures.iter().all(|e| {
+            e.host
+                .as_deref()
+                .and_then(|h| targets.get(h))
+                .and_then(mtui_hosts::Target::lastexit)
+                == Some(-1)
+        });
+        let wrap: fn(UpdateError) -> UpdateFailure = if never_ran {
+            UpdateFailure::NotRun
+        } else {
+            UpdateFailure::Check
+        };
+        aggregate_failures("update", failures).map_err(wrap)
     } else {
         let reboot_failures = reboot_transactional(targets, reboot).await;
         // Route the rollback on *why* the reboot failed, not on the fact that
@@ -1898,7 +2002,17 @@ mod tests {
             &mut Vec::new(),
         )
         .await;
-        assert!(res.is_err(), "a lost host must not report success: {res:?}");
+        // Discriminating: it must fail *for the reboot*, not for some other
+        // reason that would also satisfy a bare `is_err()`.
+        let Err(UpdateFailure::Reboot(e)) = res else {
+            panic!("a lost host must fail its reboot: {res:?}");
+        };
+        assert_eq!(e.host.as_deref(), Some("h1"));
+        assert!(
+            e.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            e.reason
+        );
 
         let contents = String::from_utf8(
             handle
@@ -1906,7 +2020,14 @@ mod tests {
                 .expect("a host lost to its reboot must still have its history row"),
         )
         .unwrap();
-        assert!(contents.contains(":update:"), "history line: {contents:?}");
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        // This call passes `id: None`, so the row carries no RRID field: the
+        // shape is `{ts}:{user}:update:{packages}`. Anchoring on the tail also
+        // pins the package list, which a bare `contains(":update:")` did not.
+        assert!(
+            contents.ends_with(":update:pkg-a\n"),
+            "history line: {contents:?}"
+        );
     }
 
     #[tokio::test]
@@ -2533,6 +2654,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_timeout_does_not_roll_back_healthy_hosts() {
+        // `Target::run` records -1 for a timeout, a mid-command connection
+        // loss, and an unconnected target — i.e. "the flow could not talk to
+        // this host", not "the patch went wrong". Routing that into the
+        // group-wide rollback would revert every host that patched cleanly on
+        // behalf of one the downgrade cannot reach anyway, which is exactly
+        // what the reboot arm already refuses to do.
+        //
+        // h1's patch times out; h2 patches cleanly. The `-1` is scripted onto
+        // the patch command only — it is exactly what `Target::run` records
+        // when the command times out, and scripting it via `with_default`
+        // would put it on the probes too.
+        let patch = WorkflowRegistry::default()
+            .doer(Role::Update, "slmicro", true)
+            .expect("slmicro has an updater")
+            .render_command(
+                &[
+                    ("repa", repa_for("42", "7").as_str()),
+                    ("packages", quote_args(&["pkg-a".to_owned()]).as_str()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .expect("safe substitution never fails");
+        let lost = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .with_response(patch.clone(), CommandLog::new(&patch, "", "", -1, 0))
+            .with_changing_boot_id();
+        let lost_handle = lost.clone();
+        let mut t1 = Target::with_connection("h1", TargetState::Enabled, Box::new(lost));
+        t1.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let (t2, healthy) = slmicro_target("h2", "pkg-a = 1.0-1\n", 0);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("a host whose patch never ran must not report success");
+        assert!(
+            err.reason.contains("timed out or failed to run"),
+            "reason: {}",
+            err.reason
+        );
+
+        // The fixture only means anything if h1's patch really did time out.
+        assert_eq!(
+            group.get("h1").and_then(mtui_hosts::Target::lastexit),
+            Some(-1),
+            "h1's patch must have recorded the never-ran sentinel"
+        );
+        // The point of the test: h2 patched cleanly and must keep its update.
+        assert!(
+            !healthy
+                .commands()
+                .iter()
+                .any(|c| c.contains("--oldpackage")),
+            "a healthy host must not be rolled back for a host that was lost: {:?}",
+            healthy.commands()
+        );
+        assert!(
+            !lost_handle
+                .commands()
+                .iter()
+                .any(|c| c.contains("--oldpackage")),
+            "the lost host cannot be rolled back either: {:?}",
+            lost_handle.commands()
+        );
+    }
+
+    #[tokio::test]
     async fn update_rolls_back_when_the_host_never_went_down() {
         // The inverse of the test above, and the reason the cause is carried
         // rather than flattened: this host is *reachable*. Its patch was staged
@@ -2658,10 +2858,48 @@ mod tests {
         // all: `update` reported success however the patch went. This is the
         // end-to-end proof the newly registered check is actually reached —
         // registering it in the table alone would not show that.
-        let (t, handle) = slmicro_target_with_stderr("h1", "System management is locked");
-        let mut group = HostsGroup::new(vec![t], false);
+        //
+        // The marker is scripted onto the **patch command specifically**, not
+        // via `with_default`. `perform_update` runs other commands first (the
+        // repo add's trailing `... -n ref`), and a default answering every
+        // command with the marker makes this test pass even with the patch
+        // fan-out deleted — the check then reads the refresh's snapshot. This
+        // test had exactly that hole; verified by deleting
+        // `targets.run(Command::PerHost(commands))` from `update_run_phase`
+        // and watching the old version stay green.
         let report = report_with_rrid();
         let packages = report.get_package_list();
+        let patch = WorkflowRegistry::default()
+            .doer(Role::Update, "slmicro", true)
+            .expect("slmicro has an updater")
+            .render_command(
+                &[
+                    ("repa", repa_for("42", "7").as_str()),
+                    ("packages", quote_args(&packages).as_str()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .expect("safe substitution never fails");
+
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "all good", "", 0, 0))
+            .with_response(
+                patch.clone(),
+                CommandLog::new(&patch, "", "System management is locked", 0, 0),
+            )
+            .with_changing_boot_id();
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
 
         let res = perform_update(
             &mut group,
@@ -2681,6 +2919,13 @@ mod tests {
         };
         assert_eq!(e.reason, "update stack locked");
         assert_eq!(e.host.as_deref(), Some("h1"));
+
+        // The verdict must come from the patch, so the patch must have run.
+        let cmds = handle.commands();
+        assert!(
+            cmds.contains(&patch),
+            "the patch command must have been dispatched: {cmds:?}"
+        );
 
         // And the check failure must suppress the reboot: activating the new
         // snapshot would hide the failed patch behind a healthy-looking boot.
@@ -2939,7 +3184,11 @@ mod tests {
         )
         .await
         .expect_err("a failed prepare must not report success");
-        assert!(err.to_string().contains("h1"), "err: {err}");
+        // Exact, not `to_string().contains("h1")`: the aggregated summary names
+        // every failed host, so a substring match would also pass if h2 had
+        // wrongly joined the failure set — which is half of what this test is
+        // about. A single failure is returned verbatim, so `host` is `Some`.
+        assert_eq!(err.host.as_deref(), Some("h1"), "err: {err}");
 
         let fired1 = h1.fired_commands();
         assert!(
@@ -2950,6 +3199,107 @@ mod tests {
         assert!(
             fired2.iter().any(|c| c.contains("systemctl reboot")),
             "healthy h2 must still reboot so its snapshot activates: {fired2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_judges_every_package_not_just_the_last() {
+        // `--installed-only` runs one fan-out per package, and its template is
+        // `if $(rpm -q pkg ...); then ...; fi` — which exits 0 when the
+        // package is absent. So the *last* package is very often a no-op
+        // success. Reading `lastexit()` once after the loop would see that 0
+        // and reboot the host into the transaction an earlier package broke.
+        //
+        // pkg-a fails; pkg-b is a clean no-op after it.
+        let failing = "if $(rpm -q pkg-a &>/dev/null); \
+                       then transactional-update -n pkg in -l  pkg-a ; fi";
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .with_response(failing.to_owned(), CommandLog::new(failing, "", "", 1, 0))
+            .with_changing_boot_id();
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned(), "pkg-b".to_owned()],
+            false,
+            false,
+            true,
+        )
+        .await;
+
+        // The fixture only means anything if pkg-a's command really ran.
+        let cmds = handle.commands();
+        assert!(
+            cmds.iter().any(|c| c == failing),
+            "pkg-a's command must have been dispatched: {cmds:?}"
+        );
+        assert!(res.is_err(), "a failed package must fail prepare: {res:?}");
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "pkg-a failed, so the host must not activate its snapshot: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_does_not_reboot_a_host_with_nothing_staged() {
+        // An empty package list dispatches no prepare command at all, but the
+        // reboot map is built from the host's transactional flag and does not
+        // know that. Rebooting stages-nothing is gratuitous on its own, and in
+        // the `update` rollback path it would activate whatever the failed
+        // update left staged.
+        let (t, handle) = slmicro_target("h1", "", 0);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_prepare(&mut group, &NoopRepo, &[], false, false, false).await;
+        assert!(res.is_ok(), "nothing to prepare is not a failure: {res:?}");
+
+        // The fixture only means anything if nothing was dispatched.
+        let cmds = handle.commands();
+        assert!(
+            !cmds.iter().any(|c| c.contains("transactional-update")),
+            "no prepare command should have been dispatched: {cmds:?}"
+        );
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a host with nothing staged must not be rebooted: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_downgrade_does_not_reboot_a_host_with_nothing_staged() {
+        // The version probe resolves nothing, so no downgrade command is built
+        // and nothing is staged. The host must not be rebooted: when this
+        // downgrade is the `update` rollback, a reboot would activate whatever
+        // the failed update left staged — undoing the update flow's own
+        // decision to suppress that reboot.
+        let (t, handle) = slmicro_target("h1", "", 0);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let _ = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
+
+        let cmds = handle.commands();
+        assert!(
+            !cmds.iter().any(|c| c.contains("--oldpackage")),
+            "nothing should have been staged: {cmds:?}"
+        );
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a host with nothing staged must not be rebooted: {fired:?}"
         );
     }
 
@@ -3015,11 +3365,9 @@ mod tests {
             .await
             .expect_err("a failed combined downgrade must not report success");
         assert_eq!(err.host.as_deref(), Some("h1"));
-        assert!(
-            err.reason.contains("downgrade command failed"),
-            "reason: {}",
-            err.reason
-        );
+        // Exact: a single failure is returned verbatim, so `contains` would
+        // also accept the multi-failure summary, whose text embeds this one.
+        assert_eq!(err.reason, "downgrade command failed");
 
         let fired = handle.fired_commands();
         assert!(

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -182,7 +182,11 @@ where
     }
 }
 
-/// Records a workflow op in every target's remote history file before fan-out.
+/// Records a workflow op in every target's remote history file.
+///
+/// Called after the command has dispatched — a row must never claim work that
+/// never started — but *before* any transactional reboot, since a host that
+/// does not come back can no longer be written to.
 ///
 /// `id_field` carries the RRID for ops that log it (`update`/`downgrade`) and
 /// is `None` for `install`/`uninstall`. The op label and package list
@@ -443,9 +447,9 @@ async fn perform_operation(
         Ok(report) => report,
     };
 
-    // The template has now dispatched a command on every host, whatever the
-    // verdict: record the history row here, not before the run started.
-    add_op_history(targets, op, None, packages).await;
+    // The history row is written inside `Operation::run`, between the command
+    // fan-out and the reboot — writing it here would lose it on exactly the
+    // transactional hosts that never came back.
 
     // A host whose post-run check failed, and any transactional host that
     // rebooted and never reconnected, both fail the operation by name. A
@@ -1012,16 +1016,19 @@ async fn downgrade_body(
             !dead_probes.contains(h)
         })
         .collect();
+    // The downgrade commands have now dispatched, whatever the verdict: record
+    // the history row here — after the run started, but *before* the reboot.
+    // A transactional host that never comes back cannot be written to
+    // afterwards, and the row would be lost on exactly the host whose state an
+    // operator most needs to reconstruct.
+    add_op_history(targets, "downgrade", id, packages).await;
+
     failures.extend(
         reboot_transactional(targets, healthy_reboot)
             .await
             .into_iter()
             .map(reboot_error),
     );
-
-    // The downgrade commands have now dispatched, whatever the verdict:
-    // record the history row here, not before the run started.
-    add_op_history(targets, "downgrade", id, packages).await;
 
     let not_downgraded = downgrade_verdict(targets).await;
 
@@ -1253,12 +1260,18 @@ pub async fn perform_update(
     }
 
     // Two-phase: run + check + reboot under the lock (unlock always), then the
-    // repo cleanup only on success.
-    let update_result = update_run_phase(targets, &registry, commands, reboot, diagnostics).await;
-
-    // The updater command has now dispatched, whatever the verdict: record
-    // the history row here, not before the run started.
-    add_op_history(targets, "update", id, packages).await;
+    // repo cleanup only on success. The history row is written inside, between
+    // the fan-out and the reboot — see `update_run_phase`.
+    let update_result = update_run_phase(
+        targets,
+        &registry,
+        commands,
+        reboot,
+        diagnostics,
+        id,
+        packages,
+    )
+    .await;
 
     if let Err(e) = update_result {
         // KEEP the test update repositories in place for retry/diagnosis.
@@ -1305,8 +1318,17 @@ async fn update_run_phase(
     commands: BTreeMap<String, String>,
     reboot: BTreeMap<String, String>,
     diagnostics: &mut Vec<Diagnostic>,
+    id: Option<&str>,
+    packages: &[String],
 ) -> Result<(), UpdateFailure> {
     targets.run(Command::PerHost(commands)).await;
+
+    // The updater command has now dispatched, whatever the verdict: record the
+    // history row here — after the run started, but *before* the reboot. A
+    // transactional host that never comes back cannot be written to
+    // afterwards, and the row would be lost on exactly the host whose state an
+    // operator most needs to reconstruct.
+    add_op_history(targets, "update", id, packages).await;
 
     let failures = run_checks(targets, registry, Role::Update, diagnostics);
     let failed_hosts: std::collections::HashSet<String> =
@@ -1823,6 +1845,87 @@ mod tests {
         assert_eq!(contents.lines().count(), 1);
         assert!(
             contents.contains(":install:pkg-a"),
+            "history line: {contents:?}"
+        );
+    }
+
+    /// A host lost to its post-operation reboot must still carry its history
+    /// row: the row is the operator's only record that the command ran there,
+    /// and it is needed most on exactly the host that did not come back.
+    ///
+    /// This is only observable because `MockConnection::sftp_append` now
+    /// reconnects at entry like the real `SshConnection::sftp()` — before that
+    /// the mock accepted an append on a dead host, so this test would have
+    /// passed whichever side of the reboot the write happened on.
+    #[tokio::test]
+    async fn install_records_history_for_a_host_lost_to_its_reboot() {
+        let (t, handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        perform_install(&mut group, &["pkg-a".to_owned()])
+            .await
+            .expect_err("a lost transactional host must not report success");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a host lost to its reboot must still have its history row"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1);
+        assert!(
+            contents.contains(":install:pkg-a"),
+            "history line: {contents:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_records_history_for_a_host_lost_to_its_reboot() {
+        let (t, handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+
+        let res = perform_update(
+            &mut group,
+            &report,
+            &packages,
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+        assert!(res.is_err(), "a lost host must not report success: {res:?}");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a host lost to its reboot must still have its history row"),
+        )
+        .unwrap();
+        assert!(contents.contains(":update:"), "history line: {contents:?}");
+    }
+
+    #[tokio::test]
+    async fn downgrade_records_history_for_a_host_lost_to_its_reboot() {
+        let (t, handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None)
+            .await
+            .expect_err("a lost transactional host must not report success");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a host lost to its reboot must still have its history row"),
+        )
+        .unwrap();
+        assert!(
+            contents.contains(":downgrade:"),
             "history line: {contents:?}"
         );
     }

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -81,13 +81,28 @@ pub enum UpdateFailure {
     /// The update command never ran to completion on any host that failed —
     /// it timed out, or the connection dropped part-way (`Target::run`'s `-1`).
     ///
-    /// Like [`Reboot`](Self::Reboot) this skips the rollback, and for the same
-    /// reason: `-1` says the flow could not talk to the host, so a group-wide
-    /// downgrade would revert the *healthy* hosts on behalf of one it cannot
-    /// reach either way. It is a distinct variant rather than a
-    /// [`Check`](Self::Check) because a check failure means "the patch ran and
-    /// went wrong" — a half-applied state the rollback repairs — whereas this
-    /// means the patch may never have started.
+    /// Like [`Reboot`](Self::Reboot) this skips the rollback — but not by the
+    /// reboot arm's reachability argument, because `-1` is a sentinel, not a
+    /// liveness verdict. It covers two situations, and each vetoes the
+    /// rollback on its own:
+    ///
+    /// * **The flow lost the host** (connection dropped mid-command, or never
+    ///   connected). A group-wide downgrade would revert the *healthy* hosts
+    ///   on behalf of one it cannot reach either way.
+    /// * **The command outlived its timeout on a host that is up.** The
+    ///   timeout closes the SSH channel, which asks the remote side to
+    ///   reclaim the process — but rpm masks signals inside its transaction,
+    ///   so the patch may have died, finished after the flow stopped
+    ///   watching, or still be holding the package-manager lock. Dispatching
+    ///   the group-wide downgrade now fires a second transaction at the one
+    ///   host whose first was never observed to end, and reverts every
+    ///   healthy host to do it.
+    ///
+    /// Both stay distinct from [`Check`](Self::Check) for the same reason: a
+    /// check failure means "the patch ran and produced a bad verdict" — a
+    /// half-applied state the rollback repairs — whereas `-1` is the absence
+    /// of a verdict. The host's state is unknown, not known-bad; it needs
+    /// eyes on it, not an automated second transaction.
     ///
     /// Only used when **every** failed host is in that state; a run mixing a
     /// real check failure with a lost host still rolls back, on behalf of the
@@ -465,8 +480,9 @@ async fn perform_operation(
         Ok(report) => report,
     };
 
-    // The history row is written inside `Operation::run`, between the command
-    // fan-out and the reboot — writing it here would lose it on exactly the
+    // Deliberately no history write here: `Operation::run` writes the row
+    // itself, between the command fan-out and the reboot, because a row
+    // written after this call returns would be lost on exactly the
     // transactional hosts that never came back.
 
     // A host whose post-run check failed, and any transactional host that
@@ -1389,7 +1405,9 @@ pub async fn perform_update(
 /// host's reboot took effect — reconnecting is not sufficient, since a host can
 /// answer without ever having gone down. Otherwise `Err` with the aggregated
 /// failure: a check failure (packages may be half-applied) is
-/// [`UpdateFailure::Check`] and **suppresses the reboot entirely**; a reboot
+/// [`UpdateFailure::Check`] and **suppresses the reboot entirely** — unless
+/// every failed host's command never completed (`lastexit()` of `-1`), which
+/// is [`UpdateFailure::NotRun`] and skips the rollback; a reboot
 /// failure is [`UpdateFailure::Reboot`] when the host is unreachable and
 /// [`UpdateFailure::RebootNotTaken`] when every failed host is still reachable,
 /// which is what decides whether the group-wide rollback runs. A single failure is returned verbatim; more than
@@ -1430,12 +1448,16 @@ async fn update_run_phase(
     // A check failure keeps precedence and suppresses the reboot entirely: a
     // transactional host whose patch failed must not be rebooted into it.
     let result = if !failures.is_empty() {
-        // Route on *why* the check failed, exactly as the reboot arm below
-        // routes on why the reboot failed. `Target::run` records `-1` when a
-        // command timed out, lost its connection, or was dispatched to an
-        // unconnected target — i.e. the flow could not talk to the host, so it
-        // does not know whether the patch ran. A group-wide rollback cannot
-        // repair such a host and would revert every healthy one on its behalf.
+        // Route on *why* the check failed, as the reboot arm below routes on
+        // why the reboot failed — though not by its reachability probe: `-1`
+        // is a sentinel, not a liveness verdict. `Target::run` records it for
+        // a dropped connection, an unconnected target, *and* a timeout on a
+        // host that is up the whole time. The first two are hosts a group-wide
+        // rollback cannot repair, so it would only revert the healthy ones on
+        // their behalf; the third is a host whose transaction was never
+        // observed to end, where a downgrade dispatched now races whatever is
+        // left of it for the package-manager lock. All three veto the
+        // rollback — `UpdateFailure::NotRun` carries the full argument.
         //
         // `all`, not `any`, for the same reason as the reboot arm: a run that
         // mixes a lost host with a genuine check failure still rolls back, on

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -15,14 +15,21 @@ use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed}
 ///
 /// # Errors
 ///
-/// Returns [`UpdateError`] with a reason of "package not found" (zypper exit
-/// `104`), "update stack locked", "Dependency Error", or "RPM Error"
+/// Returns [`UpdateError`] with a reason of "update command timed out or
+/// failed to run" (exit `-1`), "package not found" (zypper exit `104`),
+/// "update stack locked", "Dependency Error", or "RPM Error"
 /// depending on the exit code and stderr/stdout markers. Warnings
 /// (exit `106`, "Additional rpm output", "not supported by its vendor") do not
 /// fail the check; the two output sections are returned as [`Diagnostic`]s for
 /// the caller to render.
+///
+/// Note this check does **not** treat an unrecognised non-zero exit as a
+/// failure: the zypper update template ends with the same repo-cleanup loop
+/// that masks the patch status on `slmicro` (see [`transactional_update`]), so
+/// the code reaching here is not the patch's either. It is judged on the
+/// markers plus the two exit codes zypper is known to surface.
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    let mut diagnostics = Vec::new();
+    not_run(args)?;
     if args.stdin.contains("zypper") && args.exitcode == 104 {
         log_failed(args);
         return Err(UpdateError::new("package not found", args.hostname));
@@ -34,6 +41,99 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
             "zypper returns exitcode 106"
         );
     }
+    markers(args)
+}
+
+/// The transactional-update (`slmicro`) update check.
+///
+/// Deliberately has **no exit-code rule beyond the
+/// [`not_run`] sentinel**, because `lastexit()` does not carry the patch
+/// command's status on this key: the `slmicro` update template is a multi-line
+/// script executed as a single remote `exec`, and its last line is the
+/// `zypper -n lr | … | while read r; do zypper -n rr $r; done` repo-cleanup
+/// loop. The shell therefore reports *that loop's* status — which is `0`
+/// whenever the loop body never runs — and discards the
+/// `transactional-update -n pkg in … -t patch` status entirely.
+///
+/// Judging this key on the exit code would be wrong in both directions: a
+/// failed patch still exits `0`, and a hiccup in the cosmetic repo cleanup
+/// would be reported as a failed update — which, because an `update` check
+/// failure routes the **group-wide** rollback downgrade, would roll back the
+/// whole fleet over a no-op. The stdout/stderr markers below are unaffected by
+/// the masking and are what this key is judged on.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "update command timed out or
+/// failed to run", "update stack locked", "Dependency Error", or "RPM Error".
+fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    not_run(args)?;
+    markers(args)
+}
+
+/// The yum update check.
+///
+/// Unlike [`transactional_update`], this key *may* be judged on its exit code:
+/// the `YUM` update template's last line **is** `yum -y update $packages`, so
+/// the recorded status is genuinely the updater's. `yum` has no informational
+/// non-zero success code for `update` (`100` is `check-update`-only), so any
+/// non-zero status is a real failure.
+///
+/// A recognised marker still wins over the generic verdict, so a locked stack
+/// or an RPM error keeps its specific reason.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "update command timed out or
+/// failed to run", one of [`markers`]' reasons, or "update command failed" for
+/// an unrecognised non-zero exit.
+fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    not_run(args)?;
+    let diagnostics = markers(args)?;
+    if args.exitcode != 0 {
+        log_failed(args);
+        return Err(UpdateError::new("update command failed", args.hostname));
+    }
+    Ok(diagnostics)
+}
+
+/// Raises when the command never produced a real exit status.
+///
+/// `Target::run` records `-1` when a command times out, when the connection
+/// fails mid-command, and when the target is not connected at all, so `-1`
+/// means "this never ran to completion" on every key. Without this gate a
+/// timed-out patch reports success: the recorded stdout and stderr are both
+/// empty, so no marker matches and the check returns `Ok`.
+///
+/// Mirrors the identical sentinel in the downgrade check.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "update command timed out or
+/// failed to run".
+fn not_run(args: CheckArgs<'_>) -> Result<(), UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "update command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    Ok(())
+}
+
+/// The stdout/stderr classification shared by every update check.
+///
+/// Exit-code handling stays in the per-key wrappers because it differs by key
+/// (see [`transactional_update`]); everything here reads only the command's
+/// output and so is valid on all of them.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "update stack locked",
+/// "Dependency Error", or "RPM Error".
+fn markers(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    let mut diagnostics = Vec::new();
     if let Some(section) = extract_between(args.stdout, "Additional rpm output:", "Retrieving") {
         // Logs a breadcrumb, then prints the section with "warning"
         // highlighted yellow.
@@ -105,6 +205,8 @@ fn extract_between<'a>(s: &'a str, marker: &str, end: &str) -> Option<&'a str> {
 pub(crate) fn update_check(release: &str, transactional: bool) -> Option<CheckFn> {
     match (release, transactional) {
         ("11", false) | ("12", false) | ("15", false) | ("16", false) => Some(Box::new(zypper)),
+        ("YUM", false) => Some(Box::new(yum)),
+        ("slmicro", true) => Some(Box::new(transactional_update)),
         _ => None,
     }
 }
@@ -228,6 +330,97 @@ mod tests {
     #[test]
     fn table_lookup() {
         assert!(update_check("12", false).is_some());
-        assert!(update_check("YUM", false).is_none());
+        // Both keys that have an updater but used to have no check at all:
+        // an `update` on them reported success whatever happened.
+        assert!(update_check("YUM", false).is_some());
+        assert!(update_check("slmicro", true).is_some());
+        // The key shape still matters — `slmicro` is only ever transactional,
+        // and no zypper release is.
+        assert!(update_check("slmicro", false).is_none());
+        assert!(update_check("15", true).is_none());
+        assert!(update_check("nonesuch", false).is_none());
+    }
+
+    #[test]
+    fn timed_out_command_fails_on_every_key() {
+        // `-1` is `Target::run`'s catch-all for "timed out", "connection
+        // failed mid-command" and "not connected". Before this gate existed a
+        // timed-out patch reported success on every key: stdout and stderr are
+        // both empty, so no marker matched and the check returned `Ok`.
+        for (name, check) in [
+            ("zypper", update_check("15", false).unwrap()),
+            ("yum", update_check("YUM", false).unwrap()),
+            ("transactional", update_check("slmicro", true).unwrap()),
+        ] {
+            let Err(err) = check(args("some update command", "", "", -1)) else {
+                panic!("{name} must fail on exit -1");
+            };
+            assert_eq!(
+                err.reason, "update command timed out or failed to run",
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn transactional_update_ignores_the_masked_exit_code() {
+        // The slmicro template's last line is the repo-cleanup loop, so
+        // `lastexit()` is that loop's status, not the patch's. Judging this
+        // key on the exit code would roll the whole group back over a cosmetic
+        // cleanup hiccup, so a non-zero code with clean output must pass.
+        let diags = transactional_update(args("transactional-update -n pkg in", "all good", "", 1))
+            .expect("a masked non-zero exit must not fail the transactional check");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn transactional_update_still_catches_the_markers() {
+        // What it *is* judged on: the markers survive the exit-code masking.
+        let err = transactional_update(args(
+            "transactional-update -n pkg in",
+            "",
+            "System management is locked",
+            0,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "update stack locked");
+
+        let err = transactional_update(args("transactional-update", "(c): c", "", 0)).unwrap_err();
+        assert_eq!(err.reason, "Dependency Error");
+
+        let err =
+            transactional_update(args("transactional-update", "", "Error: boom", 0)).unwrap_err();
+        assert_eq!(err.reason, "RPM Error");
+    }
+
+    #[test]
+    fn yum_is_judged_on_its_exit_code() {
+        // The YUM template's last line *is* `yum -y update`, so unlike
+        // slmicro the recorded status is genuinely the updater's.
+        let err = yum(args("yum -y update pkg-a", "", "", 1)).unwrap_err();
+        assert_eq!(err.reason, "update command failed");
+        assert!(yum(args("yum -y update pkg-a", "all good", "", 0)).is_ok());
+    }
+
+    #[test]
+    fn yum_prefers_a_recognised_marker_over_the_generic_verdict() {
+        // A non-zero exit *and* a known marker: the specific reason wins, so
+        // the operator is told the stack is locked rather than just "failed".
+        let err = yum(args(
+            "yum -y update pkg-a",
+            "",
+            "System management is locked",
+            1,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "update stack locked");
+    }
+
+    #[test]
+    fn zypper_does_not_fail_on_an_unrecognised_non_zero_exit() {
+        // The zypper template ends with the same masking cleanup loop, so a
+        // bare `!= 0` rule here would be a false failure — and would fire the
+        // group-wide rollback. Only -1, 104 and the markers judge this key.
+        assert!(zypper(args("zypper -n in -t patch", "all good", "", 7)).is_ok());
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -63,6 +63,16 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// whole fleet over a no-op. The stdout/stderr markers below are unaffected by
 /// the masking and are what this key is judged on.
 ///
+/// The markers carry one residual exposure, accepted as a decision rather
+/// than an oversight: the `Error:` rule reads stderr from the whole `exec`,
+/// and the template's sibling commands (`zypper -n lr -puU`, the `zypper -n
+/// rr` cleanup loop) can emit `Error:` too — the same objection that rules
+/// the markers out for [`yum`]. The difference is the transcript: every
+/// command in this template is zypper, whose `Error:` lines are the
+/// vocabulary [`markers`] was written against, and the exposure is exactly
+/// the one the plain zypper keys have always carried. On [`yum`] the same
+/// rule would be a new one, judging a transcript it was never written for.
+///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -27,7 +27,8 @@ use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed}
 /// failure: the zypper update template ends with the same repo-cleanup loop
 /// that masks the patch status on `slmicro` (see [`transactional_update`]), so
 /// the code reaching here is not the patch's either. It is judged on the
-/// markers plus the two exit codes zypper is known to surface.
+/// markers, the `-1` never-ran sentinel, and the two exit codes zypper is
+/// known to surface.
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
     if args.stdin.contains("zypper") && args.exitcode == 104 {
@@ -73,28 +74,38 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 
 /// The yum update check.
 ///
-/// Unlike [`transactional_update`], this key *may* be judged on its exit code:
-/// the `YUM` update template's last line **is** `yum -y update $packages`, so
-/// the recorded status is genuinely the updater's. `yum` has no informational
-/// non-zero success code for `update` (`100` is `check-update`-only), so any
-/// non-zero status is a real failure.
+/// Deliberately gates **only** on the [`not_run`] sentinel. That is a narrow
+/// verdict, and narrow is the point: it is the part that can be justified
+/// without guessing, on a key whose failures route the **group-wide** rollback
+/// downgrade.
 ///
-/// A recognised marker still wins over the generic verdict, so a locked stack
-/// or an RPM error keeps its specific reason.
+/// Neither of the other two signals survives scrutiny here:
+///
+/// * **The exit code.** `("YUM", false)` is not one package manager —
+///   `System::get_release` maps *every* `rhel` version to this key, and on
+///   RHEL 8/9 `yum` is `dnf`, whose handling of a package spec matching
+///   nothing installed differs from yum 3's. mtui hands the updater the
+///   update's whole package list while a refhost routinely carries only a
+///   subset (the reason `prepare --installed-only` exists), so a bare `!= 0`
+///   rule risks failing a host that upgraded everything it had.
+/// * **The stdout/stderr markers.** [`markers`] is written for the zypper
+///   transcript; three of its four strings are zypper-only and cannot appear
+///   here. The fourth, `Error:` in stderr, *can* — but the YUM update template
+///   is three commands in one remote `exec`, so `lasterr()` also carries
+///   `yum repolist`'s output. An unreachable repository or a GPG complaint
+///   there would fail an update whose patch step succeeded.
+///
+/// Settling either would take observed `yum`/`dnf` output from a real RHEL
+/// refhost rather than inference, so the check claims only what it can prove:
+/// a command that never ran is not a successful update.
 ///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run", one of [`markers`]' reasons, or "update command failed" for
-/// an unrecognised non-zero exit.
+/// failed to run".
 fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
-    let diagnostics = markers(args)?;
-    if args.exitcode != 0 {
-        log_failed(args);
-        return Err(UpdateError::new("update command failed", args.hostname));
-    }
-    Ok(diagnostics)
+    Ok(Vec::new())
 }
 
 /// Raises when the command never produced a real exit status.
@@ -234,8 +245,10 @@ mod tests {
     }
 
     #[test]
-    fn non_zypper_104_does_not_trip_lock_branch() {
-        // 104 only means "locked" when the command was a zypper invocation.
+    fn non_zypper_104_is_not_package_not_found() {
+        // 104 only means "package not found" when the command was a zypper
+        // invocation. (The old name said "lock branch"; there is no such
+        // branch on 104 — the lock verdict comes from the stderr markers.)
         assert!(zypper(args("yum update", "", "", 104)).is_ok());
     }
 
@@ -394,26 +407,30 @@ mod tests {
     }
 
     #[test]
-    fn yum_is_judged_on_its_exit_code() {
-        // The YUM template's last line *is* `yum -y update`, so unlike
-        // slmicro the recorded status is genuinely the updater's.
-        let err = yum(args("yum -y update pkg-a", "", "", 1)).unwrap_err();
-        assert_eq!(err.reason, "update command failed");
-        assert!(yum(args("yum -y update pkg-a", "all good", "", 0)).is_ok());
-    }
+    fn yum_judges_only_whether_the_command_ran() {
+        // The narrow verdict is deliberate — see `yum`'s doc. Both of these
+        // would fail a host that updated fine:
+        //
+        // - a bare `!= 0`: on RHEL 8/9 `yum` is `dnf`, and mtui passes the
+        //   update's whole package list to a host that carries only a subset;
+        // - the `Error:` marker: the YUM template runs `yum repolist` in the
+        //   same `exec`, so an unreachable repo lands in the same stderr.
+        //
+        // Both would then route the group-wide rollback downgrade.
+        assert!(yum(args("yum -y update pkg-a pkg-b", "Upgraded: pkg-a", "", 1)).is_ok());
+        assert!(
+            yum(args(
+                "yum -y update pkg-a",
+                "",
+                "Error: Cannot retrieve repository metadata for repo 'x'",
+                0,
+            ))
+            .is_ok()
+        );
 
-    #[test]
-    fn yum_prefers_a_recognised_marker_over_the_generic_verdict() {
-        // A non-zero exit *and* a known marker: the specific reason wins, so
-        // the operator is told the stack is locked rather than just "failed".
-        let err = yum(args(
-            "yum -y update pkg-a",
-            "",
-            "System management is locked",
-            1,
-        ))
-        .unwrap_err();
-        assert_eq!(err.reason, "update stack locked");
+        // What it does catch: the command never ran to completion.
+        let err = yum(args("yum -y update pkg-a", "", "", -1)).unwrap_err();
+        assert_eq!(err.reason, "update command timed out or failed to run");
     }
 
     #[test]

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -342,10 +342,15 @@ impl mtui_hosts::PlanProvider for WorkflowRegistry {
                     Err(e) => Err(e.reason),
                 }
             }
-            // No check table for this key (`slmicro`, `YUM`): fall back to the
-            // exit code alone, exactly as `install_verdict` used to. Not "any
-            // stderr is a failure" — `transactional-update` and `yum` both
-            // write progress and warnings to stderr on a successful run.
+            // No *install/uninstall* check table for this key (`slmicro`,
+            // `YUM`): fall back to the exit code alone, exactly as
+            // `install_verdict` used to. Not "any stderr is a failure" —
+            // `transactional-update` and `yum` both write progress and
+            // warnings to stderr on a successful run.
+            //
+            // Only this adapter is meant: `update` does now have checks for
+            // both keys, but it resolves them through `CheckProvider`, not
+            // here.
             None if a.exitcode != 0 => Err(format!("{op} command failed")),
             None => Ok(()),
         })

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -479,7 +479,23 @@ mod tests {
     #[test]
     fn registry_check_unknown_key_is_none() {
         let reg = WorkflowRegistry::default();
-        assert!(reg.check(Role::Update, "slmicro", true).is_none());
+        // Was `("slmicro", true)` — which is now a *registered* update key, so
+        // it no longer demonstrates anything. Use keys with no doer either.
+        assert!(reg.check(Role::Update, "nonesuch", false).is_none());
+        assert!(reg.check(Role::Update, "15", true).is_none());
+    }
+
+    #[test]
+    fn registry_resolves_the_update_checks_that_used_to_be_missing() {
+        // `("slmicro", true)` and `("YUM", false)` have had an *updater* since
+        // the port but no check, so `run_checks` skipped them via its
+        // `else { continue }` and `update` reported success on those hosts
+        // whatever the command did. Pins the table wiring, not just the
+        // function: resolving through the registry is the path `run_checks`
+        // actually takes.
+        let reg = WorkflowRegistry::default();
+        assert!(reg.check(Role::Update, "slmicro", true).is_some());
+        assert!(reg.check(Role::Update, "YUM", false).is_some());
     }
 
     // --- the mtui-hosts PlanProvider adapter --------------------------------


### PR DESCRIPTION
Three silent failures in the update/prepare/downgrade flows. Five commits:
one per fix, bisectable and individually green; a fourth carrying the
adversarial review's findings against the first three — kept separate because
three of four reviewers independently caught the first commit's new `-1` gate
routing an unreachable host into the group-wide rollback, and that correction
is worth reading on its own; and a fifth, doc-only, answering the human
review's design question in the routing docs.

## 1. `update` had no verdict at all on SL Micro and YUM

`("slmicro", true)` and `("YUM", false)` have had an *updater* since the port
but no entry in the *check* table, so `run_checks` took its
`else { continue }` and those hosts contributed nothing. `update` reported
success however the patch went — and on SL Micro the host was then rebooted
into the failed transaction.

**SL Micro is judged on output markers, not the exit code.** Its template is a
multi-line script run as a single remote `exec` whose last line is the
`zypper -n lr | … | while read r; do zypper -n rr $r; done` cleanup loop. The
shell reports *that loop's* status — `0` whenever the body never runs — and
discards the `transactional-update` status entirely. An exit-code rule would
be wrong in both directions: a failed patch still exits 0, and a hiccup in the
cosmetic cleanup would read as a failed update — which, because an update
check failure routes the **group-wide rollback**, would roll the whole fleet
back over a no-op.

**YUM is judged only on whether the command ran.** That key is *every* `rhel`
version; on RHEL 8/9 `yum` is `dnf`, whose handling of a spec matching nothing
installed differs from yum 3's, and mtui hands the updater the whole package
list while a refhost carries only a subset. The `Error:` marker is no better —
the template runs `yum repolist` in the same `exec`, so an unreachable repo
lands in the same stderr. Either rule would fail a host that updated fine and
take the fleet down with it. Settling them needs observed output from a real
RHEL refhost, so the check claims only what it can prove.

Also adds the **"timed out or failed to run" gate** the downgrade check has and
this one lacked, on *every* key including plain zypper. `Target::run` records
`-1` for a timeout, a mid-command connection loss, or an unconnected target,
and such a run leaves stdout and stderr empty — so no marker matched and a
patch that never completed passed.

Crucially `-1` does **not** route the rollback (new `UpdateFailure::NotRun`).
It means the flow could not talk to the host, so a group-wide downgrade cannot
repair it and would only revert the hosts that patched cleanly — the same
reasoning `host_still_reachable` already applies on the reboot arm. `all`, not
`any`: a run mixing a lost host with a genuine check failure still rolls back,
on behalf of the host the rollback can repair.

## 2. A host lost to its reboot lost its history row

#385 moved `add_op_history` after the fan-out so a run that never started would
stop claiming it had — right, but it landed the write after the **reboot** too.
A transactional host that never comes back cannot be written to, so
`Target::add_history` hit a dead link and swallowed the failure at WARN. The
row went missing on precisely the host whose state most needs reconstructing,
for `install`, `uninstall`, `update` and `downgrade` alike.

It now lands between dispatch and reboot. #385's invariant holds — a run that
never started still writes nothing — and the row count and format are
unchanged, which matters because `/var/log/mtui.log` is parsed by other tools.
install/uninstall had no seam (their reboot is inside `Operation::run`), hence
`OperationGroup::add_history`; writing before `Operation::run` instead would
have skipped the `update_lock` gate and left a row for a run a foreign lock
stopped. The label comes from a new `Operation::history_label` returning the
command verb, deliberately **not** from `role()`, which yields
`"installer"`/`"uninstaller"`.

`MockConnection::sftp_append` now reconnects at entry like the real
`SshConnection::sftp()`. Without it the bug was not reproducible at all: the
mock accepted an append on a host that had gone away, so the regression tests
would have passed with the write on **either** side of the reboot.

## 3. `prepare`/`downgrade` rebooted into failed transactions

Both collected a host's failure and then handed `reboot_transactional` the full
map anyway, activating the snapshot the failure came from. The gate is
per-host, mirroring the install/uninstall template: a healthy host still
reboots so its own snapshot activates, and every skipped host is named at WARN.
Whole-group suppression is `update`'s shape because its outcome routes a
group-wide rollback; these two have no compensating group action.

The skip set never uses the stderr rule `host_command_failures` also applies —
`transactional-update` writes progress to stderr on a *successful* run, and
skipping such a host would leave a healthy snapshot inert. Exit codes are
usable here because, unlike update's script, these templates are single
commands.

A host with **nothing staged** is skipped too. It drops out of `combined` when
the probe resolved no versions — reachable with an exit-0 probe, so
`dead_probes` does not cover it. Rebooting it is not merely gratuitous: when
the downgrade *is* the update's rollback, the host would boot into the snapshot
the failed update left staged, undoing the update flow's own suppression.

`prepare --installed-only` now judges **every** package, not just the last. It
runs one fan-out per package but read a single post-loop snapshot, and its
template exits 0 when a package is absent — so a later no-op masked an earlier
failure in both the verdict and the reboot decision. Per-host failures are
deduped: a second entry for one host would push `aggregate_failures` out of its
verbatim branch into the summary, dropping `host` to `None`.

## Verification

Full gate green: `fmt`, `clippy --workspace --all-targets -D warnings`,
`test --workspace`, `test -p mtui-mcp -F mcp`, `--no-default-features` and
`--all-features` compile-only, `typos`. CHANGELOG diff is purely additive.

**14 mutants, each killed by exactly the intended test** — including "delete
the gate", "gate on stderr too", "route `-1` into the rollback again", "write
the history row after the reboot again", "label from `role()`", and "drop the
mock's reconnect guard".

Worth stating plainly: the review found that my own headline test for §1 was
**vacuous**. Its `with_default` fixture answered the repo-refresh command with
the same marker, so it passed with the patch dispatch deleted entirely. It is
rewritten to script the marker onto the patch alone plus assert the patch was
dispatched, and that mutant now dies.

## Deliberately out of scope

- The update template still masks its patch command's exit code. Fixing it
  means editing a remote command string that lands in `show_log` transcripts,
  and it would activate the currently-dead `104` branch so a zypper host could
  newly fail an update *and* fire the group-wide rollback. Own PR, wants
  sign-off.
- `prepare`/`install` still have no check for the `slmicro`/`YUM` keys — the
  gate here leans on the exit code, which is sound because those templates are
  single commands.
- `("slmicro", true)` downgrade check still gates only `-1` by design; the new
  reboot gate covers the plain non-zero case for the reboot decision.

