### PR TITLE
feat: give updates osc-qam field selection (-F), repeatable -G and --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- MCP calls passing a list to a repeatable single-value flag (e.g. `approve`
+  with two `group`s) no longer fail to parse: the reconstructed argv now
+  repeats the flag before every element instead of emitting it once for the
+  whole list.
 - `approve` no longer approves a Gitea update whose PR head differs from the
   checked-out testreport without saying so. Interactively it now logs the
   expected/actual hash pair and asks for confirmation (default no); a missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `updates` gained osc-qam-style field selection and a scripting output
+  (#415): `-F/--field` (repeatable) selects output fields by the names
+  `osc qam list -F` uses (`Rating`, `Assigned Roles`, `Unassigned Roles`,
+  `Incident Priority`, … — case-insensitive, with spaces/hyphens/underscores
+  equivalent), and `--json` (not combinable with `-F`) prints the raw TeReGen
+  rows as a JSON array. Fields the TeReGen queue listing does not carry
+  (`Products`, `SRCRPMs`, `Bugs`, `Package-Streams`, `Creator`, `Issues`,
+  `Comments`) are named in an error instead of rendering empty, and
+  `Assignee`/`Assigned Roles` are refused under `--status all`, where TeReGen
+  omits the assignment data they would render.
+- `updates --review-group` gained the short form `-G` and is now repeatable;
+  multiple groups are OR-ed via one TeReGen query per group, merged
+  priority-descending with duplicates collapsed. **MCP schema note:** the
+  `review_group` property of the `updates` tool changed from a string to an
+  array of strings.
+
 ### Changed
 
 - `refhosts.yml` rows now resolve YAML merge keys (`<<: *anchor`) instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (`Products`, `SRCRPMs`, `Bugs`, `Package-Streams`, `Creator`, `Issues`,
   `Comments`) are named in an error instead of rendering empty, and
   `Assignee`/`Assigned Roles` are refused under `--status all`, where TeReGen
-  omits the assignment data they would render.
+  omits the assignment data they would render; `Unassigned Roles` degrades to
+  `n/a` on any row carrying no assignment data rather than listing every
+  group as open.
 - `updates --review-group` gained the short form `-G` and is now repeatable;
   multiple groups are OR-ed via one TeReGen query per group, merged
   priority-descending with duplicates collapsed. **MCP schema note:** the

--- a/crates/mtui-core/src/commands/updates.rs
+++ b/crates/mtui-core/src/commands/updates.rs
@@ -1,8 +1,12 @@
 //! The `updates` command — list the update queue via the TeReGen API.
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
+use futures::future::join_all;
 use mtui_datasources::UpdatesQuery;
+use serde_json::Value;
 
 use crate::command::{Command, Scope};
 use crate::commands::apicall::teregen_client;
@@ -19,8 +23,9 @@ const STATUS_ALL: &str = "all";
 /// that are **in testing**.
 /// `--assignee`/`--mine`/`--all-assignees` pick another assignment view (and
 /// drop the unassigned default); `--status all` widens to every status. This is
-/// a session-global query, so it runs exactly once ([`Scope::Single`]) rather
-/// than fanning out per template.
+/// a session-global query, so it runs once per invocation ([`Scope::Single`])
+/// rather than fanning out per template — though it may issue one TeReGen
+/// query per `--review-group`.
 pub struct Updates;
 
 #[async_trait]
@@ -42,11 +47,38 @@ impl Command for Updates {
     fn configure(&self, cmd: clap::Command) -> clap::Command {
         cmd.arg(
             Arg::new("review_group")
+                .short('G')
                 .long("review-group")
                 .value_name("GROUP")
+                .action(ArgAction::Append)
                 .help(
                     "filter by review group as the bare group name, e.g. qam-sle \
-                     (not the '<group>-review' login form, which classic rows lack)",
+                     (not the '<group>-review' login form, which classic rows lack); \
+                     repeatable — groups are OR-ed (one server query per group)",
+                ),
+        )
+        .arg(
+            Arg::new("field")
+                .short('F')
+                .long("field")
+                .value_name("FIELD")
+                .action(ArgAction::Append)
+                .help(
+                    "select output fields by osc-qam name (e.g. -F Rating \
+                     -F 'Assigned Roles'); repeatable, rendered as one block per \
+                     update; names are case-insensitive and treat spaces, \
+                     hyphens and underscores as equivalent",
+                ),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("field")
+                .help(
+                    "print the raw TeReGen rows as a JSON array (each row \
+                     emitted whole, unlike -F; honours --limit; not combinable \
+                     with -F); an empty queue prints []",
                 ),
         )
         .arg(
@@ -100,6 +132,8 @@ impl Command for Updates {
                 &["--assignee"],
                 &["--mine"],
                 &["--all-assignees"],
+                &["--field"],
+                &["--json"],
             ],
             Vec::new(),
             line,
@@ -108,7 +142,21 @@ impl Command for Updates {
     }
 
     async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
-        let review_group = args.get_one::<String>("review_group").cloned();
+        // Dedup repeated identical groups (order-preserving) so `-G a -G a`
+        // takes the single-query path instead of firing two identical queries.
+        let review_groups: Vec<String> = {
+            let mut seen = HashSet::new();
+            args.get_many::<String>("review_group")
+                .map(|v| v.filter(|g| seen.insert((*g).clone())).cloned().collect())
+                .unwrap_or_default()
+        };
+        // Resolve every -F name up front so a typo errors before any query.
+        let specs = args
+            .get_many::<String>("field")
+            .map(|v| v.map(|f| resolve_field(f)).collect::<Result<Vec<_>, _>>())
+            .transpose()?
+            .unwrap_or_default();
+        let as_json = args.get_flag("json");
         let status_arg = args
             .get_one::<String>("status")
             .cloned()
@@ -135,51 +183,408 @@ impl Command for Updates {
         // Show the assignee column whenever assignment is part of the view.
         let want_assignment = assignee.is_some() || unassigned || all_assignees;
 
+        // Refuse assignment-derived fields in a view that cannot carry
+        // assignment data (`--status all` with no assignment flag): without
+        // `with_assignment` TeReGen omits assignee/assignees on SLFO rows, so
+        // rendering would show a false "unassigned" for an assigned row. And
+        // forcing the parameter is no fix — it implies status=testing
+        // server-side, contradicting `--status all`.
+        if !want_assignment && let Some(spec) = specs.iter().find(|s| s.needs_assignment) {
+            return Err(CommandError::Other(format!(
+                "field '{}' needs assignment data, which TeReGen omits under \
+                 '--status all'; drop --status all or pick an assignment view \
+                 (--assignee/--mine/--all-assignees)",
+                spec.canonical
+            )));
+        }
+
         let teregen = teregen_client(session)?;
-        let query = UpdatesQuery {
-            review_group: review_group.as_deref(),
-            status: status.as_deref(),
-            assignee: assignee.as_deref(),
-            unassigned,
-            with_assignment: want_assignment,
-            no_cache: false,
-        };
-        // `teregen.updates` now returns a Result: `Err` on any transport/API
+        // A closure cannot tie its return's lifetime to its argument's, so
+        // this is a named fn: one query shape, group varying per call.
+        fn query_for<'a>(
+            group: Option<&'a str>,
+            status: Option<&'a str>,
+            assignee: Option<&'a str>,
+            unassigned: bool,
+            with_assignment: bool,
+        ) -> UpdatesQuery<'a> {
+            UpdatesQuery {
+                review_group: group,
+                status,
+                assignee,
+                unassigned,
+                with_assignment,
+                no_cache: false,
+            }
+        }
+
+        // `teregen.updates` returns a Result: `Err` on any transport/API
         // failure (surfaced to the caller), `Ok(None)` on a successful response
         // missing the `updates` key, and `Ok(Some(json))` on success. Only a
-        // genuinely-empty *successful* result is "No updates in the queue"; a
-        // fetch failure is no longer conflated with an empty queue.
-        let updates = teregen.updates(&query).await.map_err(|e| {
-            CommandError::Other(format!(
-                "Update queue query failed (TeReGen unreachable): {e}"
-            ))
-        })?;
-        let Some(updates) = updates else {
-            session.display.println("No updates in the queue");
-            return Ok(());
+        // genuinely-empty *successful* result is an empty queue; a fetch
+        // failure is never conflated with one.
+        let rows: Vec<Value> = if review_groups.len() > 1 {
+            // One server query per group: TeReGen has no OR semantics for a
+            // repeated `review_group` param (the last one wins), and the
+            // filter cannot be replicated client-side — the server matches
+            // SLFO rows against a group without ever serialising
+            // `review_groups` on them.
+            let queries: Vec<UpdatesQuery<'_>> = review_groups
+                .iter()
+                .map(|g| {
+                    query_for(
+                        Some(g.as_str()),
+                        status.as_deref(),
+                        assignee.as_deref(),
+                        unassigned,
+                        want_assignment,
+                    )
+                })
+                .collect();
+            let results = join_all(queries.iter().map(|q| teregen.updates(q))).await;
+            let mut merged: Vec<Value> = Vec::new();
+            let mut seen: HashSet<String> = HashSet::new();
+            for result in results {
+                let batch = result.map_err(|e| {
+                    CommandError::Other(format!(
+                        "Update queue query failed (TeReGen unreachable): {e}"
+                    ))
+                })?;
+                let Some(batch) = batch else { continue };
+                let batch = batch.as_array().ok_or_else(|| {
+                    CommandError::Other(
+                        "Update queue query returned a malformed response".to_owned(),
+                    )
+                })?;
+                for row in batch {
+                    // Dedup by id (a row can sit in several groups). A row
+                    // without an id is kept, never silently dropped.
+                    let fresh = match row.get("id").and_then(Value::as_str) {
+                        Some(id) => seen.insert(id.to_owned()),
+                        None => true,
+                    };
+                    if fresh {
+                        merged.push(row.clone());
+                    }
+                }
+            }
+            // The server returns each group priority-descending; restore that
+            // order across the merged set (stable, so ties keep server order).
+            merged.sort_by_key(|r| {
+                std::cmp::Reverse(
+                    r.get("priority")
+                        .and_then(Value::as_i64)
+                        .unwrap_or(i64::MIN),
+                )
+            });
+            merged
+        } else {
+            let query = query_for(
+                review_groups.first().map(String::as_str),
+                status.as_deref(),
+                assignee.as_deref(),
+                unassigned,
+                want_assignment,
+            );
+            let updates = teregen.updates(&query).await.map_err(|e| {
+                CommandError::Other(format!(
+                    "Update queue query failed (TeReGen unreachable): {e}"
+                ))
+            })?;
+            match updates {
+                None => Vec::new(),
+                Some(v) => v
+                    .as_array()
+                    .ok_or_else(|| {
+                        CommandError::Other(
+                            "Update queue query returned a malformed response".to_owned(),
+                        )
+                    })?
+                    .clone(),
+            }
         };
-        let rows = updates.as_array().ok_or_else(|| {
-            CommandError::Other("Update queue query returned a malformed response".to_owned())
-        })?;
+
         if rows.is_empty() {
-            session.display.println("No updates in the queue");
+            // Keep --json output parseable even for an empty queue.
+            session.display.println(if as_json {
+                "[]"
+            } else {
+                "No updates in the queue"
+            });
             return Ok(());
         }
 
-        let shown: &[serde_json::Value] = if limit > 0 && limit < rows.len() {
+        let shown: &[Value] = if limit > 0 && limit < rows.len() {
             &rows[..limit]
         } else {
-            rows
+            &rows
         };
+
+        if as_json {
+            // The raw rows, nothing discarded — the scripting path. No count
+            // header: stdout is the JSON document.
+            let doc = Value::Array(shown.to_vec());
+            session.display.println(
+                &serde_json::to_string_pretty(&doc)
+                    .expect("serialising a serde_json::Value is infallible"),
+            );
+            return Ok(());
+        }
 
         session
             .display
             .println(&format!("Update queue ({}):", shown.len()));
-        for u in shown {
-            session.display.println(&render_row(u, want_assignment));
+        if specs.is_empty() {
+            for u in shown {
+                session.display.println(&render_row(u, want_assignment));
+            }
+        } else {
+            for (i, u) in shown.iter().enumerate() {
+                if i > 0 {
+                    session.display.println("");
+                }
+                session.display.println(&render_fields(u, &specs));
+            }
         }
         Ok(())
     }
+}
+
+/// One selectable `-F` output field: the canonical osc-qam spelling plus its
+/// extraction from a TeReGen queue row.
+struct FieldSpec {
+    /// Canonical display name, as `osc qam list -F` spells it.
+    canonical: &'static str,
+    /// Extra accepted spellings (pre-normalized), beyond the canonical name.
+    aliases: &'static [&'static str],
+    /// Whether the value only exists when the query sends `with_assignment`.
+    /// Without it TeReGen omits `assignee`/`assignees` on SLFO rows, so the
+    /// field would render a false "unassigned" for a genuinely assigned row —
+    /// requesting such a field in a view that cannot carry assignment
+    /// (`--status all` without an assignment flag) is refused, not blanked.
+    needs_assignment: bool,
+    extract: fn(&serde_json::Map<String, Value>) -> String,
+}
+
+/// The fields the TeReGen queue listing can serve today. osc-qam names are
+/// canonical so existing `osc qam list -F` muscle memory transfers; the raw
+/// TeReGen key is an alias where it differs.
+static FIELDS: &[FieldSpec] = &[
+    FieldSpec {
+        canonical: "ReviewRequestID",
+        aliases: &["id"],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "id"),
+    },
+    FieldSpec {
+        canonical: "Incident Priority",
+        aliases: &["priority", "prio"],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "priority"),
+    },
+    FieldSpec {
+        canonical: "Rating",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "rating"),
+    },
+    FieldSpec {
+        canonical: "Category",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "category"),
+    },
+    FieldSpec {
+        canonical: "Status",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "status"),
+    },
+    FieldSpec {
+        canonical: "Kind",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "kind"),
+    },
+    FieldSpec {
+        canonical: "Deadline",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "deadline"),
+    },
+    FieldSpec {
+        canonical: "Assignee",
+        aliases: &[],
+        needs_assignment: true,
+        extract: |o| {
+            o.get("assignee")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("unassigned")
+                .to_owned()
+        },
+    },
+    FieldSpec {
+        canonical: "Assigned Roles",
+        aliases: &[],
+        needs_assignment: true,
+        extract: extract_assigned_roles,
+    },
+    FieldSpec {
+        canonical: "Unassigned Roles",
+        aliases: &[],
+        needs_assignment: false,
+        extract: extract_unassigned_roles,
+    },
+    FieldSpec {
+        canonical: "Title",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "title"),
+    },
+    FieldSpec {
+        canonical: "URL",
+        aliases: &[],
+        needs_assignment: false,
+        extract: |o| scalar_field(o, "url"),
+    },
+];
+
+/// osc-qam fields the TeReGen queue listing does not carry (yet) — named so
+/// the error can say "known, but not available here" instead of "unknown".
+/// Tracked in #415.
+static UNAVAILABLE_FIELDS: &[&str] = &[
+    "Products",
+    "SRCRPMs",
+    "Bugs",
+    "Package-Streams",
+    "Creator",
+    "Issues",
+    "Comments",
+];
+
+/// Normalizes a field name for matching: lowercase, separators dropped, so
+/// `Incident Priority`, `incident-priority` and `incident_priority` coincide.
+fn normalize_field(name: &str) -> String {
+    name.chars()
+        .filter(|c| !matches!(c, '-' | '_' | ' '))
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// Resolves a `-F` name to its spec, or a self-explanatory error: a known
+/// osc-qam field the listing cannot serve names the gap (#415); anything else
+/// lists what is available.
+fn resolve_field(name: &str) -> Result<&'static FieldSpec, CommandError> {
+    let norm = normalize_field(name);
+    if let Some(spec) = FIELDS
+        .iter()
+        .find(|s| normalize_field(s.canonical) == norm || s.aliases.iter().any(|a| *a == norm))
+    {
+        return Ok(spec);
+    }
+    if let Some(known) = UNAVAILABLE_FIELDS
+        .iter()
+        .find(|f| normalize_field(f) == norm)
+    {
+        return Err(CommandError::Other(format!(
+            "field '{known}' is not in TeReGen's queue listing yet \
+             (tracked in #415); available fields: {}",
+            available_field_names()
+        )));
+    }
+    Err(CommandError::Other(format!(
+        "unknown field '{name}'; available fields: {}",
+        available_field_names()
+    )))
+}
+
+/// The canonical names of every servable field, comma-joined for error text.
+fn available_field_names() -> String {
+    FIELDS
+        .iter()
+        .map(|s| s.canonical)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// A scalar row key as display text: missing/null → `-`.
+fn scalar_field(obj: &serde_json::Map<String, Value>, key: &str) -> String {
+    match obj.get(key) {
+        None | Some(Value::Null) => "-".to_owned(),
+        Some(v) => json_scalar(v),
+    }
+}
+
+/// `Assigned Roles`: flattens TeReGen's `assignees` map
+/// (`{group: [{state, user}]}`) to `group:user` pairs; a non-`assigned` state
+/// is kept visible as `group:user(state)`.
+fn extract_assigned_roles(obj: &serde_json::Map<String, Value>) -> String {
+    let Some(map) = obj.get("assignees").and_then(Value::as_object) else {
+        return "-".to_owned();
+    };
+    let mut parts = Vec::new();
+    for (group, entries) in map {
+        for entry in entries.as_array().into_iter().flatten() {
+            let user = entry.get("user").and_then(Value::as_str).unwrap_or("?");
+            match entry.get("state").and_then(Value::as_str) {
+                Some("assigned") | None => parts.push(format!("{group}:{user}")),
+                Some(state) => parts.push(format!("{group}:{user}({state})")),
+            }
+        }
+    }
+    if parts.is_empty() {
+        "-".to_owned()
+    } else {
+        parts.join(", ")
+    }
+}
+
+/// `Unassigned Roles`: `review_groups` minus the groups present in
+/// `assignees`. TeReGen serialises `review_groups` only on classic
+/// Maintenance rows — SLFO rows omit it (while still matching a
+/// `review_group` filter server-side), so there the honest answer is `n/a`,
+/// not an empty list.
+fn extract_unassigned_roles(obj: &serde_json::Map<String, Value>) -> String {
+    let Some(groups) = obj.get("review_groups").and_then(Value::as_array) else {
+        return "n/a".to_owned();
+    };
+    // A group only counts as assigned when it has at least one entry — a
+    // `{"qam-sle": []}` group has nobody on it and must stay unassigned, not
+    // vanish from both role lists.
+    let assigned: HashSet<&str> = obj
+        .get("assignees")
+        .and_then(Value::as_object)
+        .map(|m| {
+            m.iter()
+                .filter(|(_, entries)| entries.as_array().is_some_and(|a| !a.is_empty()))
+                .map(|(group, _)| group.as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+    let open: Vec<&str> = groups
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|g| !assigned.contains(g))
+        .collect();
+    if open.is_empty() {
+        "-".to_owned()
+    } else {
+        open.join(", ")
+    }
+}
+
+/// Renders one queue row as a `-F` block: one `  Name: value` line per
+/// requested field, in the order requested.
+fn render_fields(u: &Value, specs: &[&'static FieldSpec]) -> String {
+    let Some(obj) = u.as_object() else {
+        return format!("  {u}");
+    };
+    specs
+        .iter()
+        .map(|s| format!("  {}: {}", s.canonical, (s.extract)(obj)))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Renders one queue row in a fixed-width layout.
@@ -419,5 +824,550 @@ mod tests {
         let out = buf.contents();
         assert!(out.contains("Update queue (1):"), "{out}");
         assert!(out.contains("assignee=tester"), "{out}");
+    }
+
+    // ------------------------------------------------ repeatable review-group
+
+    /// Builds a session pointed at `server`.
+    fn teregen_session(server: &MockServer) -> (Session, crate::commands::testkit::Buffer) {
+        let (mut session, buf) = empty_session();
+        let mut config = Config::default();
+        config.teregen_api = server.uri();
+        session.config = config;
+        (session, buf)
+    }
+
+    #[tokio::test]
+    async fn multi_group_queries_each_group_merges_and_dedups() {
+        // Two -G values → exactly one server query per group (TeReGen has no
+        // OR for a repeated param); rows merged priority-descending and the
+        // row present in both groups appears once.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "qam-sle"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 10, "status": "testing", "kind": "Maintenance", "id": "row-a"},
+                    {"priority": 5, "status": "testing", "kind": "Maintenance", "id": "row-both"},
+                ]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "qam-teradata"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 7, "status": "testing", "kind": "Maintenance", "id": "row-c"},
+                    {"priority": 5, "status": "testing", "kind": "Maintenance", "id": "row-both"},
+                ]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(
+            &Updates,
+            &[
+                "--review-group",
+                "qam-sle",
+                "--review-group",
+                "qam-teradata",
+            ],
+        );
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        // Three unique rows, not four.
+        assert!(out.contains("Update queue (3):"), "{out}");
+        assert_eq!(out.matches("row-both").count(), 1, "{out}");
+        // Merged order is priority-descending across groups: a(10), c(7), both(5).
+        let (pa, pc, pb) = (
+            out.find("row-a").unwrap(),
+            out.find("row-c").unwrap(),
+            out.find("row-both").unwrap(),
+        );
+        assert!(pa < pc && pc < pb, "order wrong: {out}");
+        // wiremock verifies the .expect(1) counts on drop.
+    }
+
+    #[tokio::test]
+    async fn multi_group_partial_failure_is_an_error_not_partial_output() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "good"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 1, "status": "testing", "kind": "Maintenance", "id": "ok-row"},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "bad"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(
+            &Updates,
+            &["--review-group", "good", "--review-group", "bad"],
+        );
+        let err = Updates.call(&mut session, &args).await.unwrap_err();
+        assert!(matches!(err, CommandError::Other(_)));
+        // No partial listing was printed.
+        assert!(!buf.contents().contains("ok-row"), "{}", buf.contents());
+    }
+
+    // ------------------------------------------------------- field selection
+
+    /// A row with a distinct value in every servable field, so a swapped
+    /// extractor mapping cannot pass.
+    fn distinct_row() -> serde_json::Value {
+        serde_json::json!({
+            "id": "SUSE:Maintenance:77:707",
+            "priority": 421,
+            "rating": "important",
+            "category": "security",
+            "status": "testing",
+            "kind": "Maintenance",
+            "deadline": "2026-08-09T10:00:00Z",
+            "assignee": "alice",
+            "assignees": {"qam-sle": [{"state": "assigned", "user": "alice"}]},
+            "review_groups": ["qam-sle", "qam-openqa", "qam-manager"],
+            "title": "Security update for demo",
+            "url": "/request/707/",
+        })
+    }
+
+    #[tokio::test]
+    async fn field_selection_renders_each_field_under_its_canonical_name() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"updates": [distinct_row()]})),
+            )
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        // Names in mixed spellings: canonical, raw-key alias, separator/case
+        // variants — all must resolve.
+        let args = matches(
+            &Updates,
+            &[
+                "-F",
+                "id",
+                "-F",
+                "incident-priority",
+                "-F",
+                "Rating",
+                "-F",
+                "CATEGORY",
+                "-F",
+                "Assigned Roles",
+                "-F",
+                "unassigned_roles",
+                "-F",
+                "Title",
+                "-F",
+                "URL",
+                "-F",
+                "Deadline",
+                "-F",
+                "Assignee",
+                "-F",
+                "Status",
+                "-F",
+                "Kind",
+            ],
+        );
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        // Each value sits on its canonical field's line — a swapped mapping
+        // would pair a value with the wrong name.
+        for line in [
+            "ReviewRequestID: SUSE:Maintenance:77:707",
+            "Incident Priority: 421",
+            "Rating: important",
+            "Category: security",
+            "Assigned Roles: qam-sle:alice",
+            // review_groups order is the server's, preserved verbatim.
+            "Unassigned Roles: qam-openqa, qam-manager",
+            "Title: Security update for demo",
+            "URL: /request/707/",
+            "Deadline: 2026-08-09T10:00:00Z",
+            "Assignee: alice",
+            "Status: testing",
+            "Kind: Maintenance",
+        ] {
+            assert!(out.contains(line), "missing '{line}' in:\n{out}");
+        }
+    }
+
+    #[tokio::test]
+    async fn unassigned_roles_on_slfo_row_is_na_not_empty() {
+        // SLFO rows never serialise review_groups; the honest render is n/a.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 9, "status": "testing", "kind": "SLFO",
+                     "id": "SUSE:SLFO:1.2:9",
+                     "assignees": {"qam-sle": [{"state": "assigned", "user": "bob"}]}},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(
+            &Updates,
+            &["-F", "Unassigned Roles", "-F", "Assigned Roles"],
+        );
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        assert!(out.contains("Unassigned Roles: n/a"), "{out}");
+        assert!(out.contains("Assigned Roles: qam-sle:bob"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn non_assigned_review_state_stays_visible() {
+        let obj = serde_json::json!({
+            "assignees": {"qam-sle": [{"state": "review", "user": "carol"}]}
+        });
+        let rendered = extract_assigned_roles(obj.as_object().unwrap());
+        assert_eq!(rendered, "qam-sle:carol(review)");
+    }
+
+    #[tokio::test]
+    async fn unknown_field_errors_before_any_query() {
+        // The expect(0) mock pins "before any query" independently of the
+        // error text (a resolve-after-fetch refactor would trip it).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": []})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        let (mut session, _buf) = teregen_session(&server);
+        let args = matches(&Updates, &["-F", "Bogus"]);
+        let err = Updates.call(&mut session, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown field 'Bogus'"), "{msg}");
+        assert!(msg.contains("ReviewRequestID"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn subset_selection_renders_only_requested_fields_in_request_order() {
+        // The mutation this kills: iterating the full FIELDS registry instead
+        // of the requested specs (render-everything passes the all-12 test).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"updates": [distinct_row()]})),
+            )
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        // Deliberately not in FIELDS declaration order: Status before Rating.
+        let args = matches(&Updates, &["-F", "Status", "-F", "Rating"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        assert!(out.contains("Status: testing"), "{out}");
+        assert!(out.contains("Rating: important"), "{out}");
+        // Unselected fields must be absent.
+        for absent in ["ReviewRequestID:", "Category:", "Title:", "URL:"] {
+            assert!(!out.contains(absent), "'{absent}' leaked into:\n{out}");
+        }
+        // Order follows the request, not the registry.
+        assert!(
+            out.find("Status:").unwrap() < out.find("Rating:").unwrap(),
+            "requested order not honoured: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assignment_fields_with_status_all_are_refused() {
+        // Without with_assignment TeReGen omits assignee/assignees on SLFO
+        // rows; printing "unassigned" there would be false data. The expect(0)
+        // mock pins that the refusal happens before any query.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": []})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        let (mut session, _buf) = teregen_session(&server);
+        let args = matches(&Updates, &["--status", "all", "-F", "Assigned Roles"]);
+        let err = Updates.call(&mut session, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'Assigned Roles' needs assignment data"),
+            "{msg}"
+        );
+        assert!(msg.contains("--all-assignees"), "{msg}");
+
+        // The same field in an assignment view is fine (--all-assignees).
+        let server2 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("with_assignment", "1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"updates": [distinct_row()]})),
+            )
+            .mount(&server2)
+            .await;
+        let (mut session2, buf2) = teregen_session(&server2);
+        let args2 = matches(&Updates, &["--all-assignees", "-F", "Assigned Roles"]);
+        Updates.call(&mut session2, &args2).await.unwrap();
+        assert!(
+            buf2.contents().contains("Assigned Roles: qam-sle:alice"),
+            "{}",
+            buf2.contents()
+        );
+        // Non-assignment fields under --status all stay allowed.
+        let server3 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"updates": [distinct_row()]})),
+            )
+            .mount(&server3)
+            .await;
+        let (mut session3, buf3) = teregen_session(&server3);
+        let args3 = matches(&Updates, &["--status", "all", "-F", "Rating"]);
+        Updates.call(&mut session3, &args3).await.unwrap();
+        assert!(buf3.contents().contains("Rating: important"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_group_input_collapses_to_one_query() {
+        // `-G a -G a` must fire exactly one query (input dedup routes it onto
+        // the single-group path), not two identical ones.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "qam-sle"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 3, "status": "testing", "kind": "Maintenance", "id": "solo"},
+                ]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["-G", "qam-sle", "-G", "qam-sle"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        assert!(buf.contents().contains("Update queue (1):"));
+    }
+
+    #[tokio::test]
+    async fn malformed_updates_value_errors_on_both_paths() {
+        // `{"updates": 5}` (not an array) must error, not read as empty.
+        for extra_group in [None, Some(["-G", "a", "-G", "b"])] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/updates"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": 5})),
+                )
+                .mount(&server)
+                .await;
+            let (mut session, buf) = teregen_session(&server);
+            let argv: Vec<&str> = extra_group.into_iter().flatten().collect();
+            let args = matches(&Updates, &argv);
+            let err = Updates.call(&mut session, &args).await.unwrap_err();
+            assert!(
+                err.to_string().contains("malformed response"),
+                "path {argv:?}: {err}"
+            );
+            assert!(!buf.contents().contains("No updates in the queue"));
+        }
+    }
+
+    #[tokio::test]
+    async fn merge_keeps_idless_rows_and_skips_missing_updates_key() {
+        // Two branches in one fixture: a group whose body has no `updates` key
+        // (Ok(None) → skipped, not fatal) and a row without an `id` (kept, not
+        // silently dropped).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "has-rows"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 9, "status": "testing", "kind": "Maintenance", "id": "with-id"},
+                    {"priority": 8, "status": "testing", "kind": "Maintenance"},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "no-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"other": 1})))
+            .mount(&server)
+            .await;
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["-G", "has-rows", "-G", "no-key"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        // Both rows survive: the id-less one is not dropped.
+        assert!(out.contains("Update queue (2):"), "{out}");
+        assert!(out.contains("with-id"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn multi_group_limit_slices_after_merge_sort() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "g1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 1, "status": "testing", "kind": "Maintenance", "id": "low"},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .and(query_param("review_group", "g2"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 100, "status": "testing", "kind": "Maintenance", "id": "high"},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["-G", "g1", "-G", "g2", "--limit", "1"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        // The limit keeps the highest-priority row across BOTH groups — a
+        // slice taken before the merge-sort would keep "low".
+        assert!(out.contains("Update queue (1):"), "{out}");
+        assert!(out.contains("high"), "{out}");
+        assert!(!out.contains("low"), "{out}");
+    }
+
+    #[test]
+    fn non_object_rows_render_without_panicking() {
+        let scalar = serde_json::json!("stray-string");
+        assert_eq!(render_row(&scalar, true), "  \"stray-string\"");
+        let spec = resolve_field("Rating").unwrap();
+        assert_eq!(render_fields(&scalar, &[spec]), "  \"stray-string\"");
+    }
+
+    #[tokio::test]
+    async fn known_but_unserved_field_names_the_gap() {
+        let server = MockServer::start().await;
+        let (mut session, _buf) = teregen_session(&server);
+        let args = matches(&Updates, &["-F", "bugs"]);
+        let err = Updates.call(&mut session, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'Bugs' is not in TeReGen's queue listing"),
+            "{msg}"
+        );
+        assert!(msg.contains("#415"), "{msg}");
+    }
+
+    // ------------------------------------------------------------------ json
+
+    #[tokio::test]
+    async fn json_dumps_full_rows_untouched() {
+        // A key the renderer knows nothing about must survive into --json:
+        // the flag is the everything-the-server-sent path.
+        let mut row = distinct_row();
+        row.as_object_mut()
+            .unwrap()
+            .insert("zz_future_field".to_owned(), serde_json::json!("kept"));
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [row]})),
+            )
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["--json"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        // No prose header — stdout is the JSON document.
+        assert!(!out.contains("Update queue"), "{out}");
+        let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+        let rows = parsed.as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["zz_future_field"], "kept");
+        // Types survive too: a stringified 421 would betray a re-render.
+        assert_eq!(rows[0]["priority"], serde_json::json!(421));
+    }
+
+    #[test]
+    fn empty_assignee_entry_list_counts_as_unassigned() {
+        // {"qam-sle": []} has nobody on it: it must appear in Unassigned
+        // Roles, not vanish from both role lists.
+        let obj = serde_json::json!({
+            "assignees": {"qam-sle": []},
+            "review_groups": ["qam-sle", "qam-openqa"],
+        });
+        let o = obj.as_object().unwrap();
+        assert_eq!(extract_assigned_roles(o), "-");
+        assert_eq!(extract_unassigned_roles(o), "qam-sle, qam-openqa");
+    }
+
+    #[tokio::test]
+    async fn json_empty_queue_prints_empty_array() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": []})),
+            )
+            .mount(&server)
+            .await;
+
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["--json"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        assert_eq!(out.trim(), "[]");
+        assert!(!out.contains("No updates in the queue"), "{out}");
+    }
+
+    #[test]
+    fn json_conflicts_with_field_selection() {
+        let base = clap::Command::new("updates").no_binary_name(true);
+        let cmd = Updates.configure(base);
+        assert!(
+            cmd.clone()
+                .try_get_matches_from(["--json", "-F", "Rating"])
+                .is_err()
+        );
+        assert!(cmd.try_get_matches_from(["--json"]).is_ok());
     }
 }

