### PR TITLE
fix(update): stop logging and swallowing three failures on the operation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   silently skipped the cleanup; it now warns with the lock error and that the
   repos are left configured on every host, pointing at `set_repo --remove` as
   the manual remedy. The update itself still reports success either way.
+- `install`/`uninstall` now name a host whose operation lock did not release,
+  instead of dropping the verdict. A stranded `/var/lock/mtui.lock` blocks
+  every other tester on that host; mtui now warns with the host and the lock
+  error, pointing at `unlock --force` as the manual remedy. A benign
+  foreign-owned lock is still not reported, and the operation's own verdict is
+  unaffected either way.
 
 ## [26.1.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   state; it now aborts before taking the lock or adding the repo, since
   nothing has been dispatched yet at that point. Use `--noprepare` to skip
   prepare and patch anyway.
+- `update`'s post-success repo cleanup now says why it could not run. When the
+  hosts could not be locked to remove the test update repositories, mtui
+  silently skipped the cleanup; it now warns with the lock error and that the
+  repos are left configured on every host, pointing at `set_repo --remove` as
+  the manual remedy. The update itself still reports success either way.
 
 ## [26.1.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   activates, and every skipped host is named in the log. A failed combined
   transactional downgrade is now also reported as a per-host failure rather
   than relying solely on the post-rollback version verdict.
+- `update` no longer patches hosts whose pre-update `prepare` step failed. A
+  failed prepare was logged and the flow continued regardless, adding the
+  issue repo and dispatching the patch to hosts that may already be in a bad
+  state; it now aborts before taking the lock or adding the repo, since
+  nothing has been dispatched yet at that point. Use `--noprepare` to skip
+  prepare and patch anyway.
 
 ## [26.1.1] - 2026-07-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -282,9 +282,8 @@ impl MockConnection {
     /// [`HostError::Sftp`] so a caller's directory-removal fallback path, or the
     /// fail-closed unlock path (a non-gone removal error must propagate), can be
     /// exercised.
-    #[cfg(test)]
     #[must_use]
-    pub(crate) fn failing_sftp_remove(mut self) -> Self {
+    pub fn failing_sftp_remove(mut self) -> Self {
         self.sftp_remove_fails = true;
         self
     }

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -1563,8 +1563,8 @@ impl OperationGroup for HostsGroup {
             .collect()
     }
 
-    async fn unlock(&mut self) {
-        let _ = HostsGroup::unlock(self).await;
+    async fn unlock(&mut self) -> BTreeMap<String, LockOutcome> {
+        HostsGroup::unlock(self).await
     }
 }
 
@@ -2576,6 +2576,31 @@ mod tests {
         let outcomes = g.unlock().await;
         assert_eq!(outcomes["h1"], LockOutcome::Released);
         assert_eq!(outcomes["h2"], LockOutcome::Contended);
+    }
+
+    #[tokio::test]
+    async fn operation_group_unlock_forwards_a_failed_release() {
+        // Pins that the `impl OperationGroup for HostsGroup` binding forwards
+        // the inherent `unlock`'s outcome map rather than re-swallowing it
+        // (as the pre-fix `let _ = HostsGroup::unlock(self).await;` did).
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "ok", "", 0, 0))
+            .failing_sftp_remove();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(conn),
+            )],
+            false,
+        );
+        let _ = g.lock("session").await;
+
+        let outcomes = OperationGroup::unlock(&mut g).await;
+        assert!(
+            matches!(&outcomes["h1"], LockOutcome::Failed(_)),
+            "outcomes: {outcomes:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -37,8 +37,11 @@
 //! [`hostgroup`](super::hostgroup). The template is driven against fully mocked
 //! targets and a mocked group, so it is unit-testable offline.
 
+use std::collections::BTreeMap;
+
 use mtui_types::shellquote::quote_args;
 
+use super::hostgroup::LockOutcome;
 use crate::error::HostError;
 
 /// A per-host command (or reboot) map as ordered `(hostname, command)` pairs.
@@ -213,7 +216,12 @@ pub trait OperationGroup: Send {
     async fn reboot(&mut self, reboot: HostCommandMap) -> Vec<RebootFailure>;
 
     /// Releases the shared operation lock.
-    async fn unlock(&mut self);
+    ///
+    /// Returns each host's [`LockOutcome`], keyed by hostname, so the caller
+    /// can tell a benign [`Contended`](LockOutcome::Contended) lock apart from
+    /// a real [`Failed`](LockOutcome::Failed) one — a stranded lock the
+    /// operator needs to know about — rather than losing the verdict.
+    async fn unlock(&mut self) -> BTreeMap<String, LockOutcome>;
 }
 
 /// The outcome of a completed [`Operation::run`]: the run *started* (the
@@ -233,6 +241,18 @@ pub struct OperationReport {
     /// A host whose check already failed is excluded — its reboot was skipped,
     /// not attempted and lost.
     pub reboot_failures: Vec<RebootFailure>,
+    /// `(hostname, reason)` for every host whose operation-lock release
+    /// failed with [`LockOutcome::Failed`] — a benign
+    /// [`Contended`](LockOutcome::Contended) release is excluded.
+    ///
+    /// A stranded lock does not turn a good install into a failed one, so
+    /// `Operation::run`'s verdict never depends on this field; it exists so
+    /// the caller can warn and name the host. `Operation::run` itself stays
+    /// silent about it — the per-host WARN already fires inside
+    /// `Target::unlock_reporting` — the aggregate warning belongs at the one
+    /// layer that knows the operation name (`perform_operation`, in
+    /// `mtui-testreport`).
+    pub unlock_failures: Vec<(String, String)>,
 }
 
 /// Why a transactional host's post-operation reboot did not take effect.
@@ -415,10 +435,19 @@ pub trait Operation: Send + Sync {
             .collect();
         let reboot_failures = group.reboot(reboot).await;
 
-        group.unlock().await;
+        let unlock_failures = group
+            .unlock()
+            .await
+            .into_iter()
+            .filter_map(|(host, outcome)| match outcome {
+                LockOutcome::Failed(reason) => Some((host, reason)),
+                LockOutcome::Acquired | LockOutcome::Released | LockOutcome::Contended => None,
+            })
+            .collect();
         Ok(OperationReport {
             check_failures,
             reboot_failures,
+            unlock_failures,
         })
     }
 }
