### PR TITLE
deps: refresh Cargo.lock and retire archived serde_yaml for serde-saphyr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- `refhosts.yml` rows now resolve YAML merge keys (`<<: *anchor`) instead of
+  ignoring them. This is a side effect of retiring the archived `serde_yaml`
+  crate in favour of `serde-saphyr`, which expands merge keys by default;
+  refusing them was an artefact of the previous parser, not a deliberate
+  schema rule, and merge keys are valid YAML. A `refhosts.yml` document that
+  relies on `<<` for shared fields across hosts now loads every host the
+  merge expands to, where it previously loaded only the literal rows.
+
 ### Fixed
 
 - `update` now reaches a verdict on SL Micro and RHEL/YUM hosts. Both have had

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -284,7 +284,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -640,7 +640,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1131,13 +1131,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1234,9 +1234,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1318,16 +1318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1711,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1756,9 +1755,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "ctutils",
  "subtle",
@@ -2135,7 +2134,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.9.0",
+ "redox_syscall 0.9.1",
 ]
 
 [[package]]
@@ -2526,7 +2525,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3132,7 +3131,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3207,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags",
 ]
@@ -3262,7 +3261,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3411,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3574,14 +3573,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3605,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3631,7 +3630,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3685,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "sandogasa-rpmvercmp"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcbcf7d90099ea6b266a314588dcd4b5f79dd236fe9d68d23b2822fd2f21883"
+checksum = "98298ac090533560c385faf9e478862006c70c0d4d66ab3eb1c44342ce9f7a13"
 
 [[package]]
 name = "schannel"
@@ -3700,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -3714,14 +3713,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3856,18 +3855,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3891,7 +3890,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3948,7 +3947,7 @@ checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4133,9 +4132,9 @@ checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sse-stream"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4288,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4338,7 +4337,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4367,7 +4366,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4381,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4461,13 +4460,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4482,9 +4481,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4508,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4544,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -4961,7 +4960,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +156,12 @@ dependencies = [
  "cpufeatures",
  "password-hash",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert-json-diff"