--- a/crates/mtui-core/src/commands/updates.rs
+++ b/crates/mtui-core/src/commands/updates.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
-use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use mtui_datasources::UpdatesQuery;
 use serde_json::Value;
 
@@ -124,18 +124,45 @@ impl Command for Updates {
     }
 
     fn complete(&self, _session: &Session, text: &str, line: &str) -> Vec<String> {
+        // Right after `-F`/`--field`, offer the field names, not more flags.
+        // Empty tokens are dropped: a trailing space otherwise reads as an
+        // empty "previous token" and hides the field names exactly when the
+        // user has just typed `-F `.
+        let tokens: Vec<&str> = line.split(' ').filter(|t| !t.is_empty()).collect();
+        let prev = if text.is_empty() {
+            tokens.last().copied()
+        } else {
+            tokens
+                .len()
+                .checked_sub(2)
+                .and_then(|i| tokens.get(i))
+                .copied()
+        };
+        if matches!(prev, Some("-F" | "--field")) {
+            if let Some(exact) = FIELDS.iter().find(|s| s.canonical == text) {
+                return vec![exact.canonical.to_owned()];
+            }
+            return FIELDS
+                .iter()
+                .map(|s| s.canonical.to_owned())
+                .filter(|c| c.starts_with(text))
+                .collect();
+        }
+        // `-G`/`-F` are repeatable, so they ride in `extra`, which
+        // `complete_choices` never suppresses — a synonym group would stop
+        // offering them the moment they first appear on the line.
         super::support::complete_choices(
             &[
-                &["--review-group"],
                 &["--status"],
                 &["--limit"],
                 &["--assignee"],
                 &["--mine"],
                 &["--all-assignees"],
-                &["--field"],
                 &["--json"],
             ],
-            Vec::new(),
+            ["-G", "--review-group", "-F", "--field"]
+                .map(str::to_owned)
+                .to_vec(),
             line,
             text,
         )
@@ -218,91 +245,80 @@ impl Command for Updates {
             }
         }
 
