### PR TITLE
docs: put takes literal paths by design — record the #399 decision

### DIFF
--- a/crates/mtui-core/src/commands/sftpput.rs
+++ b/crates/mtui-core/src/commands/sftpput.rs
@@ -15,8 +15,15 @@ use crate::session::Session;
 /// Files are placed under the
 /// report's remote working directory (`metadata.target_wd(<name>)`); a directory
 /// argument is walked and each contained file uploaded. Only enabled hosts are
-/// contacted. Shell-glob expansion of the argument is a Phase-6 REPL concern;
-/// here the argument is a concrete path (file or directory).
+/// contacted.
+///
+/// The path is taken **literally — shell-style globs are deliberately not
+/// expanded** (#399): `put` pushes to every enabled host in the group, which
+/// is exactly where an over-broad pattern does damage, so a pattern's blast
+/// radius stays the caller's problem (`put` the directory, or let the
+/// invoking shell expand). A path that matches nothing errors
+/// (`File … not found`, pinned by `missing_file_errors`) rather than
+/// succeeding vacuously.
 pub struct SftpPut;
 
 /// Recursively collects the regular files under `path` (a single file returns
@@ -54,7 +61,11 @@ impl Command for SftpPut {
             Arg::new("filename")
                 .required(true)
                 .value_parser(clap::value_parser!(PathBuf))
-                .help("file (or directory) to upload to all hosts"),
+                .help(
+                    "file (or directory) to upload to all hosts; the path is \
+                     literal — shell-style globs are deliberately not expanded \
+                     (put the directory, or let the invoking shell expand)",
+                ),
         )
     }
 
@@ -203,10 +214,19 @@ mod tests {
 
     #[tokio::test]
     async fn missing_file_errors() {
+        // The message text is documented contract (FAQ: an unexpanded glob
+        // errors with `File … not found`), so pin the words, not just the
+        // variant — a variant-only assert also passes for the scan-task
+        // error path.
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
         let args = matches(&SftpPut, &["/no/such/file"]);
         let err = SftpPut.call(&mut session, &args).await.unwrap_err();
-        assert!(matches!(err, CommandError::Other(_)));
+        match err {
+            CommandError::Other(msg) => {
+                assert_eq!(msg, "File /no/such/file not found");
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -986,7 +986,7 @@ expression: pretty
           "type": "boolean"
         },
         "filename": {
-          "description": "file (or directory) to upload to all hosts",
+          "description": "file (or directory) to upload to all hosts; the path is literal — shell-style globs are deliberately not expanded (put the directory, or let the invoking shell expand)",
           "type": "string"
         },
         "template": {

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -646,7 +646,7 @@ Usage: put <filename>
 
 Arguments:
   <filename>
-          file (or directory) to upload to all hosts
+          file (or directory) to upload to all hosts; the path is literal — shell-style globs are deliberately not expanded (put the directory, or let the invoking shell expand)
 
 Options:
   -h, --help

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -125,6 +125,17 @@ Yes: `export -t <host>`. By default `export` writes the collected data for every
 host in the list — including disabled ones — so to keep a temporarily-added host
 out of the report, `remove_host -t <host>` before exporting.
 
+## Why doesn't `put *.rpm` upload anything?
+
+Inside the REPL nothing expands the `*`, so `put` looks for a file literally
+named `*.rpm` and errors with `File *.rpm not found`. That is deliberate, not
+a gap ([#399](https://github.com/openSUSE/mtui/issues/399)): `put` pushes to
+**every enabled refhost in the group**, which is exactly where an over-broad
+pattern does damage, so mtui refuses to guess how wide a pattern was meant to
+be. To upload several files, `put` the directory containing them (it is
+walked recursively), or expand the glob in your own shell before invoking
+mtui.
+
 ## Where are the per-host install logs stored?
 
 Under the loaded template's checkout, in


### PR DESCRIPTION
## Why

Closes #399, per your call there: reject glob expansion + document. The docs now state the choice positively — `put` takes literal paths **by design**, because it pushes to every enabled host in the group, which is exactly where an over-broad pattern does damage.

One premise of the issue no longer holds, so the docs record the actual behaviour: a non-matching path is **not** silent today — `put *.rpm` errors with `File *.rpm not found` (the unexpanded `*` is just a literal that doesn't exist). Nothing in the REPL tokenizer (`shlex::split` — quotes/escapes only) or the MCP argv path expands globs, verified by reading both.

## What changed

- **Struct doc** (`sftpput.rs`): the old "Shell-glob expansion … is a Phase-6 REPL concern" sentence framed the rejected feature as merely deferred; replaced with the decision and its rationale. (The other Phase-N comments in the tree are #402's scope and are untouched.)
- **`filename` help**: states the path is literal and names the two escape hatches (put the directory — it is walked recursively — or let the invoking shell expand). Flows into the generated `cli.md` and the MCP tool schema description; both regenerated, byte-identical across the three copies.
- **New FAQ entry** — "Why doesn't `put *.rpm` upload anything?" — answering it where a user will actually look.
- **`missing_file_errors` strengthened**: the `File … not found` text is now documented contract, so the test pins the exact message instead of only `CommandError::Other(_)` (which the unrelated scan-task error path also satisfies). Observed red against a reworded message before restoring.

## Judgment calls, flagged rather than assumed

- **No CHANGELOG entry** — behaviour unchanged, docs-only commits carry none (07ecd6b precedent). Borderline only in that the MCP schema's `filename` *description* text changes; if you treat schema text (not just shape) as the contracted surface, happy to add a line.
- The FAQ links the issue with a full URL (first such link under `docs/src/`; renders as a link in mdBook), while the doc comment uses the repo's bare `(#399)` — deliberate split between user-facing docs and code comments.

## Verification

- Full gate: `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` / `cargo test -p mtui-mcp -F mcp` (193+48) / feature matrix compile-only / rustdoc with CI's exact invocation / `typos`
- Adversarial review before commit by two independent read-only reviewers (claim-accuracy vs code, conventions/consistency); the accuracy pass traced every documented claim — including that an empty directory, a directory of empty subdirs, and a broken symlink all still error rather than silently succeed — and caught one overclaim ("pinned by") that the strengthened test now makes true.