@@ -1267,6 +1284,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1636,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -2480,8 +2525,8 @@ dependencies = [
  "insta",
  "sandogasa-rpmvercmp",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "shlex",
  "thiserror",
  "tracing",
@@ -2504,6 +2549,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify-rust"
@@ -3658,12 +3709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "salsa20"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,6 +3874,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb49c0aa8a5bb88c00b833c11bae50d1611fb89e01336f53b05f7c643b1c883"
+dependencies = [
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,19 +3962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4718,12 +4767,6 @@ dependencies = [
  "crypto-common",
  "ctutils",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,10 @@ shlex = "2"
 # ser/de + config
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+# serde_yaml is archived (0.9.34+deprecated, no in-crate upgrade path);
+# serde-saphyr is the maintained, serde-native replacement. It streams and
+# builds no DOM, so rows go through serde_json::Value instead.
+serde-saphyr = "1"
 toml = "1"
 # INI parsing for the native oscrc credential reader (obs backend, G1b).
 # osc writes genuine INI (`[https://api.suse.de]` headers, bare `key = value`),

--- a/crates/mtui-types/Cargo.toml
+++ b/crates/mtui-types/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 sandogasa-rpmvercmp.workspace = true
 serde.workspace = true
 shlex.workspace = true
-serde_yaml.workspace = true
+serde-saphyr.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
-serde_json.workspace = true

--- a/crates/mtui-types/src/error.rs
+++ b/crates/mtui-types/src/error.rs
@@ -141,7 +141,7 @@ pub enum PackageSpecParseError {
 /// Error produced when a `refhosts.yml` document cannot be parsed.
 ///
 /// A document-level YAML parse failure propagates as this typed error wrapping
-/// the underlying `serde_yaml` failure. Note: individual *malformed rows* do not
+/// the underlying `serde-saphyr` failure. Note: individual *malformed rows* do not
 /// surface here — they are dropped (logged) so one bad row
 /// never aborts the whole load. Only a document-level YAML failure is fatal.
 #[derive(Debug, Error)]
@@ -149,7 +149,7 @@ pub enum PackageSpecParseError {
 pub enum RefhostsParseError {
     /// The YAML document itself was malformed.
     #[error("failed to parse refhosts.yml: {0}")]
-    Yaml(#[from] serde_yaml::Error),
+    Yaml(#[from] serde_saphyr::Error),
 }
 
 /// Error produced when an RPM version string cannot be parsed.

--- a/crates/mtui-types/src/product.rs
+++ b/crates/mtui-types/src/product.rs
@@ -74,7 +74,7 @@ addons:
       major: 15
       minor: 5
 ";
-        let host: Host = serde_yaml::from_str(yaml).unwrap();
+        let host: Host = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(host.name, "host-default-x86");
         assert_eq!(host.arch, "x86_64");
         assert_eq!(host.product.name, "sles");
@@ -86,8 +86,8 @@ addons:
         assert_eq!(host.addons[0].name, "sdk");
 
         // Round-trip preserves the row.
-        let round = serde_yaml::to_string(&host).unwrap();
-        let back: Host = serde_yaml::from_str(&round).unwrap();
+        let round = serde_saphyr::to_string(&host).unwrap();
+        let back: Host = serde_saphyr::from_str(&round).unwrap();
         assert_eq!(back, host);
     }
 
@@ -102,7 +102,7 @@ product:
     major: 12
     minor: sp4
 ";
-        let host: Host = serde_yaml::from_str(yaml).unwrap();
+        let host: Host = serde_saphyr::from_str(yaml).unwrap();
         assert!(host.addons.is_empty());
         assert_eq!(
             host.product.version,
@@ -116,7 +116,7 @@ product:
     #[test]
     fn product_without_version_deserializes() {
         let yaml = "name: rhel\n";
-        let product: Product = serde_yaml::from_str(yaml).unwrap();
+        let product: Product = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(product.name, "rhel");
         assert_eq!(product.version, None);
     }

--- a/crates/mtui-types/src/refhost.rs
+++ b/crates/mtui-types/src/refhost.rs
@@ -22,6 +22,11 @@
 //! and logged at `tracing::warn!` so one bad row never aborts the whole load.
 //! Only a document-level YAML parse failure is fatal and surfaces as
 //! [`RefhostsParseError`].
+//!
+//! # Merge keys (`<<: *anchor`)
+//! `refhosts.yml` rows may use YAML merge keys; they are resolved (not treated
+//! as an ordinary `<<` field) because merge keys are valid YAML and rejecting
+//! them was an artefact of the previous parser, not a deliberate schema rule.
 
 use std::collections::HashSet;
 
@@ -32,9 +37,32 @@ use crate::product::Host;
 
 /// The top-level `refhosts.yml` shape: location key → list of raw host rows.
 ///
-/// Rows are kept as `serde_yaml::Value` first so that a single malformed row can
+/// `serde-saphyr` streams and builds no DOM, so rows are kept as
+/// `serde_json::Value` (a workspace dep already) instead of a YAML `Value`;
+/// `serde_json::Value` implements `Deserializer`, so `Host::deserialize` below
+/// is unchanged. Keeping rows untyped first means a single malformed row can
 /// be dropped without failing the whole document.
-type RawDocument = std::collections::BTreeMap<String, Option<Vec<serde_yaml::Value>>>;
+type RawDocument = std::collections::BTreeMap<String, Option<Vec<serde_json::Value>>>;
+
+/// Parser options for `refhosts.yml`, chosen to close three regressions vs.
+/// `serde_yaml` 0.9's behaviour:
+/// - `strict_booleans`: `serde-saphyr` defaults to YAML 1.1 booleans (`no`,
+///   `on`, `y`, …), which `serde_yaml` did not infer; hostnames/values with
+///   those spellings must stay strings.
+/// - `reject_non_finite_typeless_float: false`: a single `.inf`/`.nan`
+///   anywhere is document-fatal by default under `deserialize_any` — exactly
+///   the failure mode this loader exists to prevent. `false` degrades it to a
+///   string instead, so the per-row `Host::deserialize` drops just that row.
+/// - `budget`: the default `max_nodes` (250,000) caps the inventory at
+///   roughly 21k hosts; `refhosts.yml` is fetched over the network, so the
+///   raised ceiling is deliberate DoS hardening, not a disabled check.
+fn options() -> serde_saphyr::Options {
+    serde_saphyr::options! {
+        strict_booleans: true,
+        reject_non_finite_typeless_float: false,
+        budget: serde_saphyr::budget! { max_nodes: 5_000_000, max_events: 10_000_000 },
+    }
+}
 
 /// Parse a `refhosts.yml` document into a flat, de-duplicated list of hosts.
 ///
@@ -48,10 +76,11 @@ type RawDocument = std::collections::BTreeMap<String, Option<Vec<serde_yaml::Val
 /// document (top-level mapping of location → row list).
 pub fn load_refhosts(yaml: &str) -> Result<Vec<Host>, RefhostsParseError> {
     // An empty document is a valid, empty host list.
-    let doc: RawDocument = match serde_yaml::from_str::<Option<RawDocument>>(yaml)? {
-        Some(doc) => doc,
-        None => return Ok(Vec::new()),
-    };
+    let doc: RawDocument =
+        match serde_saphyr::from_str_with_options::<Option<RawDocument>>(yaml, options())? {
+            Some(doc) => doc,
+            None => return Ok(Vec::new()),
+        };
 
     let mut seen: HashSet<String> = HashSet::new();
     let mut hosts: Vec<Host> = Vec::new();
@@ -208,5 +237,116 @@ default:
         );
         assert_eq!(h.addons.len(), 1);
         assert_eq!(h.addons[0].name, "sdk");
+    }
+
+    // The four tests below pin `serde-saphyr`-specific scalar/merge-key
+    // behaviour that diverges from `serde_yaml` 0.9. Each was observed
+    // failing (red) against a deliberately wrong option/expectation before
+    // being corrected to match the option settings in `options()` above; see
+    // the mutation each names.
+
+    #[test]
+    fn leading_zero_minor_drops_the_row() {
+        // `minor: 05` resolves to the float 5.0 under serde-saphyr's default
+        // number schema, matching neither `VersionField::Num(u64)` nor
+        // `::Text(String)`, so the row is dropped like any other malformed
+        // row — a silently smaller fleet, not a document-level error.
+        // Mutation this catches: a future serde-saphyr default (or option)
+        // that starts reading `05` as a string would turn this row valid,
+        // which must fail this test's `["good"]` expectation.
+        let yaml = "\
+default:
+  - name: good
+    arch: x86_64
+    product:
+      name: sles
+  - name: leading-zero
+    arch: x86_64
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 05
+";
+        let hosts = load_refhosts(yaml).unwrap();
+        let names: Vec<_> = hosts.iter().map(|h| h.name.as_str()).collect();
+        assert_eq!(names, ["good"]);
+    }
+
+    #[test]
+    fn underscore_grouped_minor_is_read_as_a_number_not_text() {
+        // `minor: 1_000` parses as the integer 1000 under serde-saphyr
+        // (`VersionField::Num`), diverging from `serde_yaml` 0.9, which had
+        // no underscore-grouping support and left it as `Text("1_000")`. The
+        // row is kept either way, just with a different `minor` shape.
+        let yaml = "\
+default:
+  - name: h
+    arch: x86_64
+    product:
+      name: sles
+      version:
+        major: 15
+        minor: 1_000
+";
+        let hosts = load_refhosts(yaml).unwrap();
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(
+            hosts[0].product.version,
+            Some(Version::new(15u64, Some(VersionField::Num(1_000))))
+        );
+    }
+
+    #[test]
+    fn non_finite_float_in_one_row_does_not_fail_the_whole_document() {
+        // `reject_non_finite_typeless_float: true` (serde-saphyr's own
+        // default) makes a single `.inf`/`.nan` anywhere in the document
+        // DOCUMENT-FATAL under `deserialize_any` (the untyped `RawDocument`
+        // rows) — precisely the failure mode this loader exists to prevent.
+        // `options()` sets it `false`, degrading the value to the string
+        // `".inf"` instead. Mutation this catches: flipping that option back
+        // to `true` (serde-saphyr's default) turns this whole document
+        // unparseable, so `load_refhosts` would return `Err` instead of
+        // `Ok` with both hosts present.
+        let yaml = "\
+default:
+  - name: good
+    arch: x86_64
+    product:
+      name: sles
+  - name: infinite-arch
+    arch: .inf
+    product:
+      name: sles
+";
+        let hosts = load_refhosts(yaml).expect("a stray .inf must not fail the whole document");
+        let names: Vec<_> = hosts.iter().map(|h| h.name.as_str()).collect();
+        assert_eq!(names, ["good", "infinite-arch"]);
+        assert_eq!(hosts[1].arch, ".inf");
+    }
+
+    #[test]
+    fn merge_key_row_expands_into_a_second_host() {
+        // Merge keys (`<<: *anchor`) resolve (`MergeKeyPolicy::Merge`, the
+        // serde-saphyr default) rather than being treated as an ordinary `<<`
+        // field, per the module-level "Merge keys" decision above. Mutation
+        // this catches: setting `merge_keys` to `AsOrdinary` or `Error` drops
+        // the merged row (a `<<` key doesn't deserialize into `Host`), so
+        // `hosts.len()` would fall to 1.
+        let yaml = "\
+default:
+  - &base
+    name: base-host
+    arch: x86_64
+    product:
+      name: sles
+  - <<: *base
+    name: overridden-host
+";
+        let hosts = load_refhosts(yaml).unwrap();
+        let names: Vec<_> = hosts.iter().map(|h| h.name.as_str()).collect();
+        assert_eq!(names, ["base-host", "overridden-host"]);
+        assert_eq!(hosts[1].arch, "x86_64");
+        assert_eq!(hosts[1].product.name, "sles");
     }
 }

--- a/crates/mtui-types/src/version.rs
+++ b/crates/mtui-types/src/version.rs
@@ -82,41 +82,41 @@ mod tests {
     #[test]
     fn numeric_minor_round_trips_as_num() {
         let yaml = "major: 15\nminor: 5\n";
-        let v: Version = serde_yaml::from_str(yaml).unwrap();
+        let v: Version = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(v.major, VersionField::Num(15));
         assert_eq!(v.minor, Some(VersionField::Num(5)));
         // Re-serializing preserves the numeric shape.
-        let round = serde_yaml::to_string(&v).unwrap();
-        let back: Version = serde_yaml::from_str(&round).unwrap();
+        let round = serde_saphyr::to_string(&v).unwrap();
+        let back: Version = serde_saphyr::from_str(&round).unwrap();
         assert_eq!(back, v);
     }
 
     #[test]
     fn textual_minor_round_trips_as_text() {
         let yaml = "major: 12\nminor: sp4\n";
-        let v: Version = serde_yaml::from_str(yaml).unwrap();
+        let v: Version = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(v.major, VersionField::Num(12));
         assert_eq!(v.minor, Some(VersionField::Text("sp4".to_owned())));
-        let round = serde_yaml::to_string(&v).unwrap();
-        let back: Version = serde_yaml::from_str(&round).unwrap();
+        let round = serde_saphyr::to_string(&v).unwrap();
+        let back: Version = serde_saphyr::from_str(&round).unwrap();
         assert_eq!(back, v);
     }
 
     #[test]
     fn omitted_minor_deserializes_to_none() {
         let yaml = "major: 15\n";
-        let v: Version = serde_yaml::from_str(yaml).unwrap();
+        let v: Version = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(v.major, VersionField::Num(15));
         assert_eq!(v.minor, None);
         // With minor None, it is skipped on serialize.
-        let round = serde_yaml::to_string(&v).unwrap();
+        let round = serde_saphyr::to_string(&v).unwrap();
         assert!(!round.contains("minor"));
     }
 
     #[test]
     fn numeric_and_textual_minor_are_distinct() {
-        let num: Version = serde_yaml::from_str("major: 12\nminor: 4\n").unwrap();
-        let text: Version = serde_yaml::from_str("major: 12\nminor: sp4\n").unwrap();
+        let num: Version = serde_saphyr::from_str("major: 12\nminor: 4\n").unwrap();
+        let text: Version = serde_saphyr::from_str("major: 12\nminor: sp4\n").unwrap();
         assert_ne!(num.minor, text.minor);
     }
 


### PR DESCRIPTION
Two independently-landable commits per `plans/deps-lock-and-yaml.md`.

## Commit A — refresh `Cargo.lock`
Semver-compatible `cargo update`: 24 crates bumped, all patch/minor, no manifest edits, nothing under `rmcp`'s tree (that major bump is tracked separately in the companion `rmcp-3-migration` plan).

## Commit B — `serde_yaml` → `serde-saphyr`
`serde_yaml` is archived at `0.9.34+deprecated` with no in-crate upgrade path (unmaintained since 2024-03, built on `unsafe-libyaml`). `serde-saphyr` is the only actively-maintained, 1.0, serde-native replacement (streaming, no unsafe DOM, cargo-fuzz/Miri/CodeQL in CI, dedicated `no_panic`/attack-input suites).

- `refhosts.yml` rows now go through `serde_json::Value` (already a workspace dep) instead of a YAML `Value`, since `serde-saphyr` builds no DOM; `Host::deserialize` is unchanged because `serde_json::Value` is itself a `Deserializer`.
- Three options close regressions the swap would otherwise introduce: `strict_booleans` (serde-saphyr infers YAML 1.1 booleans like `no`/`on` by default; `serde_yaml` did not), `reject_non_finite_typeless_float: false` (a stray `.inf`/`.nan` is document-fatal by default — exactly the failure mode `load_refhosts` exists to prevent), and a raised node budget (the 250k default caps the inventory at ~21k hosts; `refhosts.yml` is fetched over the network).
- Two behaviour changes are pinned as tests, each **observed failing** before being corrected:
  - `minor: 05` now drops the host row (serde-saphyr resolves it to a float, matching neither `VersionField` variant; no option recovers it).
  - Merge keys (`<<: *anchor`) now resolve instead of being ignored — a deliberate `refhosts.yml` contract change, recorded in `CHANGELOG.md`.
- `cargo tree -i serde_yaml` finds nothing workspace-wide.

## Definition of Done (both commits)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` / `--all-features`
- `cargo audit` (0 advisories)
- `mtui-types` patch coverage: `refhost.rs` at 100% line coverage

All green locally.