@@ -621,6 +650,8 @@ mod tests {
         /// What `reboot` should report as failed, modelling a transactional
         /// host that rebooted and did not reconnect.
         reboot_failures: Vec<RebootFailure>,
+        /// What `unlock` should report per host.
+        unlock_outcomes: BTreeMap<String, LockOutcome>,
     }
 
     impl MockGroup {
@@ -641,6 +672,7 @@ mod tests {
                 events,
                 fail_update_lock: false,
                 reboot_failures: Vec::new(),
+                unlock_outcomes: BTreeMap::new(),
             }
         }
 
@@ -654,6 +686,13 @@ mod tests {
         /// host whose post-reboot reconnect never came back.
         fn with_reboot_failures(mut self, failures: Vec<RebootFailure>) -> Self {
             self.reboot_failures = failures;
+            self
+        }
+
+        /// Scripts `unlock` to report `outcomes`, modelling a host whose lock
+        /// release failed or was contended.
+        fn with_unlock_outcomes(mut self, outcomes: BTreeMap<String, LockOutcome>) -> Self {
+            self.unlock_outcomes = outcomes;
             self
         }
 
@@ -705,8 +744,9 @@ mod tests {
             self.reboot_failures.clone()
         }
 
-        async fn unlock(&mut self) {
+        async fn unlock(&mut self) -> BTreeMap<String, LockOutcome> {
             self.events.lock().unwrap().push(Event::Unlock);
+            self.unlock_outcomes.clone()
         }
     }
 
@@ -1107,6 +1147,35 @@ mod tests {
                 "only the passing host's reboot may run: {map:?}"
             );
         }