+        // One query per group; no `-G` at all is one ungrouped query. Multiple
+        // groups fan out because TeReGen has no OR semantics for a repeated
+        // `review_group` param (the last one wins), and the filter cannot be
+        // replicated client-side — the server matches SLFO rows against a
+        // group without ever serialising `review_groups` on them.
+        let groups: Vec<Option<&str>> = if review_groups.is_empty() {
+            vec![None]
+        } else {
+            review_groups.iter().map(|g| Some(g.as_str())).collect()
+        };
+        let multi = groups.len() > 1;
+        let queries: Vec<UpdatesQuery<'_>> = groups
+            .iter()
+            .map(|g| {
+                query_for(
+                    *g,
+                    status.as_deref(),
+                    assignee.as_deref(),
+                    unassigned,
+                    want_assignment,
+                )
+            })
+            .collect();
+        // Bounded fan-out: a handful of groups is the norm, but a scripted
+        // thirty-`-G` call should not open thirty connections at once.
+        // `buffered` preserves input order, so per-group batches arrive in
+        // `-G` order regardless of completion order. (The futures are
+        // materialised eagerly: a lazy `map` closure trips a
+        // higher-ranked-lifetime limit under `buffered`.)
+        let futures: Vec<_> = queries.iter().map(|q| teregen.updates(q)).collect();
+        let results: Vec<_> = stream::iter(futures).buffered(4).collect().await;
+
         // `teregen.updates` returns a Result: `Err` on any transport/API
         // failure (surfaced to the caller), `Ok(None)` on a successful response
         // missing the `updates` key, and `Ok(Some(json))` on success. Only a
         // genuinely-empty *successful* result is an empty queue; a fetch
         // failure is never conflated with one.
