### PR TITLE
docs: retire the finished-rewrite roadmap citations (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- The headless `shell` error message no longer carries a roadmap reference:
+  `"interactive shell attach is not available in this mode (Phase 6 REPL
+  only)"` is now `"... (REPL only)"`.
 - `refhosts.yml` rows now resolve YAML merge keys (`<<: *anchor`) instead of
   ignoring them. This is a side effect of retiring the archived `serde_yaml`
   crate in favour of `serde-saphyr`, which expands merge keys by default;

--- a/crates/mtui-cli/Cargo.toml
+++ b/crates/mtui-cli/Cargo.toml
@@ -24,7 +24,7 @@ mtui-hosts = { workspace = true, features = ["shell"] }
 clap.workspace = true
 anyhow.workspace = true
 reedline.workspace = true
-# Raw-mode terminal + async EventStream for the `shell` bridge (mtui-rs-jww).
+# Raw-mode terminal + async EventStream for the `shell` bridge.
 crossterm.workspace = true
 # `StreamExt` for the crossterm `EventStream` in the bridge input pump.
 futures.workspace = true
@@ -33,7 +33,7 @@ async-trait.workspace = true
 # shlex-split the `shell` line to route it to the bridge (mirrors the engine).
 shlex.workspace = true
 nu-ansi-term.workspace = true
-# Level-token coloring in the custom tracing format layer (mtui-rs-ilt), matching
+# Level-token coloring in the custom tracing format layer, matching
 # the escapes `mtui-core`'s display uses for the `error` token.
 owo-colors.workspace = true
 # `Workflow` drives the workflow-aware left prompt (`mtui[-mode]> `).

--- a/crates/mtui-cli/src/lib.rs
+++ b/crates/mtui-cli/src/lib.rs
@@ -3,7 +3,7 @@
 //! The binary ([`main.rs`](../main.rs)) is a thin shell: it parses the
 //! top-level args, builds the [`Session`](mtui_core::Session) and command
 //! [`Registry`](mtui_core::Registry), and drives [`Repl::run`]. Exposing the
-//! REPL as a library lets the `tests/**` suite (and the P6.8 test task) exercise
+//! REPL as a library lets the `tests/**` suite exercise
 //! the loop's `repl::step` seam without a TTY.
 
 pub mod completer;
@@ -75,7 +75,7 @@ impl<'a> MakeWriter<'a> for SpinnerAwareStderr {
 /// [`logfmt::CompactLevelFormat`]). Whether escapes are emitted is resolved from
 /// `color` via the *same* [`ColorMode::resolve`] the display uses, so
 /// `--color auto/always/never` governs the level token and the `error:` line
-/// identically (`mtui-rs-ilt`).
+/// identically.
 ///
 /// Under `-d/--debug` the full verbose Rust format is kept (timestamp + level +
 /// target, e.g. `2026-07-10T09:41:39.891821Z DEBUG mtui_cli::repl: …`) for

--- a/crates/mtui-cli/src/main.rs
+++ b/crates/mtui-cli/src/main.rs
@@ -4,12 +4,14 @@
 //! `--help`/`--version` — the latter carrying the build-provenance block baked
 //! into `mtui-core` — and usage errors, exiting the process itself), initialises
 //! `tracing` from `-d/--debug` + `RUST_LOG`, seeds the session from `-a`/`-k`
-//! and `--sut` ([`seed_session`]), then enters the interactive REPL (P6.2).
+//! and `--sut` ([`seed_session`]), then enters the interactive REPL.
 //!
 //! This binary has exactly **one** driving surface: the
 //! REPL. There is no positional command / single-command mode — headless
 //! single-command dispatch is an `mtui-mcp`/embedding concern, not a CLI mode.
-//! Full config loading + `Args` merge remains later Phase-6 config work.
+//! Config is fully resolved via [`Args::resolve_config`]: the file layers via
+//! [`Config::load`](mtui_config::Config::load), then the CLI overrides
+//! overlaid on top.
 
 use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
@@ -84,7 +86,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // The session and registry are shared behind `Arc`/`Arc<Mutex>` so the tab
-    // completer (P6.3), owned by the reedline editor, reads the same live
+    // completer, owned by the reedline editor, reads the same live
     // session the loop dispatches against (see `Repl`).
     let session = Arc::new(Mutex::new(session));
     let mut repl = Repl::new(registry, session);

--- a/crates/mtui-cli/src/repl.rs
+++ b/crates/mtui-cli/src/repl.rs
@@ -15,10 +15,11 @@
 //!   `quit`): break the loop, process exit 0.
 //!
 //! The read loop and dispatch are independent of the editor's input features:
-//! tab completion (P6.3), persistent history + Ctrl-R reverse-search + inline
-//! hint (P6.4), and the workflow-aware prompt + RRID status + input highlighter
-//! (P6.5) all live in the [`Reedline`] builder / [`MtuiPrompt`] in [`Repl::new`];
-//! the command-timeout prompter (P6.6) slots in later without changing this loop.
+//! tab completion, persistent history + Ctrl-R reverse-search + inline
+//! hint, and the workflow-aware prompt + RRID status + input highlighter
+//! all live in the [`Reedline`] builder / [`MtuiPrompt`] in [`Repl::new`];
+//! the command-timeout prompter is wired in at the composition root
+//! (`main.rs`) without changing this loop.
 
 use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
@@ -63,9 +64,9 @@ impl Repl {
     /// `file_backed_history` persisting to
     /// `$XDG_DATA_HOME/mtui/history` (with Ctrl-R reverse-search from the default
     /// emacs bindings); and a [`DefaultHinter`] showing the greyed inline
-    /// suggestion. The dynamic prompt/toolbar
-    /// (P6.5) and the prompter (P6.6) slot into this builder later without
-    /// changing the loop.
+    /// suggestion. The dynamic prompt/toolbar comes from [`MtuiPrompt`]; the
+    /// command-timeout prompter is wired in separately at the composition
+    /// root (`main.rs`).
     #[must_use]
     pub fn new(registry: Arc<Registry>, session: Arc<Mutex<Session>>) -> Self {
         let completer = Box::new(MtuiCompleter::new(
@@ -142,7 +143,7 @@ impl Repl {
                     // TTY this REPL owns — the engine (shared with headless MCP)
                     // can't do that, so its `shell` command is a headless-error
                     // stub. Intercept the line *before* dispatch and drive the
-                    // raw-mode bridge here instead (mtui-rs-jww). Any other line
+                    // raw-mode bridge here instead. Any other line
                     // takes the normal engine path. A shell line never exits.
                     if let Some(argv) = crate::shell::is_shell_line(&line) {
                         let mut session = self
@@ -449,7 +450,7 @@ mod tests {
         assert_eq!(out.lines().count(), 1, "rendered exactly once");
     }
 
-    /// The de-noised, single-channel error contract (mtui-rs-7h9 / -ilt): a
+    /// The de-noised, single-channel error contract: a
     /// failing command yields exactly one `error: <message>` line through the
     /// operator log, with none of the old `tracing` noise (a target, a
     /// timestamp, or an `err=` field).
@@ -470,7 +471,7 @@ mod tests {
 
     /// Under color, the `error` level token is red-wrapped while the message
     /// text is not colorized — the same single `CompactLevelFormat` layer that
-    /// colors `info`/`warn`, so all three levels share one look (mtui-rs-ilt).
+    /// colors `info`/`warn`, so all three levels share one look.
     #[test]
     fn error_level_token_is_colorized_message_is_not() {
         let (r, _) = registry();

--- a/crates/mtui-cli/src/shell.rs
+++ b/crates/mtui-cli/src/shell.rs
@@ -1,7 +1,7 @@
 //! The interactive `shell` REPL command and its raw-mode TTY bridge.
 //!
 //! The host-library half — spawning the remote PTY and exposing it as an
-//! object-safe [`ShellChannel`] duplex — landed in P2.10 (`mtui-hosts` feature
+//! object-safe [`ShellChannel`] duplex — lives in `mtui-hosts` (feature
 //! `shell`); this module is the **CLI consumer** that owns the local terminal.
 //!
 //! ## Why this lives in the CLI, not the engine
@@ -247,7 +247,7 @@ async fn run_bridge_on(target: &mut Target) -> anyhow::Result<()> {
 ///
 /// This is the pure seam the REPL uses to route `shell` to the CLI bridge
 /// instead of the headless engine (kept off the reedline boundary so it is
-/// unit-testable, mirroring the P6.2 `step` extraction).
+/// unit-testable, mirroring the `step` extraction).
 #[must_use]
 pub(crate) fn is_shell_line(line: &str) -> Option<Vec<String>> {
     let tokens = shlex_split(line)?;

--- a/crates/mtui-cli/tests/cli_smoke.rs
+++ b/crates/mtui-cli/tests/cli_smoke.rs
@@ -1,4 +1,4 @@
-//! Smoke tests for the `mtui` binary (P6.1 skeleton + P6.2 REPL entry).
+//! Smoke tests for the `mtui` binary.
 //!
 //! These drive the built binary via `CARGO_BIN_EXE_mtui` and assert the
 //! top-level surfaces: `--version` (provenance block), `--help` (real `Args`
@@ -74,7 +74,7 @@ fn unknown_flag_is_usage_error_exit_two() {
 
 #[test]
 fn no_args_enters_the_interactive_repl() {
-    // A bare invocation now drops into the REPL (P6.2) instead of bailing. The
+    // A bare invocation now drops into the REPL instead of bailing. The
     // test harness has no controlling TTY, so `reedline::read_line` fails and
     // the process exits non-zero — but the DEBUG breadcrumb proves we reached
     // the REPL entry rather than an earlier error, and stderr must NOT carry the
@@ -112,7 +112,7 @@ fn piped_stdin_reaches_repl_and_exits_without_hanging() {
     // We do not assert a specific exit code: a bare `wait()` after closing the
     // pipe deadlocks only if the child hangs, so reaching the assertions at all
     // is itself the liveness proof. (A pty harness would let us drive real input
-    // lines and assert exit 0 on EOF, but that is out of scope for P6.8 — the
+    // lines and assert exit 0 on EOF, but that is out of scope here — the
     // 80% bar is met without adding a pty dependency.)
     let mut child = mtui()
         .arg("-d")

--- a/crates/mtui-config/src/options.rs
+++ b/crates/mtui-config/src/options.rs
@@ -809,8 +809,7 @@ pub struct Config {
     /// cycle (each teardown is bounded by the per-session disconnect timeout).
     /// Bounding the fan-out keeps a mass eviction from a host-teardown thundering
     /// herd while making sweep latency ~independent of stale-session count.
-    /// Default is 4. A hardening addition
-    /// (mtui-rs-0mop.10).
+    /// Default is 4.
     pub mcp_sweep_parallel: usize,
     /// Tool-surface profile the `mtui-mcp` server exposes: `"full"` (default,
     /// every synthesised tool) or `"core"` (the curated everyday subset — see

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -1,7 +1,7 @@
 //! The `Command` trait, its fan-out [`Scope`], and the template fan-out engine.
 //!
 //! Every command implements [`Command`] and is discovered through the
-//! registry (P5.2); the REPL, tab completion, and the MCP tool synthesiser
+//! registry; the REPL, tab completion, and the MCP tool synthesiser
 //! all iterate that one registry.
 //!
 //! A command supplies its abstract body in [`call`](Command::call); the provided
@@ -48,7 +48,7 @@ pub enum Scope {
 ///
 /// Concrete commands implement [`name`](Command::name) and the abstract
 /// [`call`](Command::call) body; the rest have sensible defaults. The engine
-/// (P5.2) dispatches a parsed line to the matching command and awaits
+/// dispatches a parsed line to the matching command and awaits
 /// [`run`](Command::run).
 #[async_trait]
 pub trait Command: Send + Sync {
@@ -65,7 +65,7 @@ pub trait Command: Send + Sync {
     /// `help` groups commands returning `Some(..)` under "Documented commands"
     /// and those returning `None` under "Undocumented commands". Defaults to
     /// `None`; commands opt in by overriding it. (It also feeds MCP tool
-    /// descriptions in Phase 7.)
+    /// descriptions.)
     fn about(&self) -> Option<&'static str> {
         None
     }
@@ -84,9 +84,9 @@ pub trait Command: Send + Sync {
     /// ([`McpSession::command_lock`](../../mtui_mcp/session/struct.McpSession.html))
     /// forces such a command onto the **exclusive** registry gate even when it
     /// resolves to a single template, so its structural mutation lands on the
-    /// canonical session rather than on a discarded per-call fork
-    /// (`mtui-rs-f36r`, steps 4-5). A content-only per-RRID command may run on a
-    /// fork because its mutations reach the shared report through the entry lock.
+    /// canonical session rather than on a discarded per-call fork. A
+    /// content-only per-RRID command may run on a fork because its mutations
+    /// reach the shared report through the entry lock.
     fn mutates_registry(&self) -> bool {
         false
     }
@@ -107,8 +107,10 @@ pub trait Command: Send + Sync {
     /// Contributes this command's arguments to its `clap` subcommand.
     ///
     /// Default is the identity: a command with no arguments. The real
-    /// argparse↔clap fidelity work (`REMAINDER`, no-exit-on-error, per-command
-    /// `--help`) lands in P5.4; this is the hook it fills in.
+    /// argparse↔clap fidelity (`REMAINDER`, no-exit-on-error, per-command
+    /// `--help`) is supplied by the shared base parser in
+    /// [`command_parser`](crate::engine::command_parser); this is the hook it
+    /// extends.
     fn configure(&self, cmd: clap::Command) -> clap::Command {
         cmd
     }
@@ -117,7 +119,7 @@ pub trait Command: Send + Sync {
     ///
     /// `text` is the token being completed and `line` the whole input line;
     /// the readline-style index args (`begidx`/`endidx`) are not needed here —
-    /// the reedline completer (Phase 6) supplies them.
+    /// the reedline completer supplies them.
     fn complete(&self, _session: &Session, _text: &str, _line: &str) -> Vec<String> {
         Vec::new()
     }
@@ -321,7 +323,7 @@ fn resolve_templates(
 
 /// Resolves the ordered *real* RRIDs a `command`/`argv` invocation would act on,
 /// for out-of-crate callers that must know the target templates *before*
-/// dispatch (the MCP per-template lock gate, `mtui-rs-76e.11`).
+/// dispatch (the MCP per-template lock gate).
 ///
 /// Builds the command's clap parser, parses `argv`, and runs the identical
 /// `resolve_templates` fan-out logic `run` uses, then drops the empty-RRID

--- a/crates/mtui-core/src/commands/apicall.rs
+++ b/crates/mtui-core/src/commands/apicall.rs
@@ -51,8 +51,8 @@ fn user_override(args: &ArgMatches) -> Option<String> {
 /// Builds a Gitea client for the loaded report, mapping the missing-PR-URL and
 /// build errors onto [`CommandError`].
 ///
-/// Reuses the session-scoped [`HttpClient`](mtui_datasources::HttpClient) (perf
-/// bead `mtui-rs-0mop.13`) via [`Gitea::with_client`], while preserving
+/// Reuses the session-scoped [`HttpClient`](mtui_datasources::HttpClient)
+/// via [`Gitea::with_client`], while preserving
 /// [`Gitea::new`]'s empty-token guard.
 pub(crate) fn gitea_client(session: &Session) -> Result<Gitea, CommandError> {
     let apiurl = session
@@ -81,7 +81,7 @@ pub(crate) fn gitea_client(session: &Session) -> Result<Gitea, CommandError> {
 }
 
 /// Builds a TeReGen client for the loaded report, reusing the session-scoped
-/// [`HttpClient`](mtui_datasources::HttpClient) (perf bead `mtui-rs-0mop.13`)
+/// [`HttpClient`](mtui_datasources::HttpClient)
 /// via [`TeReGen::with_client`].
 ///
 /// # Errors

--- a/crates/mtui-core/src/commands/export.rs
+++ b/crates/mtui-core/src/commands/export.rs
@@ -178,8 +178,8 @@ impl Command for Export {
     }
 }
 
-/// Borrows the session-scoped HTTP client for log downloads (perf bead
-/// `mtui-rs-0mop.13`: reuse one client/pool across commands).
+/// Borrows the session-scoped HTTP client for log downloads (reuse one
+/// client/pool across commands).
 fn build_http(session: &Session) -> Result<HttpClient, CommandError> {
     session
         .http_client()

--- a/crates/mtui-core/src/commands/hostslock.rs
+++ b/crates/mtui-core/src/commands/hostslock.rs
@@ -17,8 +17,7 @@ use crate::session::Session;
 /// comment (`-c`) keeps the lock effective against other sessions too.
 ///
 /// `-t` host sub-selection is not yet honoured for the lock fan-out — the whole
-/// active group is locked, matching Wave-1 `run`'s group-lock behaviour and the
-/// group-merge follow-up (`mtui-rs-qd9`).
+/// active group is locked, matching Wave-1 `run`'s group-lock behaviour.
 pub struct HostLock;
 
 #[async_trait]

--- a/crates/mtui-core/src/commands/hostsunlock.rs
+++ b/crates/mtui-core/src/commands/hostsunlock.rs
@@ -20,7 +20,7 @@ use crate::session::Session;
 /// active group. With `--force` a claim owned by another template is removed too.
 ///
 /// Like `lock`, host sub-selection via `-t` is not yet honoured for the fan-out
-/// (whole active group), matching the group-merge follow-up (`mtui-rs-qd9`).
+/// (whole active group).
 pub struct HostsUnlock;
 
 #[async_trait]

--- a/crates/mtui-core/src/commands/listhosts.rs
+++ b/crates/mtui-core/src/commands/listhosts.rs
@@ -99,7 +99,7 @@ mod tests {
         assert!(out.contains("Enabled"), "{out}");
     }
 
-    /// Regression test for mtui-rs-xlt: a host whose `Target::connect()` ran
+    /// Regression test: a host whose `Target::connect()` ran
     /// over a connection carrying real system-parse data must render its
     /// parsed system, not the pre-parse `unknown--` sentinel.
     #[tokio::test]

--- a/crates/mtui-core/src/commands/listupdatecommands.rs
+++ b/crates/mtui-core/src/commands/listupdatecommands.rs
@@ -35,9 +35,9 @@ impl Command for ListUpdateCommands {
         // touch the display, so no borrow conflict arises.
         let targets = session.targets();
         session.metadata().list_update_commands(targets);
-        // `list_update_commands` is a no-op across every report type today
-        // (unimplemented, bead mtui-rs-2d3.6): the delegate emits nothing, so
-        // print an explicit placeholder instead of returning empty success.
+        // `list_update_commands` is a no-op across every report type today:
+        // the delegate emits nothing, so print an explicit placeholder
+        // instead of returning empty success.
         session
             .display
             .println("list_update_commands: not yet implemented");

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -70,12 +70,12 @@ mod sftpput;
 mod showdiff;
 mod showlog;
 
-// Phase 5 follow-ups — deferred commands whose machinery has since landed.
+// Deferred commands whose machinery has since landed.
 mod export;
 mod list_refhosts;
 mod load_template;
 
-// Phase 6 — REPL-only command-surface additions.
+// REPL-only command-surface additions.
 mod edit;
 mod help;
 mod terms;

--- a/crates/mtui-core/src/commands/openqa_overview.rs
+++ b/crates/mtui-core/src/commands/openqa_overview.rs
@@ -19,8 +19,8 @@ const AGGREGATED_GROUP_CHOICES: &[&str] = &["core", "containers", "yast", "secur
 /// checks — and prints them to the REPL; `--export` also injects the plain-text
 /// block into the loaded testreport's `log` under `regression tests:`.
 ///
-/// The `--no-fetch` cache reuse is deferred with the openQA state holder
-/// (`mtui-rs-zs4`); passing `--no-fetch` here logs and fetches anyway.
+/// The `--no-fetch` cache reuse is not yet implemented; passing `--no-fetch`
+/// here logs and fetches anyway.
 pub struct OpenQAOverview;
 
 #[async_trait]

--- a/crates/mtui-core/src/commands/reboot.rs
+++ b/crates/mtui-core/src/commands/reboot.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[tokio::test]
     async fn target_selection_reboots_only_named_host() {
-        // Regression for mtui-rs-issz: `-t h1` must reboot only h1 and leave h2
+        // Regression: `-t h1` must reboot only h1 and leave h2
         // untouched. Both hosts would reboot cleanly if the whole group were
         // rebooted, so the absence of any h2 line proves h2 was skipped.
         let (mut session, buf) =

--- a/crates/mtui-core/src/commands/shell.rs
+++ b/crates/mtui-core/src/commands/shell.rs
@@ -11,11 +11,11 @@ use crate::session::Session;
 /// Opens an interactive shell on a reference host.
 ///
 /// Attaching an interactive PTY to a
-/// remote shell needs a controlling terminal, which only the Phase-6 `mtui`
+/// remote shell needs a controlling terminal, which only the `mtui` REPL
 /// binary owns; the command surface (name, args, host selection, completion) is
 /// defined here so the registry and MCP synthesiser see it, but the runtime PTY
-/// attach is deferred to Phase 6. Invoked headlessly it errors cleanly rather
-/// than hanging. REPL-only — on the MCP deny-list.
+/// attach lives in the REPL binary, not here. Invoked headlessly it errors
+/// cleanly rather than hanging. REPL-only — on the MCP deny-list.
 pub struct Shell;
 
 #[async_trait]
@@ -45,7 +45,8 @@ impl Command for Shell {
 
     async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
         // Validate host selection so headless callers get the same argument
-        // errors the REPL would, but the interactive PTY attach is Phase 6.
+        // errors the REPL would, but the interactive PTY attach lives in the
+        // REPL binary.
         let targets = session.targets_mut();
         let hosts =
             select_names(targets, args, true).map_err(|e| CommandError::Other(e.to_string()))?;
@@ -53,7 +54,7 @@ impl Command for Shell {
             return Err(CommandError::NoRefhostsDefined);
         }
         Err(CommandError::Other(
-            "interactive shell attach is not available in this mode (Phase 6 REPL only)".to_owned(),
+            "interactive shell attach is not available in this mode (REPL only)".to_owned(),
         ))
     }
 }

--- a/crates/mtui-core/src/commands/support.rs
+++ b/crates/mtui-core/src/commands/support.rs
@@ -24,7 +24,7 @@ use crate::session::Session;
 /// already-built [`HttpClient`] (obtain it once from
 /// [`Session::http_client`](crate::session::Session::http_client)) so the QEM
 /// dashboard fetch reuses the session connection pool instead of building a
-/// fresh client (perf bead `mtui-rs-0mop.13`), and plain values rather than
+/// fresh client, and plain values rather than
 /// `&Session` so callers never hold a (non-`Sync`) `Session` borrow across the
 /// `.await`.
 pub(crate) async fn build_incident(
@@ -59,7 +59,7 @@ pub(crate) fn build_auto_openqa(
 /// Takes an already-built [`HttpClient`] (obtain it once from
 /// [`Session::http_client`](crate::session::Session::http_client)) so a
 /// per-host loop reuses one connection pool instead of building a fresh client
-/// per instance (perf bead `mtui-rs-0mop.13`).
+/// per instance.
 #[must_use]
 pub(crate) fn build_kernel_openqa(
     incident: &QemIncident,

--- a/crates/mtui-core/src/engine.rs
+++ b/crates/mtui-core/src/engine.rs
@@ -2,7 +2,7 @@
 //!
 //! Splits a raw input line into argv, resolves the command by name (or
 //! alias) against the [`Registry`], parses its arguments, and awaits
-//! [`Command::run`] (which drives the template fan-out landed in P5.1).
+//! [`Command::run`] (which drives the template fan-out).
 //!
 //! Two entry points share one core so both driving surfaces reuse the same
 //! engine (`AGENTS.md`: MCP dispatches through the *same engine* as the REPL):
@@ -114,7 +114,7 @@ pub async fn dispatch_argv(
 /// The registry-free tail of [`dispatch_argv`]: parse `argv` through the
 /// command's own clap parser (no-exit-on-error), then drive
 /// [`Command::run`]. Exposed so the headless MCP concurrent
-/// path (`mtui-rs-f36r`, steps 4-5) can `tokio::spawn` a dispatch holding an
+/// path can `tokio::spawn` a dispatch holding an
 /// owned `Arc<dyn Command>` + forked [`Session`] — neither borrows the
 /// [`Registry`], so the spawned future is `'static`. `help` is *not* intercepted
 /// here (it resolves to the null report → the MCP exclusive path, which still
@@ -219,7 +219,7 @@ fn print_help_columns(session: &mut Session, names: &[&str]) {
 ///
 /// This is the exact parser [`dispatch_argv`] re-parses argv through, exposed so
 /// out-of-crate consumers that must introspect a command's arg surface build the
-/// *same* parser rather than reconstructing it. The MCP tool synthesiser (P7.6)
+/// *same* parser rather than reconstructing it. The MCP tool synthesiser
 /// uses it to derive a tool's JSON input schema and to reconstruct argv from a
 /// tool call, keeping schema/argv fidelity locked to real dispatch.
 #[must_use]

--- a/crates/mtui-core/src/entrypoint.rs
+++ b/crates/mtui-core/src/entrypoint.rs
@@ -1,8 +1,8 @@
 //! The process exit-code contract shared by mtui's two process entrypoints
 //! (`mtui`, `mtui-mcp`).
 //!
-//! This distinguishes the **three distinct argparse layers** mtui carries
-//! (the correction that shaped P5.10 — do not conflate them):
+//! This distinguishes the **three distinct argparse layers** mtui carries —
+//! do not conflate them:
 //!
 //! 1. **App invocation** — the top-level `mtui`/`mtui-mcp` process arguments,
 //!    [`Args`](crate::args::Args). The real binary parses these with
@@ -14,7 +14,7 @@
 //!    process; they return a typed
 //!    [`EngineError`](crate::engine::EngineError).
 //! 3. **MCP tool schema** — `mtui-mcp` translating each command's parser into
-//!    JSON parameters (Phase 7). Not touched here.
+//!    JSON parameters. Not touched here.
 //!
 //! Neither entrypoint has a headless single-command CLI mode: the `mtui`
 //! binary has only two surfaces, the interactive REPL and `mtui-mcp`, and

--- a/crates/mtui-core/src/lib.rs
+++ b/crates/mtui-core/src/lib.rs
@@ -1,26 +1,24 @@
 //! `mtui-core` — the command engine and composition root.
 //!
 //! This crate wires the lower crates together behind a uniform command surface
-//! consumed by both the REPL (Phase 6) and MCP (Phase 7). Phase 5.1 lands the
-//! foundation:
+//! consumed by both the REPL and MCP:
 //!
 //! * [`Command`] — the trait every command implements, with the template
 //!   fan-out engine ([`Command::run`]) and its [`Scope`] policy.
 //! * [`CommandError`] / [`CommandResult`] — the command-layer error hierarchy.
 //! * [`Session`] — the explicitly-passed command state, holding the
 //!   [`TemplateRegistry`] and [`CommandPromptDisplay`].
+//! * The explicit command [`Registry`] and the line-dispatch [`engine`], the
+//!   single machinery both the REPL and MCP dispatch through.
+//! * [`args`] — the top-level process argument parser (`clap`), distinct
+//!   from the per-command parsers the engine synthesises.
+//! * The [`display`] surface: the full `list_*`
+//!   family, `show_log`, the three-way
+//!   [`ColorMode`], and the `page` pager.
 //!
-//! P5.2 adds the explicit command [`Registry`] and the line-dispatch
-//! [`engine`], the single machinery both the REPL and MCP dispatch through. P5.4
-//! adds [`args`] — the top-level process argument parser (`clap`), distinct
-//! from the per-command parsers the engine synthesises. P5.3 rounds out the
-//! [`display`] surface: the full `list_*`
-//! family, `show_log`, the three-way
-//! [`ColorMode`], and the `page` pager.
-//!
-//! P5.10 adds [`entrypoint`] — the process [`ExitStatus`] contract distinct
+//! [`entrypoint`] is the process [`ExitStatus`] contract distinct
 //! from the top-level [`Args`] parser (Layer 1) and the per-command engine
-//! (Layer 2), and from the MCP schema synthesis (Layer 3, Phase 7). Both
+//! (Layer 2), and from the MCP schema synthesis (Layer 3). Both
 //! process entrypoints, `mtui`'s REPL and `mtui-mcp`, exit through it; neither
 //! has a headless single-command CLI mode.
 

--- a/crates/mtui-core/src/registry.rs
+++ b/crates/mtui-core/src/registry.rs
@@ -115,10 +115,10 @@ impl Registry {
 pub const MCP_DENYLIST: &[&str] = &[
     "quit", "exit", "EOF",    // session exit (Wave 2)
     "switch", // active-template pointer, REPL-only (Wave 2)
-    "shell",  // interactive PTY attach, Phase 6 (Wave 2)
-    "help",   // registry listing / per-command help, REPL-only (Phase 6)
-    "edit",   // $EDITOR spawn on the controlling TTY, REPL-only (Phase 6)
-    "terms",  // spawn terminal-launcher scripts to hosts, REPL-only (Phase 6)
+    "shell",  // interactive PTY attach, REPL-only (Wave 2)
+    "help",   // registry listing / per-command help, REPL-only
+    "edit",   // $EDITOR spawn on the controlling TTY, REPL-only
+    "terms",  // spawn terminal-launcher scripts to hosts, REPL-only
 ];
 
 /// Builds the process-wide command registry — the single, explicit place every
@@ -191,11 +191,11 @@ pub fn register_all() -> Registry {
     registry.register(Arc::new(commands::Approve));
     registry.register(Arc::new(commands::Regenerate));
     registry.register(Arc::new(commands::RequestReview));
-    // Phase 5 follow-ups — deferred commands now unblocked.
+    // Deferred commands whose machinery has since landed.
     registry.register(Arc::new(commands::Export));
     registry.register(Arc::new(commands::ListRefhosts));
     registry.register(Arc::new(commands::LoadTemplate));
-    // Phase 6 — REPL-only command-surface additions.
+    // REPL-only command-surface additions.
     registry.register(Arc::new(commands::Help));
     registry.register(Arc::new(commands::Edit));
     registry.register(Arc::new(commands::Terms));
@@ -342,16 +342,16 @@ mod tests {
     #[test]
     fn register_all_command_count() {
         // 9 Wave 1 (10 originally; `lrun` was later removed outright) + 14
-        // Wave 2 + 17 Wave 3 + 12 Wave 4 (incl. request_review) + 4 P5
-        // follow-ups (export, list_refhosts, load_template, list_locks) + 2
-        // openQA-holder follow-ups (reload_openqa, set_workflow:
-        // mtui-rs-zs4/plt) + 3 Phase 6 (help: mtui-rs-lhz.9; edit:
-        // mtui-rs-lhz.10; terms: mtui-rs-lhz.11) = 61 canonical commands.
+        // Wave 2 + 17 Wave 3 + 12 Wave 4 (incl. request_review) + 4
+        // follow-up commands (export, list_refhosts, load_template,
+        // list_locks) + 2 openQA-holder follow-ups (reload_openqa,
+        // set_workflow) + 3 REPL-only additions (help, edit, terms) = 61
+        // canonical commands.
         assert_eq!(register_all().names().count(), 61);
     }
 
     #[test]
-    fn register_all_wires_phase5_followups() {
+    fn register_all_wires_export_and_template_commands() {
         let r = register_all();
         for name in ["export", "list_refhosts", "load_template"] {
             assert!(r.contains(name), "expected {name} to be registered");
@@ -404,8 +404,8 @@ mod tests {
             let _reserved_or_registered = r.contains(name);
         }
         // Sanity: the currently-registered deny-listed commands are the Wave 2
-        // REPL-only set (quit+aliases, switch, shell) plus `help`, `edit`, and
-        // `terms` (Phase 6).
+        // REPL-only set (quit+aliases, switch, shell) plus the REPL-only
+        // additions `help`, `edit`, and `terms`.
         let registered_denied: Vec<&str> = MCP_DENYLIST
             .iter()
             .copied()

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -36,7 +36,7 @@ pub struct Session {
     /// Loaded templates and the active pointer.
     pub templates: TemplateRegistry,
     /// The per-call active-report handle: the [`OwnedMutexGuard`] of the entry
-    /// this dispatch is acting on (`mtui-rs-f36r`, step 2).
+    /// this dispatch is acting on.
     ///
     /// [`metadata`](Self::metadata) / [`targets`](Self::targets) and their `_mut`
     /// counterparts read through this guard when present, and through
@@ -97,7 +97,7 @@ pub struct Session {
     prompter: Option<Prompter>,
     /// Test-only count of how many times [`http_client`](Self::http_client)
     /// actually *built* a client (vs. handing back a cached clone). The
-    /// regression oracle for perf bead `mtui-rs-0mop.13`: proves back-to-back
+    /// regression oracle proves back-to-back
     /// calls under stable config reuse one client, and that a mid-session
     /// posture change rebuilds exactly once.
     #[cfg(test)]
@@ -134,7 +134,7 @@ pub struct Session {
     /// rebuilding only when the effective posture changes (e.g. a mid-session
     /// `config set ssl_verify`). Interior mutability so the `&Session` call sites
     /// (`export::build_http`) can lazily populate it; the lock is uncontended
-    /// (one dispatch at a time). Perf bead `mtui-rs-0mop.13`.
+    /// (one dispatch at a time).
     http_client: Mutex<Option<(VerifyPolicy, HttpClient)>>,
 }
 
@@ -260,7 +260,7 @@ impl Session {
     /// Builds a cheap per-call [`Session`] that **shares** this session's loaded
     /// reports and carries its own display sink.
     ///
-    /// The headless MCP concurrency seam (`mtui-rs-f36r`, steps 4-5): a
+    /// The headless MCP concurrency seam: a
     /// single-RRID tool call needs a `&mut Session` to dispatch, but holding the
     /// canonical session behind one mutex across dispatch serialises *all* calls.
     /// Instead the caller forks a per-call session — its
@@ -391,7 +391,7 @@ impl Session {
     }
 
     /// Test-only count of clients actually built by
-    /// [`http_client`](Self::http_client) (perf-bead `mtui-rs-0mop.13` oracle).
+    /// [`http_client`](Self::http_client).
     #[cfg(test)]
     fn http_builds(&self) -> usize {
         self.http_builds.load(std::sync::atomic::Ordering::SeqCst)
@@ -1561,7 +1561,7 @@ mod tests {
         assert_eq!(s.metadata().id(), "");
     }
 
-    /// Perf-bead `mtui-rs-0mop.13` oracle: repeated `http_client()` calls under
+    /// Oracle: repeated `http_client()` calls under
     /// a stable `ssl_verify` reuse one built client (a cheap clone), and a
     /// mid-session posture change rebuilds exactly once. Guards against a
     /// regression to per-command client construction.
@@ -2128,7 +2128,7 @@ mod tests {
         );
     }
 
-    // --- pool selection (host over-selection fix, mtui-rs-4eq) --------------
+    // --- pool selection (host over-selection fix) --------------------------
 
     use mtui_types::version::{Version, VersionField};
 
@@ -2314,7 +2314,7 @@ mod tests {
     /// `fork_for_call` shares the canonical session's loaded reports (same entry
     /// locks) while carrying its own display, so a per-RRID command dispatched on
     /// a fork mutates the *shared* report content visible to the canonical
-    /// session (`mtui-rs-f36r`, steps 4-5).
+    /// session.
     #[test]
     fn fork_for_call_shares_reports_with_own_display() {
         use crate::display::{ColorMode, CommandPromptDisplay};

--- a/crates/mtui-core/src/template_registry.rs
+++ b/crates/mtui-core/src/template_registry.rs
@@ -36,7 +36,7 @@ use tokio::sync::Mutex;
 
 /// A loaded report behind its own lock.
 ///
-/// Each registry entry is individually lockable (bead `mtui-rs-f36r`, step 1):
+/// Each registry entry is individually lockable:
 /// a dispatch takes the [`OwnedMutexGuard`](tokio::sync::OwnedMutexGuard) of
 /// exactly the entry it acts on (via [`TemplateRegistry::handle`]), so per-call
 /// active-report handling no longer needs to borrow the whole registry. With the
@@ -224,8 +224,7 @@ impl TemplateRegistry {
     ///
     /// The caller `.lock()`s it to read/mutate the report. This is how a dispatch
     /// (via [`Session`](crate::Session)) acquires exactly the entry it acts on
-    /// without borrowing the whole registry — the per-call active handle
-    /// (`mtui-rs-f36r`, step 2).
+    /// without borrowing the whole registry — the per-call active handle.
     #[must_use]
     pub fn handle(&self, rrid: &str) -> Option<ReportEntry> {
         self.entries.get(rrid).map(Arc::clone)
@@ -317,7 +316,7 @@ impl TemplateRegistry {
     /// [`Session::fork_for_call`](crate::Session::fork_for_call) to let a headless
     /// MCP dispatch run on its own [`Session`](crate::Session) without a session-wide lock, while
     /// different-RRID calls still act on distinct entry locks and same-RRID calls
-    /// share one (`mtui-rs-f36r`, steps 4-5).
+    /// share one.
     ///
     /// The stable [`id`](Self::id) is preserved so a snapshot keeps the same
     /// host-arbitration owner-key seed as the canonical registry.
@@ -542,7 +541,7 @@ mod tests {
 
     /// `snapshot` clones the registry structure while *sharing* each entry's
     /// `Arc<Mutex<..>>` (same report lock) and preserving the stable id + active
-    /// pointer — so a per-call fork acts on the same reports (`mtui-rs-f36r`).
+    /// pointer — so a per-call fork acts on the same reports.
     #[test]
     fn snapshot_shares_entries_and_preserves_id_and_active() {
         let mut reg = registry();

--- a/crates/mtui-core/tests/e2e_run.rs
+++ b/crates/mtui-core/tests/e2e_run.rs
@@ -1,5 +1,4 @@
-//! Golden end-to-end test for the `run` command — the deliverable that gates
-//! Phase 5 (mtui-rs-2d3.6).
+//! Golden end-to-end test for the `run` command.
 //!
 //! Drives `run "uname -a"` across two mock reference hosts through the **real
 //! dispatch path**: the process-wide [`register_all`] registry and the

--- a/crates/mtui-core/tests/help_listing.rs
+++ b/crates/mtui-core/tests/help_listing.rs
@@ -43,7 +43,7 @@ async fn help_listing_is_the_command_surface_contract() {
 /// Every registered command must document itself via
 /// [`about`](mtui_core::Command::about). This keeps the `help` listing's
 /// "Undocumented commands" bucket empty and guarantees each command
-/// contributes a description to the MCP tool synthesiser in Phase 7.
+/// contributes a description to the MCP tool synthesiser.
 #[test]
 fn every_registered_command_is_documented() {
     let registry = register_all();

--- a/crates/mtui-datasources/Cargo.toml
+++ b/crates/mtui-datasources/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 name = "it"
 path = "tests/it.rs"
 
-# Perf baseline benches (mtui-rs-0mop.1). `harness = false` -> criterion main,
+# Perf baseline benches. `harness = false` -> criterion main,
 # compiled only under `cargo bench`.
 [[bench]]
 name = "datasources"
@@ -74,5 +74,5 @@ base64ct = { version = "1", features = ["alloc"] }
 rand = { workspace = true }
 # Scoped subscriber to capture the oscrc loose-permissions warning in tests.
 tracing-subscriber.workspace = true
-# Perf baseline benches (mtui-rs-0mop.1): refhosts parse/search + client build.
+# Perf baseline benches: refhosts parse/search + client build.
 criterion.workspace = true

--- a/crates/mtui-datasources/benches/datasources.rs
+++ b/crates/mtui-datasources/benches/datasources.rs
@@ -1,4 +1,4 @@
-//! Perf baselines for datasource hot paths (mtui-rs-0mop.1).
+//! Perf baselines for datasource hot paths.
 //!
 //! Measurement-only, fully offline. Covers the pure/deterministic hot paths the
 //! remediation beads target:

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -2,11 +2,9 @@
 //!
 //! This crate holds every outbound integration (the shared HTTP policy layer,
 //! the `refhosts.yml` resolver/search/verify, and the external service
-//! clients). The first landed surface is the HTTP layer, so [`HttpError`] is
-//! the first member of the hierarchy. Later Phase-3 tasks add their own
-//! `#[from]` sub-errors (openQA, QEM dashboard, Gitea, oqa-search) as those
-//! clients land, so each variant is exercised by real tests rather than
-//! sitting dead.
+//! clients). [`HttpError`] wraps the shared HTTP layer; each client (openQA,
+//! QEM dashboard, Gitea, oqa-search) has its own `#[from]` sub-error enum,
+//! exercised by real tests.
 
 use mtui_types::Assignment;
 use thiserror::Error;

--- a/crates/mtui-datasources/src/lib.rs
+++ b/crates/mtui-datasources/src/lib.rs
@@ -1,9 +1,9 @@
 //! `mtui-datasources` — shared HTTP client, refhosts, openQA/QEM/Gitea/osc-qam.
 //!
 //! Every outbound integration lives here; consumers (commands, MCP) get typed
-//! clients. The first landed surface is the shared HTTP policy layer
-//! ([`mod@http`]): one client with a unified timeout and TLS-verify posture
-//! that every later Phase-3 client builds on.
+//! clients. The shared HTTP policy layer ([`mod@http`]) is the base: one
+//! client with a unified timeout and TLS-verify posture that every client in
+//! this crate builds on.
 
 pub mod error;
 pub mod gitea;

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -38,10 +38,10 @@ pub(crate) const OPENQA_INSTALL_DISTRI: &str = "sle";
 /// parameter.
 ///
 /// Upstream passes an `incident` metadata object and calls
-/// `incident.get_incident_name()`. The concrete metadata type lands with the
-/// testreport work (Phase 4); this trait is the seam so the connectors can be
-/// built and tested now against a mock, and the real metadata can implement it
-/// later without a connector refactor.
+/// `incident.get_incident_name()`. This trait is the seam: the connectors are
+/// built and tested against a mock, and concrete metadata
+/// ([`QemIncident`](crate::qem_dashboard::incident::QemIncident)) implements
+/// it without a connector refactor.
 pub trait IncidentName {
     /// The incident's short name (e.g. the package name `bash`).
     fn get_incident_name(&self) -> String;

--- a/crates/mtui-datasources/src/oqa_search/render.rs
+++ b/crates/mtui-datasources/src/oqa_search/render.rs
@@ -6,7 +6,7 @@
 //! the block stays scannable when pasted into a testreport.
 //!
 //! Two consumers share this: the interactive `openqa_overview` command
-//! (Phase 5) prints the lines directly, and the export injector
+//! prints the lines directly, and the export injector
 //! ([`crate::oqa_search`] via `mtui-testreport`) wraps the block with the
 //! [`OVERVIEW_BEGIN_MARKER`]/[`OVERVIEW_END_MARKER`] so it can find and replace
 //! its own block on re-export.

--- a/crates/mtui-datasources/src/oqa_search/search.rs
+++ b/crates/mtui-datasources/src/oqa_search/search.rs
@@ -12,7 +12,7 @@
 //!   contract. A memo can be reintroduced if a consumer needs it.
 //! * The plain-text renderer (`render_overview` + the `OVERVIEW_*`
 //!   markers) lives in the sibling [`super::render`] module, shared by the
-//!   command layer and the Phase 4 export injector.
+//!   command layer and the export injector.
 //! * The build-check directory-index scan uses the `scraper` HTML parser; the
 //!   golden test pins the extracted `.log` set so any parser drift is caught.
 

--- a/crates/mtui-datasources/src/qem_dashboard/dashboard_openqa.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/dashboard_openqa.rs
@@ -1635,7 +1635,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_jobs_fans_out_concurrently_and_preserves_order() {
-        // Regression for mtui-rs-4sz1: per-setting fetches must run concurrently
+        // Regression: per-setting fetches must run concurrently
         // (bounded by max_parallel) yet be consumed in submission order. Four
         // incident settings each delay their jobs response; the FIRST-submitted
         // (id 11) gets the LONGEST delay, so a naive completion-order collect

--- a/crates/mtui-datasources/src/refhost/store.rs
+++ b/crates/mtui-datasources/src/refhost/store.rs
@@ -43,8 +43,8 @@ pub struct Refhosts {
 impl Refhosts {
     /// Build a store directly from an already-parsed host list.
     ///
-    /// Useful for tests and for resolver code (Phase 3) that has already
-    /// obtained the rows via another path.
+    /// Useful for tests and for resolver code that has already obtained the
+    /// rows via another path.
     #[must_use]
     pub fn from_hosts(data: Vec<Host>) -> Self {
         let mut by_name = std::collections::HashMap::with_capacity(data.len());

--- a/crates/mtui-datasources/src/teregen.rs
+++ b/crates/mtui-datasources/src/teregen.rs
@@ -13,9 +13,10 @@
 //! a genuinely-empty queue apart from an unreachable TeReGen. The base URL comes
 //! from the
 //! `[teregen] api` option (default `https://qam.suse.de/api/v1`);
-//! wiring that config field is deferred to a later phase, so [`TeReGen::new`]
-//! takes the base URL explicitly for now (mirroring the [`Gitea`](crate::gitea)
-//! client's constructor).
+//! [`TeReGen::new`] takes the base URL explicitly rather than reading
+//! `config.teregen_api` itself (mirroring the [`Gitea`](crate::gitea) client's
+//! constructor) — callers pass `session.config.teregen_api` at the point of
+//! use.
 //!
 //! The one documented exception is [`regenerate`](TeReGen::regenerate) (a
 //! write): it returns `None` only when TeReGen is *unreachable*, and
@@ -78,9 +79,8 @@ impl TeReGen {
     /// Build a client targeting `apiurl`, deriving the TLS posture from
     /// `config.ssl_verify`.
     ///
-    /// The base URL is passed
-    /// explicitly (the `[teregen] api` config field is deferred to a later
-    /// phase) rather than read from `config.teregen_api`.
+    /// The base URL is passed explicitly rather than read from
+    /// `config.teregen_api`; callers pass that field at the point of use.
     ///
     /// # Errors
     ///

--- a/crates/mtui-datasources/tests/gitea.rs
+++ b/crates/mtui-datasources/tests/gitea.rs
@@ -198,7 +198,7 @@ async fn approve_uses_last_assignee() {
     assert!(String::from_utf8_lossy(&posts[0].body).contains("LGTM"));
 }
 
-/// Request-count oracle (mtui-rs-0mop.8: deduplicate Gitea approval fetches).
+/// Request-count oracle: deduplicate Gitea approval fetches.
 ///
 /// A single happy-path `approve` fetches the comment snapshot **once** and
 /// derives both the assignment state (`assign_state`) and the decision state
@@ -715,7 +715,7 @@ async fn assignee_none_when_unassigned() {
     assert_eq!(gitea_for(&server).assignee().await.unwrap(), None);
 }
 
-// --- token-origin restriction (mtui-rs-9po9) ---
+// --- token-origin restriction ---
 
 /// Build a Gitea client whose metadata PR URL points at `pr_host` but whose
 /// configured trusted origin is `trusted`. Used to drive hostile-metadata cases.

--- a/crates/mtui-hosts/Cargo.toml
+++ b/crates/mtui-hosts/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 name = "it"
 path = "tests/it.rs"
 
-# Perf baseline benches (mtui-rs-0mop.1). `harness = false` -> criterion's own
+# Perf baseline benches. `harness = false` -> criterion's own
 # main, compiled only under `cargo bench`, never in the default `cargo test` gate.
 [[bench]]
 name = "fanout"
@@ -66,5 +66,5 @@ russh-sftp = { workspace = true }
 hmac.workspace = true
 sha1.workspace = true
 data-encoding = "2"
-# Perf baseline benches (mtui-rs-0mop.1): fan-out scaling / SFTP / lock reporting.
+# Perf baseline benches: fan-out scaling / SFTP / lock reporting.
 criterion.workspace = true

--- a/crates/mtui-hosts/benches/fanout.rs
+++ b/crates/mtui-hosts/benches/fanout.rs
@@ -1,4 +1,4 @@
-//! Perf baselines for host fan-out and SFTP/lock I/O (mtui-rs-0mop.1).
+//! Perf baselines for host fan-out and SFTP/lock I/O.
 //!
 //! Measurement-only: these record the *current* behaviour of
 //! [`HostsGroup`]'s parallel fan-out so the remediation beads have a baseline to
@@ -164,7 +164,7 @@ fn bench_sftp(c: &mut Criterion) {
 
 /// `locks/lock` (whole-group) vs. `locks/lock_scoped` (a `-t` subset): the
 /// operation-lock fan-out cost, and the baseline for the scoped variant added
-/// with the `run` lock-enforcement fix (`mtui-rs-bwu2`). Scoping to a subset
+/// with the `run` lock-enforcement fix. Scoping to a subset
 /// must never be slower than the whole-group lock over the same fleet — it only
 /// narrows the `run_fanout` predicate. Wall-clock is advisory (see module docs);
 /// the deterministic oracle is the per-host `Connection` call count in the unit

--- a/crates/mtui-hosts/src/connection/mock.rs
+++ b/crates/mtui-hosts/src/connection/mock.rs
@@ -5,7 +5,7 @@
 //! It records every command issued (so callers can assert ordering / fan-out),
 //! serves canned [`CommandLog`] responses keyed by command (with a default),
 //! and can be scripted to fail a specific command so the retry / timeout paths
-//! in later Phase 2 tasks (P2.3 reconnect, P2.5 parallel fan-out) are testable.
+//! in reconnect and parallel fan-out are testable.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -142,7 +142,7 @@ pub struct MockConnection {
     /// Number of batched SFTP sessions opened via
     /// [`sftp_session`](Connection::sftp_session). Shared across `Clone`d
     /// handles so a test observes every session regardless of which handle
-    /// opened it — this is the `mtui-rs-0mop.3` handshake-count oracle
+    /// opened it — this is the handshake-count oracle
     /// (`parse_system` must open exactly one).
     sftp_sessions: Arc<Mutex<usize>>,
     /// Artificial delay charged **once per SFTP session open** (the
@@ -592,7 +592,7 @@ impl MockConnection {
     /// Returns how many batched SFTP sessions were opened via
     /// [`sftp_session`](Connection::sftp_session).
     ///
-    /// The `mtui-rs-0mop.3` handshake-count oracle: a multi-read probe
+    /// The handshake-count oracle: a multi-read probe
     /// (`parse_system`) that batches correctly opens exactly **one** session
     /// regardless of how many files it reads.
     #[cfg(test)]

--- a/crates/mtui-hosts/src/connection/sftp_session.rs
+++ b/crates/mtui-hosts/src/connection/sftp_session.rs
@@ -1,4 +1,4 @@
-//! The batched SFTP session primitive (mtui-rs-0mop.3).
+//! The batched SFTP session primitive.
 //!
 //! Opens **one** SFTP client and yields it for several reads against the same
 //! host, so a multi-step probe pays the SFTP channel+subsystem handshake

--- a/crates/mtui-hosts/src/connection/shell.rs
+++ b/crates/mtui-hosts/src/connection/shell.rs
@@ -1,4 +1,4 @@
-//! The interactive PTY shell primitive (feature `shell`, P2.10).
+//! The interactive PTY shell primitive (feature `shell`).
 //!
 //! Opens a session channel, requests an `xterm` PTY, and invokes a login
 //! shell, then bridges the local terminal to the channel with a raw-mode
@@ -10,7 +10,7 @@
 //! object-safe async duplex handle over the remote shell's PTY, returned by
 //! [`Connection::shell`](super::Connection::shell). The raw-`termios`
 //! stdin↔channel↔stdout bridge and the `shell` REPL command that *drive* this
-//! handle are a terminal concern and live in the CLI crate (Phase 6) — a host
+//! handle are a terminal concern and live in the CLI crate — a host
 //! library has no business toggling the local TTY into raw mode.
 //!
 //! Keeping the loop out of the library also keeps it testable: the CLI bridge
@@ -32,7 +32,7 @@ use crate::error::Result;
 /// duplex over the remote PTY.
 ///
 /// Returned by [`Connection::shell`](super::Connection::shell). The consumer
-/// (the Phase 6 CLI bridge) pumps bytes both ways:
+/// (the CLI bridge) pumps bytes both ways:
 ///
 /// * [`read`](Self::read) drains shell output (stdout/stderr merged onto the
 ///   PTY, as a real terminal sees it) into `buf`, returning the byte count;

--- a/crates/mtui-hosts/src/connection/ssh.rs
+++ b/crates/mtui-hosts/src/connection/ssh.rs
@@ -38,9 +38,9 @@
 //!   documented follow-up.
 //! * **`sftp_open`** returns the file's bytes rather than a live file handle
 //!   (the object-safe trait surface); this covers every current caller.
-//! * The interactive PTY `shell` (feature `shell`, P2.10) returns an
+//! * The interactive PTY `shell` (feature `shell`) returns an
 //!   object-safe [`ShellChannel`] duplex over the PTY; the raw-`termios` local
-//!   terminal bridge that consumes it is a CLI concern (Phase 6).
+//!   terminal bridge that consumes it is a CLI concern.
 
 use std::future::Future;
 use std::path::{Path, PathBuf};

--- a/crates/mtui-hosts/src/connection/timeout.rs
+++ b/crates/mtui-hosts/src/connection/timeout.rs
@@ -8,7 +8,7 @@
 //!   that timeout is captured here as [`CommandTimeout`].
 //! * `policy_from_config` — maps the `ssh_strict_host_key_checking` config
 //!   string onto the transport-agnostic [`HostKeyPolicy`] enum; the russh impl
-//!   (P2.3) translates it into a russh client handler.
+//!   translates it into a russh client handler.
 //!
 //! Keeping these here keeps the russh `Connection` impl focused on the
 //! SSH/SFTP wrapper proper.
@@ -22,7 +22,7 @@ use mtui_types::enums::ParseEnumError;
 /// The SSH connect + per-command timeout, as a typed [`Duration`].
 ///
 /// Sourced from `mtui-config`'s `connection_timeout` (an integer number of
-/// seconds, default `300`). The russh impl (P2.3) uses this both to bound the
+/// seconds, default `300`). The russh impl uses this both to bound the
 /// TCP connect / banner / auth handshake and to abort a command whose channel
 /// produces no output within the window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/mtui-hosts/src/error.rs
+++ b/crates/mtui-hosts/src/error.rs
@@ -2,14 +2,14 @@
 //!
 //! Lives in `mtui-hosts` (not `mtui-types`) so the foundation crate stays
 //! I/O-free per the workspace architecture. The variants cover the failure
-//! modes of the SSH connection and command-timeout layers: authentication is
-//! public-key only (there is **no** password
+//! modes of the SSH connection, command-timeout, and SFTP transfer layers:
+//! authentication is public-key only (there is **no** password
 //! fallback), a remote command may time out, and a reconnect loop may give up.
 //!
-//! Later Phase 2 tasks (the russh impl, SFTP transfers) extend this enum with
-//! transport/SFTP variants; it is `#[non_exhaustive]` so adding them is not a
-//! breaking change. It will be wired into the top-level `mtui-types::Error`
-//! via `#[from]` once a real consumer needs the unified type.
+//! The enum is `#[non_exhaustive]` so adding variants is not a breaking
+//! change. It is not wired into the top-level `mtui-types::Error` via
+//! `#[from]` — like `mtui-datasources`'s error enums, it stays a standalone
+//! type rather than folding into a single unified hierarchy.
 
 use thiserror::Error;
 

--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -1,22 +1,22 @@
 //! `mtui-hosts` — SSH/SFTP host layer (russh), host groups, locks, targets.
 //!
-//! Phase 2 builds this crate up incrementally. The current surface is the
-//! [`Connection`] abstraction, the russh-backed [`SshConnection`] (connect /
-//! run-with-timeout / SFTP transfers), the scriptable [`MockConnection`] test
-//! double, the [`HostError`] hierarchy, the [`Target`] state machine
-//! (enabled/disabled command gating + connection-only `connect`), and the
-//! [`HostsGroup`] composite with its parallel/serial command + SFTP fan-out,
-//! the remote-lock protocol ([`TargetLock`] / [`PoolLock`] / [`RemoteLock`],
-//! P2.6), the in-process [`HostArbiter`] (P2.7), and the host-output parsers —
+//! The crate provides the [`Connection`] abstraction, the russh-backed
+//! [`SshConnection`] (connect / run-with-timeout / SFTP transfers), the
+//! scriptable [`MockConnection`] test double, the [`HostError`] hierarchy, the
+//! [`Target`] state machine (enabled/disabled command gating + connection-only
+//! `connect`), and the [`HostsGroup`] composite with its parallel/serial
+//! command + SFTP fan-out, the remote-lock protocol ([`TargetLock`] /
+//! [`PoolLock`] / [`RemoteLock`]), the in-process [`HostArbiter`], and the
+//! host-output parsers —
 //! [`parse_system`] / [`parse_product`](target::parsers::product::parse_product) / [`parse_os_release`](target::parsers::product::parse_os_release) plus the
-//! [`PackageQuerier`] (P2.8), and the install/uninstall [`Operation`] template
-//! (skeleton + trait, P2.9) — the `lock → run → check → reboot → unlock`
+//! [`PackageQuerier`], and the install/uninstall [`Operation`] template
+//! (skeleton + trait) — the `lock → run → check → reboot → unlock`
 //! flow driven over the object-safe [`OperationGroup`] seam — and, behind the
-//! `shell` feature, the interactive PTY shell (P2.10): `Connection::shell` /
+//! `shell` feature, the interactive PTY shell: `Connection::shell` /
 //! `Target::shell` returning an object-safe `ShellChannel` duplex over the
 //! remote PTY. Only the transport primitive lives here; the raw-`termios` local
 //! terminal bridge and the `shell` REPL command that consume it are a CLI
-//! concern (Phase 6).
+//! concern.
 
 pub mod connection;
 pub mod error;

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -90,7 +90,7 @@ pub enum LockOutcome {
 pub struct HostsGroup {
     data: BTreeMap<String, Target>,
     /// Whether the surrounding session is interactive. Threaded through to the
-    /// fan-out helpers as the (Phase 6) spinner/prompt seam; see
+    /// fan-out helpers as the spinner/prompt seam; see
     /// [`actions`].
     is_repl: bool,
     /// The injected update-workflow doer/check resolver, or `None` until the
@@ -1972,7 +1972,7 @@ mod tests {
         assert!(matches!(ops[1], MockSftpOp::Get { .. }));
     }
 
-    // --- reboot lifecycle (P2.9) -------------------------------------------
+    // --- reboot lifecycle ---------------------------------------------------
 
     /// A mock that answers the boot-id probe with a *fixed* `boot_id` (same value
     /// on every read) and everything else with "ok". Because the pre- and
@@ -2030,7 +2030,7 @@ mod tests {
 
     #[tokio::test]
     async fn reboot_selected_touches_only_named_hosts() {
-        // Regression for mtui-rs-issz: a `-t`-scoped reboot must fire the reboot,
+        // Regression: a `-t`-scoped reboot must fire the reboot,
         // reconnect, and verify only on the named subset; unselected hosts see no
         // reboot command, no reconnect, and produce no outcome entry.
         let (m1, m2) = (rebooted_mock("h1"), rebooted_mock("h2"));
@@ -2419,7 +2419,7 @@ mod tests {
         assert!(!failures[0].cause.host_still_reachable());
     }
 
-    // --- update_lock / lock / unlock fan-out (P2.9) -------------------------
+    // --- update_lock / lock / unlock fan-out --------------------------------
 
     #[tokio::test]
     async fn update_lock_locks_all_free_hosts() {

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -1226,7 +1226,7 @@ impl Target {
     /// does nothing and returns `None`.
     ///
     /// The returned handle is a transport duplex only; the raw-`termios` local
-    /// terminal bridge that consumes it is a CLI concern (Phase 6).
+    /// terminal bridge that consumes it is a CLI concern.
     ///
     /// Available only with the `shell` feature.
     #[cfg(feature = "shell")]
@@ -1801,7 +1801,7 @@ mod tests {
         t.check_stale_lock().await;
     }
 
-    // --- reboot / reconnect / boot_id lifecycle (P2.9) ----------------------
+    // --- reboot / reconnect / boot_id lifecycle -----------------------------
 
     #[tokio::test]
     async fn boot_id_reads_proc_and_strips() {
@@ -2054,7 +2054,7 @@ mod tests {
         assert!(!t.lock_status(true).await.is_locked);
     }
 
-    /// Oracle for mtui-rs-0mop.4: resolving a full `LockRow` must read the
+    /// Oracle: resolving a full `LockRow` must read the
     /// lockfile exactly once, not once per derived field.
     #[tokio::test]
     async fn lock_status_reads_lockfile_once() {

--- a/crates/mtui-hosts/src/target/parsers/system.rs
+++ b/crates/mtui-hosts/src/target/parsers/system.rs
@@ -3,7 +3,7 @@
 //! Every SFTP
 //! read is issued through a **single** batched [`SftpSession`] opened once via
 //! [`Connection::sftp_session`] — a host with many product files pays the SFTP
-//! channel+subsystem handshake once, not per probe (mtui-rs-0mop.3). The
+//! channel+subsystem handshake once, not per probe. The
 //! `sftp_session_count == 1` invariant
 //! is pinned by the `parse_system_opens_single_sftp_session` oracle.
 //!
@@ -218,7 +218,7 @@ mod tests {
 
     #[tokio::test]
     async fn parse_system_opens_single_sftp_session() {
-        // mtui-rs-0mop.3 handshake-count oracle: a host with a base + 2 addons
+        // Handshake-count oracle: a host with a base + 2 addons
         // (listdir + readlink + 3 opens + 2 transactional probes = 7 reads)
         // must open exactly ONE batched SFTP session, not one per read.
         let mut conn = sles_with_two_addons();

--- a/crates/mtui-hosts/tests/history_append.rs
+++ b/crates/mtui-hosts/tests/history_append.rs
@@ -1,4 +1,4 @@
-//! Integration tests for remote history append (mtui-rs-0mop.5).
+//! Integration tests for remote history append.
 //!
 //! `Target::add_history` records one `/var/log/mtui.log` line per call via the
 //! `Connection::sftp_append` primitive instead of the former

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -164,7 +164,7 @@ async fn install_drives_doer_and_reboots_only_transactional() {
 
     // The transactional host ran only the install as a normal command; the
     // reboot is dispatched fire-and-forget (the reboot drops the connection),
-    // then the host is reconnected — the P2.9 `_reboot` lifecycle.
+    // then the host is reconnected — the `_reboot` lifecycle.
     assert_eq!(
         package_commands(&m2),
         vec!["zypper -n in -y -l pkg-a pkg-b".to_owned()]

--- a/crates/mtui-hosts/tests/spinner_concurrent_logging.rs
+++ b/crates/mtui-hosts/tests/spinner_concurrent_logging.rs
@@ -1,6 +1,6 @@
 //! Regression: a live TTY spinner survives concurrent "logging" writes.
 //!
-//! The visible symptom this guards against (mtui-rs-wbo): the spinner is
+//! The visible symptom this guards against: the spinner is
 //! started by `run_parallel`/`run_fanout`, but during a fan-out the worker log
 //! lines and command output were written straight to the terminal, clobbering
 //! the `\r[|] desc` frame so it never rendered cleanly. Every log

--- a/crates/mtui-hosts/tests/ssh_integration.rs
+++ b/crates/mtui-hosts/tests/ssh_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the russh-backed [`SshConnection`] (P2.3).
+//! Integration tests for the russh-backed [`SshConnection`].
 //!
 //! These run **offline** against an **ephemeral in-process russh server** with
 //! a freshly generated host key — no Docker, no external sshd, so they execute
@@ -535,7 +535,7 @@ async fn connect(port: u16, timeout: CommandTimeout) -> SshConnection {
 /// Builds a [`Target`] whose live connection is a real [`SshConnection`] to the
 /// in-process fixture on `port`, labelled `name` and gated by `state`.
 ///
-/// This is the multi-target seam the P2.5 fan-out / P2.6 lock integration tests
+/// This is the multi-target seam the fan-out / lock integration tests
 /// need: several `Target`s can point at one shared server (one `SharedFs`), so
 /// `HostsGroup::run` and the remote-lock protocol are exercised over real SSH
 /// rather than a `MockConnection`.
@@ -1023,7 +1023,7 @@ async fn shell_spawns_pty_and_bridges_bytes() {
 }
 
 // ----------------------------------------------------------------------------
-// HostsGroup fan-out over real SSH targets (P2.5 DoD).
+// HostsGroup fan-out over real SSH targets.
 //
 // The colocated `hostgroup.rs` unit tests drive fan-out over `MockConnection`.
 // These prove the same fan-out end-to-end over the in-process russh server:
@@ -1087,7 +1087,7 @@ async fn hostsgroup_run_honours_per_host_state_end_to_end() {
 }
 
 // ----------------------------------------------------------------------------
-// Remote lock lifecycle over the fixture's real SFTP (P2.6 DoD).
+// Remote lock lifecycle over the fixture's real SFTP.
 //
 // `locks.rs` unit-tests the protocol over `MockConnection`. These prove the
 // same protocol over the in-process server's real SFTP subsystem — crucially

--- a/crates/mtui-mcp/Cargo.toml
+++ b/crates/mtui-mcp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "mtui-mcp"
 path = "src/main.rs"
 
-# Perf baseline bench (mtui-rs-0mop.1). Requires the `mcp` feature (the session +
+# Perf baseline bench. Requires the `mcp` feature (the session +
 # job model live behind it); `harness = false` -> criterion main. Run with
 # `cargo bench -p mtui-mcp --features mcp --bench mcp_jobs`.
 [[bench]]
@@ -27,7 +27,7 @@ path = "benches/mcp_jobs.rs"
 harness = false
 required-features = ["mcp"]
 
-# Contention measurement for different-RRID dispatch (mtui-rs-0mop.11). Requires
+# Contention measurement for different-RRID dispatch. Requires
 # the `mcp` feature. Run with
 # `cargo bench -p mtui-mcp --features mcp --bench dispatch_concurrency`.
 [[bench]]
@@ -85,5 +85,5 @@ mtui-types.workspace = true
 tokio-util = { workspace = true }
 futures.workspace = true
 tempfile = "3"
-# Perf baseline bench (mtui-rs-0mop.1): MCP scoped-lock acquire/release contention.
+# Perf baseline bench: MCP scoped-lock acquire/release contention.
 criterion.workspace = true

--- a/crates/mtui-mcp/benches/dispatch_concurrency.rs
+++ b/crates/mtui-mcp/benches/dispatch_concurrency.rs
@@ -1,22 +1,21 @@
-//! Contention measurement for different-RRID MCP dispatch (mtui-rs-0mop.11).
+//! Contention measurement for different-RRID MCP dispatch.
 //!
-//! Measurement-only, offline; requires the `mcp` feature. The lock *discipline*
-//! (RwGate + per-RRID locks) is already correct, but `McpSession::run_command`
-//! holds one monolithic `Arc<Mutex<Session>>` over the whole dispatch, so N
-//! commands scoped to N *distinct* RRIDs still serialise on that inner mutex.
+//! Measurement-only, offline; requires the `mcp` feature. `McpSession::run_command`
+//! dispatches a single-real-RRID call on a per-call [`Session::fork_for_call`]
+//! that shares the loaded reports' per-entry locks, so N commands scoped to N
+//! *distinct* RRIDs run concurrently rather than serialising on one session-wide
+//! mutex.
 //!
 //! This bench dispatches N probe commands — each scoped to its own loaded RRID
 //! and each holding a fixed CPU-free `hold` window inside the session lock — via
 //! `join_all`, at N ∈ {1,2,4,8}. The verdict oracle is the *shape* of the curve:
-//!
-//! * **Serialised** (today): wall-clock ≈ N × hold (each waits for the mutex).
-//! * **Concurrent** (post-f36r refactor): wall-clock ≈ ~1 × hold (they overlap).
+//! wall-clock ≈ ~1 × hold (the calls overlap) rather than ≈ N × hold (serialised).
 //!
 //! Wall-clock async timing is scheduler-noisy (the baseline calls it advisory);
-//! the deterministic oracle for the eventual fix is the interval-overlap
+//! the deterministic oracle is the interval-overlap
 //! assertion in `tests/session_concurrency.rs`, not these numbers. This bench
-//! only quantifies *whether* the contention is material enough to justify the
-//! Phase-2 refactor (see plans/mtui-rs-0mop.11-mcp-lock-contention.md).
+//! is a regression guard against contention creeping back into the dispatch
+//! path.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/mtui-mcp/benches/mcp_jobs.rs
+++ b/crates/mtui-mcp/benches/mcp_jobs.rs
@@ -1,4 +1,4 @@
-//! Perf baseline for MCP session lock behaviour (mtui-rs-0mop.1).
+//! Perf baseline for MCP session lock behaviour.
 //!
 //! Measurement-only, offline; requires the `mcp` feature (the session model is
 //! gated behind it). Measures [`McpSession::scoped_lock`] acquire+release, the

--- a/crates/mtui-mcp/src/argv.rs
+++ b/crates/mtui-mcp/src/argv.rs
@@ -33,8 +33,9 @@ use serde_json::{Map, Value};
 
 /// Re-encode a tool-call kwargs dict as `clap`-compatible argv.
 ///
-/// `argv_prefix` is prepended verbatim — used by the P7.6 subparser fan-out to
-/// inject a subcommand name (`["show"]` for the `config_show` tool). Args absent
+/// `argv_prefix` is prepended verbatim — used by the MCP tool synthesiser's
+/// subparser fan-out to inject a subcommand name (`["show"]` for the
+/// `config_show` tool). Args absent
 /// from `kwargs` or whose value is JSON `null` are skipped. Flags come first,
 /// then the positional tail (see the module docs for why).
 #[must_use]
@@ -472,8 +473,9 @@ mod tests {
 
     #[test]
     fn argv_prefix_is_prepended() {
-        // P7.6 fans `config` out per-subcommand and passes the *subparser* here
-        // (its args live on `set`, not the parent). Mirror that: introspect the
+        // The MCP tool synthesiser fans `config` out per-subcommand and passes
+        // the *subparser* here (its args live on `set`, not the parent). Mirror
+        // that: introspect the
         // `set` subcommand and prepend its name as the prefix.
         let parent = parser_for("config");
         let set = parent

--- a/crates/mtui-mcp/src/capture.rs
+++ b/crates/mtui-mcp/src/capture.rs
@@ -6,7 +6,7 @@
 //! provides a shared in-memory sink and a `session` constructor that wires it
 //! in via the public [`Session::with_display`] seam.
 //!
-//! ## Write-time cap (bead `mtui-rs-th4o.8`)
+//! ## Write-time cap
 //!
 //! The sink is **bounded**: it accepts at most `limit` bytes and *discards* the
 //! overflow at write time, recording the dropped-byte count. A command that

--- a/crates/mtui-mcp/src/concurrency.rs
+++ b/crates/mtui-mcp/src/concurrency.rs
@@ -13,12 +13,12 @@
 //! fairness queue beyond that; the single-session workload (a handful of
 //! concurrent subagents) does not need one.
 //!
-//! ## Locking depth (beads `mtui-rs-76e.11` + `mtui-rs-f36r` / `mtui-rs-0mop.11`)
+//! ## Locking depth
 //!
 //! This gate + the per-RRID lock map in [`crate::session`] land the lock
 //! *discipline*: same-RRID and unscoped calls serialise, and registry mutators
 //! drain in-flight per-RRID work. Genuine wall-clock concurrency between
-//! *different-RRID* calls **has landed** (`mtui-rs-f36r`): `mtui-core` report
+//! *different-RRID* calls **has landed**: `mtui-core` report
 //! entries are per-entry `Arc<Mutex<..>>`, and a single-real-RRID call dispatches
 //! on a [`Session::fork_for_call`](mtui_core::Session::fork_for_call) (sharing
 //! the entry locks, with its own display) via
@@ -102,7 +102,7 @@ impl RwGate {
     /// **Cancellation-safe:** the `writers_waiting` bump is owned by a
     /// [`PendingWriter`] RAII guard, so dropping this future while parked (e.g. a
     /// cancelled MCP request) restores the counter and wakes waiters rather than
-    /// leaking the bump and deadlocking readers (`mtui-rs-b8yi`). On success the
+    /// leaking the bump and deadlocking readers. On success the
     /// pending guard is disarmed and the count is handed to the [`ExclusiveGuard`],
     /// which decrements it on its own drop — so success-path accounting is
     /// unchanged.
@@ -304,7 +304,7 @@ mod tests {
 
     /// Cancelling a *waiting* writer (its `exclusive()` future is dropped before
     /// it ever acquires) must not leak `writers_waiting`, or new shared
-    /// acquisitions would be blocked forever. Regression for `mtui-rs-b8yi`.
+    /// acquisitions would be blocked forever.
     #[tokio::test]
     async fn cancelled_writer_does_not_block_readers() {
         let gate = RwGate::new();

--- a/crates/mtui-mcp/src/deny.rs
+++ b/crates/mtui-mcp/src/deny.rs
@@ -16,7 +16,7 @@
 //! - `quit`, `exit`, `EOF`: exit the process and would tear down the MCP server
 //!   along with the client connection.
 //! - `edit`: spawns `$EDITOR` on the controlling TTY; the testreport tools
-//!   (P7.8) operate on the loaded report file directly instead.
+//!   operate on the loaded report file directly instead.
 //! - `shell`: opens an interactive root PTY on a refhost and needs a TTY the MCP
 //!   transports do not provide.
 //! - `help`: prints argparser help to stdout; the MCP protocol already

--- a/crates/mtui-mcp/src/provider.rs
+++ b/crates/mtui-mcp/src/provider.rs
@@ -1,7 +1,7 @@
 //! Session resolution seam: [`SessionProvider`] + the stdio [`StdioProvider`],
 //! plus the http [`SessionRegistry`] factory with its cap + idle-TTL enforcement.
 //!
-//! The tool layer (P7.6 `tools`, P7.8 `testreport_tools`) resolves the
+//! The tool layer ([`crate::tools`], [`crate::testreport_tools`]) resolves the
 //! [`McpSession`] for each call through a [`SessionProvider`], so it never cares
 //! which transport it runs under. There are exactly two implementers:
 //!
@@ -18,7 +18,7 @@
 //! `get_or_create(key)` signature, which is why the trait — not a concrete
 //! session — is the seam.
 //!
-//! ## Cap + idle-TTL (bead `mtui-rs-odq8`)
+//! ## Cap + idle-TTL
 //!
 //! rmcp 2.2.0 gives no built-in max-sessions or idle-TTL knob, and its
 //! `service_factory` receives **no** session key while rmcp itself owns session

--- a/crates/mtui-mcp/src/schema.rs
+++ b/crates/mtui-mcp/src/schema.rs
@@ -43,7 +43,8 @@ pub(crate) fn command_input_schema(cmd: &clap::Command) -> Map<String, Value> {
     for arg in cmd.get_arguments() {
         // clap injects `help`/`version` args (unless disabled). They carry no
         // callable value — the tool envelope advertises descriptions instead —
-        // so drop them exactly as upstream drops `_HelpAction`/`_VersionAction`.
+        // so `--help`/`--version` are parser plumbing, not tool inputs, and are
+        // dropped from the schema.
         let id = arg.get_id().as_str();
         if id == "help" || id == "version" {
             continue;
@@ -114,8 +115,8 @@ fn arg_to_property(arg: &Arg) -> (Value, bool) {
         array.insert("items".to_owned(), Value::Object(inner));
         apply_list_bounds(&mut array, arg.get_num_args());
         // A list arg is required only when clap marks it required *and* it has no
-        // default; otherwise it is optional (upstream defaults optional lists to
-        // `[]`/their real default, keeping the schema a plain array).
+        // default; otherwise it is optional, defaulting to `[]` or its real
+        // default so the schema stays a plain array.
         let has_default = !arg.get_default_values().is_empty();
         let required = arg.is_required_set() && !has_default;
         if let Some(def) = default_array(arg) {
@@ -150,8 +151,8 @@ fn arg_to_property(arg: &Arg) -> (Value, bool) {
     }
 
     // Optional scalar with no default: widen to `X | null` so the schema
-    // reflects nullability rather than failing client-side validation (upstream
-    // `Annotated[T | None, …]`). enum members stay inside the string alternative.
+    // reflects nullability rather than failing client-side validation. enum
+    // members stay inside the string alternative.
     let nullable = wrap_nullable(inner);
     (nullable, false)
 }
@@ -184,8 +185,7 @@ impl ScalarKind {
 ///
 /// Possible values (`PossibleValuesParser`) win → `enum`. Otherwise the value
 /// parser's output [`TypeId`] selects integer vs string; an unrecognised parser
-/// degrades to string with a WARNING, mirroring upstream's "unknown argparse
-/// type … falling back to str".
+/// degrades to string with a WARNING rather than failing schema synthesis.
 fn base_type(arg: &Arg) -> BaseType {
     let choices = arg.get_possible_values();
     if !choices.is_empty() {

--- a/crates/mtui-mcp/src/schema.rs
+++ b/crates/mtui-mcp/src/schema.rs
@@ -5,9 +5,9 @@
 //! like `{"type":"object","properties":{…},"required":[…]}`.
 //!
 //! It is intentionally pure: the single entry point [`command_input_schema`]
-//! takes a `&clap::Command` and returns plain data. Tool registration, argv
-//! reconstruction, and schema slimming live in the sibling P7.6/P7.5/P7.9
-//! modules.
+//! takes a `&clap::Command` and returns plain data. Tool registration
+//! ([`crate::tools`]), argv reconstruction ([`crate::argv`]), and schema
+//! slimming ([`crate::slim`]) live in the sibling modules.
 //!
 //! # Design notes
 //!
@@ -33,8 +33,8 @@ use serde_json::{Map, Value, json};
 ///
 /// Walks `cmd.get_arguments()`, skipping the auto `--help`/`--version` args, and
 /// emits one property per remaining arg plus a top-level `required` list. The
-/// result is the `inputSchema` for the tool `rmcp` synthesises from this command
-/// (P7.6). `required` is omitted entirely when empty.
+/// result is the `inputSchema` for the tool `rmcp` synthesises from this
+/// command. `required` is omitted entirely when empty.
 #[must_use]
 pub(crate) fn command_input_schema(cmd: &clap::Command) -> Map<String, Value> {
     let mut properties = Map::new();
@@ -344,8 +344,9 @@ mod tests {
 
     /// Build the per-command clap parser the way each command's own unit tests
     /// do: a bare `no_binary_name` base with the command's `configure` applied.
-    /// The base template flags (`-T`/`--all-templates`) are the caller's concern
-    /// (P7.6) and out of scope for the per-arg schema this task produces.
+    /// The base template flags (`-T`/`--all-templates`) are the tool
+    /// synthesiser's concern and out of scope for the per-arg schema this
+    /// module produces.
     fn schema_for(command: &str) -> Map<String, Value> {
         let registry: Registry = register_all();
         let cmd = registry

--- a/crates/mtui-mcp/src/server.rs
+++ b/crates/mtui-mcp/src/server.rs
@@ -1,11 +1,9 @@
-//! The production MCP server handler (P7.7).
+//! The production MCP server handler.
 //!
 //! A hand-written [`ServerHandler`] whose [`list_tools`](ServerHandler::list_tools)
 //! and [`call_tool`](ServerHandler::call_tool) are built at *runtime* from the
-//! command [`Registry`], built dynamically rather than declared per tool. This
-//! grew out of the P7.1 spike (which proved
-//! the runtime-registration approach against rmcp 2.x with a single hard-coded
-//! `whoami` tool); it now synthesises the **full** tool surface via
+//! command [`Registry`], built dynamically rather than declared per tool, and
+//! synthesises the **full** tool surface via
 //! [`crate::tools`].
 //!
 //! On construction the server precomputes, once:
@@ -23,8 +21,8 @@
 //! server instance serves the process's one client; under http the
 //! [`SessionRegistry`](crate::provider::SessionRegistry) mints a fresh server
 //! (hence a fresh isolated session) per MCP session. The testreport tools are
-//! bead `mtui-rs-76e.8`; the job tools drive the session's background-job table
-//! (bead `mtui-rs-76e.12`).
+//! hand-written (not synthesised from the registry); the job tools drive the
+//! session's background-job table.
 
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -303,10 +301,9 @@ impl ServerHandler for McpServer {
 
 /// Render a dispatch result into a [`CallToolResult`].
 ///
-/// Success returns the captured (output-capped) stdout; failure returns an error
-/// result whose text is the captured stdout followed by the error summary — the
-/// same envelope the P7.1 spike used, preserving any output produced before the
-/// failure.
+/// Success returns the captured (output-capped) stdout; failure returns an
+/// error result whose text is the captured stdout followed by the error
+/// summary, preserving any output produced before the failure.
 fn render(result: Result<String, crate::session::McpCommandError>) -> CallToolResult {
     match result {
         Ok(text) => CallToolResult::success(vec![ContentBlock::text(text)]),

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -6,40 +6,36 @@
 //! result, and
 //! exposes [`run_command`](McpSession::run_command) — the central dispatch
 //! primitive the tool layer calls (drain → dispatch → capture → output-cap).
+//! `run_command` also supplies the [`McpCommandError`] failure envelope and
+//! the per-result output cap (`[mcp] max_output_bytes`); the non-interactive
+//! contract (`interactive = false`, unset prompter) is provided by
+//! `capture::session` passing `is_repl = false`.
 //!
 //! Under **stdio** one instance serves the single client; under **http** the
-//! future `SessionRegistry` (P7.10) owns one instance per client. In both cases
+//! `SessionRegistry` owns one instance per client. In both cases
 //! the [`crate::provider::SessionProvider`] seam hands callers an
-//! `Arc<McpSession>`, so the tool layer (P7.6/P7.8) stays transport-agnostic.
+//! `Arc<McpSession>`, so the tool layer stays transport-agnostic.
 //!
-//! ## Scope (landed vs deferred)
+//! ## Four mechanisms
 //!
-//! P7.3 landed the dispatch primitive: `run_command`, the [`McpCommandError`]
-//! failure envelope, and the per-result output cap (`[mcp] max_output_bytes`).
-//! The non-interactive contract (`interactive = false`, unset prompter) is
-//! already provided by `capture::session` passing `is_repl = false`.
+//! **Per-template lock discipline.** A shared/exclusive registry gate
+//! ([`crate::concurrency::RwGate`]) plus a lazily-created per-RRID lock map.
+//! `command_lock` takes the gate *shared* + one per-RRID lock for a
+//! single-template call (so same-RRID calls serialise and different-RRID
+//! calls take distinct locks) and the gate *exclusive* for fan-out / registry
+//! mutators; [`scoped_lock`](McpSession::scoped_lock) is the same hold for
+//! the hand-written testreport tools. This also gives genuine wall-clock
+//! concurrency between *different-RRID* calls plus per-call output isolation:
+//! a single-real-RRID call dispatches on a [`Session::fork_for_call`] (which
+//! shares the loaded reports' per-entry `Arc<Mutex<..>>` locks and carries its
+//! own display) via [`dispatch_command`], spawned so it overlaps a concurrent
+//! different-RRID call; [`run_command`](McpSession::run_command) does not hold
+//! a session-wide mutex across the scoped dispatch. Registry-structure
+//! mutators ([`Command::mutates_registry`](mtui_core::Command::mutates_registry))
+//! and unscoped fan-out still take the gate *exclusive* against the canonical
+//! session.
 //!
-//! P7.3a (`mtui-rs-76e.11`) landed the per-template **lock discipline**: a
-//! shared/exclusive registry gate ([`crate::concurrency::RwGate`]) plus a
-//! lazily-created per-RRID lock map.
-//! `command_lock` takes the gate *shared* + one
-//! per-RRID lock for a single-template call (so same-RRID calls serialise and
-//! different-RRID calls take distinct locks) and the gate *exclusive* for
-//! fan-out / registry mutators; [`scoped_lock`](McpSession::scoped_lock) is the
-//! same hold for the hand-written testreport tools.
-//!
-//! **Landed** (`mtui-rs-f36r` / `mtui-rs-0mop.11`) — genuine wall-clock
-//! concurrency between *different-RRID* calls plus per-call output isolation. A
-//! single-real-RRID call dispatches on a [`Session::fork_for_call`] (which shares
-//! the loaded reports' per-entry `Arc<Mutex<..>>` locks and carries its own
-//! display) via [`dispatch_command`], spawned so it overlaps a concurrent
-//! different-RRID call; [`run_command`](McpSession::run_command) no longer holds
-//! a session-wide mutex across the scoped dispatch. Registry-structure mutators
-//! ([`Command::mutates_registry`](mtui_core::Command::mutates_registry)) and
-//! unscoped fan-out still take the gate *exclusive* against the canonical
-//! session. All four `tests/session_concurrency.rs` parity tests pass.
-//!
-//! P7.3b (`mtui-rs-76e.12`) landed the **background-job table** (`_jobs`): a slow
+//! **Background-job table** (`_jobs`). A slow
 //! `run`/`update`/`downgrade` can be started with
 //! [`start_jobs`](McpSession::start_jobs) (one job per resolved template, each
 //! `-T <rrid>`-scoped) and returns a handle immediately instead of holding the
@@ -48,9 +44,8 @@
 //! and controlled via [`job_list`](McpSession::job_list) /
 //! [`job_cancel`](McpSession::job_cancel). Each job worker runs through the same
 //! [`run_command`](McpSession::run_command) primitive (so it takes the same
-//! per-RRID / registry gate and output cap as a foreground call).
-//!
-//! Bead `mtui-rs-th4o.8` bounded this table's resource use: a spawn is rejected
+//! per-RRID / registry gate and output cap as a foreground call). The table's
+//! resource use is bounded: a spawn is rejected
 //! (before allocating a worker) once the session holds
 //! `[mcp] max_active_jobs` running jobs — a fan-out is admitted or rejected as a
 //! whole — and terminal records are FIFO-evicted to `[mcp] max_completed_jobs`
@@ -59,8 +54,8 @@
 //! (see [`crate::capture`]) so a single command cannot buffer more than
 //! `[mcp] max_output_bytes` before the cap applies.
 //!
-//! P7.3d (`mtui-rs-76e.14`) landed the `notifications/progress` **heartbeats**:
-//! a long-running foreground tool call (`run_command_with_progress`) races the
+//! **Progress heartbeats** (`notifications/progress`). A long-running
+//! foreground tool call (`run_command_with_progress`) races the
 //! dispatch against a ticker that emits a progress frame every
 //! `DEFAULT_PROGRESS_INTERVAL` against a transport-free [`ProgressSink`], so an
 //! MCP client that honours the protocol's progress contract does not time out on
@@ -68,8 +63,8 @@
 //! `progressToken`) is built in [`crate::server`] from the request context; this
 //! layer stays rmcp-free. A `None` sink takes the original zero-overhead path.
 //!
-//! P7.3c (`mtui-rs-76e.13`) landed [`close`](McpSession::close): the session
-//! teardown the http `SessionRegistry` (P7.10 / `mtui-rs-odq8`) calls on
+//! **[`close`](McpSession::close).** The session
+//! teardown the http `SessionRegistry` calls on
 //! eviction. For **every** loaded template it releases the report's pool claims
 //! then disconnects its host group, best-effort + idempotent, under a bounded
 //! `DISCONNECT_TIMEOUT` so a wedged host close cannot block the idle-sweep.
@@ -318,14 +313,14 @@ pub struct JobView {
 
 /// Process-global monotonic source of [`McpSession::id`] values. Each session
 /// pulls a fresh id at construction, so two distinct sessions never share one
-/// (freshness independent of heap-address reuse — bead `mtui-rs-1edj`).
+/// (freshness independent of heap-address reuse).
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(0);
 
 /// A headless mtui session backing one MCP client.
 ///
 /// Holds the [`Session`] behind a [`Mutex`] because command dispatch
 /// ([`mtui_core::dispatch_argv`]) needs `&mut Session` while the rmcp
-/// `ServerHandler` methods take `&self` (P7.1 spike finding). The paired
+/// `ServerHandler` methods take `&self`. The paired
 /// [`SharedBuf`] is the sink the session's display writes to; a tool call
 /// [`take`](SharedBuf::take)s it to isolate its own output.
 pub struct McpSession {
@@ -376,8 +371,8 @@ pub struct McpSession {
     /// sweep drops the whole session and its table with it; within a session's
     /// lifetime the table is **bounded** — active spawns are capped by
     /// [`max_active_jobs`](Self::max_active_jobs) and terminal records are
-    /// FIFO-evicted to [`max_completed_jobs`](Self::max_completed_jobs) (bead
-    /// `mtui-rs-th4o.8`). The outer [`StdMutex`] guards insert/lookup/eviction
+    /// FIFO-evicted to [`max_completed_jobs`](Self::max_completed_jobs). The
+    /// outer [`StdMutex`] guards insert/lookup/eviction
     /// only (never held across an await).
     jobs: StdMutex<HashMap<String, Arc<StdMutex<Job>>>>,
     /// Monotonic job-id counter, pre-incremented per minted job so ids are
@@ -550,7 +545,7 @@ impl McpSession {
             // to a single template: the concurrent path dispatches on a per-call
             // fork whose registry snapshot is discarded, so a structural mutation
             // would be lost unless it runs against the canonical session under
-            // the exclusive gate (`mtui-rs-f36r`, steps 4-5).
+            // the exclusive gate.
             Some(command) if command.mutates_registry() => None,
             Some(command) => {
                 let session = self.session.lock().await;
@@ -610,7 +605,7 @@ impl McpSession {
 
     /// Releases pool claims and disconnects every loaded template's hosts.
     ///
-    /// Owned by the http `SessionRegistry` (P7.10 / `mtui-rs-odq8`), which calls
+    /// Owned by the http `SessionRegistry`, which calls
     /// it when it evicts a session (idle-TTL sweep or explicit eviction).
     /// Mirrors the REPL `quit`
     /// disconnect path — `HostsGroup::close` per
@@ -700,7 +695,7 @@ impl McpSession {
     /// (non-mutator) call then dispatches on a
     /// [`Session::fork_for_call`](mtui_core::Session::fork_for_call) — sharing the
     /// report entry locks, with its own display — spawned so it runs in genuine
-    /// parallel with a concurrent different-RRID call (`mtui-rs-f36r`); the
+    /// parallel with a concurrent different-RRID call; the
     /// exclusive path dispatches on the canonical session so its config/registry
     /// mutations persist. A `--help`/`--version` request is a *success* (its text
     /// is returned), matching argparse's exit-0 semantics.
@@ -743,7 +738,7 @@ impl McpSession {
         // whole dispatch, released when `_lock` drops at end of scope.
         let lock = self.command_lock(registry, name, argv).await;
 
-        // Per-call output isolation (bead `mtui-rs-f36r`, step 3): give this
+        // Per-call output isolation: give this
         // dispatch its *own* fresh capture buffer + display so two overlapping
         // calls never write into the same buffer and clobber each other's stdout.
         // Bounded to the same budget as the session-wide sink.
@@ -752,7 +747,7 @@ impl McpSession {
             CommandPromptDisplay::with_sink(Box::new(call_buf.clone()), ColorMode::Never);
 
         let result = match &lock {
-            // Concurrent path (bead `mtui-rs-f36r`, steps 4-5): a single-real-RRID
+            // Concurrent path: a single-real-RRID
             // call holds the gate *shared* + its per-RRID lock. Fork a per-call
             // `Session` that *shares* the loaded reports' per-entry locks (so this
             // call locks only its own template's entry) and dispatch on it —
@@ -934,7 +929,7 @@ impl McpSession {
     /// Reject a spawn of `n` new jobs when it would breach the active cap.
     ///
     /// Enforced against the *projected* running count so a fan-out is admitted or
-    /// rejected as a whole (no partial spawn — bead `mtui-rs-th4o.8`). Must be
+    /// rejected as a whole (no partial spawn). Must be
     /// called while holding `jobs_guard` so the count and the subsequent inserts
     /// are atomic against a concurrent (http) spawn. `max_active_jobs == 0`
     /// disables the cap.
@@ -1331,7 +1326,7 @@ mod tests {
 
     /// Each session gets a distinct id, and a session's id is stable across
     /// calls — the freshness invariant `remint_after_drop_is_a_new_session`
-    /// relies on instead of `Arc` address identity (bead `mtui-rs-1edj`).
+    /// relies on instead of `Arc` address identity.
     #[test]
     fn session_id_is_unique_and_stable() {
         let a = McpSession::new(Config::default());
@@ -1718,7 +1713,7 @@ mod tests {
     /// A registry-structure mutator (`load_template`) takes the gate *exclusive*
     /// even when a single template is loaded (so its `resolve_command_rrids`
     /// would otherwise be a single RRID). Guards the `mutates_registry` routing
-    /// added in `mtui-rs-f36r` steps 4-5: a structural mutation must land on the
+    /// added for the concurrent dispatch path: a structural mutation must land on the
     /// canonical session, not a discarded per-call fork. A content command scoped
     /// to that same template still takes the *scoped* (concurrent) path.
     #[tokio::test]
@@ -1964,7 +1959,7 @@ mod tests {
         assert_eq!(err.exit_code, 1);
     }
 
-    // ---- progress heartbeats (bead mtui-rs-76e.14) ------------------------ //
+    // ---- progress heartbeats ----------------------------------------------- //
 
     /// Records every frame `report` receives.
     #[derive(Default)]

--- a/crates/mtui-mcp/src/slim.rs
+++ b/crates/mtui-mcp/src/slim.rs
@@ -3,7 +3,7 @@
 //! Two token-budget concerns live here, co-located:
 //!
 //! * `cap_output` — the per-tool-result byte bound.
-//! * `slim_tool_schema` — the JSON-Schema slimming pass (P7.9) that drops
+//! * `slim_tool_schema` — the JSON-Schema slimming pass that drops
 //!   redundant `title` keys, flattens `anyOf: [{type: X}, {type: null}]` unions,
 //!   and terse-rewrites the long shared `help` strings before the tool list goes
 //!   on the wire.

--- a/crates/mtui-mcp/src/testreport_tools.rs
+++ b/crates/mtui-mcp/src/testreport_tools.rs
@@ -32,7 +32,7 @@
 //! with >1 loaded refuses (no client-addressable "active" pointer under MCP);
 //! omitted with 0/1 loaded falls back to the active report.
 //!
-//! ## Progress heartbeats (bead `mtui-rs-76e.14`)
+//! ## Progress heartbeats
 //!
 //! [`dispatch_testreport_tool`] races the tool body against the same heartbeat as
 //! the auto-generated command tools (via `run_with_heartbeat`) when the client
@@ -167,7 +167,7 @@ fn resolve_dir(session: &Session, template: Option<&str>) -> Result<PathBuf, Mcp
 /// path), then a symlink-aware re-check that canonicalizes the target's longest
 /// *existing* ancestor. The second stage catches a symlink placed *inside* the
 /// checkout that points outside the tree, which the lexical pass alone would
-/// follow (bead `mtui-rs-ir0d`).
+/// follow.
 fn safe_template_file(base: &Path, relpath: &str) -> Result<PathBuf, McpCommandError> {
     let base_resolved = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
     let joined = base_resolved.join(relpath);

--- a/crates/mtui-mcp/src/tools.rs
+++ b/crates/mtui-mcp/src/tools.rs
@@ -15,12 +15,12 @@
 //! fields are required). Slow host commands gain a `background` boolean.
 //!
 //! This layer is intentionally **transport-free**: it returns plain descriptors
-//! and routes, not `rmcp` types. P7.7 converts a [`ToolDescriptor`] into an
-//! `rmcp::model::Tool` and wires `dispatch_tool` into the `ServerHandler`.
+//! and routes, not `rmcp` types. [`crate::server`] converts a [`ToolDescriptor`]
+//! into an `rmcp::model::Tool` and wires `dispatch_tool` into the `ServerHandler`.
 //!
 //! The background-job path (`dispatch_tool` with `background = true`, and the
 //! four job tools from [`job_tool_descriptors`]) drives the session's `_jobs`
-//! table (bead `mtui-rs-76e.12`): a `background=true` slow call fans out one job
+//! table: a `background=true` slow call fans out one job
 //! per resolved template and returns their ids immediately, and the four job
 //! tools poll/control that table.
 
@@ -69,7 +69,7 @@ const READ_ONLY_EXACT: &[&str] = &["whoami", "openqa_overview", "openqa_jobs"];
 
 /// A synthesised MCP tool as plain data (transport-free).
 ///
-/// P7.7 converts this into `rmcp::model::Tool` (name + description +
+/// [`crate::server`] converts this into `rmcp::model::Tool` (name + description +
 /// `Arc<input_schema>` + `ToolAnnotations { read_only_hint }`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolDescriptor {

--- a/crates/mtui-mcp/tests/http_body_limit.rs
+++ b/crates/mtui-mcp/tests/http_body_limit.rs
@@ -1,4 +1,4 @@
-//! HTTP request-body limit wiring for the http transport (mtui-rs-kr7j).
+//! HTTP request-body limit wiring for the http transport.
 //!
 //! `serve_http` mounts rmcp behind an axum `DefaultBodyLimit` derived from
 //! `config.mcp_max_request_bytes`, so an unauthenticated pre-session request

--- a/crates/mtui-mcp/tests/http_isolation.rs
+++ b/crates/mtui-mcp/tests/http_isolation.rs
@@ -1,4 +1,4 @@
-//! Per-client session isolation for the http transport (P7.10, mtui-rs-76e.10).
+//! Per-client session isolation for the http transport.
 //!
 //! Under `--transport http` one process serves many clients, and each must see
 //! **only its own** loaded template + SSH `targets`; sharing one session would

--- a/crates/mtui-mcp/tests/mcp_jobs.rs
+++ b/crates/mtui-mcp/tests/mcp_jobs.rs
@@ -1,4 +1,4 @@
-//! Tests for the background-job (async slow-op) path (bead `mtui-rs-76e.12`).
+//! Tests for the background-job (async slow-op) path.
 //!
 //! A backgrounded command runs in a spawned worker that goes through the same
 //! [`McpSession::run_command`] primitive (so it takes the same per-RRID /
@@ -339,7 +339,7 @@ async fn cancel_one_template_job_leaves_others() {
 }
 
 // --------------------------------------------------------------------------- //
-// Resource limits (bead mtui-rs-th4o.8)                                        //
+// Resource limits                                                              //
 // --------------------------------------------------------------------------- //
 
 /// A session with explicit active/completed job caps and a deterministic user.
@@ -463,7 +463,7 @@ async fn completed_jobs_are_fifo_evicted_to_the_cap() {
 // The "eviction spares running jobs" invariant is proven deterministically as a
 // unit test in `session.rs` (it needs direct access to the private jobs table;
 // an integration test cannot drive a concurrent completion while another job
-// holds the single session mutex — see the `mtui-rs-f36r` caveat).
+// holds the single session mutex).
 
 // --------------------------------------------------------------------------- //
 // Test-only blocking probes                                                   //

--- a/crates/mtui-mcp/tests/mcp_version.rs
+++ b/crates/mtui-mcp/tests/mcp_version.rs
@@ -1,4 +1,4 @@
-//! Smoke test for the `mtui-mcp` binary's `--version` surface (P8.1).
+//! Smoke test for the `mtui-mcp` binary's `--version` surface.
 //!
 //! Mirrors `mtui-cli/tests/cli_smoke.rs::version_prints_provenance_block_and_exits_zero`
 //! for the second binary: drive the built `mtui-mcp` via `CARGO_BIN_EXE_mtui-mcp`

--- a/crates/mtui-mcp/tests/session_close.rs
+++ b/crates/mtui-mcp/tests/session_close.rs
@@ -1,4 +1,4 @@
-//! Tests for the `close()` host-teardown behaviours (bead `mtui-rs-76e.13`).
+//! Tests for the `close()` host-teardown behaviours.
 //!
 //! Three behaviours:
 //!

--- a/crates/mtui-mcp/tests/session_concurrency.rs
+++ b/crates/mtui-mcp/tests/session_concurrency.rs
@@ -177,7 +177,7 @@ async fn same_rrid_serialises() {
 
 /// Two calls scoped to *different* templates overlap in time.
 ///
-/// Genuine wall-clock concurrency (bead `mtui-rs-f36r`, steps 4-5): each call
+/// Genuine wall-clock concurrency: each call
 /// forks a per-call `Session` sharing only its own template's per-entry report
 /// lock, so different-RRID dispatch no longer serialises on a session-wide
 /// mutex.
@@ -214,11 +214,11 @@ async fn different_rrids_run_concurrently() {
 
 /// Overlapping different-RRID runs each capture only their own output.
 ///
-/// Per-call output isolation (bead `mtui-rs-f36r`, step 3): `run_command` swaps a
+/// Per-call output isolation: `run_command` swaps a
 /// fresh capture buffer + display onto the session for each dispatch, so even
 /// interleaved calls each return exactly their own stdout. (This does not require
-/// wall-clock parallelism — the sibling `different_rrids_run_concurrently` still
-/// awaits the step-5 outer-mutex removal.)
+/// wall-clock parallelism, which the sibling `different_rrids_run_concurrently`
+/// proves independently.)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn do_not_clobber_each_others_stdout() {
     let seen: Intervals = Arc::new(Mutex::new(Vec::new()));

--- a/crates/mtui-mcp/tests/session_registry.rs
+++ b/crates/mtui-mcp/tests/session_registry.rs
@@ -1,4 +1,4 @@
-//! Cap + idle-TTL enforcement for the http `SessionRegistry` (bead `mtui-rs-odq8`).
+//! Cap + idle-TTL enforcement for the http `SessionRegistry`.
 //!
 //! Covers the offline-portable subset of the registry's cap/idle-TTL behaviour.
 //! Session-key/log-label-style cases do not apply here: rmcp owns session
@@ -107,7 +107,7 @@ async fn remint_after_drop_is_a_new_session() {
     // the re-mint. Freshness is asserted via the session's stable, monotonic
     // `id()` — not `Arc` address identity, which the allocator can reuse after a
     // drop (a flake that surfaced once these tests share one process, the
-    // consolidated `it` binary, instead of one binary each — bead mtui-rs-1edj).
+    // consolidated `it` binary, instead of one binary each).
     let reg = registry(2, 0);
 
     let first = reg.live_sessions();

--- a/crates/mtui-mcp/tests/slim_profile.rs
+++ b/crates/mtui-mcp/tests/slim_profile.rs
@@ -1,9 +1,9 @@
-//! P7.9 golden contracts: the slimmed tool schemas and the `core` keep-set.
+//! Golden contracts: the slimmed tool schemas and the `core` keep-set.
 //!
 //! These pin two things a client depends on:
 //!
 //! * the full **slimmed** JSON schema of every synthesised command tool (the
-//!   half `tools_synthesis.rs` deferred to P7.9), so a schema-slimming or
+//!   half `tools_synthesis.rs` leaves to this file), so a schema-slimming or
 //!   arg-spec regression surfaces in review; and
 //! * the resolved `core` profile keep-set against the live registry, so a
 //!   rename that drops a curated tool from `core` is caught.

--- a/crates/mtui-mcp/tests/stdio_roundtrip.rs
+++ b/crates/mtui-mcp/tests/stdio_roundtrip.rs
@@ -1,4 +1,4 @@
-//! P7.7 gate: the MCP round-trip contract test.
+//! The MCP round-trip contract test.
 //!
 //! It connects an rmcp client to the production [`McpServer`] over an in-memory
 //! duplex transport (no subprocess, no socket) and proves the runtime-synthesis
@@ -93,7 +93,7 @@ async fn tools_list_reflects_synthesised_surface_and_denylist() {
             );
         }
 
-        // The hand-written testreport tools (bead mtui-rs-76e.8).
+        // The hand-written testreport tools.
         for expected in [
             "testreport_read",
             "testreport_logs",

--- a/crates/mtui-mcp/tests/testreport_tools.rs
+++ b/crates/mtui-mcp/tests/testreport_tools.rs
@@ -1,4 +1,4 @@
-//! P7.8 testreport-tools integration test.
+//! Integration test for the testreport tools.
 //!
 //! Library-level (not stdio) checks that the hand-written testreport tools drive
 //! a fixture checkout end-to-end through the public `dispatch_testreport_tool`

--- a/crates/mtui-mcp/tests/tools_synthesis.rs
+++ b/crates/mtui-mcp/tests/tools_synthesis.rs
@@ -1,9 +1,10 @@
-//! P7.6 synthesis contract test.
+//! Contract test for tool synthesis.
 //!
 //! Library-level (not stdio) checks that the tool set synthesised from the
 //! command registry honours the deny-list, the `config` fan-out, the slow-command
 //! `background` flag, and the read-only allow-list. The full stdio round-trip
-//! (`tools/list` + `tools/call` over a transport) is P7.7's gating test.
+//! (`tools/list` + `tools/call` over a transport) is gated by
+//! `stdio_roundtrip.rs`.
 
 #![cfg(feature = "mcp")]
 
@@ -37,7 +38,7 @@ fn config_fan_out() {
 
 /// Snapshot the synthesised surface — tool name + read_only flag — plus the job
 /// tools, so an accidental deny/rename/hint change surfaces in review. Full-schema
-/// goldens are P7.9's job; this pins names + hints only.
+/// goldens are `slim_profile.rs`'s job; this pins names + hints only.
 #[test]
 fn tool_surface_snapshot() {
     let mut rows: Vec<String> = build_tools(&register_all())

--- a/crates/mtui-testreport/Cargo.toml
+++ b/crates/mtui-testreport/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 name = "it"
 path = "tests/it.rs"
 
-# Perf baseline bench (mtui-rs-0mop.1). `harness = false` -> criterion main.
+# Perf baseline bench. `harness = false` -> criterion main.
 [[bench]]
 name = "testreport"
 path = "benches/testreport.rs"
@@ -42,7 +42,7 @@ thiserror.workspace = true
 insta.workspace = true
 tempfile = "3"
 wiremock.workspace = true
-# Perf baseline bench (mtui-rs-0mop.1): metadata JSON parse hot path.
+# Perf baseline bench: metadata JSON parse hot path.
 criterion.workspace = true
 # Scoped subscriber to capture WARN output in tests.
 tracing-subscriber.workspace = true

--- a/crates/mtui-testreport/benches/testreport.rs
+++ b/crates/mtui-testreport/benches/testreport.rs
@@ -1,5 +1,5 @@
-//! Perf baseline for testreport metadata parsing (mtui-rs-0mop.1) plus the
-//! blocking-filesystem paths converted in mtui-rs-0mop.9.
+//! Perf baseline for testreport metadata parsing plus the
+//! blocking-filesystem paths.
 //!
 //! Measurement-only, offline. `metadata/parse` measures `JSONParser::parse_str`
 //! populating a fresh `TestReportBase` from the golden `metadata.json` fixture —

--- a/crates/mtui-testreport/src/checkout/mod.rs
+++ b/crates/mtui-testreport/src/checkout/mod.rs
@@ -115,10 +115,10 @@ pub struct TestReportNotLoaded;
 
 /// Outcome of a template read attempt inside the checkout seam.
 ///
-/// The seam is generic over how a report is read so it can be wired now, before
-/// the `TestReport::read` lifecycle method lands (a later Phase 4 task). It
-/// catches a missing template (→ checkout) and lets other errors from the
-/// retry propagate.
+/// The seam is generic over how a report is read, decoupling it from the
+/// [`TestReport::read`](crate::TestReport::read) lifecycle method. It catches
+/// a missing template (→ checkout) and lets other errors from the retry
+/// propagate.
 #[derive(Debug)]
 pub enum ReadOutcome {
     /// The template was read successfully.

--- a/crates/mtui-testreport/src/export/base.rs
+++ b/crates/mtui-testreport/src/export/base.rs
@@ -8,7 +8,7 @@
 //!
 //! Writing a divergent existing file asks whether to overwrite it. Per the
 //! established crate-boundary pattern (see `mtui-hosts::target::actions`),
-//! the interactive prompt is a display concern owned by `mtui-cli` (Phase 6);
+//! the interactive prompt is a display concern owned by `mtui-cli`;
 //! here it is injected as the [`OverwritePrompt`] trait so the exporter stays
 //! testable and free of a CLI dependency. The default [`DenyOverwrite`] never
 //! overwrites (safe for non-interactive runs and the MCP surface).
@@ -24,7 +24,7 @@ use crate::support::sysinfo::{EXPORT_PREFIX, detect_system, system_info};
 /// The decision an exporter makes when an existing file differs from what it is
 /// about to write.
 ///
-/// `mtui` (Phase 6) supplies an interactive implementation; library and test
+/// `mtui` supplies an interactive implementation; library and test
 /// callers use [`DenyOverwrite`].
 ///
 /// The bound is `Send + Sync` because [`AutoExport::run`](crate::AutoExport) is

--- a/crates/mtui-testreport/src/export/manual.rs
+++ b/crates/mtui-testreport/src/export/manual.rs
@@ -10,8 +10,8 @@
 //! live connection state) would be the wrong dependency direction, so the
 //! exporter takes a decoupled [`ManualHost`] view capturing exactly the
 //! `hostname`, `system`, `packages`, and `hostlog` fields it needs. The
-//! composition root (Phase 5) builds these from the live targets, mirroring
-//! how the downloader takes `(host, tests)` pairs.
+//! composition root (`mtui-core`) builds these from the live targets,
+//! mirroring how the downloader takes `(host, tests)` pairs.
 
 use std::sync::LazyLock;
 

--- a/crates/mtui-testreport/src/export/mod.rs
+++ b/crates/mtui-testreport/src/export/mod.rs
@@ -11,8 +11,9 @@
 //! deliberately different constructors — [`ManualExport`] needs the connected
 //! hosts, [`KernelExport`] needs the kernel connectors — so a single boxed
 //! factory would flatten inputs that legitimately differ. The composition root
-//! (Phase 5) matches on `Workflow` and constructs the right exporter directly;
-//! this module exposes the concrete types rather than prescribing that match.
+//! (`mtui-core`) matches on `Workflow` and constructs the right exporter
+//! directly; this module exposes the concrete types rather than prescribing
+//! that match.
 
 pub mod auto;
 pub mod base;

--- a/crates/mtui-testreport/src/export/overview_inject.rs
+++ b/crates/mtui-testreport/src/export/overview_inject.rs
@@ -5,7 +5,7 @@
 //! appended after any existing content in that section; on subsequent exports a
 //! previously-inserted block is detected via the `OVERVIEW_*` markers and
 //! replaced in place, so the file never accumulates duplicate copies
-//! (**idempotent re-export** — a Phase 4 text-format contract).
+//! (**idempotent re-export** — a text-format contract).
 
 use mtui_datasources::oqa_search::render::{
     OVERVIEW_BEGIN_MARKER, OVERVIEW_END_MARKER, render_overview,

--- a/crates/mtui-testreport/src/lib.rs
+++ b/crates/mtui-testreport/src/lib.rs
@@ -1,10 +1,10 @@
 //! `mtui-testreport` — TestReport lifecycle, metadata parsers, update workflow.
 //!
-//! Lands the [`TestReport`] trait, the shared-state [`TestReportBase`] carrier,
-//! the [`NullReport`] null object, and the SUSE Linux report [`SlReport`] (with
-//! its [`repoparse`](reports::repoparse) helpers), plus the metadata parsers and
-//! product-normalization tables. The remaining concrete reports, checkout
-//! backends, and update workflow arrive in the later Phase 4 tasks.
+//! Provides the [`TestReport`] trait, the shared-state [`TestReportBase`]
+//! carrier, the [`NullReport`] null object, and the concrete reports (SL, PI,
+//! OBS — with the [`repoparse`](reports::repoparse) helpers), plus the
+//! metadata parsers, product-normalization tables, checkout backends, and
+//! update workflow.
 
 pub mod checkout;
 pub mod export;

--- a/crates/mtui-testreport/src/reports/obs.rs
+++ b/crates/mtui-testreport/src/reports/obs.rs
@@ -13,10 +13,10 @@
 //! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses the OBS-specific
 //!   `-n ar -ckn` (note: no `fG`, unlike SL/PI), remove uses `-n rr`.
-//! * `list_update_commands` would render per-host commands via
-//!   `target.doer('updater')`, but the `OperationGroup`/doer seam on `Target`
-//!   is deferred (see the `TODO(Phase 4)` in `mtui-hosts::target::operation`).
-//!   Until it is wired this is a documented no-op stub.
+//! * `list_update_commands` would render per-host commands via the doer seam
+//!   ([`PlanProvider::doer`](mtui_hosts::PlanProvider::doer)), which is wired
+//!   for install/uninstall but has no listing consumer yet — this is a
+//!   documented no-op stub.
 //! * `_show_yourself_data` is not on the trait skeleton yet (same deferral as
 //!   `SlReport`/`PiReport`).
 //! * `id()` returns `""` when no RRID is loaded; this matches the graceful
@@ -97,10 +97,10 @@ impl TestReport for ObsReport {
     fn list_update_commands(&self, _targets: &HostsGroup) {
         // This would render per-host `updater` commands for display; the
         // bespoke `perform_update` flow that runs them is implemented below.
-        // A standalone read-only listing has no consumer yet (the `list`/`run`
-        // Wave-1 command lands in mtui-rs-2d3.6), so this stays a no-op until
-        // then.
-        debug!("list_update_commands: no listing consumer yet (see mtui-rs-2d3.6)");
+        // The read-only listing is a documented no-op stub across every
+        // report — the `list_update_commands` command calls this but only
+        // ever prints a placeholder.
+        debug!("list_update_commands: no-op stub, not yet implemented");
     }
 
     // Shared `perform_*` flows (SL/PI/OBS behave identically). See

--- a/crates/mtui-testreport/src/reports/pi.rs
+++ b/crates/mtui-testreport/src/reports/pi.rs
@@ -13,10 +13,10 @@
 //! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses `-n ar -cfGkn` (same as
 //!   SL), remove uses `-n rr`.
-//! * `list_update_commands` would render per-host commands via
-//!   `target.doer('updater')`, but the `OperationGroup`/doer seam on `Target`
-//!   is deferred (see the `TODO(Phase 4)` in `mtui-hosts::target::operation`).
-//!   Until it is wired this is a documented no-op stub.
+//! * `list_update_commands` would render per-host commands via the doer seam
+//!   ([`PlanProvider::doer`](mtui_hosts::PlanProvider::doer)), which is wired
+//!   for install/uninstall but has no listing consumer yet — this is a
+//!   documented no-op stub.
 //! * `id()` returns `""` when no RRID is loaded; this matches the graceful
 //!   path chosen for `SlReport`.
 
@@ -89,10 +89,10 @@ impl TestReport for PiReport {
     fn list_update_commands(&self, _targets: &HostsGroup) {
         // This would render per-host `updater` commands for display; the
         // bespoke `perform_update` flow that runs them is implemented below.
-        // A standalone read-only listing has no consumer yet (the `list`/`run`
-        // Wave-1 command lands in mtui-rs-2d3.6), so this stays a no-op until
-        // then.
-        debug!("list_update_commands: no listing consumer yet (see mtui-rs-2d3.6)");
+        // The read-only listing is a documented no-op stub across every
+        // report — the `list_update_commands` command calls this but only
+        // ever prints a placeholder.
+        debug!("list_update_commands: no-op stub, not yet implemented");
     }
 
     // Shared `perform_*` flows (SL/PI/OBS behave identically). See

--- a/crates/mtui-testreport/src/reports/sl.rs
+++ b/crates/mtui-testreport/src/reports/sl.rs
@@ -10,10 +10,10 @@
 //! * `set_repo` (the [`SetRepo`] impl driving [`RepoManager::run_zypper`](mtui_hosts::RepoManager::run_zypper)) is
 //!   implemented here (task nbv.fly): add uses `-n ar -cfGkn`, remove
 //!   uses `-n rr`, both fanned out over [`TestReportBase::update_repos`].
-//! * `list_update_commands` would render per-host commands via
-//!   `target.doer('updater')`, but the `OperationGroup`/doer seam on `Target`
-//!   is deferred (see the `TODO(Phase 4)` in `mtui-hosts::target::operation`).
-//!   Until it is wired this is a documented no-op stub.
+//! * `list_update_commands` would render per-host commands via the doer seam
+//!   ([`PlanProvider::doer`](mtui_hosts::PlanProvider::doer)), which is wired
+//!   for install/uninstall but has no listing consumer yet — this is a
+//!   documented no-op stub.
 
 use std::collections::HashMap;
 
@@ -100,11 +100,11 @@ impl TestReport for SlReport {
     fn list_update_commands(&self, _targets: &HostsGroup) {
         // Upstream renders per-host `updater` commands for display via
         // `target.doer('updater')['command'].safe_substitute(...)`. The bespoke
-        // `perform_update` flow that actually runs them is implemented below; a
-        // standalone read-only *listing* has no consumer yet (the `list`/`run`
-        // Wave-1 command lands in mtui-rs-2d3.6), so this stays a no-op until
-        // that command needs it.
-        debug!("list_update_commands: no listing consumer yet (see mtui-rs-2d3.6)");
+        // `perform_update` flow that actually runs them is implemented below;
+        // the read-only *listing* is a documented no-op stub across every
+        // report — the `list_update_commands` command calls this but only
+        // ever prints a placeholder.
+        debug!("list_update_commands: no-op stub, not yet implemented");
     }
 
     // Upstream defines these five `perform_*` flows once on the base

--- a/crates/mtui-testreport/src/support/mod.rs
+++ b/crates/mtui-testreport/src/support/mod.rs
@@ -1,7 +1,7 @@
 //! Shared support helpers for the testreport export subsystem.
 //!
 //! Kept local to `mtui-testreport` to avoid widening a cross-crate public
-//! surface (see Phase 4 crate-boundary decision).
+//! surface.
 
 pub mod filelist;
 pub mod fileops;

--- a/crates/mtui-testreport/src/testreport.rs
+++ b/crates/mtui-testreport/src/testreport.rs
@@ -1,6 +1,6 @@
 //! The [`TestReport`] trait and its shared-state carrier [`TestReportBase`].
 //!
-//! This is the Phase 4.1 skeleton. Each concrete report (SL/PI/OBS/Null)
+//! Each concrete report (SL/PI/OBS/Null)
 //! shares a large block of state, plus a handful of behaviors that only the
 //! concrete report can supply.
 //!
@@ -13,9 +13,9 @@
 //! inject collaborators).
 //!
 //! Only the shared state and the abstract-method surface land here. The
-//! concrete lifecycle (load/checkout/commit/export), metadata parsing, pool
-//! selection, and host-connect logic arrive in the later Phase 4 tasks that
-//! depend on this skeleton.
+//! concrete lifecycle (load/checkout/commit/export) lives in [`crate::lifecycle`],
+//! metadata parsing in [`crate::metadata_parsers`], and each report's
+//! host-connect logic in [`crate::reports`].
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -40,10 +40,6 @@ use crate::checkout::TemplateIoError;
 use crate::metadata_parsers::{JSONParser, ReducedMetadataParser, patchinfo_titles};
 
 /// Shared state common to every [`TestReport`] implementation.
-///
-/// Fields whose behavior is only exercised by later Phase 4 tasks (pool
-/// selection, host arbitration, connect) are carried here as pure state — no
-/// logic is wired to them yet.
 ///
 /// The [`openqa`](Self::openqa) holder carries the report's openQA state
 /// ([`ReportOpenQA`]) — the QEM-dashboard "auto" result, the per-instance
@@ -286,8 +282,8 @@ pub fn packages_for_map(
 /// Concrete reports embed a [`TestReportBase`] and expose it through
 /// [`base`](Self::base) / [`base_mut`](Self::base_mut); the remaining
 /// required methods are the abstract surface every report must supply.
-/// Non-abstract lifecycle methods (`connect_target`, `export`, pool
-/// selection, …) are added by the later Phase 4 tasks.
+/// Non-abstract lifecycle methods (`read`, `release_pool_claims`,
+/// `perform_install`, …) are provided as trait defaults below.
 ///
 /// The trait is `#[async_trait]` because [`check_hash`](Self::check_hash) drives
 /// async I/O for git-backed reports (`SLTestReport` awaits `Gitea::get_hash`).
@@ -304,9 +300,8 @@ pub trait TestReport {
 
     /// The metadata field parser table.
     ///
-    /// Maps a template field name to its parsed value. The concrete shape of
-    /// parsed values is refined in the metadata-parser task (P4.2); the
-    /// skeleton uses `String` values, which the null object leaves empty.
+    /// Maps a template field name to its parsed value. The table models
+    /// values as `String`; the null object leaves it empty.
     fn parser(&self) -> HashMap<String, String>;
 
     /// The update-repository parser table.

--- a/crates/mtui-testreport/tests/fs_responsiveness.rs
+++ b/crates/mtui-testreport/tests/fs_responsiveness.rs
@@ -1,4 +1,4 @@
-//! Scheduler-responsiveness oracle for bead `mtui-rs-0mop.9`.
+//! Scheduler-responsiveness oracle.
 //!
 //! The blocking-filesystem conversions (spawn_blocking / `tokio::fs`) exist so a
 //! slow filesystem cannot wedge a Tokio worker mid-operation. On a

--- a/crates/mtui-testreport/tests/lifecycle.rs
+++ b/crates/mtui-testreport/tests/lifecycle.rs
@@ -1,4 +1,4 @@
-//! Sub-bead A (mtui-rs-0pe.1): `TestReport::read` + `make_testreport`.
+//! `TestReport::read` + `make_testreport`.
 //!
 //! Tests the parse-and-populate slice of `TestReport::read` and the
 //! `make_testreport` factory (report-class selection + checkout +

--- a/crates/mtui-types/src/error.rs
+++ b/crates/mtui-types/src/error.rs
@@ -1,14 +1,13 @@
 //! The `mtui-types` error hierarchy.
 //!
 //! This is the foundation error module every later crate imports, scoped to
-//! what Phase 1 (the domain types) actually needs.
+//! what the domain types actually need.
 //!
-//! Only the RRID / Request-Review-ID parse errors live here for now — they are
-//! consumed by the RRID parser (see the `rrid` task) and are covered by golden
-//! test vectors. The `UpdateError` and `GiteaError` families
-//! belong to later phases (`mtui-hosts` / `mtui-datasources`) and will be added
-//! as `#[from]` sub-errors when those crates land, so they can be exercised by
-//! real tests rather than sitting dead here.
+//! Only the RRID / Request-Review-ID parse errors live here — they are
+//! consumed by the RRID parser (see the `rrid` module) and are covered by
+//! golden test vectors. `mtui-hosts` and `mtui-datasources` define their own
+//! error enums (`HostError`, `GiteaError`, and friends) rather than extending
+//! this one via `#[from]`.
 
 use thiserror::Error;
 

--- a/crates/mtui-types/src/lib.rs
+++ b/crates/mtui-types/src/lib.rs
@@ -1,6 +1,6 @@
 //! `mtui-types` — domain types and the error hierarchy for mtui.
 //!
-//! Foundation crate: no I/O, no async. Real types land in Phase 1.
+//! Foundation crate: no I/O, no async.
 
 pub mod enums;
 pub mod error;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result, bail};
 use clap::CommandFactory;
 use clap_complete::Shell;
 
-/// The three shells the Phase 8 DoD names explicitly.
+/// The three shells the release artefacts cover.
 const SHELLS: [Shell; 3] = [Shell::Bash, Shell::Zsh, Shell::Fish];
 
 /// Fixed column width for rendered command help, so the generated CLI reference


### PR DESCRIPTION
Closes #402.

Docs-only sweep retiring ~243 stale citations of the now-finished Rust
rewrite roadmap (`Phase N` / `PN.x` / `later phase`, internal `mtui-rs-*`
bead IDs, and the last four Python-upstream citations), one commit per
crate per the plan in `plans/402-retire-roadmap-citations.md`.

## What changed and why

Each site is rewritten as a **positive statement of what the code does
and why**, not a position on a timeline — per the rewrite rule in
`AGENTS.md`. Concretely:

- `docs(types,config,xtask)` — `mtui-types/error.rs` claimed
  `HostError`/`GiteaError` would be wired into the top-level error via
  `#[from]`; they weren't — each crate kept its own error enum. Restated.
- `docs(datasources)` — `teregen.rs`'s wiring claim and `openqa::base.rs`'s
  `IncidentName` seam were both stale; the config field is read at the
  call site, and `QemIncident` already implements the seam.
- `docs(hosts)` — the issue's headline site, `error.rs:9`: russh + SFTP
  landed, and the error type stayed deliberately un-unified with
  `mtui-types::Error` rather than being wired via `#[from]`. The 22
  legitimate algorithmic `Phase 1..4` reboot/lock stage labels in
  `hostgroup.rs` are untouched.
- `docs(testreport)` — fixed a **dangling pointer**: three reports cited a
  `TODO(Phase 4)` in `mtui-hosts::target::operation` that no longer
  exists. Replaced with the present truth: the doer seam is wired for
  install/uninstall, but `list_update_commands` has no listing consumer
  beyond a placeholder, so it stays a documented no-op stub.
- `docs(core)` — rewrote the crate header and registry section headers as
  present-tense facts; converged the `shell`/`edit` REPL-only error
  strings on the same wording (CHANGELOG entry, since it's user-visible).
- `docs(cli)` — `main.rs` claimed config loading/merging was deferred;
  `Args::resolve_config` already composes `Config::load` with the CLI
  overlay, so the claim was factually stale, not just aging.
- `docs(mcp)` (2 commits) — `session.rs`'s module header was a changelog
  of P7.3a/b/c/d landings; rewritten as a description of the four
  mechanisms (per-template lock discipline, background-job table,
  progress heartbeats, `close`). Two sites had drifted **past** their own
  citations: a bench described an already-landed concurrency fix as
  future work, and a test comment claimed a sibling test "still awaits" a
  removal that sibling test already proves — both restated as present
  fact. A separate commit retires the last four Python-upstream citations
  in `schema.rs`, restating each as the downstream contract it protects.

Out of scope (per the plan): a CI grep guard, and any *code* change.

## Follow-up

Filed as a comment on #402: a stale `_show_yourself_data` claim in
`obs.rs`, bare non-`mtui-rs-`-prefixed bead numbers left in a few bench
module docs, and a pre-existing `mtui-mcp` `--features mcp` clippy
failure unrelated to this branch (reproduced against the base commit).

## Verification

- `rg -in 'phase [0-9]|P[0-9]\.[0-9]|later phase' crates xtask -g '*.rs'`
  → only the algorithmic stage labels in `mtui-hosts/target/hostgroup.rs`
  and `mtui-mcp/provider.rs`.
- `rg -n 'mtui-rs-' crates xtask` → only the confirmed false positive in
  `mtui-datasources/tests/obs_facade.rs:254` (an `OSC_CONFIG` path).
- `rg -in 'upstream' crates/mtui-mcp/src/schema.rs` → empty.
- `git diff --stat -- '**/*.snap'` against the base commit → empty (no
  snapshot changed).
- `git diff --stat` against the base commit → changes touch only
  comments/doc comments, one user-facing error string, three `debug!`
  strings, one test-fn rename, and `CHANGELOG.md`.
- Full gate green: `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`,
  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
  --all-features --document-private-items`, `cargo test --workspace`,
  `cargo test -p mtui-mcp -F mcp`, `cargo build --workspace
  --no-default-features`, `cargo build --workspace --all-features`.