+    }
+
+    // --- run(): unlock_failures names a Failed host, not a Contended one ----
+
+    #[tokio::test]
+    async fn run_reports_a_failed_unlock_but_not_a_contended_one() {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let plans = vec![
+            plan_with_recording_check("h1", false, Doer::new("in $packages", "r"), sink.clone()),
+            plan_with_recording_check("h2", false, Doer::new("in $packages", "r"), sink),
+        ];
+        let mut group = MockGroup::new(Ok(plans)).with_unlock_outcomes(
+            [
+                ("h1".to_owned(), LockOutcome::Failed("boom".to_owned())),
+                ("h2".to_owned(), LockOutcome::Contended),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let op = InstallOperation::new(strs(&["pkg-a"]));
+        let report = op.run(&mut group).await.expect("the run started");
+
+        assert_eq!(
+            report.unlock_failures,
+            vec![("h1".to_owned(), "boom".to_owned())],
+            "a Contended unlock is benign and must not be reported: {:?}",
+            report.unlock_failures
+        );
     }
 
     // --- role strings + missing_error sentinels -----------------------------

--- a/crates/mtui-testreport/Cargo.toml
+++ b/crates/mtui-testreport/Cargo.toml
@@ -44,3 +44,5 @@ tempfile = "3"
 wiremock.workspace = true
 # Perf baseline bench (mtui-rs-0mop.1): metadata JSON parse hot path.
 criterion.workspace = true
+# Scoped subscriber to capture WARN output in tests.
+tracing-subscriber.workspace = true

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -514,6 +514,13 @@ async fn perform_operation(
     // written after this call returns would be lost on exactly the
     // transactional hosts that never came back.
 
+    // A stranded operation lock does not turn a good install/uninstall into a
+    // failed one — it warns, naming the hosts and the manual remedy, rather
+    // than joining `failures` below.
+    if !report.unlock_failures.is_empty() {
+        warn!("{}", unlock_failure_message(op, &report.unlock_failures));
+    }
+
     // A host whose post-run check failed, and any transactional host that
     // rebooted and never reconnected, both fail the operation by name. A
     // failed check already excluded its host from the reboot map (see
@@ -525,6 +532,25 @@ async fn perform_operation(
         .collect();
     failures.extend(report.reboot_failures.into_iter().map(reboot_error));
     aggregate_failures(op, failures)
+}
+
+/// Renders the WARN for an `install`/`uninstall` operation lock that did not
+/// release, naming the affected hosts and the manual remedy.
+///
+/// A pure helper so the message is unit-testable without driving the whole
+/// [`Operation`] template.
+fn unlock_failure_message(op: &str, unlock_failures: &[(String, String)]) -> String {
+    let hosts: Vec<&str> = unlock_failures.iter().map(|(h, _)| h.as_str()).collect();
+    format!(
+        "{op} succeeded but the operation lock did not release on {}: {} \
+         (release it with `unlock --force`)",
+        hosts.join(", "),
+        unlock_failures
+            .iter()
+            .map(|(h, reason)| format!("{h}: {reason}"))
+            .collect::<Vec<_>>()
+            .join("; ")
+    )
 }
 
 /// Renders a [`RebootFailure`] as the operator-facing per-host error.
@@ -1928,6 +1954,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn perform_install_warns_but_still_succeeds_when_unlock_fails() {
+        // The install itself must succeed even though the lock never released:
+        // a stranded lock does not turn a good install into a failed one.
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .failing_sftp_remove();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let (res, logs) = capture_logs(perform_install(&mut group, &["pkg-a".to_owned()])).await;
+
+        assert!(
+            res.is_ok(),
+            "a stranded lock must not turn a good install into a failure: {res:?}"
+        );
+        assert!(
+            logs.contains("h1"),
+            "the WARN must name the stranded host: {logs}"
+        );
+        assert!(
+            logs.contains("unlock --force"),
+            "the WARN must name the manual remedy: {logs}"
+        );
+    }
+
+    #[tokio::test]
     async fn install_stops_at_the_entry_gate_when_cancelled() {
         // install/uninstall had no cancellation checkpoint of their own; a
         // cancel requested before the run must stop it before any command
@@ -3166,12 +3226,12 @@ mod tests {
     }
 
     /// Runs `fut` under a scoped tracing subscriber that captures each
-    /// event's message synchronously into an in-memory buffer, returning the
-    /// joined records. Mirrors `mtui-datasources/tests/obs_oscrc.rs`'s
-    /// `capture_logs`, adapted for an async body: `set_default`'s guard stays
-    /// live across the awaited future on the single-threaded `#[tokio::test]`
-    /// runtime these tests run under.
-    async fn capture_logs(fut: impl std::future::Future<Output = ()>) -> String {
+    /// event's message synchronously into an in-memory buffer, returning
+    /// `fut`'s output paired with the joined records. Mirrors
+    /// `mtui-datasources/tests/obs_oscrc.rs`'s `capture_logs`, adapted for an
+    /// async body: `set_default`'s guard stays live across the awaited future
+    /// on the single-threaded `#[tokio::test]` runtime these tests run under.
+    async fn capture_logs<T>(fut: impl std::future::Future<Output = T>) -> (T, String) {
         use std::fmt::Write as _;
         use std::sync::{Arc, Mutex};
         use tracing::field::{Field, Visit};
@@ -3203,8 +3263,8 @@ mod tests {
         let records = Arc::new(Mutex::new(Vec::new()));
         let sub = Registry::default().with(CaptureLayer(records.clone()));
         let _guard = tracing::subscriber::set_default(sub);
-        fut.await;
-        records.lock().unwrap().join("\n")
+        let out = fut.await;
+        (out, records.lock().unwrap().join("\n"))
     }
 
     #[tokio::test]
@@ -3222,7 +3282,7 @@ mod tests {
         let mut group = HostsGroup::new(vec![t], false);
         let repo = RecordingRepo::default();
 
-        let logs = capture_logs(remove_test_repos(&mut group, &repo)).await;
+        let ((), logs) = capture_logs(remove_test_repos(&mut group, &repo)).await;
 
         let ops = repo.ops.lock().unwrap().clone();
         assert!(
@@ -3328,6 +3388,14 @@ mod tests {
             prepare_failure(UpdateError::new("boom", "h1")),
             UpdateFailure::Prepare(_)
         ));
+    }
+
+    #[test]
+    fn unlock_failure_message_names_hosts_reasons_and_remedy() {
+        let msg = unlock_failure_message("install", &[("h1".to_owned(), "boom".to_owned())]);
+        assert!(msg.contains("h1"));
+        assert!(msg.contains("boom"));
+        assert!(msg.contains("unlock --force"));
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -50,6 +50,14 @@ type UpdateMaps = (BTreeMap<String, String>, BTreeMap<String, String>);
 pub enum UpdateFailure {
     /// One or more hosts failed the `updater` check after the command ran.
     Check(UpdateError),
+    /// The pre-update `prepare` step failed.
+    ///
+    /// Like [`MissingUpdater`](Self::MissingUpdater) this skips the rollback,
+    /// but for a different reason: nothing has been dispatched yet at this
+    /// point — no lock taken, no issue repo added, no patch command sent — so
+    /// there is nothing on any host for a downgrade to undo. `--noprepare` is
+    /// the opt-out for a caller that wants to patch anyway.
+    Prepare(UpdateError),
     /// A concrete target has no updater doer; mtui treats this as a hard
     /// failure (rather than logging and returning as if successful) so a
     /// target that cannot be updated never reports "finished".
@@ -171,6 +179,12 @@ where
 {
     match perform_update_from_report(report, targets, noprepare, newpackage, diagnostics).await {
         Ok(()) => Ok(()),
+        Err(UpdateFailure::Prepare(e)) => {
+            // Nothing was dispatched (no lock, no repo add, no patch) → no
+            // rollback.
+            error!(error = %e, "update aborted: prepare failed");
+            Err(e)
+        }
         Err(UpdateFailure::MissingUpdater(e)) => {
             // Hard fail, but nothing was installed → no rollback.
             error!(error = %e, "update failed");
@@ -241,6 +255,21 @@ pub async fn add_op_history(
 /// The `$repa` maintenance-selector for an update.
 fn repa_for(maintenance_id: &str, review_id: &str) -> String {
     format!(":p={maintenance_id}:{review_id}")
+}
+
+/// Classifies a pre-update `prepare` failure.
+///
+/// The cancel arm is defensive rather than live on this call path: the
+/// pre-update prepare always runs with `installed_only = false`, and only the
+/// per-package (`installed_only = true`) loop sets `cancelled_at`. It stays
+/// because [`perform_prepare`] is public and the "a cancel surfaces as
+/// `Cancelled`, never a generic failure" invariant applies to every caller.
+fn prepare_failure(e: UpdateError) -> UpdateFailure {
+    if e.is_cancelled() {
+        UpdateFailure::Cancelled(e)
+    } else {
+        UpdateFailure::Prepare(e)
+    }
 }
 
 /// Resolves a host's `(release, transactional)` key from its parsed system.
@@ -1308,11 +1337,11 @@ pub async fn perform_update(
     }
 
     if !noprepare {
-        // Runs prepare with default flags (remove-repo prepare). Prepare is
-        // best-effort within the update flow, so a failure is logged, not
-        // returned.
+        // Runs prepare with default flags (remove-repo prepare). Nothing has
+        // been dispatched yet, so a failure aborts here rather than patching
+        // hosts prepare may have left in a bad state; `--noprepare` opts out.
         if let Err(e) = perform_prepare(targets, report, packages, false, false, false).await {
-            warn!(error = %e, "prepare before update failed");
+            return Err(prepare_failure(e));
         }
     }
 
@@ -3152,6 +3181,57 @@ mod tests {
             "expected the initial prepare install: {cmds:?}"
         );
         assert!(cmds.iter().any(|c| c.contains(":p=42:7")));
+    }
+
+    #[tokio::test]
+    async fn perform_update_aborts_when_the_prepare_fails() {
+        // h1's prepare command exits non-zero ⇒ the update must abort before
+        // taking the lock, adding the issue repo, or dispatching the patch.
+        let (t, handle) = sles_target_with_exit("h1", "", 1);
+        let mut group = HostsGroup::new(vec![t], false);
+        let repo = RecordingRepo::default();
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+
+        let res = perform_update(
+            &mut group,
+            &repo,
+            &packages,
+            "42",
+            "7",
+            None,
+            false,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+        assert!(
+            matches!(res, Err(UpdateFailure::Prepare(_))),
+            "a failed prepare aborts the update: {res:?}"
+        );
+
+        let ops = repo.ops.lock().unwrap().clone();
+        assert!(
+            !ops.contains(&RepoOp::Add),
+            "no issue repo must be added when prepare fails: {ops:?}"
+        );
+        let cmds = handle.commands();
+        assert!(
+            !cmds.iter().any(|c| c.contains(":p=42:7")),
+            "no patch command must be dispatched when prepare fails: {cmds:?}"
+        );
+    }
+
+    #[test]
+    fn prepare_failure_classifies_cancelled_vs_plain_errors() {
+        assert!(matches!(
+            prepare_failure(UpdateError::cancelled("cancelled")),
+            UpdateFailure::Cancelled(_)
+        ));
+        assert!(matches!(
+            prepare_failure(UpdateError::new("boom", "h1")),
+            UpdateFailure::Prepare(_)
+        ));
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1417,14 +1417,27 @@ pub async fn perform_update(
 
     targets.package_check(true).await;
 
-    // Success: remove the test update repositories.
-    if targets.update_lock().await.is_err() {
-        warn!("could not lock hosts to remove update repositories; skipping repo cleanup");
-        return Ok(());
+    remove_test_repos(targets, report).await;
+    Ok(())
+}
+
+/// Removes the test update repositories after a successful update.
+///
+/// Best-effort: a lock failure here does not turn a successful update into a
+/// failed one, so it warns — naming the error, that the repos are left
+/// configured, and the manual remedy — rather than failing the update.
+async fn remove_test_repos(targets: &mut HostsGroup, report: &dyn SetRepo) {
+    if let Err(e) = targets.update_lock().await {
+        warn!(
+            error = %e,
+            "could not lock hosts to remove the test update repositories; \
+             they are left configured on every host (remove later with \
+             `set_repo --remove`)"
+        );
+        return;
     }
     targets.fanout_set_repo(RepoOp::Remove, report).await;
     targets.unlock().await;
-    Ok(())
 }
 
 /// Runs the update commands, checks every host (collecting failures), reboots on
@@ -3149,6 +3162,89 @@ mod tests {
         assert!(
             ops.contains(&RepoOp::Remove),
             "on success the repos are removed: {ops:?}"
+        );
+    }
+
+    /// Runs `fut` under a scoped tracing subscriber that captures each
+    /// event's message synchronously into an in-memory buffer, returning the
+    /// joined records. Mirrors `mtui-datasources/tests/obs_oscrc.rs`'s
+    /// `capture_logs`, adapted for an async body: `set_default`'s guard stays
+    /// live across the awaited future on the single-threaded `#[tokio::test]`
+    /// runtime these tests run under.
+    async fn capture_logs(fut: impl std::future::Future<Output = ()>) -> String {
+        use std::fmt::Write as _;
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+        use tracing_subscriber::registry::Registry;
+
+        #[derive(Clone)]
+        struct CaptureLayer(Arc<Mutex<Vec<String>>>);
+
+        struct MessageVisitor(String);
+        impl Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    let _ = write!(self.0, "{value:?}");
+                } else {
+                    let _ = write!(self.0, " {}={value:?}", field.name());
+                }
+            }
+        }
+
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                self.0.lock().unwrap().push(visitor.0);
+            }
+        }
+
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let sub = Registry::default().with(CaptureLayer(records.clone()));
+        let _guard = tracing::subscriber::set_default(sub);
+        fut.await;
+        records.lock().unwrap().join("\n")
+    }
+
+    #[tokio::test]
+    async fn remove_test_repos_names_the_error_when_it_cannot_lock() {
+        // A foreign lock makes update_lock fail on the only host, so the
+        // cleanup cannot run; it must warn (naming the error and the remedy)
+        // rather than removing the repos.
+        let foreign = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .with_file(
+                mtui_hosts::TARGET_LOCK_PATH,
+                b"1700000000:alice:4242:busy".to_vec(),
+            );
+        let t = Target::with_connection("h1", TargetState::Enabled, Box::new(foreign));
+        let mut group = HostsGroup::new(vec![t], false);
+        let repo = RecordingRepo::default();
+
+        let logs = capture_logs(remove_test_repos(&mut group, &repo)).await;
+
+        let ops = repo.ops.lock().unwrap().clone();
+        assert!(
+            !ops.contains(&RepoOp::Remove),
+            "cleanup must not run when the lock fails: {ops:?}"
+        );
+        // The cleanup's own warning must carry both the lock error and the
+        // remedy in the same line: `update_lock`'s internal fanout also logs
+        // WARNs about the individual foreign-locked host, so a
+        // `logs.contains` across every captured line would still pass with
+        // the error field dropped from this warning.
+        let cleanup_line = logs
+            .lines()
+            .find(|l| l.contains("left configured on every host"))
+            .unwrap_or_else(|| panic!("no cleanup warning found: {logs}"));
+        assert!(
+            cleanup_line.contains("Hosts locked"),
+            "cleanup warning must name the lock error: {cleanup_line}"
+        );
+        assert!(
+            cleanup_line.contains("set_repo --remove"),
+            "cleanup warning must name the manual remedy: {cleanup_line}"
         );
     }
 


### PR DESCRIPTION
Closes #409.

Three independent fixes, three commits:

1. **`fix(update)`: abort when the pre-update prepare fails.** Previously a
   failed `prepare` was logged and the flow continued regardless, taking the
   lock, adding the issue repo, and dispatching the patch to hosts that may
   already be in a bad state. Adds `UpdateFailure::Prepare`; nothing has been
   dispatched at that point, so the abort skips the rollback and needs no
   undo. `--noprepare` remains the opt-out. The `--newpackage` prepare after a
   successful patch is unchanged (stays a warn).

2. **`fix(update)`: name the error when the success-path repo cleanup cannot
   lock.** The cleanup discarded the lock error with `.is_err()` and silently
   skipped removing the test update repositories. Extracted into
   `remove_test_repos` (reachable from a test with existing fixtures — a
   foreign lock on the only host); it now warns with the lock error, the
   "repos left configured" state, and the `set_repo --remove` remedy. Verdict
   stays `Ok(())`: a cleanup failure must not turn a successful update into a
   failed one.

3. **`feat(hosts)`: the unlock seam reports its aggregate verdict.**
   `OperationGroup::unlock` returned `()`, so `Operation::run` could not see
   the per-host `LockOutcome` map `HostsGroup` already computes. Widened the
   trait to return `BTreeMap<String, LockOutcome>`; `OperationReport` gains
   `unlock_failures` (populated from `LockOutcome::Failed` only — `Contended`
   stays benign); `perform_operation` warns (not fails) when it's non-empty,
   naming the hosts and pointing at `unlock --force`.

Each regression test was observed red against the unfixed code before the
fix landed (reverted the relevant line, confirmed the assertion failed,
restored it).

## Verification

Full gate per `AGENTS.md`, all green:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` / `--all-features`

## Out of scope

#406 (missing prepare/install/uninstall checks on slmicro/YUM) and #405
(forced `job_cancel` skips the unlock) — noted in the issue as related but
separate. Fix 1 shrinks #406's blast radius (an unjudged prepare failure on
those keys can no longer sail into a patch) but does not close it.