-        let rows: Vec<Value> = if review_groups.len() > 1 {
-            // One server query per group: TeReGen has no OR semantics for a
-            // repeated `review_group` param (the last one wins), and the
-            // filter cannot be replicated client-side — the server matches
-            // SLFO rows against a group without ever serialising
-            // `review_groups` on them.
-            let queries: Vec<UpdatesQuery<'_>> = review_groups
-                .iter()
-                .map(|g| {
-                    query_for(
-                        Some(g.as_str()),
-                        status.as_deref(),
-                        assignee.as_deref(),
-                        unassigned,
-                        want_assignment,
-                    )
-                })
-                .collect();
-            let results = join_all(queries.iter().map(|q| teregen.updates(q))).await;
-            let mut merged: Vec<Value> = Vec::new();
-            let mut seen: HashSet<String> = HashSet::new();
-            for result in results {
-                let batch = result.map_err(|e| {
-                    CommandError::Other(format!(
-                        "Update queue query failed (TeReGen unreachable): {e}"
-                    ))
-                })?;
-                let Some(batch) = batch else { continue };
-                let batch = batch.as_array().ok_or_else(|| {
-                    CommandError::Other(
-                        "Update queue query returned a malformed response".to_owned(),
-                    )
-                })?;
-                for row in batch {
-                    // Dedup by id (a row can sit in several groups). A row
-                    // without an id is kept, never silently dropped.
-                    let fresh = match row.get("id").and_then(Value::as_str) {
+        let mut rows: Vec<Value> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for result in results {
+            let batch = result.map_err(|e| {
+                CommandError::Other(format!(
+                    "Update queue query failed (TeReGen unreachable): {e}"
+                ))
+            })?;
+            let Some(batch) = batch else { continue };
+            let batch = batch.as_array().ok_or_else(|| {
+                CommandError::Other("Update queue query returned a malformed response".to_owned())
+            })?;
+            for row in batch {
+                // Dedup by id — a row can sit in several groups. A row without
+                // an id is kept, never silently dropped. Pointless (and
+                // skipped) for a single query, which cannot repeat a row.
+                let fresh = !multi
+                    || match row.get("id").and_then(Value::as_str) {
                         Some(id) => seen.insert(id.to_owned()),
                         None => true,
                     };
-                    if fresh {
-                        merged.push(row.clone());
-                    }
+                if fresh {
+                    rows.push(row.clone());
                 }
             }
+        }
+        if multi {
             // The server returns each group priority-descending; restore that
             // order across the merged set (stable, so ties keep server order).
-            merged.sort_by_key(|r| {
+            rows.sort_by_key(|r| {
                 std::cmp::Reverse(
                     r.get("priority")
                         .and_then(Value::as_i64)
                         .unwrap_or(i64::MIN),
                 )
             });
-            merged
-        } else {
-            let query = query_for(
-                review_groups.first().map(String::as_str),
-                status.as_deref(),
-                assignee.as_deref(),
-                unassigned,
-                want_assignment,
-            );
-            let updates = teregen.updates(&query).await.map_err(|e| {
-                CommandError::Other(format!(
-                    "Update queue query failed (TeReGen unreachable): {e}"
-                ))
-            })?;
-            match updates {
-                None => Vec::new(),
-                Some(v) => v
-                    .as_array()
-                    .ok_or_else(|| {
-                        CommandError::Other(
-                            "Update queue query returned a malformed response".to_owned(),
-                        )
-                    })?
-                    .clone(),
-            }
-        };
+        }
 
         if rows.is_empty() {
             // Keep --json output parseable even for an empty queue.
@@ -549,19 +565,24 @@ fn extract_unassigned_roles(obj: &serde_json::Map<String, Value>) -> String {
     let Some(groups) = obj.get("review_groups").and_then(Value::as_array) else {
         return "n/a".to_owned();
     };
+    // The subtraction needs the assignees map. Its key being absent means the
+    // view carried no assignment data (TeReGen omits it without
+    // `with_assignment`) — indistinguishable from "nobody assigned", so the
+    // honest render is `n/a`, not a list claiming every group is still open.
+    // Live (2026-08-03) `review_groups` and `assignees` travel together on
+    // every row, so this arm is unreachable today; the guard is for the day
+    // they don't.
+    let Some(assignee_map) = obj.get("assignees").and_then(Value::as_object) else {
+        return "n/a".to_owned();
+    };
     // A group only counts as assigned when it has at least one entry — a
     // `{"qam-sle": []}` group has nobody on it and must stay unassigned, not
     // vanish from both role lists.
-    let assigned: HashSet<&str> = obj
-        .get("assignees")
-        .and_then(Value::as_object)
-        .map(|m| {
-            m.iter()
-                .filter(|(_, entries)| entries.as_array().is_some_and(|a| !a.is_empty()))
-                .map(|(group, _)| group.as_str())
-                .collect()
-        })
-        .unwrap_or_default();
+    let assigned: HashSet<&str> = assignee_map
+        .iter()
+        .filter(|(_, entries)| entries.as_array().is_some_and(|a| !a.is_empty()))
+        .map(|(group, _)| group.as_str())
+        .collect();
     let open: Vec<&str> = groups
         .iter()
         .filter_map(Value::as_str)
@@ -665,11 +686,15 @@ mod tests {
         let all = Updates.complete(&session, "", "updates ");
         for f in [
             "--review-group",
+            "-G",
             "--status",
             "--limit",
             "--assignee",
             "--mine",
             "--all-assignees",
+            "--field",
+            "-F",
+            "--json",
         ] {
             assert!(all.contains(&f.to_owned()), "missing {f}: {all:?}");
         }
@@ -678,6 +703,46 @@ mod tests {
             Updates.complete(&session, "--r", "updates --r"),
             vec!["--review-group"]
         );
+    }
+
+    #[test]
+    fn complete_still_offers_repeatable_flags_after_first_use() {
+        // --review-group/-F became repeatable; a synonym group would suppress
+        // them once typed, so they must survive prior use on the line.
+        let (session, _buf) = empty_session();
+        assert_eq!(
+            Updates.complete(&session, "--r", "updates --review-group qam-sle --r"),
+            vec!["--review-group"]
+        );
+        let after_field = Updates.complete(&session, "-", "updates -F Rating -");
+        assert!(after_field.contains(&"-F".to_owned()), "{after_field:?}");
+        // A once-only flag IS suppressed after use.
+        let after_json = Updates.complete(&session, "--j", "updates --json --j");
+        assert!(after_json.is_empty(), "{after_json:?}");
+    }
+
+    #[test]
+    fn complete_offers_field_names_after_field_flag() {
+        let (session, _buf) = empty_session();
+        // Bare -F: all twelve canonical names, in registry order.
+        let names = Updates.complete(&session, "", "updates -F ");
+        assert_eq!(names.len(), FIELDS.len(), "{names:?}");
+        assert_eq!(names[0], "ReviewRequestID");
+        assert!(names.contains(&"Assigned Roles".to_owned()), "{names:?}");
+        // Prefix narrows.
+        assert_eq!(
+            Updates.complete(&session, "Rat", "updates -F Rat"),
+            vec!["Rating"]
+        );
+        // Long form too.
+        assert_eq!(
+            Updates.complete(&session, "Cat", "updates --field Cat"),
+            vec!["Category"]
+        );
+        // Not right after -F, flags come back, field names don't.
+        let flags = Updates.complete(&session, "", "updates -F Rating ");
+        assert!(!flags.contains(&"Category".to_owned()), "{flags:?}");
+        assert!(flags.contains(&"--status".to_owned()), "{flags:?}");
     }
 
     #[test]
@@ -1325,6 +1390,46 @@ mod tests {
         assert_eq!(rows[0]["zz_future_field"], "kept");
         // Types survive too: a stringified 421 would betray a re-render.
         assert_eq!(rows[0]["priority"], serde_json::json!(421));
+    }
+
+    #[tokio::test]
+    async fn unassigned_roles_without_assignment_data_is_na_not_all_open() {
+        // The reviewer's scenario: a classic row served in a view that carries
+        // no assignment data (`--status all`) has `review_groups` but no
+        // `assignees` key. Rendering every group as open would be false data
+        // indistinguishable from the truth; the honest answer is n/a. (Live,
+        // the two keys travel together — this pins the guard for server
+        // drift.) `Unassigned Roles` stays *allowed* under `--status all`
+        // precisely because of this per-row degradation.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/updates"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"updates": [
+                    {"priority": 7, "status": "accepted_merged", "kind": "Maintenance",
+                     "id": "SUSE:Maintenance:11:111",
+                     "review_groups": ["qam-sle", "qam-openqa"]},
+                ]})),
+            )
+            .mount(&server)
+            .await;
+        let (mut session, buf) = teregen_session(&server);
+        let args = matches(&Updates, &["--status", "all", "-F", "Unassigned Roles"]);
+        Updates.call(&mut session, &args).await.unwrap();
+        let out = buf.contents();
+        assert!(out.contains("Unassigned Roles: n/a"), "{out}");
+        assert!(!out.contains("qam-sle"), "false open-group list: {out}");
+
+        // With the assignees key PRESENT (even empty), the derivation runs:
+        // every review group is genuinely open.
+        let obj = serde_json::json!({
+            "assignees": {},
+            "review_groups": ["qam-sle", "qam-openqa"],
+        });
+        assert_eq!(
+            extract_unassigned_roles(obj.as_object().unwrap()),
+            "qam-sle, qam-openqa"
+        );
     }
 
     #[test]

--- a/crates/mtui-mcp/src/argv.rs
+++ b/crates/mtui-mcp/src/argv.rs
@@ -22,9 +22,10 @@
 //!
 //! Plain optional flags are emitted first (in `get_arguments()` order), then the
 //! positional tail. Append / multi-value flags are routed into the tail as well:
-//! such a flag consumes every token after it, so a later flag (notably the base
-//! parser's `-T/--template`, declared after per-command args) must not sit behind
-//! it.
+//! a greedy (`num_args(1..)`) one consumes every token after it, so a later flag
+//! (notably the base parser's `-T/--template`, declared after per-command args)
+//! must not sit behind it. Each such flag is emitted once per element (see the
+//! loop below) — the only form every Append arg parses.
 
 use clap::{Arg, ArgAction};
 use serde_json::{Map, Value};
@@ -86,11 +87,17 @@ pub(crate) fn kwargs_to_argv(
         }
 
         // ---- append / multi-value flag -----------------------------------
-        // Emit the flag once followed by every token, into the tail so a later
-        // flag cannot be swallowed as one of its values.
+        // Emit the flag before *every* token, into the tail so a later flag
+        // cannot be swallowed as one of its values. The repeated form is the
+        // only one every Append arg parses: with the default `num_args = 1`
+        // (e.g. `approve --group`), clap rejects `--group a b` as an
+        // unexpected argument, while `num_args(1..)` args (e.g. `commit -m`)
+        // parse `--msg a --msg b` identically to `--msg a b`.
         if is_multi(arg) {
-            tail.push(long_flag(arg));
-            tail.extend(items);
+            for item in items {
+                tail.push(long_flag(arg));
+                tail.push(item);
+            }
             continue;
         }
 
@@ -268,9 +275,43 @@ mod tests {
     // ---------------------------------------------------------------- lists
 
     #[test]
-    fn append_multi_flag_emits_once_into_tail() {
-        // `commit -m/--msg` (Append, num_args 1..): one flag then every token,
-        // in the positional tail so a trailing base flag stays safe.
+    fn append_single_value_flag_repeats_per_element() {
+        // `approve -g/--group` (Append, default num_args = 1): the flag must
+        // repeat before every element — the flag-once form `--group a b` is
+        // rejected by clap ("unexpected argument 'b'") because each occurrence
+        // takes exactly one value. This is the shape `updates --review-group`
+        // and `-F` use too.
+        let out = argv("approve", json!({ "group": ["qam-sle", "qam-teradata"] }));
+        assert_eq!(out, vec!["--group", "qam-sle", "--group", "qam-teradata"]);
+        assert_reparses("approve", &out);
+    }
+
+    #[test]
+    fn updates_multi_group_and_fields_round_trip() {
+        // The #415 surface: two review groups and two osc-qam field names
+        // (one with an embedded space) reconstruct and re-parse to the same
+        // value lists an MCP client sent.
+        let out = argv(
+            "updates",
+            json!({
+                "review_group": ["qam-sle", "qam-teradata"],
+                "field": ["Rating", "Assigned Roles"],
+            }),
+        );
+        assert_reparses("updates", &out);
+        let parsed = parser_for("updates").try_get_matches_from(&out).unwrap();
+        let groups: Vec<&String> = parsed.get_many::<String>("review_group").unwrap().collect();
+        assert_eq!(groups, ["qam-sle", "qam-teradata"]);
+        let fields: Vec<&String> = parsed.get_many::<String>("field").unwrap().collect();
+        assert_eq!(fields, ["Rating", "Assigned Roles"]);
+    }
+
+    #[test]
+    fn append_multi_flag_repeats_per_element_and_reparses_identically() {
+        // `commit -m/--msg` (Append, num_args 1..): the flag repeats before
+        // every token (tail-routed so a trailing base flag stays safe). For a
+        // `num_args(1..)` arg the repeated form parses to the same value list
+        // as the flag-once form — pinned by re-parsing.
         let out = argv(
             "commit",
             json!({ "msg": ["hello", "world"], "template": "a:b:1:1" }),
@@ -278,30 +319,42 @@ mod tests {
         // `-T` (flag) precedes the tail-routed `--msg`.
         assert_eq!(
             out,
-            vec!["--template", "a:b:1:1", "--msg", "hello", "world"]
+            vec!["--template", "a:b:1:1", "--msg", "hello", "--msg", "world"]
         );
         assert_reparses("commit", &out);
+        let parsed = parser_for("commit").try_get_matches_from(&out).unwrap();
+        let msgs: Vec<&String> = parsed.get_many::<String>("msg").unwrap().collect();
+        assert_eq!(msgs, ["hello", "world"]);
     }
 
     #[test]
-    fn append_list_flag_with_choices_emits_once() {
-        // `openqa_overview --aggregated-groups` (Append + PossibleValues).
+    fn append_list_flag_with_choices_repeats_per_element() {
+        // `openqa_overview --aggregated-groups` (Append + PossibleValues,
+        // default num_args = 1): every element gets its own flag. With the
+        // old flag-once emission a two-element call could not re-parse.
         let parser = parser_for("openqa_overview");
-        // Discover a valid enum member from the parser so the re-parse succeeds.
+        // Discover valid enum members from the parser so the re-parse succeeds.
         let arg = parser
             .get_arguments()
             .find(|a| a.get_id() == "aggregated_groups")
             .expect("aggregated_groups arg");
-        let member = arg
+        let members: Vec<String> = arg
             .get_possible_values()
-            .first()
+            .iter()
+            .take(2)
             .map(|pv| pv.get_name().to_owned())
-            .expect("aggregated_groups has choices");
+            .collect();
+        assert!(!members.is_empty(), "aggregated_groups has choices");
         let out = argv(
             "openqa_overview",
-            json!({ "aggregated_groups": [member.clone()] }),
+            json!({ "aggregated_groups": members.clone() }),
         );
-        assert_eq!(out, vec!["--aggregated-groups".to_owned(), member]);
+        // One `--aggregated-groups` immediately before each member, in order.
+        let expected: Vec<String> = members
+            .iter()
+            .flat_map(|m| ["--aggregated-groups".to_owned(), m.clone()])
+            .collect();
+        assert_eq!(out, expected);
         assert_reparses("openqa_overview", &out);
     }
 

--- a/crates/mtui-mcp/src/argv.rs
+++ b/crates/mtui-mcp/src/argv.rs
@@ -24,8 +24,9 @@
 //! positional tail. Append / multi-value flags are routed into the tail as well:
 //! a greedy (`num_args(1..)`) one consumes every token after it, so a later flag
 //! (notably the base parser's `-T/--template`, declared after per-command args)
-//! must not sit behind it. Each such flag is emitted once per element (see the
-//! loop below) — the only form every Append arg parses.
+//! must not sit behind it. An `Append` flag is emitted once per element (the only
+//! form clap parses when each occurrence takes one value); a non-`Append`
+//! multi-value option is emitted once with all its values (see the loop below).
 
 use clap::{Arg, ArgAction};
 use serde_json::{Map, Value};
@@ -87,16 +88,27 @@ pub(crate) fn kwargs_to_argv(
         }
 
         // ---- append / multi-value flag -----------------------------------
-        // Emit the flag before *every* token, into the tail so a later flag
-        // cannot be swallowed as one of its values. The repeated form is the
-        // only one every Append arg parses: with the default `num_args = 1`
-        // (e.g. `approve --group`), clap rejects `--group a b` as an
-        // unexpected argument, while `num_args(1..)` args (e.g. `commit -m`)
-        // parse `--msg a --msg b` identically to `--msg a b`.
+        // Both shapes route into the tail so a later flag cannot be swallowed
+        // as one of their values, but they emit differently:
+        //
+        // * `ArgAction::Append` → repeat the flag before *every* element. This
+        //   is the only form every Append arg parses: with the default
+        //   `num_args = 1` (e.g. `approve --group`), clap rejects `--group a b`
+        //   as an unexpected argument, while `num_args(1..)` Append args (e.g.
+        //   `commit -m`) parse `--msg a --msg b` identically to `--msg a b`.
+        // * non-`Append` multi-value option (`ArgAction::Set` + `num_args(1..)`)
+        //   → emit the flag *once* followed by all items. One occurrence
+        //   consumes many values there, and repeating the flag would make the
+        //   last occurrence win, silently dropping the earlier values.
         if is_multi(arg) {
-            for item in items {
+            if matches!(arg.get_action(), ArgAction::Append) {
+                for item in items {
+                    tail.push(long_flag(arg));
+                    tail.push(item);
+                }
+            } else {
                 tail.push(long_flag(arg));
-                tail.push(item);
+                tail.extend(items);
             }
             continue;
         }
@@ -287,6 +299,28 @@ mod tests {
     }
 
     #[test]
+    fn run_hosts_and_command_round_trip_without_leaking_across_boundary() {
+        // The silent-corruption case the repeat-per-element fix closes. `run`'s
+        // `-t/--target` (Append) and its trailing `COMMAND` positional share the
+        // tail. The pre-fix flag-once emission produced
+        // `--target h1 h2 uname -a`, which clap parsed as hosts=["h1"] and
+        // command=["h2","uname","-a"] — i.e. it would run `h2 uname -a` on h1.
+        // Repeating `--target` per host keeps the multi-flag/positional boundary
+        // intact; no other test covers this interaction.
+        let out = argv(
+            "run",
+            json!({ "hosts": ["h1", "h2"], "command": ["uname", "-a"] }),
+        );
+        assert_eq!(out, vec!["--target", "h1", "--target", "h2", "uname", "-a"]);
+        assert_reparses("run", &out);
+        let parsed = parser_for("run").try_get_matches_from(&out).unwrap();
+        let hosts: Vec<&String> = parsed.get_many::<String>("hosts").unwrap().collect();
+        assert_eq!(hosts, ["h1", "h2"]);
+        let command: Vec<&String> = parsed.get_many::<String>("command").unwrap().collect();
+        assert_eq!(command, ["uname", "-a"]);
+    }
+
+    #[test]
     fn updates_multi_group_and_fields_round_trip() {
         // The #415 surface: two review groups and two osc-qam field names
         // (one with an embedded space) reconstruct and re-parse to the same
@@ -356,6 +390,32 @@ mod tests {
             .collect();
         assert_eq!(out, expected);
         assert_reparses("openqa_overview", &out);
+    }
+
+    #[test]
+    fn set_multi_value_option_emits_flag_once() {
+        // No mtui registry arg is a non-Append multi-value option, so pin the
+        // branch on a bespoke parser (as `store_false_off_side_emits_flag`
+        // does). An `ArgAction::Set` option with `num_args(2..)` consumes many
+        // values from ONE occurrence; repeating the flag would make the last
+        // occurrence win and silently drop earlier values, so it must emit the
+        // flag once followed by all items — and that form re-parses to the full
+        // value list.
+        let parser = clap::Command::new("probe").no_binary_name(true).arg(
+            clap::Arg::new("point")
+                .long("point")
+                .action(ArgAction::Set)
+                .num_args(2..),
+        );
+        let out = kwargs_to_argv(
+            &parser,
+            json!({ "point": ["1", "2", "3"] }).as_object().unwrap(),
+            &[],
+        );
+        assert_eq!(out, vec!["--point", "1", "2", "3"]);
+        let parsed = parser.try_get_matches_from(&out).unwrap();
+        let values: Vec<&String> = parsed.get_many::<String>("point").unwrap().collect();
+        assert_eq!(values, ["1", "2", "3"]);
     }
 
     // ------------------------------------------------------------ omission

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/mtui-mcp/tests/slim_profile.rs
-assertion_line: 40
 expression: pretty
 ---
 [
@@ -1714,6 +1713,18 @@ expression: pretty
           "description": "filter to updates assigned to this user (any qam group)",
           "type": "string"
         },
+        "field": {
+          "items": {
+            "description": "select output fields by osc-qam name (e.g. -F Rating -F 'Assigned Roles'); repeatable, rendered as one block per update; names are case-insensitive and treat spaces, hyphens and underscores as equivalent",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "json": {
+          "default": false,
+          "description": "print the raw TeReGen rows as a JSON array (each row emitted whole, unlike -F; honours --limit; not combinable with -F); an empty queue prints []",
+          "type": "boolean"
+        },
         "limit": {
           "default": 0,
           "description": "cap the number of rows (0 = all)",
@@ -1725,8 +1736,11 @@ expression: pretty
           "type": "boolean"
         },
         "review_group": {
-          "description": "filter by review group as the bare group name, e.g. qam-sle (not the '<group>-review' login form, which classic rows lack)",
-          "type": "string"
+          "items": {
+            "description": "filter by review group as the bare group name, e.g. qam-sle (not the '<group>-review' login form, which classic rows lack); repeatable — groups are OR-ed (one server query per group)",
+            "type": "string"
+          },
+          "type": "array"
         },
         "status": {
           "default": "testing",

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -689,8 +689,14 @@ Lists the update queue (unassigned + in-testing by default), fetched live from t
 Usage: updates [OPTIONS]
 
 Options:
-      --review-group <GROUP>
-          filter by review group as the bare group name, e.g. qam-sle (not the '<group>-review' login form, which classic rows lack)
+  -G, --review-group <GROUP>
+          filter by review group as the bare group name, e.g. qam-sle (not the '<group>-review' login form, which classic rows lack); repeatable — groups are OR-ed (one server query per group)
+
+  -F, --field <FIELD>
+          select output fields by osc-qam name (e.g. -F Rating -F 'Assigned Roles'); repeatable, rendered as one block per update; names are case-insensitive and treat spaces, hyphens and underscores as equivalent
+
+      --json
+          print the raw TeReGen rows as a JSON array (each row emitted whole, unlike -F; honours --limit; not combinable with -F); an empty queue prints []
 
       --status <STATUS>
           filter by status (default: testing); use 'all' for every status

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -147,6 +147,20 @@ testing**. Widen or filter it:
 
 ```
 updates --review-group qam-sle --limit 5
+updates -G qam-sle -G qam-teradata                           # groups OR together
 updates --mine                # updates assigned to you
 updates --status all          # every status and assignee
+updates -F Rating -F 'Assigned Roles' -F 'Unassigned Roles'  # osc-qam field names
+updates --json                # the raw TeReGen rows, for scripting
 ```
+
+`-F` accepts the field names `osc qam list -F` uses — case-insensitively, with
+spaces, hyphens and underscores treated as equivalent: `ReviewRequestID`,
+`Incident Priority`, `Rating`, `Category`, `Status`, `Kind`, `Deadline`,
+`Assignee`, `Assigned Roles`, `Unassigned Roles`, `Title`, `URL`. Fields the
+TeReGen queue listing does not carry (`Products`, `SRCRPMs`, `Bugs`,
+`Package-Streams`, `Creator`, `Issues`, `Comments`) are named in the error
+rather than silently absent. On SLFO rows `Unassigned Roles` renders `n/a` —
+TeReGen does not expose review groups on them. `--json` and `-F` are mutually
+exclusive, and `Assignee`/`Assigned Roles` are refused under `--status all`,
+where TeReGen omits the assignment data they would render.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -160,7 +160,9 @@ spaces, hyphens and underscores treated as equivalent: `ReviewRequestID`,
 `Assignee`, `Assigned Roles`, `Unassigned Roles`, `Title`, `URL`. Fields the
 TeReGen queue listing does not carry (`Products`, `SRCRPMs`, `Bugs`,
 `Package-Streams`, `Creator`, `Issues`, `Comments`) are named in the error
-rather than silently absent. On SLFO rows `Unassigned Roles` renders `n/a` —
-TeReGen does not expose review groups on them. `--json` and `-F` are mutually
+rather than silently absent. `Unassigned Roles` renders `n/a` when it cannot
+be answered honestly: on SLFO rows (TeReGen does not expose review groups on
+them) and on any row served without assignment data, where "every group open"
+would be indistinguishable from the truth. `--json` and `-F` are mutually
 exclusive, and `Assignee`/`Assigned Roles` are refused under `--status all`,
 where TeReGen omits the assignment data they would render.


### PR DESCRIPTION
## Why

#415 reports two gaps against `osc qam list`: no field selection and no way to pass several review groups. Investigation against live TeReGen (2026-08-02) showed the cheap half is real: five of the reporter's twelve fields are already in the `/updates` payload and silently discarded — `rating` among them — and `assignees`/`review_groups` are enough to derive both role fields. This PR lands that half; the seven genuinely missing fields need TeReGen enrichment, asked for in [qa-maintenance/teregen#1](https://gitlab.suse.de/qa-maintenance/teregen/-/issues/1).

## What changed

- **`-F/--field` (repeatable)** — osc-qam field names, case-insensitive with spaces/hyphens/underscores equivalent, rendered as one `Name: value` block per update in the requested order. Serves: `ReviewRequestID`, `Incident Priority`, `Rating`, `Category`, `Status`, `Kind`, `Deadline`, `Assignee`, `Assigned Roles`, `Unassigned Roles`, `Title`, `URL`. The unserved seven (`Products`, `SRCRPMs`, `Bugs`, `Package-Streams`, `Creator`, `Issues`, `Comments`) are named in an error citing the gap rather than rendering empty. `Assignee`/`Assigned Roles` are refused under `--status all` — TeReGen omits assignment data there on SLFO rows, and printing "unassigned" for an assigned row is false data (forcing `with_assignment` is no fix: it implies `status=testing` server-side).
- **`-G/--review-group` repeatable** — groups OR together as one server query per group: a repeated `review_group` param is not OR-ed by TeReGen (last wins), and the filter cannot be replicated client-side because the server matches SLFO rows against a group without ever serialising `review_groups` on them. Merged priority-descending (stable), duplicate ids collapsed, duplicate input groups collapse to one query.
- **`--json`** — the raw rows as a JSON array (each row whole, nothing re-rendered); `[]` on an empty queue; conflicts with `-F`. Follows `list_refhosts --json`.
- **`fix(mcp)` (first commit, pre-existing bug):** the MCP argv reconstruction emitted an Append flag once for a whole list (`--group a b`), which clap rejects for every default-`num_args` Append arg — `approve` with two groups failed to parse, and `run` with two hosts leaked the second host into the command. The flag is now repeated per element, the only form every Append arg parses.
- **MCP schema note:** `updates.review_group` changes string → array (breaking for schema-validating clients; a string still dispatches — scalars render as one-element lists), plus new `field`/`json` properties. Snapshot updated.
- Docs: FAQ example block + field list; `cli.md` regenerated; CHANGELOG entries in Added and Fixed.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (29 `updates` tests, incl. 13 new) and `cargo test -p mtui-mcp -F mcp` (191+48, incl. 3 new argv round-trips through the real dispatch parser)
- Feature matrix compile-only: `--no-default-features` / `--all-features`
- Mutation-checked by hand-breaking and observing red: dedup disabled, merge sort removed, Assigned/Unassigned extractors swapped, render-all-ignoring-`-F`, assignment-refusal deleted; the argv fix's new test was observed red against the unfixed builder
- Adversarial review before commit by four independent read-only reviewers (correctness, test-vacuity, MCP-surface, docs-contract); all confirmed findings addressed — the `--status all` refusal and the empty-assignee-group handling came out of it
- Server behavior (last-wins repeated param, SLFO rows matching a group filter without serialising `review_groups`, priority-descending order, `with_assignment` presence effects) verified against live qam.suse.de, not assumed
