### PR TITLE
entrypoint.rs: wire ExitStatus, drop the run_once ghost, and gate CI on rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,17 @@ jobs:
         run: rustup component add clippy
       - name: Clippy (warnings as errors)
         run: cargo clippy --workspace --all-targets -- -D warnings
+  docs:
+    runs-on: ubuntu-latest
+    name: MTUI docs
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check rustdoc (warnings as errors)
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
   feature-matrix:
     runs-on: ubuntu-latest
     name: MTUI feature matrix (compile-only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ next actionable task before working on a subsystem.
 - Run the MCP server: `cargo run -p mtui-mcp --features mcp -- --help`
 - Format: `cargo fmt --all`
 - Lint (warnings are errors): `cargo clippy --workspace --all-targets -- -D warnings`
+- Docs (broken/private links are errors): `RUSTDOCFLAGS="-D warnings" cargo doc
+  --workspace --no-deps --all-features --document-private-items`
 - Test: `cargo test --workspace` — **the cost is compilation, not test
   execution.** A cold `cargo build --workspace --tests` is ~80s; the actual test
   *run*, once compiled, is only ~20-25s. The default 120s timeout is exceeded
@@ -128,7 +130,9 @@ next actionable task before working on a subsystem.
 - Run the **full gate on the whole workspace** before claiming done, mirroring
   CI: `cargo fmt --all --check` **and**
   `cargo clippy --workspace --all-targets -- -D warnings` **and**
-  `cargo test --workspace` (default features) **and** `cargo test -p mtui-mcp -F
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+  --document-private-items` **and** `cargo test --workspace` (default features)
+  **and** `cargo test -p mtui-mcp -F
   mcp` (the mcp server/transport tests are `-F mcp`-gated, so the default
   workspace run never exercises them) **and** the compile-only feature matrix
   `cargo build --workspace --no-default-features` +

--- a/crates/mtui-cli/src/highlighter.rs
+++ b/crates/mtui-cli/src/highlighter.rs
@@ -70,7 +70,7 @@ impl MtuiHighlighter {
         Self { registry, session }
     }
 
-    /// Whether colored output is currently enabled (live [`ColorMode`] resolve).
+    /// Whether colored output is currently enabled (live [`ColorMode`](mtui_core::ColorMode) resolve).
     fn color_enabled(&self) -> bool {
         self.session
             .lock()

--- a/crates/mtui-cli/src/history.rs
+++ b/crates/mtui-cli/src/history.rs
@@ -6,7 +6,7 @@
 //!   sessions.
 //! * **Reverse-search** — Ctrl-R, provided by reedline's default emacs edit
 //!   mode; it needs no wiring here, only a populated history to search.
-//! * **Inline suggestion** — the greyed hint shown by [`DefaultHinter`] is
+//! * **Inline suggestion** — the greyed hint shown by [`DefaultHinter`](reedline::DefaultHinter) is
 //!   wired in [`crate::repl::Repl::new`] alongside [`file_backed_history`].
 //!
 //! ## Location

--- a/crates/mtui-cli/src/lib.rs
+++ b/crates/mtui-cli/src/lib.rs
@@ -4,7 +4,7 @@
 //! top-level args, builds the [`Session`](mtui_core::Session) and command
 //! [`Registry`](mtui_core::Registry), and drives [`Repl::run`]. Exposing the
 //! REPL as a library lets the `tests/**` suite (and the P6.8 test task) exercise
-//! the loop's [`step`](repl::step) seam without a TTY.
+//! the loop's `repl::step` seam without a TTY.
 
 pub mod completer;
 pub(crate) mod edit;

--- a/crates/mtui-cli/src/logfmt.rs
+++ b/crates/mtui-cli/src/logfmt.rs
@@ -38,7 +38,7 @@ pub(crate) const CLAP_PREFIXED_TARGET: &str = "mtui::clap_prefixed";
 /// A [`FormatEvent`] that renders `"{level}: {message}"` with a lowercased,
 /// optionally colorized level token and no timestamp/target.
 ///
-/// Construct via [`CompactLevelFormat::new`], passing whether ANSI escapes
+/// Construct via `CompactLevelFormat::new`, passing whether ANSI escapes
 /// should be emitted (already resolved from the process `ColorMode`).
 #[derive(Debug, Clone, Copy)]
 pub struct CompactLevelFormat {

--- a/crates/mtui-cli/src/main.rs
+++ b/crates/mtui-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! `mtui` — the interactive REPL entry point.
 //!
-//! Parses the top-level [`Args`](mtui_core::Args) (clap handles
+//! Parses the top-level [`Args`] (clap handles
 //! `--help`/`--version` — the latter carrying the build-provenance block baked
 //! into `mtui-core` — and usage errors, exiting the process itself), initialises
 //! `tracing` from `-d/--debug` + `RUST_LOG`, seeds the session from `-a`/`-k`

--- a/crates/mtui-cli/src/main.rs
+++ b/crates/mtui-cli/src/main.rs
@@ -8,9 +8,8 @@
 //!
 //! This binary has exactly **one** driving surface: the
 //! REPL. There is no positional command / single-command mode — headless
-//! single-command dispatch is an `mtui-mcp`/embedding concern
-//! ([`mtui_core::run_once`]), not a CLI mode. Full config loading + `Args` merge
-//! remains later Phase-6 config work.
+//! single-command dispatch is an `mtui-mcp`/embedding concern, not a CLI mode.
+//! Full config loading + `Args` merge remains later Phase-6 config work.
 
 use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
@@ -81,7 +80,7 @@ fn main() -> anyhow::Result<()> {
     // entering an empty REPL.
     if let ControlFlow::Break(code) = runtime.block_on(seed_session(&registry, &mut session, &args))
     {
-        std::process::exit(code);
+        std::process::exit(code.into());
     }
 
     // The session and registry are shared behind `Arc`/`Arc<Mutex>` so the tab

--- a/crates/mtui-cli/src/notification.rs
+++ b/crates/mtui-cli/src/notification.rs
@@ -1,16 +1,16 @@
 //! Best-effort desktop notifications for the interactive REPL.
 //!
 //! Desktop toasts are an opt-in courtesy compiled in behind the `notify`
-//! feature (which pulls in [`notify-rust`]). When the feature is absent, or the
-//! process is not attached to an interactive desktop session, [`display`]
+//! feature (which pulls in `notify-rust`). When the feature is absent, or the
+//! process is not attached to an interactive desktop session, `display`
 //! degrades to a quiet no-op so headless, piped, cron, and `mtui-mcp` runs never
 //! attempt to pop a toast.
 //!
 //! ## Headless guard
 //!
 //! A toast only makes sense when a user is sitting at an interactive terminal
-//! with a graphical session, so [`display`] first checks
-//! [`desktop_available`]: `stdin` must be a TTY, and on Linux/BSD a graphical
+//! with a graphical session, so `display` first checks
+//! `desktop_available`: `stdin` must be a TTY, and on Linux/BSD a graphical
 //! session (`DISPLAY` / `WAYLAND_DISPLAY`) must be present; macOS always
 //! qualifies once the TTY check passes. The predicate is factored out and
 //! parameterised (`desktop_available_with`) so it is unit-testable without a
@@ -46,7 +46,7 @@ fn desktop_available_with(stdin_is_tty: bool, os: &str, has_env: impl Fn(&str) -
 
 /// Displays a best-effort desktop notification.
 ///
-/// A no-op when [`desktop_available`] is false, and (without the `notify`
+/// A no-op when `desktop_available` is false, and (without the `notify`
 /// feature) always a no-op beyond the guard + a debug log. Failures from the
 /// backend are swallowed and debug-logged — a notification must never break the
 /// REPL.
@@ -88,7 +88,7 @@ fn display_backend(_summary: Option<&str>, _text: Option<&str>, _icon: Option<&s
     tracing::debug!("notify feature disabled; skipping desktop notification");
 }
 
-/// Shows a `"MTUI"`-titled toast via [`display`], using the freedesktop
+/// Shows a `"MTUI"`-titled toast via `display`, using the freedesktop
 /// `dialog-error` icon for error-class messages.
 ///
 /// A thin convenience for command code (e.g. the `update` start/finish toasts)

--- a/crates/mtui-cli/src/repl.rs
+++ b/crates/mtui-cli/src/repl.rs
@@ -60,7 +60,7 @@ impl Repl {
     ///
     /// The line editor is given an [`MtuiCompleter`] sharing `registry`/`session`
     /// plus a columnar completion menu bound to <kbd>Tab</kbd>; a
-    /// [`file_backed_history`](crate::history::file_backed_history) persisting to
+    /// `file_backed_history` persisting to
     /// `$XDG_DATA_HOME/mtui/history` (with Ctrl-R reverse-search from the default
     /// emacs bindings); and a [`DefaultHinter`] showing the greyed inline
     /// suggestion. The dynamic prompt/toolbar

--- a/crates/mtui-cli/src/repl.rs
+++ b/crates/mtui-cli/src/repl.rs
@@ -249,12 +249,11 @@ async fn step(registry: &Registry, session: &mut Session, line: &str) -> Control
 /// message is the event's *message* (not a structured field), so no `err=`
 /// noise appears; the default format carries no timestamp/target either.
 ///
-/// This deliberately differs from the headless
-/// [`run_once`](mtui_core::entrypoint::run_once) entrypoint (`mtui-mcp` /
-/// embedding), which has no `tracing` subscriber and renders the same
-/// `error: <message>` text through its captured display buffer. The two present
-/// failures with identical *text*; each uses the channel appropriate to its
-/// surface (REPL → operator log on stderr; headless → captured display sink).
+/// This deliberately differs from the headless `mtui-mcp` surface, which has
+/// no `tracing` subscriber and renders the same `error: <message>` text
+/// through its captured display buffer. The two present failures with
+/// identical *text*; each uses the channel appropriate to its surface
+/// (REPL → operator log on stderr; headless → captured display sink).
 ///
 /// One exception: a genuine usage error (`Parse { help_or_version: false,
 /// .. }`) carries clap's *own* already-rendered `error: ` prefix (and

--- a/crates/mtui-cli/src/shell.rs
+++ b/crates/mtui-cli/src/shell.rs
@@ -9,17 +9,17 @@
 //! Attaching an interactive PTY needs a controlling terminal, which only the
 //! `mtui` binary owns. `mtui-core`'s `shell` command therefore stays a
 //! headless-error stub (correct for MCP / non-interactive), and the REPL
-//! **intercepts** the `shell` line before dispatch (see [`is_shell_line`]) and
+//! **intercepts** the `shell` line before dispatch (see `is_shell_line`) and
 //! drives the bridge here. A host library has no business toggling the local TTY
 //! into raw mode, so the raw-mode bridge is a terminal concern by construction.
 //!
 //! ## Testability
 //!
-//! The pump loop [`bridge`] is generic over a [`BridgeIo`] trait abstracting the
+//! The pump loop `bridge` is generic over a `BridgeIo` trait abstracting the
 //! three terminal touch-points (async input, stdout write, flush), so it runs
 //! entirely offline against `MockConnection`'s scriptable [`ShellChannel`] — the
 //! same mocking doctrine as the rest of the host layer. The only untested sliver
-//! is the thin [`TerminalIo`] / [`RawModeGuard`] wiring around a real TTY.
+//! is the thin `TerminalIo` / `RawModeGuard` wiring around a real TTY.
 
 use std::io::Write as _;
 

--- a/crates/mtui-cli/src/startup.rs
+++ b/crates/mtui-cli/src/startup.rs
@@ -13,8 +13,7 @@
 //! There is **no single-command / non-interactive mode**: mtui has only two
 //! surfaces — the REPL and `mtui-mcp` — and neither takes a positional
 //! command. This module therefore only *seeds* the session; the binary always
-//! enters the REPL afterwards. (The `run_once`/`ExitStatus` primitive in
-//! `mtui-core` exists for `mtui-mcp`/embedding, not a CLI headless mode.)
+//! enters the REPL afterwards.
 //!
 //! [`seed_session`] is the testable seam: it takes an already-built [`Session`]
 //! and the parsed [`Args`], performs the seeding, and returns [`ControlFlow`] so
@@ -23,7 +22,7 @@
 
 use std::ops::ControlFlow;
 
-use mtui_core::{Args, Registry, Session, dispatch_line};
+use mtui_core::{Args, ExitStatus, Registry, Session, dispatch_line};
 use mtui_testreport::UpdateKind;
 use mtui_types::Workflow;
 
@@ -33,19 +32,20 @@ use mtui_types::Workflow;
 ///   [`Session::load_update`]. Autoconnect is requested iff no `--sut` override
 ///   was given. If the load yields an empty RRID — a null report for an
 ///   *explicitly requested* update — the user-facing "does not exist" message
-///   has already been logged, so this returns [`ControlFlow::Break`] with exit
-///   code `1` rather than entering an empty REPL.
+///   has already been logged, so this returns [`ControlFlow::Break`] with
+///   [`ExitStatus::Failure`] rather than entering an empty REPL.
 /// * For each `--sut` entry, dispatches `add_host <fragment>` through the shared
 ///   engine, logging any failure and continuing — one bad host never aborts
 ///   startup.
 ///
 /// Returns [`ControlFlow::Continue`] when the session is ready for the REPL, or
-/// [`ControlFlow::Break(code)`] when the process should exit with `code` instead.
+/// [`ControlFlow::Break`] with the [`ExitStatus`] the process should exit with
+/// instead.
 pub async fn seed_session(
     registry: &Registry,
     session: &mut Session,
     args: &Args,
-) -> ControlFlow<i32> {
+) -> ControlFlow<ExitStatus> {
     if let Some(update) = args.update() {
         let autoconnect = args.sut.is_empty();
         let kind = match update.workflow {
@@ -60,7 +60,7 @@ pub async fn seed_session(
             // exist" message was already logged by the load path. Exit rather
             // than drop into an empty interactive session.
             tracing::error!(update = %update.id, "requested update could not be loaded");
-            return ControlFlow::Break(1);
+            return ControlFlow::Break(ExitStatus::Failure);
         }
     }
 
@@ -154,7 +154,7 @@ mod tests {
         let mut a = args();
         a.auto_review_id = Some("SUSE:Maintenance:99999:99999".parse().unwrap());
         let flow = seed_session(&registry, &mut session, &a).await;
-        assert_eq!(flow, ControlFlow::Break(1));
+        assert_eq!(flow, ControlFlow::Break(ExitStatus::Failure));
     }
 
     /// A `--sut` host that cannot connect is logged and skipped; seeding still

--- a/crates/mtui-cli/tests/cli_smoke.rs
+++ b/crates/mtui-cli/tests/cli_smoke.rs
@@ -13,9 +13,8 @@
 //!
 //! There is deliberately **no** non-interactive / single-command CLI mode to
 //! e2e here: the `mtui` binary's one driving surface is the REPL — headless
-//! single-command dispatch is an `mtui-mcp`/`run_once` concern, covered in
-//! `mtui-core`/`mtui-mcp`. The closest binary-level analogue is the
-//! piped-stdin path exercised below: it
+//! single-command dispatch is an `mtui-mcp` concern. The closest binary-level
+//! analogue is the piped-stdin path exercised below: it
 //! drives the real `reedline` editor (not the `step` unit seam), so it is the
 //! only test that reaches `repl::Repl::run` itself — the intro banner and the
 //! loop's exit-on-`read_line`-failure arm.

--- a/crates/mtui-config/src/lib.rs
+++ b/crates/mtui-config/src/lib.rs
@@ -39,7 +39,7 @@ impl Config {
     /// Load configuration from the resolved search paths.
     ///
     /// `explicit` is the optional `--config` path. Files are merged
-    /// **lowest-precedence first** (see [`config_search_paths`]): `/etc` →
+    /// **lowest-precedence first** (see `config_search_paths`): `/etc` →
     /// `~/.mtui.toml` → the XDG file, so a per-user file overrides `/etc` on
     /// shared keys and the XDG file wins over the home dotfile. A file that does not exist is
     /// silently skipped; a file that fails to read or parse is logged at ERROR

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -620,7 +620,7 @@ impl RawConfig {
 ///
 /// Construct via [`Config::load`](crate::Config::load) (file/env/defaults) or
 /// [`Config::default`] (all defaults). Path-typed options have `~`
-/// expanded to the user's home directory via [`expanduser`].
+/// expanded to the user's home directory via `expanduser`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Config {
@@ -655,7 +655,7 @@ pub struct Config {
     pub max_parallel: u64,
     /// Maximum number of independent openQA/QAM HTTP requests to run
     /// concurrently in the oqa-search overview (per-version, group×version, and
-    /// per-log fan-out). Kept lower than [`max_parallel`] to stay polite toward
+    /// per-log fan-out). Kept lower than [`Self::max_parallel`] to stay polite toward
     /// the shared openQA/QAM hosts. A non-positive value falls back to the
     /// default.
     pub max_oqa_parallel: u64,

--- a/crates/mtui-config/src/paths.rs
+++ b/crates/mtui-config/src/paths.rs
@@ -2,7 +2,7 @@
 //!
 //! Two flavours of paths live here:
 //!
-//! * **Config search paths** ([`config_search_paths`]) — the ordered list of
+//! * **Config search paths** (`config_search_paths`) — the ordered list of
 //!   candidate config files, later entries overriding earlier ones when merged.
 //! * **User data path** ([`data_dir`]) — the XDG data directory where mtui
 //!   persists per-user state.

--- a/crates/mtui-core/src/args.rs
+++ b/crates/mtui-core/src/args.rs
@@ -22,7 +22,7 @@
 //!   same [`UpdateID`] value type (all this crate has today)
 //!   paired with the [`Workflow`] the flag selects, surfaced as [`Args::update`].
 //!
-//! Config merging lives here as [`Args::apply_to`] / [`Args::resolve_config`]:
+//! Config merging lives here as `Args::apply_to` / [`Args::resolve_config`]:
 //! the CLI overrides are the highest-precedence config layer, overlaid on top of
 //! the loaded file chain. (It lives in `mtui-core`, not `mtui-config`, because it
 //! needs [`Args`]; `mtui-config` must not depend on `mtui-core`.) The `auto` →
@@ -203,7 +203,7 @@ impl Args {
     /// CLI overrides, returning the fully-resolved [`Config`].
     ///
     /// The one-call composition both binaries use: [`Config::load`] for the file
-    /// layers followed by [`apply_to`](Self::apply_to) for the CLI layer.
+    /// layers followed by `apply_to` for the CLI layer.
     #[must_use]
     pub fn resolve_config(&self) -> Config {
         let mut config = Config::load(self.config.clone());

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -75,7 +75,7 @@ pub trait Command: Send + Sync {
         Scope::Active
     }
 
-    /// Whether this command's body mutates the [`TemplateRegistry`] *structure*
+    /// Whether this command's body mutates the [`TemplateRegistry`](crate::TemplateRegistry) *structure*
     /// (loads/replaces/removes an entry or re-points the active template), as
     /// opposed to only mutating an already-loaded report's *content*.
     ///
@@ -324,7 +324,7 @@ fn resolve_templates(
 /// dispatch (the MCP per-template lock gate, `mtui-rs-76e.11`).
 ///
 /// Builds the command's clap parser, parses `argv`, and runs the identical
-/// [`resolve_templates`] fan-out logic `run` uses, then drops the empty-RRID
+/// `resolve_templates` fan-out logic `run` uses, then drops the empty-RRID
 /// null-report sentinel so the caller sees only genuinely-loaded templates.
 ///
 /// Returns:
@@ -334,7 +334,7 @@ fn resolve_templates(
 ///   multi-RRID case) as "take the registry gate exclusively" whenever
 ///   resolution is not a single real template.
 ///
-/// This never errors: a `-T <unloaded-rrid>` (which [`resolve_templates`] would
+/// This never errors: a `-T <unloaded-rrid>` (which `resolve_templates` would
 /// reject) yields `None` so the caller serialises conservatively rather than
 /// surfacing a lock-layer parse error; the real error surfaces later at dispatch.
 #[must_use]

--- a/crates/mtui-core/src/commands/addhost.rs
+++ b/crates/mtui-core/src/commands/addhost.rs
@@ -17,10 +17,10 @@ use crate::session::Session;
 /// manual (unless `-k`/`--keep-mode`). Then:
 ///
 /// * **with `-t`/`--target`:** each named host is connected and added to the
-///   active report's group ([`Session::add_named_hosts`]).
+///   active report's group (`Session::add_named_hosts`).
 /// * **without `-t`:** the report's testplatforms are resolved through the
 ///   refhosts factory and the resulting hosts are connected and added
-///   ([`Session::add_testplatform_hosts`]).
+///   (`Session::add_testplatform_hosts`).
 ///
 /// Refreshing the REPL prompt string after the workflow switch is a separate,
 /// Phase-6 REPL concern, so this command only mutates the report's workflow.

--- a/crates/mtui-core/src/commands/hostsunlock.rs
+++ b/crates/mtui-core/src/commands/hostsunlock.rs
@@ -16,7 +16,7 @@ use crate::session::Session;
 /// or sessions.
 ///
 /// `-p`/`--pool` removes the host *pool* claim (RRID-based ownership) instead of
-/// the zypper/operation lock, fanning [`HostsGroup::pool_unlock`] out across the
+/// the zypper/operation lock, fanning [`HostsGroup::pool_unlock`](mtui_hosts::HostsGroup::pool_unlock) out across the
 /// active group. With `--force` a claim owned by another template is removed too.
 ///
 /// Like `lock`, host sub-selection via `-t` is not yet honoured for the fan-out

--- a/crates/mtui-core/src/commands/listlocks.rs
+++ b/crates/mtui-core/src/commands/listlocks.rs
@@ -19,7 +19,7 @@ use crate::session::Session;
 ///
 /// The enabled hosts (honouring the `-t` sub-selection) are resolved via
 /// [`Target::lock_status`](mtui_hosts::Target::lock_status) and forwarded through
-/// the per-host [`Reporter::locks`](mtui_hosts::Reporter) sink into
+/// the per-host [`Reporter::locks`](mtui_hosts) sink into
 /// `display.list_locks`. The lock accessors are async `&mut self`; the resolved
 /// (sync) [`LockStatus`] values are collected first so `display` — which borrows
 /// the session mutably — is driven afterwards.

--- a/crates/mtui-core/src/commands/quit.rs
+++ b/crates/mtui-core/src/commands/quit.rs
@@ -18,7 +18,7 @@ const BOOT_ACTIONS: [&str; 2] = ["reboot", "poweroff"];
 const CLOSE_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Resolves the per-template close budget. In tests it is overridable (via
-/// [`tests::set_close_timeout`]) so the straggler path can be exercised without
+/// `tests::set_close_timeout`) so the straggler path can be exercised without
 /// waiting the full 45s; in production it is always [`CLOSE_TIMEOUT`].
 #[cfg(not(test))]
 fn close_timeout() -> Duration {

--- a/crates/mtui-core/src/commands/support.rs
+++ b/crates/mtui-core/src/commands/support.rs
@@ -82,7 +82,7 @@ pub(crate) fn build_kernel_openqa(
 /// Returns [`CommandError::Other`] with a stable message when no report is
 /// loaded, so a data-source command errors cleanly instead of building a client
 /// for an empty RRID. On success returns the active report's
-/// [`RequestReviewID`](mtui_types::RequestReviewID).
+/// [`RequestReviewID`].
 ///
 /// # Errors
 ///

--- a/crates/mtui-core/src/display.rs
+++ b/crates/mtui-core/src/display.rs
@@ -2,7 +2,7 @@
 //!
 //! The `list_*`
 //! family (bugs, history, host status, locks, sessions, timeout, versions,
-//! products, update repos) plus [`show_log`](CommandPromptDisplay::show_log)
+//! products, update repos) plus `show_log`
 //! gives the command bodies their output seam.
 //!
 //! Output is captured through a boxed [`std::io::Write`] sink so tests can
@@ -12,7 +12,7 @@
 //! call time via [`ColorMode::resolve`], with the precedence: `Always` →
 //! `Never` → `NO_COLOR` → `COLOR=never|always` → `stderr.is_terminal()`.
 //!
-//! **Timestamps:** [`list_history`](CommandPromptDisplay::list_history)
+//! **Timestamps:** `list_history`
 //! formats timestamps in **UTC** rather than local time. Local time would
 //! require chrono's `clock` feature (pulling `iana-time-zone`, against the
 //! no-runtime-deps goal) and make snapshot output timezone-dependent. UTC
@@ -36,7 +36,7 @@ pub(crate) type PackageVersions = (String, Vec<RPMVersion>);
 pub(crate) type VersionGroup = (Vec<HostSystem>, Vec<PackageVersions>);
 
 /// Already-resolved lock state for a host, as displayed by
-/// [`list_locks`](CommandPromptDisplay::list_locks).
+/// `list_locks`.
 ///
 /// The lock accessors are async `&mut self` in `mtui-hosts`; callers do
 /// that I/O and hand the resolved values here so display stays sync and
@@ -113,7 +113,7 @@ impl ColorMode {
 /// Handles the display of formatted output in the command prompt.
 ///
 /// Owns its output sink; construct with [`with_sink`](Self::with_sink) for tests
-/// (a `Vec<u8>` buffer) or [`stdout`](Self::stdout) for the interactive REPL.
+/// (a `Vec<u8>` buffer) or `stdout` for the interactive REPL.
 pub struct CommandPromptDisplay {
     output: Box<dyn Write + Send>,
     color: ColorMode,

--- a/crates/mtui-core/src/engine.rs
+++ b/crates/mtui-core/src/engine.rs
@@ -113,7 +113,7 @@ pub async fn dispatch_argv(
 ///
 /// The registry-free tail of [`dispatch_argv`]: parse `argv` through the
 /// command's own clap parser (no-exit-on-error), then drive
-/// [`Command::run`](crate::Command::run). Exposed so the headless MCP concurrent
+/// [`Command::run`]. Exposed so the headless MCP concurrent
 /// path (`mtui-rs-f36r`, steps 4-5) can `tokio::spawn` a dispatch holding an
 /// owned `Arc<dyn Command>` + forked [`Session`] — neither borrows the
 /// [`Registry`], so the spawned future is `'static`. `help` is *not* intercepted

--- a/crates/mtui-core/src/engine.rs
+++ b/crates/mtui-core/src/engine.rs
@@ -41,9 +41,9 @@ pub enum EngineError {
     ///
     /// `help_or_version` records whether the "error" was actually clap emitting
     /// `--help`/`--version` text (a success in argparse terms, exit 0) rather
-    /// than a genuine usage error (argparse exit 2). The headless entrypoint
-    /// ([`run_once`](crate::entrypoint::run_once)) reads it to pick the right
-    /// process exit code; the REPL ignores it and just renders the message.
+    /// than a genuine usage error (argparse exit 2). `mtui-cli::repl::render_error`
+    /// ignores it and just renders the message; `mtui-mcp::session::run_command`
+    /// reads it to pick the right result/exit code.
     #[error("{message}")]
     Parse {
         /// clap's already-rendered help/usage text.

--- a/crates/mtui-core/src/entrypoint.rs
+++ b/crates/mtui-core/src/entrypoint.rs
@@ -1,31 +1,25 @@
-//! Headless single-command dispatch entrypoint (`mtui-mcp` / embedding).
+//! The process exit-code contract shared by mtui's two process entrypoints
+//! (`mtui`, `mtui-mcp`).
 //!
-//! This is the glue between the **three distinct argparse layers** mtui carries
+//! This distinguishes the **three distinct argparse layers** mtui carries
 //! (the correction that shaped P5.10 — do not conflate them):
 //!
 //! 1. **App invocation** — the top-level `mtui`/`mtui-mcp` process arguments,
 //!    [`Args`](crate::args::Args). The real binary parses these with
 //!    `Args::parse`, which exits the process on `--help`/`--version`/error, the
-//!    standard clap convention. This module takes an
-//!    *already-parsed* `&Args`, so Layer 1 is the caller's responsibility (the
-//!    binary is Phase 6).
+//!    standard clap convention.
 //! 2. **REPL commands** — the per-command parsers the [`engine`](crate::engine)
-//!    synthesises from the [`Registry`], run inside the REPL `cmdloop` and
-//!    reused as MCP tools. These never exit the process; they return
-//!    a typed [`EngineError`].
+//!    synthesises from the [`Registry`](crate::registry::Registry), run inside
+//!    the REPL `cmdloop` and reused as MCP tools. These never exit the
+//!    process; they return a typed
+//!    [`EngineError`](crate::engine::EngineError).
 //! 3. **MCP tool schema** — `mtui-mcp` translating each command's parser into
 //!    JSON parameters (Phase 7). Not touched here.
 //!
-//! The headless single-command driver dispatches exactly one Layer-2 command
-//! against a session and yields a process [`ExitStatus`]: given the parsed
-//! top-level `Args` and one command line, it resolves, parses, and runs a
-//! single command with no interactive loop. It is the headless single-command
-//! primitive for `mtui-mcp` (Phase 7) and embedding callers.
-//!
-//! It is **not** a CLI mode: the `mtui` binary has only two surfaces, the
-//! interactive REPL and `mtui-mcp`, and neither takes a positional command.
-//! The interactive binary seeds the session and enters the REPL
-//! (`mtui-cli::seed_session` + `Repl`); it never calls `run_once`.
+//! Neither entrypoint has a headless single-command CLI mode: the `mtui`
+//! binary has only two surfaces, the interactive REPL and `mtui-mcp`, and
+//! neither takes a positional command. The interactive binary seeds the
+//! session and enters the REPL (`mtui-cli::seed_session` + `Repl`).
 //!
 //! ## Exit-code contract
 //!

--- a/crates/mtui-core/src/lib.rs
+++ b/crates/mtui-core/src/lib.rs
@@ -18,13 +18,11 @@
 //! family, [`show_log`](CommandPromptDisplay::show_log), the three-way
 //! [`ColorMode`], and the [`page`](display::page) pager.
 //!
-//! P5.10 adds [`entrypoint`] — the single-command driver ([`run_once`]) that
-//! runs one Layer-2 REPL command to completion and yields a process
-//! [`ExitStatus`]. It is the seam between the top-level [`Args`] parser (Layer 1)
-//! and the per-command engine (Layer 2), distinct from both and from the MCP
-//! schema synthesis (Layer 3, Phase 7). It is consumed by `mtui-mcp` and
-//! embedding callers that dispatch a single command headlessly; the interactive
-//! `mtui` binary (Phase 6) is REPL-only — the CLI has no single-command mode.
+//! P5.10 adds [`entrypoint`] — the process [`ExitStatus`] contract distinct
+//! from the top-level [`Args`] parser (Layer 1) and the per-command engine
+//! (Layer 2), and from the MCP schema synthesis (Layer 3, Phase 7). Both
+//! process entrypoints, `mtui`'s REPL and `mtui-mcp`, exit through it; neither
+//! has a headless single-command CLI mode.
 
 pub mod args;
 pub mod command;
@@ -41,6 +39,7 @@ pub use args::{Args, ColorArg, Sut, Update};
 pub use command::{Command, Scope, resolve_command_rrids};
 pub use display::{ColorMode, CommandPromptDisplay};
 pub use engine::{EngineError, command_parser, dispatch_argv, dispatch_command, dispatch_line};
+pub use entrypoint::ExitStatus;
 pub use error::{CommandError, CommandResult};
 pub use registry::{MCP_DENYLIST, Registry, register_all};
 pub use session::{LogLevel, LogLevelSink, NotifySink, Session};

--- a/crates/mtui-core/src/lib.rs
+++ b/crates/mtui-core/src/lib.rs
@@ -15,8 +15,8 @@
 //! adds [`args`] — the top-level process argument parser (`clap`), distinct
 //! from the per-command parsers the engine synthesises. P5.3 rounds out the
 //! [`display`] surface: the full `list_*`
-//! family, [`show_log`](CommandPromptDisplay::show_log), the three-way
-//! [`ColorMode`], and the [`page`](display::page) pager.
+//! family, `show_log`, the three-way
+//! [`ColorMode`], and the `page` pager.
 //!
 //! P5.10 adds [`entrypoint`] — the process [`ExitStatus`] contract distinct
 //! from the top-level [`Args`] parser (Layer 1) and the per-command engine

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -149,7 +149,7 @@ fn random_shuffle(candidates: &mut [String]) {
 }
 
 /// Render a refhosts [`Slot`](mtui_datasources::refhost::Slot) tuple as a stable
-/// string key for [`TestReportBase::slot_candidates`]
+/// string key for [`TestReportBase::slot_candidates`](mtui_testreport::TestReportBase::slot_candidates)
 /// (`product|version|arch|addon,addon`).
 ///
 /// The tuple already sorts its addons, so this is a deterministic 1:1 encoding
@@ -264,7 +264,7 @@ impl Session {
     /// single-RRID tool call needs a `&mut Session` to dispatch, but holding the
     /// canonical session behind one mutex across dispatch serialises *all* calls.
     /// Instead the caller forks a per-call session — its
-    /// [`TemplateRegistry::snapshot`] shares the same per-entry report locks, so a
+    /// `TemplateRegistry::snapshot` shares the same per-entry report locks, so a
     /// command acting on RRID `X` locks only `X`'s entry (letting a concurrent
     /// call on `Y` proceed), and the report content it mutates is visible to the
     /// canonical session (same `Arc<Mutex<..>>`).
@@ -398,7 +398,7 @@ impl Session {
     }
 
     /// Makes `rrid` the active template *and* installs its per-call active
-    /// handle ([`active_guard`](Self::active_guard)).
+    /// handle (`active_guard`).
     ///
     /// The unified activation seam: it re-points the registry's active pointer
     /// and acquires the entry's lock so [`metadata`](Self::metadata) /
@@ -636,7 +636,7 @@ impl Session {
     /// 2. The report is added to the registry and — when it carries a real RRID —
     ///    made active. Re-loading an already-loaded RRID replaces its stored
     ///    report and makes it active; sibling templates are untouched.
-    /// 3. If the report asked for autoconnect ([`TestReportBase::autoconnect_pending`],
+    /// 3. If the report asked for autoconnect ([`TestReportBase::autoconnect_pending`](mtui_testreport::TestReportBase::autoconnect_pending),
     ///    set by `make_testreport` for `-a` with `autoconnect`), its reference
     ///    hosts are connected. The connect is driven **here** (the composition
     ///    root) rather than inside `mtui-testreport`, so that crate never depends
@@ -652,7 +652,7 @@ impl Session {
     /// Returns the loaded report's RRID (empty when the load failed and the null
     /// report was substituted).
     ///
-    /// A thin wrapper over [`load_update_reported`](Self::load_update_reported)
+    /// A thin wrapper over `load_update_reported`
     /// that discards the failure reason, for callers that only branch on
     /// success/failure (REPL startup, `regenerate`).
     pub async fn load_update(
@@ -668,7 +668,7 @@ impl Session {
     ///
     /// Returns `(rrid, load_error)`: on success the RRID and `None`; on failure
     /// an empty RRID and `Some(reason)` — the diagnostic
-    /// [`make_testreport`](make_testreport) stashed on the substituted null
+    /// [`make_testreport`] stashed on the substituted null
     /// report (svn checkout / gitea / hash / read failure). Lets `load_template`
     /// surface the real cause to the operator (and, via MCP, the LLM) instead of
     /// a bare "could not load".
@@ -737,7 +737,7 @@ impl Session {
     /// Connects the active report's reference hosts (the deferred half of
     /// [`load_update`](Self::load_update)).
     ///
-    /// Computes the wanted host list via [`autoconnect_hosts`](Self::autoconnect_hosts)
+    /// Computes the wanted host list via `autoconnect_hosts`
     /// — the template's parsed `reference host:` names plus one host per matching
     /// slot resolved from each testplatform — then builds and connects a
     /// [`Target`] for each, stamping the report's RRID as the pool-claim
@@ -745,7 +745,7 @@ impl Session {
     /// (best-effort).
     ///
     /// The offline host-selection is factored into the pure, unit-tested
-    /// [`autoconnect_hosts`](Self::autoconnect_hosts); this thin connect loop
+    /// `autoconnect_hosts`; this thin connect loop
     /// builds real [`Target`]s and is exercised by the gated sshd integration
     /// path (the same seam `list_refhosts --free` uses for its live probe).
     async fn autoconnect_active(&mut self, rrid: &str) {
@@ -1253,7 +1253,7 @@ impl Session {
     /// Builds the refhosts inventory on demand from `config`, or `None` on any
     /// resolver/resolve failure.
     ///
-    /// The shared store-builder behind [`resolve_testplatform_hosts`] (host
+    /// The shared store-builder behind `resolve_testplatform_hosts` (host
     /// selection) and [`verify_target_products`](Self::verify_target_products)
     /// (post-connect product-drift check) — the same on-demand pattern
     /// `list_refhosts`/`add_host` use, with no cached Session state. A `None`
@@ -1340,7 +1340,7 @@ impl Session {
     ///
     /// Returns `(chosen_hosts, slot_candidates)`: the claimed hosts (this batch's
     /// `pool_claims`) and the per-slot ordered candidate lists (keyed by the slot
-    /// rendered as a stable string, matching [`TestReportBase::slot_candidates`]).
+    /// rendered as a stable string, matching [`TestReportBase::slot_candidates`](mtui_testreport::TestReportBase::slot_candidates)).
     /// The caller writes both onto the active report before connecting.
     ///
     /// Static (owned/borrowed plain data, `&'static` arbiter) so the caller's
@@ -1497,7 +1497,7 @@ impl Session {
         }
     }
 
-    /// Installs the callback [`notify_user`](Self::notify_user) uses to surface a
+    /// Installs the callback `notify_user` uses to surface a
     /// desktop notification.
     ///
     /// The Phase-6 REPL wires this to `mtui-cli`'s `notification::notify_user`;
@@ -1530,7 +1530,7 @@ impl Session {
     /// the REPL; `mtui-mcp` leaves it unset. Also pushes the prompter onto the
     /// active report's [`HostsGroup`] so any already-connected hosts pick up the
     /// derived command-timeout prompt immediately; freshly-connected hosts
-    /// inherit it via [`connect_and_add_hosts`](Self::connect_and_add_hosts).
+    /// inherit it via `connect_and_add_hosts`.
     pub fn set_prompter(&mut self, prompter: Prompter) {
         // Push onto the active report's group first (already-connected hosts),
         // then retain a clone for future connects.

--- a/crates/mtui-core/src/template_registry.rs
+++ b/crates/mtui-core/src/template_registry.rs
@@ -20,7 +20,7 @@
 //! (`/var/lock/mtui-pool.lock`), and the remote operation lock
 //! (`/var/lock/mtui.lock`) all need an `await`, and a wedged host must not hang
 //! removal. So [`remove`](TemplateRegistry::remove) and the same-RRID
-//! replacement path in [`add_or_replace`](TemplateRegistry::add_or_replace) are
+//! replacement path in `add_or_replace` are
 //! **async** and run the same bounded teardown as the REPL `quit` command
 //! (release pool claims, then `targets.close(None)` under a per-report budget)
 //! before the entry is dropped and the active pointer is repointed.
@@ -51,7 +51,7 @@ pub type ReportEntry = Arc<Mutex<Box<dyn TestReport + Send + Sync>>>;
 const REMOVE_CLOSE_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Resolves the per-report close budget. Overridable in tests (via
-/// [`tests::set_close_timeout`]) so the wedged-host path can be exercised without
+/// `tests::set_close_timeout`) so the wedged-host path can be exercised without
 /// waiting the full 45s; always [`REMOVE_CLOSE_TIMEOUT`] in production.
 #[cfg(not(test))]
 fn remove_close_timeout() -> Duration {
@@ -110,7 +110,7 @@ impl TemplateRegistry {
     ///
     /// The first template added becomes active; re-adding an existing RRID
     /// replaces the stored report but leaves the active pointer alone. A report
-    /// with an empty RRID is the failed-load sentinel ([`NullReport`]) and is
+    /// with an empty RRID is the failed-load sentinel ([`NullReport`](mtui_testreport::NullReport)) and is
     /// silently ignored so it never becomes a phantom entry that breaks fan-out.
     pub fn add(&mut self, mut report: Box<dyn TestReport + Send + Sync>) {
         let rrid = report.id();
@@ -171,7 +171,7 @@ impl TemplateRegistry {
     /// report: [`release_pool_claims`](mtui_testreport::TestReport::release_pool_claims)
     /// (in-process arbiter ownership + remote pool-claim lock) then
     /// [`HostsGroup::close`](mtui_hosts::HostsGroup)`(None)` (per-host operation
-    /// lock + graceful disconnect) under [`remove_close_timeout`]. Only after the
+    /// lock + graceful disconnect) under `remove_close_timeout`. Only after the
     /// teardown returns is the entry dropped and — if it was active — the active
     /// pointer repointed to the next remaining entry (insertion order), so a
     /// reader never observes a half-torn-down active report. A no-op if `rrid`
@@ -315,7 +315,7 @@ impl TemplateRegistry {
     /// lockable report — a per-RRID command acting through a snapshot mutates the
     /// report content visible to the canonical registry too. Used by
     /// [`Session::fork_for_call`](crate::Session::fork_for_call) to let a headless
-    /// MCP dispatch run on its own [`Session`] without a session-wide lock, while
+    /// MCP dispatch run on its own [`Session`](crate::Session) without a session-wide lock, while
     /// different-RRID calls still act on distinct entry locks and same-RRID calls
     /// share one (`mtui-rs-f36r`, steps 4-5).
     ///

--- a/crates/mtui-datasources/src/gitea.rs
+++ b/crates/mtui-datasources/src/gitea.rs
@@ -8,7 +8,7 @@
 //! * **assignment** — magic marker comments
 //!   (`<MTUI: PR - UV assigned to user: X - group: Y >` and its unassign twin)
 //!   are replayed as a state machine scoped to the review group, "last marker
-//!   wins" (see [`Gitea::assignee_from_comments`]);
+//!   wins" (see `Gitea::assignee_from_comments`);
 //! * **decision** — a `@<group>-review: LGTM|approve|decline` comment records a
 //!   decision, but a *re-requested* review (e.g. after a rebuild) supersedes a
 //!   stale decision, so [`Gitea`] only treats the PR as decided when a decision
@@ -274,7 +274,7 @@ impl Gitea {
     /// Build a Gitea client for the PR at `giteaprapi` (a REST API URL).
     ///
     /// Reads the token/session user/TLS
-    /// posture from `config`, defaults the group to [`DEFAULT_GROUP`], and
+    /// posture from `config`, defaults the group to `DEFAULT_GROUP`, and
     /// derives the issue-comments endpoint from the PR URL.
     ///
     /// # Errors

--- a/crates/mtui-datasources/src/http.rs
+++ b/crates/mtui-datasources/src/http.rs
@@ -6,13 +6,13 @@
 //! `(connect, read)` timeout and one TLS-verification policy instead of each
 //! making its own, inconsistent decision. This module centralises both:
 //!
-//! - [`HTTP_TIMEOUT`] is the one `(connect, read)` timeout shared by all
+//! - `HTTP_TIMEOUT` is the one `(connect, read)` timeout shared by all
 //!   callers. It bounds a stuck socket so a broken network cannot hang mtui.
 //! - [`resolve_verify`] turns a per-call default plus the user's global
 //!   preference into the effective [`VerifyPolicy`].
 //! - [`HttpClient`] builds one `reqwest::Client` with a fixed timeout + verify
 //!   posture. Verification is **on by default for every call site.**
-//! - [`is_ssl_verification_error`] / [`ssl_verification_hint`] give a short,
+//! - `is_ssl_verification_error` / `ssl_verification_hint` give a short,
 //!   actionable message for the internal-CA hosts (openqa.suse.de,
 //!   dashboard.qam.suse.de, ...) instead of a raw transport error.
 //!
@@ -30,11 +30,11 @@
 //!
 //! ## Bounded response bodies
 //!
-//! Every body is read through [`read_body_capped`], which rejects an oversized advertised
+//! Every body is read through `read_body_capped`, which rejects an oversized advertised
 //! `Content-Length` before reading and enforces the same ceiling while streaming
 //! chunked/unknown-length bodies — a hostile or misconfigured datasource cannot
 //! OOM mtui. Callers pick [`MAX_API_BODY`] (small JSON/text) or
-//! [`MAX_DOWNLOAD_BODY`] (bulk downloads); overflow surfaces as
+//! `MAX_DOWNLOAD_BODY` (bulk downloads); overflow surfaces as
 //! [`HttpError::BodyTooLarge`], which carries no URL so it cannot leak a
 //! credential embedded in a datasource URL.
 
@@ -108,7 +108,7 @@ impl VerifyPolicy {
     /// Bridge a typed [`mtui_config::SslVerify`] into this layer's posture.
     ///
     /// - [`SslVerify::Enabled`] → verify, preferring the system CA bundle
-    ///   ([`system_ca_bundle`]) when one is found (the distribution bundle
+    ///   (`system_ca_bundle`) when one is found (the distribution bundle
     ///   takes precedence over any bundled default), else `Default(true)`.
     /// - [`SslVerify::Disabled`] → `Default(false)`.
     /// - [`SslVerify::CaBundle`] → the configured path verbatim.
@@ -169,12 +169,12 @@ pub struct HttpClient {
 impl HttpClient {
     /// Build a client with the given [`VerifyPolicy`].
     ///
-    /// Applies [`HTTP_TIMEOUT`] (connect + read), sizes the per-host idle pool
-    /// to [`default_pool_size`], and derives the TLS posture:
+    /// Applies `HTTP_TIMEOUT` (connect + read), sizes the per-host idle pool
+    /// to `default_pool_size`, and derives the TLS posture:
     ///
     /// - `Default(true)` → verify against the built-in trust store;
     /// - `Default(false)` → accept invalid certs (and warn once via
-    ///   [`disable_insecure_warnings`]);
+    ///   `disable_insecure_warnings`);
     /// - `CaBundle(path)` → verify against *only* that PEM bundle (replacing,
     ///   not augmenting, the trust store).
     ///
@@ -213,7 +213,7 @@ impl HttpClient {
     }
 
     /// GET `url` and return the raw response body as bytes, capped at
-    /// [`MAX_DOWNLOAD_BODY`].
+    /// `MAX_DOWNLOAD_BODY`.
     ///
     /// The single GET-to-bytes path for callers that just want a payload (a log
     /// file, a YAML document). Errors on any non-2xx status. Use
@@ -345,7 +345,7 @@ pub(crate) fn ssl_verification_hint(host: Option<&str>) -> String {
 /// (`scheme://user:pass@host/…`); those must never reach the log stream. This
 /// preserves the scheme, host, port, path and query so a log line stays useful,
 /// and touches only the authority's userinfo. Parsing is deliberately
-/// dependency-free and mirrors [`host_of`]-style string splitting; on any
+/// dependency-free and mirrors `host_of`-style string splitting; on any
 /// unexpected shape it fails closed by stripping an entire `…@` authority prefix
 /// rather than risk echoing a credential.
 #[must_use]

--- a/crates/mtui-datasources/src/obs/client.rs
+++ b/crates/mtui-datasources/src/obs/client.rs
@@ -2,7 +2,7 @@
 //!
 //! Mirrors the crate's
 //! [`Gitea`](crate::gitea::Gitea) request wrapper: one shared
-//! [`HttpClient`](crate::http::HttpClient) (built with a fixed timeout + TLS
+//! [`HttpClient`] (built with a fixed timeout + TLS
 //! posture) carries the handful of calls one QAM operation makes. SSH-signature
 //! auth is injected through the [`ObsAuth`] seam so this transport foundation
 //! (G1a) is testable now with [`NoAuth`]; the real signer lands in G1c.

--- a/crates/mtui-datasources/src/obs/errors.rs
+++ b/crates/mtui-datasources/src/obs/errors.rs
@@ -4,7 +4,7 @@
 //! timeout, config/credential, XML parse, and workflow-precondition — so the
 //! `OSC` facade can match it exhaustively with a single `Err(_)` arm and fold
 //! it into a logged `false`, mirroring the crate's other typed error families
-//! ([`crate::error::GiteaError`], [`crate::error::OscError`]).
+//! ([`crate::error::GiteaError`], `crate::error::OscError`).
 //!
 //! The transport foundation (G1a) landed [`Api`](ObsError::Api),
 //! [`Timeout`](ObsError::Timeout) and the [`Http`](ObsError::Http) transport

--- a/crates/mtui-datasources/src/obs/mod.rs
+++ b/crates/mtui-datasources/src/obs/mod.rs
@@ -1,7 +1,7 @@
 //! The native OBS/IBS review backend (direct OBS API, no `osc` subprocess).
 //!
 //! This backend replaces the `osc qam` subprocess wrapper
-//! ([`crate::oscqam`]) with a native Rust OBS API client. The transport
+//! (`oscqam`) with a native Rust OBS API client. The transport
 //! foundation ([`client`], [`errors`]), the native oscrc
 //! credential reader ([`oscrc`]), the XML models ([`models`]), the
 //! assignment-inference state machine ([`inference`]) and the SSH-signature

--- a/crates/mtui-datasources/src/obs/models.rs
+++ b/crates/mtui-datasources/src/obs/models.rs
@@ -14,7 +14,7 @@
 //! third-party XML parser. Defence in depth: `quick-xml` does not expand general
 //! entities anyway (it surfaces them as distinct events), so a DTD-free body
 //! with an entity reference never expands either. This mirrors the guard in
-//! [`crate::obs::client::error_summary`].
+//! `crate::obs::client::error_summary`.
 //!
 //! The four `parse_*` entry points are `pub` (not `pub(crate)`) solely so the
 //! detached cargo-fuzz harness in `fuzz/` can drive them with arbitrary bytes;

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -5,7 +5,7 @@
 //! and folds every transport/HTTP failure into a `None` result so a command
 //! never aborts on a flaky openQA. This module provides that shared machinery;
 //! the concrete `auto` and `kernel` workflows live in
-//! [`standard`](crate::openqa::standard) and [`kernel`](crate::openqa::kernel).
+//! `standard` and [`kernel`](crate::openqa::kernel).
 
 use mtui_types::{RequestKind, RequestReviewID};
 use serde::Deserialize;

--- a/crates/mtui-datasources/src/openqa/client.rs
+++ b/crates/mtui-datasources/src/openqa/client.rs
@@ -86,7 +86,7 @@ impl ClientConf {
         paths
     }
 
-    /// Read and merge the [`default_paths`](Self::default_paths).
+    /// Read and merge the `default_paths`.
     ///
     /// Missing files are skipped; an unreadable or malformed file is logged at
     /// `warn` and skipped, so a bad config never hard-fails a lookup.

--- a/crates/mtui-datasources/src/openqa/mod.rs
+++ b/crates/mtui-datasources/src/openqa/mod.rs
@@ -11,7 +11,7 @@
 //!   (INI `client.conf`, `X-API-Key`, HMAC-SHA1 `X-API-Hash`) over this crate's
 //!   shared [`HttpClient`](crate::http::HttpClient).
 //! * [`kernel`] — the "kernel" workflow ([`KernelOpenQA`]): the LTP test matrix.
-//! * [`install`] — the install-job → log-filename map ([`install_logfile_for`]).
+//! * `install` — the install-job → log-filename map (`install_logfile_for`).
 
 pub mod base;
 pub mod client;

--- a/crates/mtui-datasources/src/oqa_search/mod.rs
+++ b/crates/mtui-datasources/src/oqa_search/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! The module is split along these submodule seams:
 //!
-//! * [`heuristics`] — the constants / blocklists that drive
+//! * `heuristics` — the constants / blocklists that drive
 //!   group filtering and log-line extraction.
 //! * [`results`] — the public result shapes.
 //! * [`search`] — the fetch layer, the pure helpers, and the entry points.

--- a/crates/mtui-datasources/src/qem_dashboard/client.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/client.rs
@@ -1,9 +1,9 @@
 //! Low-level read-only HTTP client for the QEM Dashboard API.
 //!
 //! Every endpoint is a thin GET-to-JSON wrapper over the shared
-//! [`HttpClient`](crate::http::HttpClient). Any transport, non-2xx, or
+//! [`HttpClient`]. Any transport, non-2xx, or
 //! JSON-parse failure is logged at `debug` and folded into a `None` (for
-//! [`incident`](Self::incident))
+//! `incident`)
 //! or an empty `Vec` (for the list endpoints), so a fetch failure never escapes
 //! the client — the caller sees the same "no data" shape whether the dashboard
 //! was unreachable or genuinely empty.
@@ -151,7 +151,7 @@ impl QemDashboardClient {
             .await
     }
 
-    /// Fallible sibling of [`incident_settings`](Self::incident_settings): a
+    /// Fallible sibling of `incident_settings`: a
     /// fetch failure returns [`QemDashboardError::Fetch`] instead of `[]`.
     ///
     /// # Errors
@@ -166,7 +166,7 @@ impl QemDashboardClient {
             .await
     }
 
-    /// Fallible sibling of [`update_settings`](Self::update_settings): a fetch
+    /// Fallible sibling of `update_settings`: a fetch
     /// failure returns [`QemDashboardError::Fetch`] instead of `[]`.
     ///
     /// # Errors

--- a/crates/mtui-datasources/src/qem_dashboard/dashboard_openqa.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/dashboard_openqa.rs
@@ -171,7 +171,7 @@ impl NormalizedJob {
     /// dashboard keeps the older run but marks it superseded — either with an
     /// `obsolete` flag or an `"obsoleted"` result. Both must be dropped so a
     /// stale failure does not poison the install verdict
-    /// ([`has_passed_install_jobs`](Self::has_passed_install_jobs)) or surface as
+    /// (`has_passed_install_jobs`) or surface as
     /// a phantom entry in the failed-jobs listing. Matches `oqa_search`'s
     /// `incident_jobs`, which filters `result == "obsoleted"`; only the current
     /// run matters.
@@ -258,11 +258,11 @@ pub struct DashboardAutoOpenQA {
     client: QemDashboardClient,
     /// The resolved dashboard incident number.
     incident_number: String,
-    /// The rendered `Results from openQA jobs` block (empty until [`run`]).
+    /// The rendered `Results from openQA jobs` block (empty until [`run`](Self::run)).
     pub pp: Vec<String>,
     /// The install-log URLs, or `None` when the install jobs did not all pass.
     pub results: Option<Vec<URLs>>,
-    /// The normalized jobs (populated by [`run`]).
+    /// The normalized jobs (populated by [`run`](Self::run)).
     jobs: Vec<NormalizedJob>,
     /// Upper bound on concurrent per-setting job fetches (clamped to `>=1`).
     max_parallel: usize,
@@ -275,7 +275,7 @@ impl DashboardAutoOpenQA {
     /// Build the provider for an incident on a given openQA `host`.
     ///
     /// `max_parallel` bounds how many per-setting job fetches run concurrently
-    /// in [`load_jobs`](Self::load_jobs) (clamped to `>=1`).
+    /// in `load_jobs` (clamped to `>=1`).
     #[must_use]
     pub fn new(
         host: impl Into<String>,

--- a/crates/mtui-datasources/src/qem_dashboard/mod.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/mod.rs
@@ -19,14 +19,14 @@
 //! * **Native async fan-out.** Jobs are fanned out
 //!   concurrently with `tokio`, each fetch guarded by
 //!   [`tokio::time::timeout`] with a 60s per-future wall-clock cap
-//!   ([`FUTURE_TIMEOUT`](dashboard_openqa::FUTURE_TIMEOUT)), preserving a
+//!   (`FUTURE_TIMEOUT`), preserving a
 //!   fixed ordering (incident settings first, then update settings; jobs in
 //!   submission order) and a warn-and-skip-on-timeout behaviour, without a
 //!   thread pool.
 //! * **No `config` dependency.** [`DashboardAutoOpenQA`]'s
 //!   `openqa_install_distri` / `openqa_install_logs` are pinned Rust
-//!   constants ([`OPENQA_INSTALL_DISTRI`](crate::openqa::OPENQA_INSTALL_DISTRI),
-//!   [`install_logfile_for`](crate::openqa::install_logfile_for)), so the
+//!   constants (`OPENQA_INSTALL_DISTRI`,
+//!   `install_logfile_for`), so the
 //!   constructor takes no config.
 //!
 //! [`RequestReviewID`]: mtui_types::RequestReviewID

--- a/crates/mtui-datasources/src/refhost/models.rs
+++ b/crates/mtui-datasources/src/refhost/models.rs
@@ -1,6 +1,6 @@
 //! Refhost **search query** model.
 //!
-//! The `refhosts.yml` *row* schema ([`Host`], [`Product`], [`Addon`],
+//! The `refhosts.yml` *row* schema ([`Host`](mtui_types::Host), [`Product`], [`Addon`],
 //! [`Version`]) lives in `mtui-types` (it is pure, I/O-free wire data). This
 //! module adds the **query side**: [`Attributes`], the mutable search filter,
 //! and [`Attributes::from_testplatform`], which parses a SMELT `testplatform`

--- a/crates/mtui-datasources/src/refhost/resolvers.rs
+++ b/crates/mtui-datasources/src/refhost/resolvers.rs
@@ -168,7 +168,7 @@ impl FileStat for FsStat {
 /// The client's TLS posture is fixed at build time (see [`HttpClient::new`]), so
 /// this fetcher ignores the per-call `verify` argument beyond recording that the
 /// resolver already resolved it — the client it holds was constructed with that
-/// same policy. It is created via [`HttpFetcher::new`], which builds the client
+/// same policy. It is created via `HttpFetcher::new`, which builds the client
 /// from the effective [`VerifyPolicy`].
 #[derive(Debug)]
 pub struct HttpFetcher {

--- a/crates/mtui-datasources/src/refhost/store.rs
+++ b/crates/mtui-datasources/src/refhost/store.rs
@@ -197,7 +197,7 @@ impl Refhosts {
     /// An unset filter (empty/`None`) imposes no constraint: `name` is a shell
     /// glob, `arch` is membership in a list,
     /// `product` is a case-insensitive substring of the base product name,
-    /// `version` is the loose form matched by [`version_str_match`], and each
+    /// `version` is the loose form matched by [`version_str_match`](Self::version_str_match), and each
     /// `addon` term is a case-insensitive substring of some installed addon.
     #[must_use]
     fn field_match(
@@ -316,7 +316,7 @@ impl Refhosts {
     /// Return pool candidates `(host, slot)` keyed on the query slot.
     ///
     /// Each host matching any of `attributes` is returned once, tagged with the
-    /// [`slot_for_query`](Self::slot_for_query) of the **first** attribute it
+    /// `slot_for_query` of the **first** attribute it
     /// matches — the testplatform's requested identity rather than the host's
     /// full installed-module identity — so host-arbitration draws one host per
     /// *requested* test-target slot.

--- a/crates/mtui-datasources/src/refhost/verify.rs
+++ b/crates/mtui-datasources/src/refhost/verify.rs
@@ -26,7 +26,7 @@
 //! The mtui
 //! [`Version`] preserves the numeric-vs-textual distinction via
 //! [`VersionField`], rather than collapsing it into one untyped field.
-//! [`normalize_version`] therefore yields
+//! `normalize_version` therefore yields
 //! [`VersionField::Text`] for a service-pack minor (`"SP4"`) and
 //! [`VersionField::Num`] for a dotted numeric minor (`"0"`), matching how
 //! `refhosts.yml` metadata deserializes so exact-match hosts compare equal.

--- a/crates/mtui-datasources/src/slack.rs
+++ b/crates/mtui-datasources/src/slack.rs
@@ -11,7 +11,7 @@
 //!
 //! * **Application errors arrive as HTTP 200.** A refused call still returns
 //!   `200 OK`, carrying `{"ok": false, "error": "channel_not_found"}`. Checking
-//!   the status is therefore *not* enough — [`Slack::request`] inspects the
+//!   the status is therefore *not* enough — `Slack::request` inspects the
 //!   `ok` field on every response and converts a false one into
 //!   [`SlackError::Api`].
 //! * **Rate limiting is routine, not exceptional.** Tier-3 methods allow
@@ -454,7 +454,7 @@ impl Slack {
 
     /// Read the threaded replies to the message identified by `channel`/`ts`.
     ///
-    /// Follows Slack's cursor pagination, bounded by [`MAX_REPLY_PAGES`]. The
+    /// Follows Slack's cursor pagination, bounded by `MAX_REPLY_PAGES`. The
     /// parent message is excluded: Slack returns it as the first element of
     /// the first page, and it is the request itself, not a reply to it.
     ///

--- a/crates/mtui-datasources/src/teregen.rs
+++ b/crates/mtui-datasources/src/teregen.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Interruptible waiting
 //!
-//! [`wait_for_template`](TeReGen::wait_for_template) is `async`, and the
+//! `wait_for_template` is `async`, and the
 //! inter-poll wait uses [`tokio::time::sleep`], polling `should_stop` in small
 //! steps so cancellation takes effect promptly rather than after a full
 //! interval.
@@ -363,7 +363,7 @@ impl TeReGen {
     /// Enqueue a regeneration and wait for the job to finish.
     ///
     /// Bundles [`regenerate`](Self::regenerate) +
-    /// [`wait_for_template`](Self::wait_for_template) into the single protocol
+    /// `wait_for_template` into the single protocol
     /// both the `regenerate` command and the stale-template loader share,
     /// returning a [`RegenOutcome`] the caller maps to its own messaging and
     /// reload strategy. `should_stop` is forwarded so the wait stays

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -90,7 +90,7 @@ pub enum MockSftpOp {
 /// Construct with [`MockConnection::new`], script responses with
 /// [`with_response`](MockConnection::with_response) /
 /// [`with_default`](MockConnection::with_default) /
-/// [`with_timeout`](MockConnection::with_timeout), then inspect issued commands
+/// `with_timeout`, then inspect issued commands
 /// via [`commands`](MockConnection::commands).
 #[derive(Debug, Clone)]
 pub struct MockConnection {
@@ -110,7 +110,7 @@ pub struct MockConnection {
     issued: Arc<Mutex<Vec<String>>>,
     /// Set once [`close`](Connection::close) has been called.
     closed: Arc<Mutex<bool>>,
-    /// When set, [`close`](Connection::close) blocks until the [`Notify`] is
+    /// When set, [`close`](Connection::close) blocks until the [`Notify`](tokio::sync::Notify) is
     /// fired before completing — models a wedged teardown (a dead peer
     /// with no RST) so a caller's bounded close budget can be exercised. Shared
     /// across `Clone`d handles so the test fires the same notify. Never set by
@@ -302,7 +302,7 @@ impl MockConnection {
     /// Makes [`sftp_get`](Connection::sftp_get) /
     /// [`sftp_get_folder`](Connection::sftp_get_folder) fail with a generic
     /// [`HostError::Sftp`], so a caller's per-host download outcome tracking
-    /// ([`Target::sftp_get`]) can be exercised. The op is still recorded before
+    /// ([`Target::sftp_get`](crate::Target::sftp_get)) can be exercised. The op is still recorded before
     /// failing.
     #[must_use]
     pub fn failing_sftp_get(mut self) -> Self {
@@ -630,7 +630,7 @@ impl MockConnection {
     }
 
     /// Scripts one chunk of shell output served by
-    /// [`ShellChannel::read`](crate::connection::ShellChannel::read) on a
+    /// [`ShellChannel::read`] on a
     /// spawned shell. Chunks are drained in order, one per `read`, then `read`
     /// returns `0` (EOF) — the bridge loop's stop condition.
     #[cfg(feature = "shell")]

--- a/crates/mtui-hosts/src/connection/ssh.rs
+++ b/crates/mtui-hosts/src/connection/ssh.rs
@@ -448,7 +448,7 @@ impl SshConnection {
     /// SSH handshake and the per-command wait; this builder lets a caller keep a
     /// normal handshake timeout while setting a different command timeout — the
     /// two concerns are otherwise conflated. Builder-style for the same reason as
-    /// [`with_timeout_prompt`](Self::with_timeout_prompt): it stays off the
+    /// `with_timeout_prompt`: it stays off the
     /// object-safe [`Connection`] trait.
     #[must_use]
     pub fn with_command_timeout(mut self, timeout: CommandTimeout) -> Self {
@@ -520,6 +520,9 @@ impl SshConnection {
     /// * every other status (`PermissionDenied`, `OpUnsupported`,
     ///   `NoConnection`, `ConnectionLost`, …) → [`HostError::Sftp`],
     /// * a non-status (transport/IO) error → [`HostError::Transport`].
+    ///
+    /// [`StatusCode::Failure`]: russh_sftp::protocol::StatusCode::Failure
+    /// [`StatusCode::NoSuchFile`]: russh_sftp::protocol::StatusCode::NoSuchFile
     fn exclusive_create_err(
         &self,
         e: russh_sftp::client::error::Error,
@@ -572,7 +575,7 @@ fn sftp_err_at_for(host: &str, e: russh_sftp::client::error::Error, path: &Path)
 }
 
 /// Categorizes the error from an **atomic exclusive create**
-/// ([`Connection::sftp_write`](crate::Connection::sftp_write) with
+/// ([`Connection::sftp_write`] with
 /// `exclusive = true`).
 ///
 /// SFTPv3 has no dedicated "file exists" status, so an `O_EXCL` collision

--- a/crates/mtui-hosts/src/connection/timeout.rs
+++ b/crates/mtui-hosts/src/connection/timeout.rs
@@ -99,7 +99,7 @@ impl From<CommandTimeout> for Duration {
 /// The wire tokens are the exact
 /// `ssh_strict_host_key_checking` config values (`auto_add` / `warn` /
 /// `reject`), so a config string round-trips through
-/// [`FromStr`](std::str::FromStr)/[`Display`](std::fmt::Display).
+/// [`FromStr`]/[`Display`](std::fmt::Display).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum HostKeyPolicy {
     /// Silently add an unknown host key and continue.

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`HostsGroup`] composite with its parallel/serial command + SFTP fan-out,
 //! the remote-lock protocol ([`TargetLock`] / [`PoolLock`] / [`RemoteLock`],
 //! P2.6), the in-process [`HostArbiter`] (P2.7), and the host-output parsers —
-//! [`parse_system`] / [`parse_product`] / [`parse_os_release`] plus the
+//! [`parse_system`] / [`parse_product`](target::parsers::product::parse_product) / [`parse_os_release`](target::parsers::product::parse_os_release) plus the
 //! [`PackageQuerier`] (P2.8), and the install/uninstall [`Operation`] template
 //! (skeleton + trait, P2.9) — the `lock → run → check → reboot → unlock`
 //! flow driven over the object-safe [`OperationGroup`] seam — and, behind the

--- a/crates/mtui-hosts/src/prompter.rs
+++ b/crates/mtui-hosts/src/prompter.rs
@@ -9,7 +9,7 @@
 //! [`Prompter`] serialises those reads behind a single lock — only one worker
 //! reads `stdin` at a time; the others queue on the lock until the current
 //! prompt returns. During the read it holds a
-//! [`suspend_async`](crate::target::suspend_async) guard so a live TTY spinner
+//! `suspend_async` guard so a live TTY spinner
 //! erases its frame and stops repainting over the prompt until the user answers.
 //!
 //! ## Async lock
@@ -93,7 +93,7 @@ impl Prompter {
     /// Prompts the user with `text` and returns the typed response.
     ///
     /// Acquires the prompter's lock for the whole read so sibling tasks cannot
-    /// race for `stdin`, and holds a [`suspend_async`] guard so a live spinner
+    /// race for `stdin`, and holds a `suspend_async` guard so a live spinner
     /// erases its frame and stays quiet until the user answers.
     ///
     /// # Errors

--- a/crates/mtui-hosts/src/target/actions.rs
+++ b/crates/mtui-hosts/src/target/actions.rs
@@ -1,10 +1,10 @@
 //! Parallel fan-out primitives over a group of [`Target`]s.
 //!
-//! * [`run_parallel`] drives a set of caller-supplied futures to completion
+//! * `run_parallel` drives a set of caller-supplied futures to completion
 //!   concurrently.
-//! * [`RunCommand`] dispatches a command (one string for all hosts, or a
+//! * `RunCommand` dispatches a command (one string for all hosts, or a
 //!   per-host map) to every host in parallel.
-//! * [`sftp_put_all`] / [`sftp_get_all`] fan the corresponding transfer out
+//! * `sftp_put_all` / `sftp_get_all` fan the corresponding transfer out
 //!   across the group.
 //!
 //! ### Why no output lock
@@ -16,7 +16,7 @@
 //!
 //! ### The TTY spinner
 //!
-//! [`run_parallel`] starts a [`TtySpinner`](super::spinner) for
+//! `run_parallel` starts a [`TtySpinner`](mod@super::spinner) for
 //! the duration of the fan-out when a `desc` is given; it is a strict no-op off
 //! a TTY (tests, redirected output, `mtui-mcp`), so behaviour with `desc=None`
 //! (or off a terminal) is identical to the plain `join_all`. The spinner erases

--- a/crates/mtui-hosts/src/target/arbiter.rs
+++ b/crates/mtui-hosts/src/target/arbiter.rs
@@ -216,7 +216,7 @@ impl<C: Clock> HostArbiter<C> {
 /// The process-global [`HostArbiter`] (created on first use).
 ///
 /// A double-checked singleton, pinned to [`SystemClock`]; tests construct their
-/// own [`HostArbiter::with_clock`] instead of touching the global.
+/// own `HostArbiter::with_clock` instead of touching the global.
 #[must_use]
 pub fn get_arbiter() -> &'static HostArbiter<SystemClock> {
     static ARBITER: OnceLock<HostArbiter<SystemClock>> = OnceLock::new();

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -11,9 +11,9 @@
 //!   the unselected hosts over a shared-reference set of hosts),
 //! * [`names`](HostsGroup::names) / iteration,
 //! * command fan-out via [`run`](HostsGroup::run) (delegating to
-//!   [`super::actions::RunCommand`]),
+//!   `super::actions::RunCommand`),
 //! * SFTP fan-out ([`sftp_put`](HostsGroup::sftp_put) /
-//!   [`sftp_get`](HostsGroup::sftp_get) / [`sftp_remove`](HostsGroup::sftp_remove)),
+//!   [`sftp_get`](HostsGroup::sftp_get) / `sftp_remove`),
 //! * the operation-lock fan-out ([`lock`](HostsGroup::lock) /
 //!   [`unlock`](HostsGroup::unlock) / [`update_lock`](HostsGroup::update_lock)),
 //!   over the per-[`Target`] [`TargetLock`](super::TargetLock),
@@ -91,7 +91,7 @@ pub struct HostsGroup {
     data: BTreeMap<String, Target>,
     /// Whether the surrounding session is interactive. Threaded through to the
     /// fan-out helpers as the (Phase 6) spinner/prompt seam; see
-    /// [`actions`](super::actions).
+    /// [`actions`].
     is_repl: bool,
     /// The injected update-workflow doer/check resolver, or `None` until the
     /// install/uninstall flow injects one.
@@ -237,7 +237,7 @@ impl HostsGroup {
     /// Reconciles the group's session mode to `is_repl` at **load time**.
     ///
     /// The report's targets group is default-built headless
-    /// ([`TestReportBase`](mtui_testreport docs)); the load site applies the real
+    /// (`TestReportBase` in `mtui-testreport`'s docs); the load site applies the real
     /// session mode once, before any host is added or fan-out runs, so the
     /// spinner/prompt seam matches the session. The session is the single source
     /// of truth; this is not a runtime toggle.
@@ -460,7 +460,7 @@ impl HostsGroup {
     ///
     /// `cmd` accepts a single string (run on every host) or a per-host
     /// [`Command::PerHost`] map (hosts absent from the map are skipped). See
-    /// [`RunCommand`].
+    /// `RunCommand`.
     pub async fn run(&mut self, cmd: impl Into<Command>) {
         let max_parallel = self.max_parallel;
         RunCommand::new(&mut self.data, cmd, self.is_repl)
@@ -647,7 +647,7 @@ impl HostsGroup {
     /// session exit; unlike [`reboot`](Self::reboot) it never reconnects.
     ///
     /// Fans out concurrently across the group via
-    /// [`run_fanout`](super::actions::run_fanout). The overall wait budget is
+    /// `run_fanout`. The overall wait budget is
     /// applied by the caller. A
     /// no-op when the group is empty.
     ///
@@ -690,7 +690,7 @@ impl HostsGroup {
     /// pool-claim lock when `pool` is `true` — via
     /// [`Target::lock_status`](Target::lock_status), then forward
     /// `(hostname, system, &row)` through the per-target
-    /// [`Reporter::locks`](crate::Reporter::locks) sink. `sink` is `FnMut` so it
+    /// `Reporter::locks` sink. `sink` is `FnMut` so it
     /// is invoked once per host. Async because each host's lock is read over
     /// SFTP; best-effort per host (a read failure resolves to the unlocked row
     /// rather than aborting the fan-out).
@@ -759,7 +759,7 @@ impl HostsGroup {
     /// by `update_flow::perform_prepare`), so the group never depends on the
     /// report crate.
     ///
-    /// Fans out concurrently via [`run_fanout`](super::actions::run_fanout):
+    /// Fans out concurrently via `run_fanout`:
     /// every host runs its repo change in
     /// parallel. The per-host `last*` state is left in place so a caller can
     /// inspect `lasterr()` after the fan-out (prepare aborts on `lasterr`).
@@ -826,7 +826,7 @@ impl HostsGroup {
     ///
     /// The I/O phase shared by [`package_check`](Self::package_check) and the
     /// downgrade verdict: fans [`Target::query_versions`] out through the shared
-    /// [`run_fanout`](super::actions::run_fanout) primitive in parallel, so the
+    /// `run_fanout` primitive in parallel, so the
     /// pure per-package bookkeeping that follows never blocks on I/O.
     pub async fn query_versions(&mut self) {
         let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
@@ -1008,12 +1008,12 @@ impl HostsGroup {
 
     /// Reboots only the named hosts and reconnects each, verifying the reboot.
     ///
-    /// * capture each host's [`boot_id`](Target::boot_id) *before* rebooting,
+    /// * capture each host's `boot_id` *before* rebooting,
     /// * dispatch `command` fire-and-forget on every host (the reboot drops the
     ///   connection),
     /// * reconnect each host (sorted) with the connection's retry + backoff,
     /// * verify each host's boot id changed (see
-    ///   [`verify_reboot`](Self::verify_reboot)),
+    ///   `verify_reboot`),
     /// * if `relock_comment` is non-empty, re-apply the lock across the group —
     ///   a reboot clears `/var/lock` (tmpfs), so an active lock (e.g. a Product
     ///   Increment testing lock) must be re-asserted to survive.

--- a/crates/mtui-hosts/src/target/locks.rs
+++ b/crates/mtui-hosts/src/target/locks.rs
@@ -114,7 +114,7 @@ pub struct RemoteLock {
 
 /// A resolved snapshot of a host's lock ownership, produced by
 /// [`Target::lock_status`](crate::Target::lock_status) and forwarded by the
-/// [`Reporter`](crate::Reporter)/[`HostsGroup`](crate::HostsGroup) lock sinks to
+/// `Reporter`/[`HostsGroup`](crate::HostsGroup) lock sinks to
 /// the display layer.
 ///
 /// The lock accessors are async `&mut self`; the resolving code does
@@ -140,7 +140,7 @@ pub struct LockRow {
 
 /// A single-read view of a lock's on-disk state plus derived ownership.
 ///
-/// Produced by [`TargetLock::snapshot`] / [`PoolLock::snapshot`] with **exactly
+/// Produced by `TargetLock::snapshot` / `PoolLock::snapshot` with **exactly
 /// one** remote read, so [`Target::lock_status`](crate::Target::lock_status) can
 /// derive every displayed field without re-reading the lockfile per field.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -219,7 +219,7 @@ impl RemoteLock {
         }
     }
 
-    /// Human-readable "locked by <user> (<comment>)." string.
+    /// Human-readable "locked by `<user>` (`<comment>`)." string.
     #[must_use]
     fn describe(&self) -> String {
         if self.comment.is_empty() {
@@ -346,7 +346,7 @@ impl<C: Clock> TargetLock<C> {
     /// Whether the host is currently locked (by anyone).
     ///
     /// # Errors
-    /// Propagates an SFTP error from [`load`](Self::load).
+    /// Propagates an SFTP error from `load`.
     pub async fn is_locked(&mut self) -> Result<bool> {
         self.load().await?;
         Ok(!self.lock.user.is_empty())

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -6,13 +6,13 @@
 //! This module owns only the **state machine over `Connection`**:
 //!
 //! * the per-host execution [`TargetState`] gate (enabled / disabled),
-//! * command execution via [`Target::run`] with the `-1` exit-code
+//! * command execution via `Target::run` with the `-1` exit-code
 //!   sentinel and never-propagate error handling,
 //! * the `last*` output accessors,
-//! * state-gated SFTP delegation ([`Target::sftp_put`] / [`Target::sftp_get`]),
+//! * state-gated SFTP delegation (`Target::sftp_put` / [`Target::sftp_get`]),
 //! * and [`Target::connect`], which establishes the transport and then applies
 //!   the post-connect ordering: system/product parse
-//!   ([`parse_system`](parsers::parse_system)) and package version query
+//!   ([`parse_system`]) and package version query
 //!   ([`Target::query_versions`]).
 //!
 //! The remaining responsibilities that this module does *not* own are
@@ -22,7 +22,7 @@
 //!   ([`TargetLock`]) and the pool-claim lock ([`PoolLock`]);
 //!   [`Target::connect`] builds both objects over the live connection and runs
 //!   the connect-time op-lock check + stale-reap
-//!   ([`check_stale_lock`](Target::check_stale_lock)),
+//!   (`check_stale_lock`),
 //! * reboot / reconnect lifecycle and the install/uninstall
 //!   [`Operation`] template drive their group through the object-safe
 //!   [`OperationGroup`] seam; the concrete `impl OperationGroup for HostsGroup`
@@ -111,7 +111,7 @@ pub struct Target {
     /// test injection) supplies one.
     connection: Option<Box<dyn Connection>>,
     /// The parsed host system (base product + addons). Defaults to an unknown
-    /// system until [`parse_system`](parsers::parse_system) populates it via
+    /// system until [`parse_system`] populates it via
     /// [`set_system`](Target::set_system); [`PackageQuerier`] reads it to choose
     /// the rpm-vs-dpkg query path.
     system: System,
@@ -392,7 +392,7 @@ impl Target {
     /// Sets the owning template's RRID, the [`PoolLock`] ownership identity.
     ///
     /// The report layer pushes the RRID down onto each target (see
-    /// [`HostsGroup::set_rrid`]) so a pool claim already built for a connected
+    /// `HostsGroup::set_rrid`) so a pool claim already built for a connected
     /// target adopts the identity too. The RRID is pushed down after the fact
     /// because the target is
     /// built before the report that owns it is known.
@@ -405,7 +405,7 @@ impl Target {
 
     /// Releases this target's pool claim, best-effort.
     ///
-    /// Delegates to [`PoolLock::unlock`]
+    /// Delegates to `PoolLock::unlock`
     /// (RRID-based ownership), swallowing a [`HostError::TargetLocked`] (the
     /// claim is owned by another template and `force` was not set) so a cleanup
     /// path never fails. A no-op when the target is not connected (no pool lock
@@ -429,7 +429,7 @@ impl Target {
     /// Claims this target's remote pool lock with `comment` (the
     /// `mtui pool <RRID> [<owner>]` stamp), returning whether the claim was won.
     ///
-    /// Delegates to [`PoolLock::try_claim`]
+    /// Delegates to `PoolLock::try_claim`
     /// (RRID-based ownership). `true` when this session now holds the remote
     /// claim (freshly won or already ours); `false` when another process holds
     /// it — the caller then drops the host so a sibling can be tried. A
@@ -692,7 +692,7 @@ impl Target {
     /// Records the parsed host system and its transactional flag.
     ///
     /// Called with the pair returned by
-    /// [`parse_system`](parsers::parse_system) once a connection is live; the
+    /// [`parse_system`] once a connection is live; the
     /// two values always move together (they are set in the same parse step).
     pub fn set_system(&mut self, system: System, transactional: bool) {
         self.system = system;
@@ -703,7 +703,7 @@ impl Target {
     /// the result.
     ///
     /// Driven by the `reload_products`
-    /// command: re-runs [`parse_system`](parsers::parse_system) and stores the
+    /// command: re-runs [`parse_system`] and stores the
     /// `(System, transactional)` pair via [`set_system`](Self::set_system). A
     /// no-op (logged) when the target is not connected; a parse failure is
     /// logged and the previously recorded system is left untouched, matching the
@@ -869,9 +869,9 @@ impl Target {
     /// Builds an [`SshConnection`] from the
     /// host/port/timeout/policy resolved at construction, builds the two
     /// remote locks over it, runs the connect-time lock check + stale-reap
-    /// ([`check_stale_lock`](Target::check_stale_lock)), then — in
+    /// (`check_stale_lock`), then — in
     /// post-dial ordering — parses the system/product
-    /// ([`parse_system`](parsers::parse_system)) and queries installed package
+    /// ([`parse_system`]) and queries installed package
     /// versions ([`Target::query_versions`]). If a connection is already
     /// attached (e.g. a test-injected
     /// [`MockConnection`](crate::MockConnection)), the dial + lock-building
@@ -893,7 +893,7 @@ impl Target {
     ///
     /// Propagates [`HostError::Connect`] / [`HostError::Auth`] from
     /// [`SshConnection::connect`] when the host is unreachable or auth fails, and
-    /// the last [`parse_system`](parsers::parse_system) error when the system
+    /// the last [`parse_system`] error when the system
     /// cannot be parsed after the retry budget is exhausted.
     pub async fn connect(&mut self) -> Result<()> {
         if self.connection.is_none() {

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -53,8 +53,8 @@ pub type HostCommandMap = Vec<(String, String)>;
 ///
 /// The templates store values interpolated via variable substitution. The
 /// only variable the install/uninstall command templates interpolate is
-/// `$packages`; the reboot template takes none. [`Doer::command`] performs that
-/// single substitution and [`Doer::reboot`] returns the reboot command verbatim.
+/// `$packages`; the reboot template takes none. `Doer::command` performs that
+/// single substitution and `Doer::reboot` returns the reboot command verbatim.
 /// Full `string.Template` parity (`$$`, `${name}`) is unnecessary here; the
 /// real doers are constructed by the [`PlanProvider`] implementation in
 /// `mtui-testreport`.

--- a/crates/mtui-hosts/src/target/repo_manager.rs
+++ b/crates/mtui-hosts/src/target/repo_manager.rs
@@ -5,7 +5,7 @@
 //! [`RepoManager`] collects the two repository-shape methods so [`Target`] can
 //! stay focused on the connection/lock skeleton:
 //!
-//! * [`set`](RepoManager::set) — the one-line forward into
+//! * `set` — the one-line forward into
 //!   `testreport.set_repo(target, operation)`; kept on the collaborator so
 //!   callers reach for `target.repo_manager().set(...)` instead of
 //!   `target.set_repo(...)`.
@@ -15,11 +15,11 @@
 //!   hosts). The unknown-cmd safeguard (force-unlock followed by an error) is
 //!   preserved.
 //!
-//! ## `&mut Target` vs the immutable [`Reporter`]
+//! ## `&mut Target` vs the immutable `Reporter`
 //!
-//! Unlike the sibling [`Reporter`](super::reporter::Reporter), which only
+//! Unlike the sibling `Reporter`, which only
 //! *reads* the target and so borrows it immutably, `RepoManager` must **mutate**
-//! the target: it issues commands ([`Target::run`]) and, on the unknown-cmd
+//! the target: it issues commands (`Target::run`) and, on the unknown-cmd
 //! safeguard path, force-unlocks it ([`Target::unlock`]). It therefore borrows
 //! `&mut Target`. Obtain one via [`Target::repo_manager`], which hands out a
 //! fresh binding over the live target each time.
@@ -46,10 +46,10 @@ use tracing::{debug, info, warn};
 
 use super::Target;
 
-/// Which repository change a [`set`](RepoManager::set) forwards: add or remove.
+/// Which repository change a `set` forwards: add or remove.
 ///
 /// Modelling them as a two-variant enum keeps the seam
-/// typed; [`as_str`](RepoOp::as_str) renders the wire token for a
+/// typed; `as_str` renders the wire token for a
 /// [`SetRepo`] implementer that wants it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepoOp {
@@ -70,7 +70,7 @@ impl RepoOp {
     }
 }
 
-/// The report-side hook a [`RepoManager::set`] forwards into — the injection
+/// The report-side hook a `RepoManager::set` forwards into — the injection
 /// point for `testreport.set_repo(target, operation)`.
 ///
 /// Object-safe (`&dyn SetRepo`) and `async` (the report's `set_repo` ultimately

--- a/crates/mtui-hosts/src/target/spinner.rs
+++ b/crates/mtui-hosts/src/target/spinner.rs
@@ -171,7 +171,7 @@ pub fn suspend() -> Suspend {
 /// A `Send` guard that pauses spinner painting across an `.await` (e.g. an
 /// interactive stdin read) without holding a non-`Send` [`std::sync::MutexGuard`].
 ///
-/// [`suspend_async`] erases any active frame and sets a paused flag the paint
+/// `suspend_async` erases any active frame and sets a paused flag the paint
 /// tasks honour; dropping this guard clears the flag so painting resumes on the
 /// next tick. Unlike [`Suspend`], nothing lock-guard-shaped is held for the
 /// guard's lifetime, so it is safe to keep alive across the await points of an
@@ -240,9 +240,9 @@ pub struct TtySpinner {
 static TEST_SINK: Mutex<Option<Sink>> = Mutex::new(None);
 
 /// Installs (or clears with `None`) the global test sink used by
-/// [`TtySpinner::new`]. When set, every default spinner is forced enabled and
+/// `TtySpinner::new`. When set, every default spinner is forced enabled and
 /// paints into `sink` instead of stderr. Test-only; guard concurrent use with
-/// [`TEST_SERIAL`](crate::target::spinner::TEST_SERIAL) in unit tests, or a
+/// `TEST_SERIAL` in unit tests, or a
 /// per-file convention in integration tests.
 pub fn set_test_sink(sink: Option<Sink>) {
     *TEST_SINK
@@ -483,7 +483,7 @@ impl Drop for SpinnerGuard {
 /// Runs a TTY spinner labelled `desc` for the returned guard's lifetime.
 ///
 /// The high-level counterpart to the fan-out spinner in
-/// [`run_parallel`](super::actions::run_parallel): wrap a long-running
+/// `run_parallel`: wrap a long-running
 /// *non-fan-out* operation (e.g. `regenerate`) by holding the returned
 /// [`SpinnerGuard`] across it. A strict no-op off a TTY, so it is safe in tests
 /// and over `mtui-mcp`. Dropping the guard stops the spinner and erases its

--- a/crates/mtui-mcp/src/capture.rs
+++ b/crates/mtui-mcp/src/capture.rs
@@ -3,7 +3,7 @@
 //! Commands write human-readable output to [`Session`]'s
 //! [`CommandPromptDisplay`]. The REPL points that at stdout; an MCP tool must
 //! instead *capture* it so it can be returned as the tool result. This module
-//! provides a shared in-memory sink and a [`session`] constructor that wires it
+//! provides a shared in-memory sink and a `session` constructor that wires it
 //! in via the public [`Session::with_display`] seam.
 //!
 //! ## Write-time cap (bead `mtui-rs-th4o.8`)
@@ -12,9 +12,9 @@
 //! overflow at write time, recording the dropped-byte count. A command that
 //! emits gigabytes (a huge fan-out `run` log) therefore never buffers more than
 //! `limit` bytes of it in memory — the cap applies before allocation, not after.
-//! [`SharedBuf::take_with_dropped`] returns the captured bytes plus the overflow
+//! `SharedBuf::take_with_dropped` returns the captured bytes plus the overflow
 //! count so [`crate::session::McpSession::run_command`] can append the same
-//! truncation notice [`crate::slim::cap_output`] would (exactly once, with a
+//! truncation notice `crate::slim::cap_output` would (exactly once, with a
 //! correct count). `limit == 0` disables the cap (the buffer is unbounded, the
 //! prior behaviour).
 
@@ -39,7 +39,7 @@ struct Inner {
 /// A cloneable handle to a command's captured output.
 ///
 /// Backed by an `Arc<Mutex<Inner>>` shared with the [`Session`]'s display sink.
-/// [`take`](SharedBuf::take) / [`take_with_dropped`](SharedBuf::take_with_dropped)
+/// [`take`](SharedBuf::take) / `take_with_dropped`
 /// atomically read and clear it, which is how each `call_tool` isolates its own
 /// output. Writes beyond `limit` are discarded and counted (see the module docs).
 #[derive(Clone, Default)]

--- a/crates/mtui-mcp/src/deny.rs
+++ b/crates/mtui-mcp/src/deny.rs
@@ -2,7 +2,7 @@
 //!
 //! Each entry cannot meaningfully run outside an interactive terminal session,
 //! and is filtered out when [`crate::tools`] synthesises tools from the command
-//! [`Registry`]. (Local process execution via `lrun` needs no denying: the
+//! [`mtui_core::Registry`]. (Local process execution via `lrun` needs no denying: the
 //! command was removed from mtui entirely.)
 //!
 //! The deny surface is **not** re-declared here: it is the single

--- a/crates/mtui-mcp/src/main.rs
+++ b/crates/mtui-mcp/src/main.rs
@@ -25,5 +25,5 @@ fn main() -> anyhow::Result<()> {
         "mtui-mcp was built without the `mcp` feature; rebuild with \
          `cargo build -p mtui-mcp --features mcp`."
     );
-    std::process::exit(2);
+    std::process::exit(mtui_core::ExitStatus::Usage.into());
 }

--- a/crates/mtui-mcp/src/profiles.rs
+++ b/crates/mtui-mcp/src/profiles.rs
@@ -10,7 +10,7 @@
 //! (every synthesised tool stays). The `core` profile keeps only the curated
 //! everyday subset in [`CORE`], removing the rest so they never reach the wire.
 //! An operator selects a profile with `[mcp] profile` and can fine-tune with
-//! `[mcp] tools_allow` / `[mcp] tools_deny` (see [`apply_profile`]).
+//! `[mcp] tools_allow` / `[mcp] tools_deny` (see `apply_profile`).
 //! Profiles only filter the surface remaining after the permanent MCP deny-list;
 //! `tools_allow` cannot restore a command such as `shell` that was never
 //! synthesised.
@@ -19,7 +19,7 @@
 //! surface is strictly opt-in.
 //!
 //! The tool surface is built from a plain
-//! `Vec<`[`ToolDescriptor`]`>`, so [`apply_profile`] simply filters that vec
+//! `Vec<`[`ToolDescriptor`]`>`, so `apply_profile` simply filters that vec
 //! before it is converted to `rmcp::model::Tool`s.
 
 use std::collections::BTreeSet;

--- a/crates/mtui-mcp/src/provider.rs
+++ b/crates/mtui-mcp/src/provider.rs
@@ -330,7 +330,7 @@ impl SessionRegistry {
     /// mid-sweep is spared) and removed from the live set under the lock, then the
     /// confirmed-stale set is [`McpSession::close`]d (best-effort, idempotent) to
     /// reclaim its SSH host connections. The closes run **concurrently under
-    /// [`sweep_parallel`](Self::sweep_parallel)** with a single per-cycle deadline,
+    /// `sweep_parallel`** with a single per-cycle deadline,
     /// so one wedged host teardown cannot serialize reclamation of the rest. Runs
     /// until `cancel` fires.
     ///

--- a/crates/mtui-mcp/src/runner.rs
+++ b/crates/mtui-mcp/src/runner.rs
@@ -1,7 +1,7 @@
 //! The `mtui-mcp` boot sequence: parse args → resolve config → serve.
 //!
 //! It parses [`McpArgs`], initialises a stderr `tracing` subscriber (under
-//! stdio, stdout is the JSON-RPC transport), resolves the [`Config`] the way
+//! stdio, stdout is the JSON-RPC transport), resolves the [`mtui_config::Config`] the way
 //! the REPL does, and
 //! serves the runtime-synthesised tool surface on the chosen transport:
 //!

--- a/crates/mtui-mcp/src/server.rs
+++ b/crates/mtui-mcp/src/server.rs
@@ -12,7 +12,7 @@
 //!
 //! * the `rmcp::model::Tool` list (command tools from [`build_tools`] + the four
 //!   job tools from [`job_tool_descriptors`]), each carrying a `readOnlyHint`;
-//! * the tool-name → [`ToolRoute`] map from [`tool_routes`], so a call dispatches
+//! * the tool-name → [`ToolRoute`] map from `tool_routes`, so a call dispatches
 //!   through the *same* engine entry the REPL uses.
 //!
 //! Deny-listed commands never enter the surface — [`build_tools`]

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -17,12 +17,12 @@
 //! P7.3 landed the dispatch primitive: `run_command`, the [`McpCommandError`]
 //! failure envelope, and the per-result output cap (`[mcp] max_output_bytes`).
 //! The non-interactive contract (`interactive = false`, unset prompter) is
-//! already provided by [`capture::session`] passing `is_repl = false`.
+//! already provided by `capture::session` passing `is_repl = false`.
 //!
 //! P7.3a (`mtui-rs-76e.11`) landed the per-template **lock discipline**: a
 //! shared/exclusive registry gate ([`crate::concurrency::RwGate`]) plus a
 //! lazily-created per-RRID lock map.
-//! [`command_lock`](McpSession::command_lock) takes the gate *shared* + one
+//! `command_lock` takes the gate *shared* + one
 //! per-RRID lock for a single-template call (so same-RRID calls serialise and
 //! different-RRID calls take distinct locks) and the gate *exclusive* for
 //! fan-out / registry mutators; [`scoped_lock`](McpSession::scoped_lock) is the
@@ -60,9 +60,9 @@
 //! `[mcp] max_output_bytes` before the cap applies.
 //!
 //! P7.3d (`mtui-rs-76e.14`) landed the `notifications/progress` **heartbeats**:
-//! a long-running foreground tool call ([`run_command_with_progress`]) races the
+//! a long-running foreground tool call (`run_command_with_progress`) races the
 //! dispatch against a ticker that emits a progress frame every
-//! [`DEFAULT_PROGRESS_INTERVAL`] against a transport-free [`ProgressSink`], so an
+//! `DEFAULT_PROGRESS_INTERVAL` against a transport-free [`ProgressSink`], so an
 //! MCP client that honours the protocol's progress contract does not time out on
 //! `run`/`update`/`set_repo`/`commit`. The rmcp-backed sink (peer +
 //! `progressToken`) is built in [`crate::server`] from the request context; this
@@ -72,7 +72,7 @@
 //! teardown the http `SessionRegistry` (P7.10 / `mtui-rs-odq8`) calls on
 //! eviction. For **every** loaded template it releases the report's pool claims
 //! then disconnects its host group, best-effort + idempotent, under a bounded
-//! [`DISCONNECT_TIMEOUT`] so a wedged host close cannot block the idle-sweep.
+//! `DISCONNECT_TIMEOUT` so a wedged host close cannot block the idle-sweep.
 //! It does not empty each `HostsGroup` (a closed `Target` is left in the group
 //! with a dead connection, dropped whole with the report) and it bounds the
 //! wait with [`tokio::time::timeout`].
@@ -247,9 +247,9 @@ impl std::error::Error for McpCommandError {}
 pub enum JobState {
     /// The worker task is still executing (or queued behind its lock).
     Running,
-    /// The command finished successfully; its stdout is in [`Job::result`].
+    /// The command finished successfully; its stdout is in `Job::result`.
     Done,
-    /// The command failed; [`Job::error`]/[`Job::exit_code`] carry the envelope.
+    /// The command failed; `Job::error`/`Job::exit_code` carry the envelope.
     Failed,
     /// The job was cancelled via [`McpSession::job_cancel`].
     Cancelled,
@@ -301,7 +301,7 @@ struct Job {
     cancel: CancellationToken,
 }
 
-/// A public, poll-facing snapshot of a [`Job`] (no task handle).
+/// A public, poll-facing snapshot of a `Job` (no task handle).
 ///
 /// The job tools render it into the one-line status text.
 #[derive(Debug, Clone, PartialEq)]
@@ -395,7 +395,7 @@ pub struct McpSession {
 
 /// An acquired hold on the concurrency gate for one command/tool invocation.
 ///
-/// Returned by [`McpSession::command_lock`] / [`McpSession::scoped_lock`] and
+/// Returned by `McpSession::command_lock` / [`McpSession::scoped_lock`] and
 /// kept alive for the duration of the critical section; dropping it releases the
 /// gate (and any per-RRID lock) in the right order. The fields are never read —
 /// they exist to own the guards — hence the leading underscores.
@@ -420,7 +420,7 @@ impl McpSession {
     /// out).
     ///
     /// The session is non-interactive with color disabled — see
-    /// [`capture::session`].
+    /// `capture::session`.
     #[must_use]
     pub fn new(config: Config) -> Arc<Self> {
         let max_output_bytes = config.mcp_max_output_bytes;
@@ -475,7 +475,7 @@ impl McpSession {
     ///
     /// Exposed for the hand-written testreport tools ([`crate::testreport_tools`]),
     /// which cap their file-content payloads with the same
-    /// [`cap_output`](crate::slim::cap_output) budget `run_command` applies.
+    /// [`cap_output`] budget `run_command` applies.
     #[must_use]
     pub(crate) fn max_output_bytes(&self) -> usize {
         self.max_output_bytes
@@ -613,7 +613,7 @@ impl McpSession {
     /// Owned by the http `SessionRegistry` (P7.10 / `mtui-rs-odq8`), which calls
     /// it when it evicts a session (idle-TTL sweep or explicit eviction).
     /// Mirrors the REPL `quit`
-    /// disconnect path — [`HostsGroup::close`](mtui_hosts::HostsGroup::close) per
+    /// disconnect path — `HostsGroup::close` per
     /// template, its per-host `Target::close` fanning out concurrently — but
     /// **without** the exit-flag / history-flush tail, since the process keeps
     /// serving other clients.
@@ -628,7 +628,7 @@ impl McpSession {
     /// remote pool locks; a no-op when pool selection was never used) then closes
     /// its host group. A second call re-runs both over already-released claims and
     /// already-closed targets, both no-ops. The fan-out is bounded by
-    /// [`DISCONNECT_TIMEOUT`]: a wedged host close is logged and abandoned so
+    /// `DISCONNECT_TIMEOUT`: a wedged host close is logged and abandoned so
     /// `close()` — and the registry idle-sweep awaiting it — always returns.
     ///
     /// `HostsGroup::close` (like the REPL `quit`) closes each `Target` but leaves
@@ -690,10 +690,10 @@ impl McpSession {
     /// the **same** engine the REPL uses (a forked-session [`dispatch_command`] on the
     /// concurrent path, [`dispatch_argv`] on the canonical session for the
     /// exclusive path), then returns what the command wrote to the call's own
-    /// captured display — passed through [`cap_output`] so one large result cannot
+    /// captured display — passed through `cap_output` so one large result cannot
     /// dwarf the client's context.
     ///
-    /// Before dispatch the call takes its [`command_lock`](Self::command_lock):
+    /// Before dispatch the call takes its `command_lock`:
     /// a single-template call holds the registry gate *shared* plus its per-RRID
     /// lock (so same-RRID calls serialise, different-RRID calls take distinct
     /// locks), while fan-out / mutators take the gate *exclusive*. A single-RRID
@@ -1093,7 +1093,7 @@ impl McpSession {
     /// # Errors
     ///
     /// [`McpCommandError`] (exit 1) when the session is already at
-    /// [`max_active_jobs`](Self::max_active_jobs) running jobs; no worker is
+    /// `max_active_jobs` running jobs; no worker is
     /// spawned in that case.
     pub fn start_job(
         self: &Arc<Self>,
@@ -1112,7 +1112,7 @@ impl McpSession {
     ///
     /// Resolves the target templates
     /// exactly as the foreground path does (via
-    /// [`resolve_job_rrids`](Self::resolve_job_rrids)). When more than one
+    /// `resolve_job_rrids`). When more than one
     /// template resolves, mints **one job per template** — each running `argv`
     /// scoped to that template with `-T <rrid>` **prepended** (a positional
     /// `REMAINDER` command like `run` would otherwise swallow a trailing
@@ -1124,7 +1124,7 @@ impl McpSession {
     /// # Errors
     ///
     /// [`McpCommandError`] (exit 1) when spawning the resolved jobs would breach
-    /// [`max_active_jobs`](Self::max_active_jobs); the whole fan-out is rejected
+    /// `max_active_jobs`; the whole fan-out is rejected
     /// atomically (no partial spawn).
     pub async fn start_jobs(
         self: &Arc<Self>,
@@ -1242,7 +1242,7 @@ impl McpSession {
     ///    so a dispatch parked at a seam checkpoint (the `Command::run` driver's
     ///    pre-flight / between-templates checks, or a body observing
     ///    [`mtui_core::Session::cancel_requested`]) unwinds cleanly. The worker
-    ///    gets [`CANCEL_GRACE`] to settle.
+    ///    gets `CANCEL_GRACE` to settle.
     /// 2. **Forced:** if the grace elapses (the body never checks the seam —
     ///    e.g. it is blocked mid host-op), the worker task is aborted. The
     ///    underlying SSH/subprocess operation may still run to completion on

--- a/crates/mtui-mcp/src/slim.rs
+++ b/crates/mtui-mcp/src/slim.rs
@@ -2,16 +2,16 @@
 //!
 //! Two token-budget concerns live here, co-located:
 //!
-//! * [`cap_output`] — the per-tool-result byte bound.
-//! * [`slim_tool_schema`] — the JSON-Schema slimming pass (P7.9) that drops
+//! * `cap_output` — the per-tool-result byte bound.
+//! * `slim_tool_schema` — the JSON-Schema slimming pass (P7.9) that drops
 //!   redundant `title` keys, flattens `anyOf: [{type: X}, {type: null}]` unions,
 //!   and terse-rewrites the long shared `help` strings before the tool list goes
 //!   on the wire.
 //!
-//! The schema is built directly from `clap` by [`crate::schema`], so it never
+//! The schema is built directly from `clap` by `crate::schema`, so it never
 //! emits a `title` key and renders a nullable scalar as the
 //! `anyOf: [{type: X}, {type: null}]` shape via
-//! [`crate::schema::command_input_schema`]'s `wrap_nullable`. The `title`-drop is
+//! `crate::schema::command_input_schema`'s `wrap_nullable`. The `title`-drop is
 //! therefore mostly defensive here; the substantive wins are the nullable
 //! flatten and the terse descriptions. The transforms run on the plain
 //! [`ToolDescriptor`](crate::tools::ToolDescriptor) schema `Value`s in

--- a/crates/mtui-mcp/src/testreport_tools.rs
+++ b/crates/mtui-mcp/src/testreport_tools.rs
@@ -4,15 +4,15 @@
 //! but the REPL `edit` command
 //! spawns `$EDITOR` on `metadata.path` — meaningless under MCP (and hence
 //! deny-listed). This module replaces it with five explicit tools that operate
-//! directly on the file path tracked by the loaded [`TestReport`]:
+//! directly on the file path tracked by the loaded [`mtui_testreport::TestReport`]:
 //!
-//! * [`testreport_read`] — return a checkout file's content plus a line count
+//! * `testreport_read` — return a checkout file's content plus a line count
 //!   (defaults to the `log` file; `relpath` reads any other checkout file,
 //!   traversal-guarded; `offset`/`limit` page a 1-indexed line window).
-//! * [`testreport_logs`] — list the `build_checks/` and `install_logs/` files.
-//! * [`testreport_patch`] — splice an inclusive 1-indexed line range, atomically.
-//! * [`testreport_write`] — full-file atomic overwrite.
-//! * [`testreport_fill`] — bulk-set the repetitive per-bug placeholder tokens an
+//! * `testreport_logs` — list the `build_checks/` and `install_logs/` files.
+//! * `testreport_patch` — splice an inclusive 1-indexed line range, atomically.
+//! * `testreport_write` — full-file atomic overwrite.
+//! * `testreport_fill` — bulk-set the repetitive per-bug placeholder tokens an
 //!   exported testreport ships with, idempotently.
 //!
 //! ## Locking
@@ -35,7 +35,7 @@
 //! ## Progress heartbeats (bead `mtui-rs-76e.14`)
 //!
 //! [`dispatch_testreport_tool`] races the tool body against the same heartbeat as
-//! the auto-generated command tools (via [`run_with_heartbeat`]) when the client
+//! the auto-generated command tools (via `run_with_heartbeat`) when the client
 //! supplied a `progressToken`, so a slow file op (a large `testreport_read`/
 //! `testreport_write`) does not time the client out. The frames carry the tool
 //! name; a `None` sink takes the zero-overhead path.

--- a/crates/mtui-mcp/src/tools.rs
+++ b/crates/mtui-mcp/src/tools.rs
@@ -6,7 +6,7 @@
 //! * **name** is the command name (e.g. `run`);
 //! * **description** is the command's [`about`](mtui_core::Command::about);
 //! * **`input_schema`** is derived from the command's built `clap` parser via
-//!   [`crate::schema::command_input_schema`];
+//!   `crate::schema::command_input_schema`;
 //! * **`read_only`** hint is set conservatively from a name allow-list.
 //!
 //! The subparser command (`config` today) is fanned out into one tool per
@@ -16,9 +16,9 @@
 //!
 //! This layer is intentionally **transport-free**: it returns plain descriptors
 //! and routes, not `rmcp` types. P7.7 converts a [`ToolDescriptor`] into an
-//! `rmcp::model::Tool` and wires [`dispatch_tool`] into the `ServerHandler`.
+//! `rmcp::model::Tool` and wires `dispatch_tool` into the `ServerHandler`.
 //!
-//! The background-job path ([`dispatch_tool`] with `background = true`, and the
+//! The background-job path (`dispatch_tool` with `background = true`, and the
 //! four job tools from [`job_tool_descriptors`]) drives the session's `_jobs`
 //! table (bead `mtui-rs-76e.12`): a `background=true` slow call fans out one job
 //! per resolved template and returns their ids immediately, and the four job
@@ -86,7 +86,7 @@ pub struct ToolDescriptor {
 /// How a tool name routes back to the engine when called.
 ///
 /// Built in the same pass as the descriptors so a tool's schema and its dispatch
-/// can never diverge. [`dispatch_tool`] consumes it.
+/// can never diverge. `dispatch_tool` consumes it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolRoute {
     /// The registry command name to dispatch (`config` for `config_show`).
@@ -380,7 +380,7 @@ fn started_jobs_reply(command: &str, job_ids: &[String]) -> String {
 /// Their names and schemas are a downstream contract (see `AGENTS.md`) and are
 /// snapshot-tested; the schemas are strict (`additionalProperties: false`) so a
 /// misspelled field is a clean error rather than a silently ignored argument.
-/// [`dispatch_job_tool`] routes them onto the session's job table.
+/// `dispatch_job_tool` routes them onto the session's job table.
 #[must_use]
 pub fn job_tool_descriptors() -> Vec<ToolDescriptor> {
     let job_id_schema = || {

--- a/crates/mtui-testreport/src/export/downloader.rs
+++ b/crates/mtui-testreport/src/export/downloader.rs
@@ -17,7 +17,7 @@
 //! ## Fetch seam
 //!
 //! HTTP is abstracted behind the [`BytesFetcher`] trait so the exporters inject
-//! an [`HttpClient`]-backed fetcher while tests inject a mock.
+//! an [`HttpClient`](mtui_datasources::http::HttpClient)-backed fetcher while tests inject a mock.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/mtui-testreport/src/lifecycle.rs
+++ b/crates/mtui-testreport/src/lifecycle.rs
@@ -8,7 +8,7 @@
 //! * The actual host connect is **deferred to the caller** (the composition
 //!   root, `mtui-core::Session::load_update`), which owns the arbiter wiring and
 //!   the refhosts-from-testplatform resolution. `make_testreport` only records
-//!   the intent via [`TestReportBase::autoconnect_pending`].
+//!   the intent via [`TestReportBase::autoconnect_pending`](crate::testreport::TestReportBase::autoconnect_pending).
 //! * The QEM Dashboard / auto-openQA enrichment runs inside `make_testreport`
 //!   for the `-a` (auto) kind: it builds the [`QemIncident`], runs
 //!   [`DashboardAutoOpenQA`], and — when the auto result has no install jobs
@@ -33,7 +33,7 @@ use crate::testreport::{HashCheck, ReadError, TestReport};
 /// autoconnect defaults on.
 ///
 /// The distinction between the `-a` (auto) and `-k` (kernel) update kinds:
-/// the concrete `TestReport` class is chosen by RRID kind ([`tr_factory`]),
+/// the concrete `TestReport` class is chosen by RRID kind (`tr_factory`),
 /// but the *workflow* and *autoconnect default* come from the update kind
 /// the operator named on the command line.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +73,7 @@ fn tr_factory(update: &UpdateID, config: Config) -> Box<dyn TestReport + Send + 
 /// A [`NullReport`] carrying the reason its load failed.
 ///
 /// The load-failure substitute [`make_testreport`] returns instead of a real
-/// report. The reason is stashed on [`TestReportBase::load_error`] so the caller
+/// report. The reason is stashed on [`TestReportBase::load_error`](crate::testreport::TestReportBase::load_error) so the caller
 /// (`Session::load_update` → `load_template`) can surface *why* the load failed
 /// rather than a bare "could not load".
 fn null_with_error(config: Config, reason: String) -> NullReport {
@@ -84,8 +84,8 @@ fn null_with_error(config: Config, reason: String) -> NullReport {
 
 /// Builds and populates a [`TestReport`] for `update`.
 ///
-/// 1. Selects the report class by RRID kind ([`tr_factory`]).
-/// 2. Drives [`checkout_and_read`]: reads `template_dir/<rrid>/log`; a missing
+/// 1. Selects the report class by RRID kind (`tr_factory`).
+/// 2. Drives [`checkout_and_read`](crate::checkout::checkout_and_read): reads `template_dir/<rrid>/log`; a missing
 ///    template triggers a `svn` checkout and one retry.
 /// 3. On a load failure returns a [`NullReport`], so the caller can add a
 ///    benign inactive template rather than propagate an error.
@@ -100,7 +100,7 @@ fn null_with_error(config: Config, reason: String) -> NullReport {
 ///    **downgraded to [`Workflow::Manual`]**.
 ///
 /// `autoconnect` is the caller's explicit choice. A reference-host connect is
-/// deferred (via [`TestReportBase::autoconnect_pending`], honoured by the
+/// deferred (via [`TestReportBase::autoconnect_pending`](crate::testreport::TestReportBase::autoconnect_pending), honoured by the
 /// composition root *after* wiring the host arbiter) **only** when
 /// `autoconnect` is `true` **and** the auto load downgraded to `MANUAL`. The
 /// auto happy-path (workflow stays `AUTO`) and the kernel kind never

--- a/crates/mtui-testreport/src/metadata_parsers.rs
+++ b/crates/mtui-testreport/src/metadata_parsers.rs
@@ -151,14 +151,14 @@ pub struct MetadataEnvelope {
 
 /// A parser for the JSON metadata envelope.
 ///
-/// Stateless; [`parse`](JSONParser::parse) mutates the supplied
+/// Stateless; `parse` mutates the supplied
 /// [`TestReportBase`] in place.
 pub struct JSONParser;
 
 impl JSONParser {
     /// Parses a raw JSON string into a [`MetadataEnvelope`] and applies it.
     ///
-    /// Convenience wrapper over [`parse`](JSONParser::parse) for the common case
+    /// Convenience wrapper over `parse` for the common case
     /// of loading straight from a `metadata.json`.
     ///
     /// # Errors
@@ -240,7 +240,7 @@ impl JSONParser {
 /// Maps `issue id -> title` from a checkout's `patchinfo.xml`.
 ///
 /// The JSON metadata envelope carries only bare bug/jira *ids* (their
-/// descriptions are the [`NO_DESCRIPTION`] placeholder); the human-readable
+/// descriptions are the `NO_DESCRIPTION` placeholder); the human-readable
 /// titles live in the checkout's `patchinfo.xml` as
 /// `<issue tracker="bnc" id="123">title</issue>` elements.
 ///

--- a/crates/mtui-testreport/src/reports/obs.rs
+++ b/crates/mtui-testreport/src/reports/obs.rs
@@ -2,7 +2,7 @@
 //!
 //! Keys its identity on the parsed [`RequestReviewID`] and derives its
 //! update-repo map by parsing the OBS/IBS checkout's `project.xml` via
-//! [`obsrepoparse`](super::repoparse::obsrepoparse), reading the checkout under
+//! [`obsrepoparse`], reading the checkout under
 //! [`report_wd`](TestReportBase::report_wd). OBS is checked out with
 //! `osc qam` / SVN (not Gitea), so there is no git commit to verify —
 //! [`check_hash`](TestReport::check_hash) is the constant `(true, "", "")`.
@@ -10,7 +10,7 @@
 //! ## Scope (task nbv.11)
 //!
 //! Mirrors the `SlReport`/`PiReport` boundaries:
-//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`]) is
+//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses the OBS-specific
 //!   `-n ar -ckn` (note: no `fG`, unlike SL/PI), remove uses `-n rr`.
 //! * `list_update_commands` would render per-host commands via

--- a/crates/mtui-testreport/src/reports/pi.rs
+++ b/crates/mtui-testreport/src/reports/pi.rs
@@ -2,7 +2,7 @@
 //!
 //! Keys its identity on the parsed [`RequestReviewID`] and derives its
 //! update-repo map by delegating unconditionally to
-//! [`reporepoparse`](super::repoparse::reporepoparse) — the simplest of the
+//! [`reporepoparse`] — the simplest of the
 //! concrete reports, reusing the same helper as
 //! [`SlReport`](super::sl::SlReport). PI has no git commit to verify, so
 //! [`check_hash`](TestReport::check_hash) is a constant `(true, "", "")`.
@@ -10,7 +10,7 @@
 //! ## Scope (task nbv.12)
 //!
 //! Mirrors the `SlReport` boundaries:
-//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`]) is
+//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses `-n ar -cfGkn` (same as
 //!   SL), remove uses `-n rr`.
 //! * `list_update_commands` would render per-host commands via

--- a/crates/mtui-testreport/src/reports/sl.rs
+++ b/crates/mtui-testreport/src/reports/sl.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Scope
 //!
-//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`]) is
+//! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses `-n ar -cfGkn`, remove
 //!   uses `-n rr`, both fanned out over [`TestReportBase::update_repos`].
 //! * `list_update_commands` would render per-host commands via

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -4,7 +4,7 @@
 //! ## Design
 //!
 //! Unlike install/uninstall (which route through the shared
-//! [`Operation`](mtui_hosts::Operation) template), these three are deliberately
+//! [`Operation`] template), these three are deliberately
 //! open-coded — they have per-package loops, `set_repo` add/remove
 //! fan-outs, package-version comparison, and (for `update`) a two-phase
 //! try/finally that guarantees repo cleanup on success while **keeping** the
@@ -384,12 +384,12 @@ fn host_command_failures(targets: &HostsGroup, reason: &str) -> Vec<UpdateError>
 /// The shared body behind every report's `perform_install`. Injects the
 /// [`WorkflowRegistry`] as the group's
 /// [`PlanProvider`](mtui_hosts::PlanProvider) and drives the
-/// [`InstallOperation`](mtui_hosts::InstallOperation) template, whose own
+/// [`InstallOperation`] template, whose own
 /// per-host [`Check`](mtui_hosts::Check) — also adapted from this registry —
 /// now produces the verdict, before the (possible) reboot.
 ///
 /// Injecting here rather than where the group is built is deliberate:
-/// [`OperationGroup::plans`](mtui_hosts::OperationGroup::plans) has exactly one
+/// [`OperationGroup::plans`] has exactly one
 /// consumer — the template these two functions drive — so this is the one place
 /// that cannot forget. Construction sites can: for the whole life of the Rust
 /// port none of them injected a provider, so `plans()` failed with
@@ -514,7 +514,7 @@ fn reboot_error(failure: RebootFailure) -> UpdateError {
     UpdateError::new(format!("{what} ({})", failure.reason), failure.host)
 }
 
-/// Turns an [`Operation::run`](mtui_hosts::Operation::run) start failure into a
+/// Turns an [`Operation::run`] start failure into a
 /// message that names the hosts responsible.
 ///
 /// `plans()` aborts on the first host it cannot resolve and reports only the

--- a/crates/mtui-testreport/src/support/filelist.rs
+++ b/crates/mtui-testreport/src/support/filelist.rs
@@ -8,9 +8,9 @@
 //! A hash of the content captured at load time is tracked so a write can be
 //! skipped when nothing changed:
 //!
-//! * [`FileList::is_dirty`] reports whether the buffer differs from what was
+//! * `FileList::is_dirty` reports whether the buffer differs from what was
 //!   loaded, and
-//! * [`FileList::write_if_dirty`] performs the conditional atomic write.
+//! * `FileList::write_if_dirty` performs the conditional atomic write.
 //!
 //! [`FileList::write`] always writes unconditionally.
 

--- a/crates/mtui-testreport/src/support/fileops.rs
+++ b/crates/mtui-testreport/src/support/fileops.rs
@@ -1,6 +1,6 @@
 //! File and time helpers shared by the exporters.
 //!
-//! * [`timestamp`] — a whole-second Unix timestamp string, used as a
+//! * `timestamp` — a whole-second Unix timestamp string, used as a
 //!   filename suffix when the user declines to overwrite an existing export.
 //! * [`atomic_write_file`] — a thin wrapper over [`mtui_config::atomic::write`],
 //!   the single secure temp-file + rename implementation shared across the

--- a/crates/mtui-testreport/src/support/sysinfo.rs
+++ b/crates/mtui-testreport/src/support/sysinfo.rs
@@ -66,7 +66,7 @@ fn extract_quoted(content: &str, key: &str) -> Option<String> {
 /// Formats the system-information footer line (trailing `\n` included).
 ///
 /// Shape: `"{prefix} MTUI:{mtui_version} on {distro}-{verid} (kernel: {kernel})
-/// by {user}\n"`. The `prefix` defaults to [`EXPORT_PREFIX`] for the export
+/// by {user}\n"`. The `prefix` defaults to `EXPORT_PREFIX` for the export
 /// footer; the `commit` command passes `"committed from"`.
 #[must_use]
 pub fn system_info(distro: &str, verid: &str, kernel: &str, user: &str, prefix: &str) -> String {

--- a/crates/mtui-testreport/src/testreport.rs
+++ b/crates/mtui-testreport/src/testreport.rs
@@ -155,7 +155,7 @@ impl TestReportBase {
     /// The
     /// targets [`HostsGroup`] starts headless (`is_repl = false`); the load site
     /// ([`make_testreport`](crate::make_testreport)) reconciles it to the
-    /// session mode once, via [`set_is_repl`](Self::set_is_repl), before the
+    /// session mode once, via [`set_is_repl`](HostsGroup::set_is_repl), before the
     /// report is handed to the session — the session is the single source of
     /// truth and the flag is never mutated afterwards.
     #[must_use]
@@ -204,7 +204,7 @@ impl TestReportBase {
     /// [`obsrepoparse`](crate::reports::repoparse::obsrepoparse), which reads
     /// `project.xml` from it.
     ///
-    /// Returns [`io::ErrorKind::NotFound`] when no report is loaded, and
+    /// Returns [`std::io::ErrorKind::NotFound`] when no report is loaded, and
     /// propagates any directory-creation error, so callers can degrade
     /// explicitly rather than panic.
     ///
@@ -418,7 +418,7 @@ pub trait TestReport {
     /// The per-host analogue of
     /// [`release_pool_claims`](Self::release_pool_claims), called from
     /// `remove_host` so a disconnected refhost does not stay claimed in the
-    /// process-global [`HostArbiter`](mtui_hosts::HostArbiter) for the rest of
+    /// process-global [`HostArbiter`] for the rest of
     /// the server's lifetime (there is no `unload` over MCP, so the template
     /// stays loaded). [`Target::close`](mtui_hosts::Target::close) already drops
     /// the remote operation/pool-lock files; this clears the in-process

--- a/crates/mtui-testreport/src/update_workflow/actions/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/mod.rs
@@ -4,7 +4,7 @@
 //! ## Reference
 //!
 //! Each action's templates are keyed by `(release, transactional)` and
-//! resolved through [`crate::update_workflow::substitute`], preserving `$$`
+//! resolved through `substitute`, preserving `$$`
 //! escaping and `${}` bracing (see [`template`] docs).
 //!
 //! The value type is [`ActionCommands`]: an owning bundle of the command
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 
 use crate::update_workflow::template::{TemplateError, safe_substitute, substitute};
 
-/// Whether a template is rendered with strict [`substitute`] or lenient
-/// [`safe_substitute`] semantics.
+/// Whether a template is rendered with strict `substitute` or lenient
+/// `safe_substitute` semantics.
 ///
 /// `install` / `uninstall` / `prepare` use [`Strict`](SubstMode::Strict);
 /// `update` / `downgrade` use [`Safe`](SubstMode::Safe) because their templates
@@ -53,7 +53,7 @@ impl SubstMode {
 /// The command templates for one resolved action.
 ///
 /// `command` is always present; the remaining fields are optional and used
-/// only by specific actions. [`mode`](Self::mode) records whether the
+/// only by specific actions. `mode` records whether the
 /// action's call site uses [`Strict`](SubstMode::Strict) or
 /// [`Safe`](SubstMode::Safe) substitution.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/mtui-testreport/src/update_workflow/template.rs
+++ b/crates/mtui-testreport/src/update_workflow/template.rs
@@ -11,25 +11,25 @@
 //! * `$$`            → a single literal `$`,
 //! * `$name`         → the value of `name` (identifier = `[A-Za-z_][A-Za-z0-9_]*`),
 //! * `${name}`       → the value of `name`,
-//! * a missing key   → [`TemplateError::MissingKey`] ([`substitute`] only,
-//!   not [`safe_substitute`]),
+//! * a missing key   → [`TemplateError::MissingKey`] (`substitute` only,
+//!   not `safe_substitute`),
 //! * a malformed `$` (e.g. `$` at end of string, `$1`, `${}`, unterminated
 //!   `${`) → [`TemplateError::Invalid`].
 //!
-//! [`substitute`] and [`safe_substitute`] serve different call sites: the
-//! `install`, `uninstall`, and `prepare` call sites use [`substitute`] (raise
+//! `substitute` and `safe_substitute` serve different call sites: the
+//! `install`, `uninstall`, and `prepare` call sites use `substitute` (raise
 //! on a missing key / malformed `$`), while `update` and `downgrade` use
-//! [`safe_substitute`] (leave a missing key or malformed `$` untouched). The
+//! `safe_substitute` (leave a missing key or malformed `$` untouched). The
 //! distinction matters: the `update`/`downgrade` templates embed shell/awk
 //! `$`-tokens — `$2` awk fields and `$$r`-style escapes — that only
-//! [`safe_substitute`] tolerates alongside the real `$repa` / `$package`
+//! `safe_substitute` tolerates alongside the real `$repa` / `$package`
 //! placeholders.
 
 use std::collections::HashMap;
 
 use thiserror::Error;
 
-/// Errors raised by [`substitute`].
+/// Errors raised by `substitute`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum TemplateError {
     /// A `$name` / `${name}` referenced a key not present in the mapping.

--- a/crates/mtui-types/src/enums.rs
+++ b/crates/mtui-types/src/enums.rs
@@ -114,7 +114,7 @@ impl FromStr for Workflow {
 /// Kind component of an OBS Request Review ID.
 ///
 /// The canonical wire values are `SLFO` / `Maintenance` / `PI`;
-/// [`RequestKind::from_token`] also accepts the single-letter CLI aliases
+/// `RequestKind::from_token` also accepts the single-letter CLI aliases
 /// `S` / `M` / `P`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RequestKind {

--- a/crates/mtui-types/src/rrid.rs
+++ b/crates/mtui-types/src/rrid.rs
@@ -17,7 +17,7 @@
 //!
 //! 1. **project** — one of `SUSE` / `S`; the short form `S` normalises to `SUSE`.
 //! 2. **kind** — one of `SLFO` / `S` / `Maintenance` / `M` / `PI` / `P`, mapped
-//!    to a [`RequestKind`] via [`RequestKind::from_token`].
+//!    to a [`RequestKind`] via `RequestKind::from_token`.
 //! 3. **maintenance_id** — any non-empty token (an integer, or a string
 //!    fallback, so every non-empty token parses). Stored as the raw token
 //!    string.

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -19,6 +19,7 @@ dev box runs a Homebrew `rustc`). Edition 2024, **MSRV 1.96**, pinned via
 | Run the MCP server | `cargo run -p mtui-mcp --features mcp -- --help` |
 | Format | `cargo fmt --all` |
 | Lint (warnings are errors) | `cargo clippy --workspace --all-targets -- -D warnings` |
+| Docs (broken/private links are errors) | `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items` |
 | Test | `cargo test --workspace` |
 | Coverage | `cargo llvm-cov --workspace --lcov --output-path lcov.info` |
 
@@ -39,6 +40,7 @@ claiming done:
 ```sh
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items
 cargo test --workspace                       # default features only
 cargo build --workspace --no-default-features # feature matrix (compile-only)
 cargo build --workspace --all-features        # feature matrix (compile-only)

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -83,7 +83,7 @@ pub const CLI_REFERENCE_FILE: &str = "cli.md";
 /// long help of the *exact* per-command clap parser [`mtui_core::command_parser`]
 /// builds (the same parser real REPL/MCP dispatch uses), so the reference never
 /// drifts from the actual arg surface. Deterministic: help is rendered at a
-/// fixed [`CLI_TERM_WIDTH`] and the parser version is pinned to the crate
+/// fixed `CLI_TERM_WIDTH` and the parser version is pinned to the crate
 /// version, so the output is stable and committable.
 #[must_use]
 pub fn render_cli_reference() -> String {
@@ -162,9 +162,9 @@ pub const INVOCATION_REFERENCE_FILE: &str = "invocation.md";
 /// this documents how the *binaries* are launched: their flags, and the fact that
 /// `mtui` is REPL-only (there is no positional single-command mode — headless
 /// single-command dispatch is `mtui-mcp`'s job). Deterministic: help is rendered
-/// at a fixed [`CLI_TERM_WIDTH`] and the version is pinned to the crate version
+/// at a fixed `CLI_TERM_WIDTH` and the version is pinned to the crate version
 /// (the live parsers carry the build-provenance `MTUI_LONG_VERSION`, which would
-/// churn the committed file), mirroring the man-page pin in [`gen_binary`].
+/// churn the committed file), mirroring the man-page pin in `gen_binary`.
 #[must_use]
 pub fn render_invocation_reference() -> String {
     let mut out = String::new();


### PR DESCRIPTION
Fixes #403.

## Summary

`crates/mtui-core/src/entrypoint.rs` still documented `run_once`, removed in
`7ce0438e`. What survives in the file — `ExitStatus` (the 0/1/2 argparse
exit-code contract) — was reachable but unwired: both binaries hard-coded raw
exit codes instead of going through it, and the crate carried a 268-warning
rustdoc backlog with no CI gate to stop it growing.

## Changes

**`refactor(core): wire ExitStatus to the real exit sites, drop the run_once ghost`**
- `seed_session` now returns `ControlFlow<ExitStatus>` instead of a bare `i32`.
- `mtui-cli`'s and `mtui-mcp`'s `main.rs` both exit through `ExitStatus`
  (`Usage`/`Failure`) instead of raw integers.
- Rewrote every doc comment still describing the removed `run_once`, and fixed
  `entrypoint.rs`'s own two broken intra-doc links.
- `ExitStatus` is kept (not deleted, contra the issue's own suggestion) — the
  0/1/2 contract is real and both binaries were open-coding it.

**`docs(<crate>): fix rustdoc link warnings`** (one commit per crate,
bottom-up: types → config → xtask → hosts → datasources → testreport → core →
cli → mcp)
- Clears all 268 rustdoc warnings workspace-wide: `private_intra_doc_links`,
  unresolved links, `redundant_explicit_links`, an `invalid_html_tags` pair,
  and one ambiguous fn/mod link (`super::spinner` in
  `mtui-hosts/src/target/actions.rs`, disambiguated with `mod@`).
- Mechanical, minimal fixes only: de-link private-item references to plain
  code, qualify cross-crate paths, drop redundant explicit targets. No link
  was pointed at a guessed target — genuinely ambiguous/removed items were
  de-linked to plain code instead.

**`ci: gate CI on rustdoc warnings`**
- New `docs` CI job mirroring `fmt`'s shape:
  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`.
  `RUSTDOCFLAGS` is used instead of `[workspace.lints.rustdoc]` because the
  lints table can't express "deny every rustdoc lint" without enumerating
  them — which would silently miss future ones, the exact failure mode this
  issue is about.
- Added the doc command to `AGENTS.md`'s Definition of Done and
  `docs/src/developer.md`'s local gate list.

No `CHANGELOG.md` entry: this is internal-only (doc/lint fixes and an
exit-code refactor with unchanged exit codes), nothing a user or MCP client
would notice.

## Verification

- `rg -n "run_once" --glob '!target' .` → zero matches
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items` → exit 0
- That command observed **failing** after hand-reverting one link fix
  (`mtui-types/src/rrid.rs`), then restored to green
- `mtui-cli/src/main.rs` / `mtui-mcp/src/main.rs` contain no bare integer exit
  code; `seed_session` returns `ControlFlow<ExitStatus>`
- Exit codes unchanged: `startup::tests::explicit_update_that_fails_to_load_exits_one`
  still asserts exit `1`; the `mtui-mcp` no-`mcp`-feature stub exits `2` via
  `ExitStatus::Usage.into()` (that path is process-exit and stays untested, as
  it was before)
- Full gate green locally: `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`,
  `cargo build --workspace --no-default-features`,
  `cargo build --workspace --all-features`

One pre-existing, unrelated clippy finding
(`clippy::unwrap_or_default` in `mtui-mcp/src/session.rs`, only surfaces under
`--all-features`, confirmed via `git stash` to predate this branch) was left
untouched — out of scope for a rustdoc-only issue.
