### PR TITLE
Adopt ruoqa as mtui's openQA REST client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- The openQA REST client is now built on the `ruoqa` crate instead of mtui's
+  own hand-rolled signed-request implementation. User-visible effects:
+  `$OPENQA_CONFIG` and `$XDG_CONFIG_HOME/openqa/client.conf` are now honoured
+  as `client.conf` search paths, in addition to `/etc/openqa/client.conf` and
+  `~/.config/openqa/client.conf`; a credentialed `openqa_instance` URL
+  (`https://user:pass@host`) now has the userinfo dropped when resolving the
+  request target, rather than merely redacted for display; and the
+  unauthenticated `Accept` header sent with every request changed from `json`
+  to `application/json` (both are accepted by openQA).
 - The headless `shell` error message no longer carries a roadmap reference:
   `"interactive shell attach is not available in this mode (Phase 6 REPL
   only)"` is now `"... (REPL only)"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   request target, rather than merely redacted for display; and the
   unauthenticated `Accept` header sent with every request changed from `json`
   to `application/json` (both are accepted by openQA).
+- `openqa_jobs` and `openqa_overview` now authenticate against openQA when
+  `client.conf` has credentials for the target instance (`-u/--url-openqa`'s
+  host). Both previously queried openQA unauthenticated even when credentials
+  were configured.
 - The headless `shell` error message no longer carries a roadmap reference:
   `"interactive shell attach is not available in this mode (Phase 6 REPL
   only)"` is now `"... (REPL only)"`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1865,9 +1875,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2393,6 +2405,7 @@ dependencies = [
  "owo-colors",
  "rand",
  "regex",
+ "reqwest",
  "serde_json",
  "serial_test",
  "shlex",
@@ -2415,8 +2428,6 @@ dependencies = [
  "criterion",
  "directories",
  "futures",
- "hex",
- "hmac",
  "insta",
  "mtui-config",
  "mtui-types",
@@ -2424,13 +2435,13 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "ruoqa",
  "russh",
  "rust-ini",
  "scraper",
  "serde",
  "serde_json",
  "serial_test",
- "sha1",
  "signature",
  "ssh-key",
  "tempfile",
@@ -3353,7 +3364,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3362,6 +3375,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3457,6 +3471,28 @@ dependencies = [
  "sha2",
  "signature",
  "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "ruoqa"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6931448e1649502f2f4476333d816d07a459aad6c5786d26746a5fb4813b4cbc"
+dependencies = [
+ "bytes",
+ "hmac",
+ "httpdate",
+ "reqwest",
+ "rust-ini",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "sha1",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
  "zeroize",
 ]
 
@@ -3670,7 +3706,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3823,7 +3859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4364,6 +4400,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5159,6 +5216,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,6 +5572,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,13 +55,17 @@ directories = "6"
 sandogasa-rpmvercmp = "0.18"
 # http
 reqwest = { version = "0.13", features = ["json", "rustls"], default-features = false }
-# openQA API auth: HMAC-SHA1 request signing (X-API-Hash), matching the
-# third-party python `openqa_client` auth design (openQA/lib/OpenQA/client.pm).
+# The openQA REST API client: signed-request auth (HMAC-SHA1 X-API-Hash),
+# `client.conf`/$OPENQA_CONFIG credential discovery, retries, and redirect
+# restriction, replacing mtui's own hand-rolled implementation. reqwest 0.13.4
+# on both sides so `ClientBuilder::http_client` shares mtui's connection pool.
+ruoqa = "0.1.3"
+# HMAC-SHA1, for the OpenSSH hashed known_hosts test helper (mtui-hosts dev-dep);
+# not used for openQA auth any more (ruoqa owns that).
 hmac = "0.13"
 sha1 = "0.11"
-hex = "0.4"
-# percent-encoding of the request path before HMAC signing (openQA quirks:
-# %20 -> +, ~ -> %7E)
+# percent-encoding of URL components (Slack/TeReGen/OBS API params, oqa-search
+# build-check log URLs).
 urlencoding = "2"
 # regex — SMELT testplatform grammar parsing (refhost Attributes::from_testplatform)
 regex = "1"

--- a/crates/mtui-core/Cargo.toml
+++ b/crates/mtui-core/Cargo.toml
@@ -31,6 +31,10 @@ uuid.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 rand.workspace = true
+# The session-scoped openQA transport (`Session::openqa_transport`) hands out
+# a `reqwest::Client` for injection into `ruoqa::ClientBuilder::http_client`,
+# mirroring `Session::http_client`'s pool-reuse pattern.
+reqwest.workspace = true
 # `~user` resolution in file-path tab completion (`complete_path`), mirroring
 # Python's `os.path.expanduser` getpwnam lookup. Unix-only `user` feature; the
 # call sites are `#[cfg(unix)]`-gated with an unexpanded fallback elsewhere.

--- a/crates/mtui-core/src/commands/export.rs
+++ b/crates/mtui-core/src/commands/export.rs
@@ -375,12 +375,15 @@ mod tests {
         // Build a real, populated kernel connector against the mock and seed it.
         let rrid = session.metadata().rrid().unwrap().clone();
         let http = HttpClient::new(VerifyPolicy::Default(false)).unwrap();
+        let openqa_transport = HttpClient::openqa_transport(VerifyPolicy::Default(false)).unwrap();
         let incident =
             build_incident(rrid.clone(), format!("{}/api", oqa.uri()), http.clone()).await;
-        let kernel = crate::commands::support::build_kernel_openqa(&incident, &oqa.uri(), http)
-            .run()
-            .await
-            .unwrap();
+        let kernel =
+            crate::commands::support::build_kernel_openqa(&incident, &oqa.uri(), openqa_transport)
+                .unwrap()
+                .run()
+                .await
+                .unwrap();
         assert!(
             kernel.results().is_some_and(|r| !r.is_empty()),
             "mock kernel connector should populate"

--- a/crates/mtui-core/src/commands/openqa_jobs.rs
+++ b/crates/mtui-core/src/commands/openqa_jobs.rs
@@ -124,6 +124,14 @@ impl Command for OpenQAJobs {
         let http = session
             .http_client()
             .map_err(|e| CommandError::Other(format!("could not build HTTP client: {e}")))?;
+        let openqa_transport = session
+            .openqa_transport()
+            .map_err(|e| CommandError::Other(format!("could not build openQA transport: {e}")))?;
+        let oqa_client = mtui_datasources::openqa::build_openqa_client_with_transport(
+            openqa_transport,
+            &url_openqa,
+        )
+        .map_err(|e| CommandError::Other(format!("could not build openQA client: {e}")))?;
 
         // incident_id is maintenance_id (int for Maintenance, "1.2" for SLFO);
         // fall back to the review id in the SLFO case — mirrors openqa_overview.
@@ -143,8 +151,7 @@ impl Command for OpenQAJobs {
                 }
             };
 
-        let mut jobs = match oqa::incident_jobs(&http, &build, &url_openqa, include_obsoleted).await
-        {
+        let mut jobs = match oqa::incident_jobs(&oqa_client, &build, include_obsoleted).await {
             Ok(j) => j,
             Err(e) => {
                 return Err(CommandError::Other(format!(
@@ -222,7 +229,7 @@ impl Command for OpenQAJobs {
 mod tests {
     use super::*;
     use crate::commands::testkit::{empty_session, matches, session_with_hosts};
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{header, header_exists, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -445,5 +452,62 @@ mod tests {
         let out = buf.contents();
         assert!(out.contains("kdump"), "{out}");
         assert!(out.contains("1 still pending"), "{out}");
+    }
+
+    /// Proves Phase 2 of the ruoqa migration: `openqa_jobs` authenticates when
+    /// `client.conf` has credentials for the instance, not just when openQA
+    /// happens to accept an unauthenticated GET.
+    #[tokio::test]
+    #[serial_test::serial(openqa_config_env)]
+    // `std::env::set_var`/`remove_var` are `unsafe` in edition 2024; the
+    // `#[serial(openqa_config_env)]` guard makes the mutation exclusive.
+    #[allow(unsafe_code)]
+    async fn authenticates_against_an_instance_requiring_x_api_hash() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/incident_settings/1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"settings": {"BUILD": "BUILD-42", "DISTRI": "sle", "VERSION": "15-SP5"}}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/jobs"))
+            .and(header("X-API-Key", "MYKEY"))
+            .and(header_exists("X-API-Hash"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"jobs": []})))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let host = server.uri();
+        let host = host.split_once("://").map_or(host.as_str(), |(_, h)| h);
+        std::fs::write(
+            dir.path().join("client.conf"),
+            format!("[{host}]\nkey = MYKEY\nsecret = MYSECRET\n"),
+        )
+        .unwrap();
+        // SAFETY: serialised via `#[serial(openqa_config_env)]`.
+        unsafe { std::env::set_var("OPENQA_CONFIG", dir.path()) };
+
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        let args = matches(
+            &OpenQAJobs,
+            &[
+                "--url-dashboard-qam",
+                &server.uri(),
+                "--url-openqa",
+                &server.uri(),
+            ],
+        );
+        let result = OpenQAJobs.call(&mut session, &args).await;
+        // SAFETY: still inside the `#[serial(openqa_config_env)]` critical section.
+        unsafe { std::env::remove_var("OPENQA_CONFIG") };
+        result.unwrap();
+        assert!(
+            buf.contents().contains("No openQA jobs"),
+            "{}",
+            buf.contents()
+        );
     }
 }

--- a/crates/mtui-core/src/commands/openqa_overview.rs
+++ b/crates/mtui-core/src/commands/openqa_overview.rs
@@ -152,6 +152,14 @@ impl Command for OpenQAOverview {
         let http = session
             .http_client()
             .map_err(|e| CommandError::Other(format!("could not build HTTP client: {e}")))?;
+        let openqa_transport = session
+            .openqa_transport()
+            .map_err(|e| CommandError::Other(format!("could not build openQA transport: {e}")))?;
+        let oqa_client = mtui_datasources::openqa::build_openqa_client_with_transport(
+            openqa_transport,
+            &url_openqa,
+        )
+        .map_err(|e| CommandError::Other(format!("could not build openQA client: {e}")))?;
 
         // incident_id is maintenance_id ("1.2" for SLFO); effective id falls back
         // to the review id (the Gitea PR number) when maintenance_id is non-int.
@@ -196,8 +204,7 @@ impl Command for OpenQAOverview {
         let single_fut = async {
             match openqa_versions {
                 Some(versions) => {
-                    oqa::single_incidents(&http, &build, versions, &url_openqa, max_oqa_parallel)
-                        .await
+                    oqa::single_incidents(&oqa_client, &build, versions, max_oqa_parallel).await
                 }
                 None => Vec::new(),
             }
@@ -206,12 +213,11 @@ impl Command for OpenQAOverview {
             match openqa_versions {
                 Some(versions) if !no_aggregated => {
                     oqa::aggregated_updates(
-                        &http,
+                        &oqa_client,
                         &effective_incident_id,
                         versions,
                         days,
                         &groups,
-                        &url_openqa,
                         max_oqa_parallel,
                     )
                     .await

--- a/crates/mtui-core/src/commands/reload_openqa.rs
+++ b/crates/mtui-core/src/commands/reload_openqa.rs
@@ -49,6 +49,9 @@ impl Command for ReloadOpenQA {
         let http = session
             .http_client()
             .map_err(|e| CommandError::Other(format!("could not build HTTP client: {e}")))?;
+        let openqa_transport = session
+            .openqa_transport()
+            .map_err(|e| CommandError::Other(format!("could not build openQA transport: {e}")))?;
         let dashboard_api = session.config.qem_dashboard_api.clone();
         let openqa_instance = session.config.openqa_instance.clone();
         let openqa_baremetal = session.config.openqa_instance_baremetal.clone();
@@ -60,7 +63,8 @@ impl Command for ReloadOpenQA {
             if session.metadata().openqa().kernel.is_empty() {
                 tracing::info!("Getting data from kernel openQA");
                 for host in [openqa_instance.clone(), openqa_baremetal] {
-                    let oqa = build_kernel_openqa(&incident, &host, http.clone())
+                    let oqa = build_kernel_openqa(&incident, &host, openqa_transport.clone())
+                        .map_err(openqa_fetch_err)?
                         .run()
                         .await
                         .map_err(openqa_fetch_err)?;

--- a/crates/mtui-core/src/commands/simpleset.rs
+++ b/crates/mtui-core/src/commands/simpleset.rs
@@ -126,6 +126,9 @@ impl Command for SetWorkflow {
         let http = session
             .http_client()
             .map_err(|e| CommandError::Other(format!("could not build HTTP client: {e}")))?;
+        let openqa_transport = session
+            .openqa_transport()
+            .map_err(|e| CommandError::Other(format!("could not build openQA transport: {e}")))?;
         let dashboard_api = session.config.qem_dashboard_api.clone();
         let openqa_instance = session.config.openqa_instance.clone();
         let openqa_baremetal = session.config.openqa_instance_baremetal.clone();
@@ -160,7 +163,8 @@ impl Command for SetWorkflow {
                 let mut kernel = Vec::new();
                 for host in [openqa_instance, openqa_baremetal] {
                     kernel.push(
-                        build_kernel_openqa(&incident, &host, http.clone())
+                        build_kernel_openqa(&incident, &host, openqa_transport.clone())
+                            .map_err(openqa_fetch_err)?
                             .run()
                             .await
                             .map_err(openqa_fetch_err)?,
@@ -464,11 +468,12 @@ mod tests {
         let host = session.config.openqa_instance.clone();
         let http = session.http_client().unwrap();
         let incident = build_incident(rrid, dashboard_api, http.clone()).await;
+        let openqa_transport = session.openqa_transport().unwrap();
         session
             .metadata_mut()
             .openqa_mut()
             .kernel
-            .push(build_kernel_openqa(&incident, &host, http));
+            .push(build_kernel_openqa(&incident, &host, openqa_transport).unwrap());
 
         let args = matches(&SetWorkflow, &["manual"]);
         SetWorkflow.call(&mut session, &args).await.unwrap();

--- a/crates/mtui-core/src/commands/support.rs
+++ b/crates/mtui-core/src/commands/support.rs
@@ -5,11 +5,11 @@
 
 use clap::{Arg, ArgAction, ArgMatches};
 use mtui_datasources::openqa::base::OpenQABase;
-use mtui_datasources::openqa::client::{ApiCredentials, ClientConf, OpenQAClient};
+use mtui_datasources::openqa::build_openqa_client_with_transport;
 use mtui_datasources::openqa::kernel::KernelOpenQA;
 use mtui_datasources::qem_dashboard::dashboard_openqa::DashboardAutoOpenQA;
 use mtui_datasources::qem_dashboard::incident::QemIncident;
-use mtui_datasources::{HttpClient, QemDashboardClient};
+use mtui_datasources::{HttpClient, OpenQAError, QemDashboardClient};
 use mtui_hosts::HostsGroup;
 use mtui_types::RequestReviewID;
 
@@ -53,28 +53,28 @@ pub(crate) fn build_auto_openqa(
 /// Builds a fresh, unpopulated [`KernelOpenQA`] connector for a given openQA
 /// instance `host`.
 ///
-/// Resolves openQA API credentials from the standard `client.conf` search
-/// paths, keyed on the instance host. Call [`KernelOpenQA::run`] to populate it.
+/// Resolves openQA API credentials from the standard `client.conf`/
+/// `$OPENQA_CONFIG` search path, keyed on the instance host. Call
+/// [`KernelOpenQA::run`] to populate it.
 ///
-/// Takes an already-built [`HttpClient`] (obtain it once from
-/// [`Session::http_client`](crate::session::Session::http_client)) so a
-/// per-host loop reuses one connection pool instead of building a fresh client
-/// per instance.
-#[must_use]
+/// Takes an already-built openQA transport (obtain it once from
+/// [`Session::openqa_transport`](crate::session::Session::openqa_transport))
+/// so a per-host loop (the kernel workflow's primary + baremetal instances)
+/// reuses one connection pool instead of building a fresh transport per
+/// instance.
+///
+/// # Errors
+///
+/// Returns [`OpenQAError::ClientBuild`] if the underlying `ruoqa` client fails
+/// to build (a malformed `client.conf`, or an invalid `User-Agent`/API key).
 pub(crate) fn build_kernel_openqa(
     incident: &QemIncident,
     host: &str,
-    http: HttpClient,
-) -> KernelOpenQA {
-    let server = host
-        .rsplit("://")
-        .next()
-        .unwrap_or(host)
-        .trim_end_matches('/');
-    let creds: ApiCredentials = ApiCredentials::resolve(&ClientConf::load(), server, host);
-    let client = OpenQAClient::new(http, host.to_owned(), creds);
+    transport: reqwest::Client,
+) -> Result<KernelOpenQA, OpenQAError> {
+    let client = build_openqa_client_with_transport(transport, host)?;
     let base = OpenQABase::new(client, &incident.rrid, incident);
-    KernelOpenQA::new(base)
+    Ok(KernelOpenQA::new(base))
 }
 
 /// Guards a command body that requires a loaded update.

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -136,6 +136,13 @@ pub struct Session {
     /// (`export::build_http`) can lazily populate it; the lock is uncontended
     /// (one dispatch at a time).
     http_client: Mutex<Option<(VerifyPolicy, HttpClient)>>,
+    /// Lazily-built, session-scoped openQA transport: a redirect-less,
+    /// no-reqwest-retry `reqwest::Client` for injection into
+    /// `ruoqa::ClientBuilder::http_client`, cached the same way as
+    /// [`http_client`](Self::http_client) so back-to-back openQA connectors
+    /// (e.g. `reload_openqa`'s primary + baremetal instances) share one pool
+    /// instead of building a fresh transport per host.
+    openqa_transport: Mutex<Option<(VerifyPolicy, reqwest::Client)>>,
 }
 
 /// A candidate-order shuffle seam. Mutates the slot's
@@ -228,6 +235,7 @@ impl Session {
             shuffle: random_shuffle,
             cancel: CancellationToken::new(),
             http_client: Mutex::new(None),
+            openqa_transport: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -252,6 +260,7 @@ impl Session {
             shuffle: random_shuffle,
             cancel: CancellationToken::new(),
             http_client: Mutex::new(None),
+            openqa_transport: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -298,6 +307,7 @@ impl Session {
             // fork) must be observable on both sides of the fork.
             cancel: self.cancel.clone(),
             http_client: Mutex::new(None),
+            openqa_transport: Mutex::new(None),
             #[cfg(test)]
             http_builds: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -395,6 +405,38 @@ impl Session {
     #[cfg(test)]
     fn http_builds(&self) -> usize {
         self.http_builds.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// The session-scoped openQA transport, built lazily and reused.
+    ///
+    /// Mirrors [`http_client`](Self::http_client)'s cache-by-[`VerifyPolicy`]
+    /// pattern, but hands out a bare `reqwest::Client` for
+    /// `ruoqa::ClientBuilder::http_client` rather than this crate's
+    /// [`HttpClient`] wrapper: `ruoqa` re-signs and redirects every request
+    /// itself, so the transport it owns must not follow redirects or retry at
+    /// the reqwest level (see [`HttpClient::openqa_transport`]).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`HttpError`] when the transport cannot be built (e.g. a
+    /// configured CA bundle cannot be read).
+    pub(crate) fn openqa_transport(&self) -> Result<reqwest::Client, HttpError> {
+        let policy = resolve_verify(
+            VerifyPolicy::Default(true),
+            Some(VerifyPolicy::from_config(&self.config.ssl_verify)),
+        );
+        let mut cache = self
+            .openqa_transport
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((cached_policy, transport)) = cache.as_ref()
+            && *cached_policy == policy
+        {
+            return Ok(transport.clone());
+        }
+        let transport = HttpClient::openqa_transport(policy.clone())?;
+        *cache = Some((policy, transport.clone()));
+        Ok(transport)
     }
 
     /// Makes `rrid` the active template *and* installs its per-call active

--- a/crates/mtui-datasources/Cargo.toml
+++ b/crates/mtui-datasources/Cargo.toml
@@ -40,9 +40,7 @@ scraper.workspace = true
 quick-xml.workspace = true
 chrono.workspace = true
 async-trait.workspace = true
-hmac.workspace = true
-sha1.workspace = true
-hex.workspace = true
+ruoqa.workspace = true
 urlencoding.workspace = true
 # OBS "Signature" (SSH) auth (G1c). `ssh-key` provides the SSHSIG wire-format
 # signer (`sshsig` module) + `Fingerprint` for any key type; pinned to the exact

--- a/crates/mtui-datasources/benches/datasources.rs
+++ b/crates/mtui-datasources/benches/datasources.rs
@@ -247,12 +247,20 @@ fn bench_oqa_single_incidents(c: &mut Criterion) {
         (server, uri, versions)
     });
 
-    let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
+    let transport =
+        HttpClient::openqa_transport(VerifyPolicy::Default(true)).expect("transport builds");
+    let oqa = ruoqa::ClientBuilder::new()
+        .server(uri.clone())
+        .http_client(transport)
+        .config_paths(vec![])
+        .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
+        .build()
+        .expect("ruoqa client builds");
     let mut g = c.benchmark_group("oqa/single_incidents");
     for bound in [1usize, OQA_VERSIONS] {
         g.bench_with_input(BenchmarkId::from_parameter(bound), &bound, |b, &bound| {
             b.to_async(&rt).iter(|| async {
-                black_box(single_incidents(&http, ":1:pkg", &versions, &uri, bound).await)
+                black_box(single_incidents(&oqa, ":1:pkg", &versions, bound).await)
             });
         });
     }

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -278,6 +278,17 @@ impl From<HttpError> for OqaSearchError {
     }
 }
 
+impl From<ruoqa::Error> for OqaSearchError {
+    /// Routed through the `openqa::client` module's `redact` helper first:
+    /// `ruoqa::Error` can embed a `url::Url` (`Request`/`Connection`/
+    /// `CrossOriginRedirect`),
+    /// and this crate's contract is that a fetch failure never carries a raw
+    /// URL (which could embed a credentialed openQA instance URL).
+    fn from(source: ruoqa::Error) -> Self {
+        Self::Http(crate::openqa::client::redact(&source))
+    }
+}
+
 /// Errors from the QEM Dashboard connector ([`crate::qem_dashboard`]).
 ///
 /// The dashboard client's default read helpers remain best-effort: every

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -100,31 +100,36 @@ pub enum RefhostError {
     RefreshJustFailed,
 }
 
-/// Errors from building an openQA API request or fetching jobs.
+/// Errors from building the openQA API client or fetching jobs.
 ///
 /// The connectors' best-effort helper [`OpenQABase::get_jobs`](crate::openqa)
 /// folds all *fetch* failures into a "no jobs" [`None`] result. The fallible variant
 /// [`OpenQABase::try_get_jobs`](crate::openqa) instead surfaces a fetch failure
 /// as [`Fetch`](Self::Fetch) so a caller (e.g. `KernelOpenQA::run`) can tell a
-/// genuinely-empty result apart from an unreachable openQA. This type also
-/// covers the failures that surface *before* the request is dispatched —
-/// building the signed request — plus the HMAC/clock preconditions for signing.
+/// genuinely-empty result apart from an unreachable openQA. `ruoqa::Error` is
+/// `#[non_exhaustive]` and covers eleven distinct failure modes (bad status,
+/// transport, TLS, config, redirect limits, ...); every one collapses onto
+/// [`Fetch`](Self::Fetch)/[`ClientBuild`](Self::ClientBuild) via the
+/// `openqa::client` module's `redact` helper, which strips any URL userinfo
+/// before the message reaches this type.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum OpenQAError {
-    /// The underlying HTTP layer failed to build the request or client.
+    /// The underlying HTTP layer failed to build the injected transport (e.g.
+    /// an unreadable CA bundle).
     #[error(transparent)]
     Http(#[from] HttpError),
 
+    /// The `ruoqa` client itself failed to build: a malformed `client.conf`,
+    /// invalid TLS setup, or an incompatible builder combination. Carries a
+    /// sanitized description (never the raw URL).
+    #[error("openQA client could not be built: {0}")]
+    ClientBuild(String),
+
     /// A jobs fetch failed: a transport error, a non-2xx status, or a malformed
-    /// JSON body. Carries a sanitized description (never the raw URL).
+    /// response body. Carries a sanitized description (never the raw URL).
     #[error("openQA jobs fetch failed: {0}")]
     Fetch(String),
-
-    /// The system clock is before the Unix epoch, so a request microtime
-    /// cannot be computed (required for the `X-API-Microtime` auth header).
-    #[error("system clock is before the Unix epoch; cannot compute request microtime")]
-    Clock,
 }
 
 /// Errors from the Gitea PR review-workflow connector ([`crate::gitea`]).

--- a/crates/mtui-datasources/src/http.rs
+++ b/crates/mtui-datasources/src/http.rs
@@ -157,6 +157,30 @@ fn disable_insecure_warnings() {
     }
 }
 
+/// The timeout + TLS-verify posture shared by every `reqwest::Client` this
+/// crate builds: [`HttpClient::new`] and [`HttpClient::openqa_transport`].
+/// Kept as a single function so the two clients' TLS/timeout behaviour cannot
+/// drift apart.
+fn base_builder(verify: VerifyPolicy) -> Result<reqwest::ClientBuilder> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .pool_max_idle_per_host(default_pool_size());
+
+    builder = match verify {
+        VerifyPolicy::Default(true) => builder,
+        VerifyPolicy::Default(false) => {
+            disable_insecure_warnings();
+            builder.danger_accept_invalid_certs(true)
+        }
+        VerifyPolicy::CaBundle(path) => {
+            let certs = load_ca_bundle(&path)?;
+            builder.tls_certs_only(certs)
+        }
+    };
+    Ok(builder)
+}
+
 /// A shared outbound HTTP client with a fixed timeout and TLS-verify posture.
 ///
 /// Built once and reused so concurrent fan-out at a single host reuses pooled
@@ -183,26 +207,33 @@ impl HttpClient {
     /// Returns [`HttpError::CaBundle`] if a configured CA bundle cannot be read
     /// or parsed, or [`HttpError::Request`] if the client fails to build.
     pub fn new(verify: VerifyPolicy) -> Result<Self> {
-        let mut builder = reqwest::Client::builder()
-            .connect_timeout(CONNECT_TIMEOUT)
-            .read_timeout(READ_TIMEOUT)
-            .pool_max_idle_per_host(default_pool_size());
-
-        builder = match verify {
-            VerifyPolicy::Default(true) => builder,
-            VerifyPolicy::Default(false) => {
-                disable_insecure_warnings();
-                builder.danger_accept_invalid_certs(true)
-            }
-            VerifyPolicy::CaBundle(path) => {
-                let certs = load_ca_bundle(&path)?;
-                builder.tls_certs_only(certs)
-            }
-        };
-
         Ok(Self {
-            inner: builder.build()?,
+            inner: base_builder(verify)?.build()?,
         })
+    }
+
+    /// Builds a dedicated `reqwest::Client` for injection into
+    /// [`ruoqa::ClientBuilder::http_client`](https://docs.rs/ruoqa).
+    ///
+    /// Shares this crate's timeout/TLS posture (via the crate-internal
+    /// `base_builder`) but is
+    /// **not** part of the shared connection pool: it additionally disables
+    /// redirects and reqwest-level retries, which `ruoqa` requires of an
+    /// injected client — it re-signs every request and follows same-origin
+    /// redirects itself, so a reqwest-level redirect would forward the
+    /// `X-API-Key`/`X-API-Hash` headers cross-origin (reqwest only strips
+    /// `Authorization`/`Cookie`/`Proxy-Authorization`), and a reqwest-level
+    /// retry would replay a stale signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HttpError::CaBundle`] if a configured CA bundle cannot be read
+    /// or parsed, or [`HttpError::Request`] if the client fails to build.
+    pub fn openqa_transport(verify: VerifyPolicy) -> Result<reqwest::Client> {
+        Ok(base_builder(verify)?
+            .redirect(reqwest::redirect::Policy::none())
+            .retry(reqwest::retry::never())
+            .build()?)
     }
 
     /// Borrow the underlying `reqwest::Client` for callers that need the full
@@ -635,5 +666,41 @@ mod tests {
         let out = sanitize_url("alice:s3cret@host.example/x");
         assert_eq!(out, "***@host.example/x");
         assert!(!out.contains("s3cret"));
+    }
+
+    /// [`HttpClient::openqa_transport`] must not follow a redirect: a
+    /// reqwest-level redirect would forward `X-API-Key`/`X-API-Hash` to
+    /// whatever `Location` says, off-origin, since reqwest only strips the
+    /// standard `Authorization`/`Cookie`/`Proxy-Authorization` headers on a
+    /// cross-origin hop. `ruoqa` follows redirects itself (same-origin only),
+    /// so the injected client must be a dead end at the first hop.
+    #[tokio::test]
+    async fn openqa_transport_does_not_follow_redirects() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/start"))
+            .respond_with(ResponseTemplate::new(302).insert_header("Location", "/end"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/end"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let client = HttpClient::openqa_transport(VerifyPolicy::Default(true)).unwrap();
+        let resp = client
+            .get(format!("{}/start", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            302,
+            "the transport must not follow the redirect itself"
+        );
     }
 }

--- a/crates/mtui-datasources/src/lib.rs
+++ b/crates/mtui-datasources/src/lib.rs
@@ -23,9 +23,7 @@ pub use error::{
 pub use gitea::{Gitea, assign_marker};
 pub use http::{HttpClient, MAX_API_BODY, VerifyPolicy, resolve_verify};
 pub use obs::{NoAuth, ObsAuth, ObsClient, ObsError, Osc};
-pub use openqa::{
-    ApiCredentials, ClientConf, IncidentName, Job, KernelOpenQA, OpenQABase, OpenQAClient,
-};
+pub use openqa::{IncidentName, Job, KernelOpenQA, OpenQABase, build_openqa_client_with_transport};
 pub use oqa_search::{
     BuildCheckResult, GroupResult, JobResult, OVERVIEW_BEGIN_MARKER, OVERVIEW_END_MARKER,
     OpenQAOverviewResult, VersionResult, aggregated_updates, build_checks, get_incident_info,

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -45,9 +45,9 @@ pub struct Job {
     /// The test/job name (e.g. `qam-incidentinstall`).
     #[serde(default)]
     pub test: String,
-    /// The overall job result (e.g. `passed`, `failed`).
-    #[serde(default)]
-    pub(crate) result: String,
+    /// The overall job result.
+    #[serde(default = "default_job_result")]
+    pub(crate) result: ruoqa::consts::JobResult,
     /// The id of the job this job was cloned as, if any.
     #[serde(default)]
     pub(crate) clone_id: Option<i64>,
@@ -57,6 +57,22 @@ pub struct Job {
     /// The per-module results.
     #[serde(default)]
     pub(crate) modules: Vec<JobModule>,
+}
+
+/// The default for [`Job::result`] when the field is missing from the
+/// response: `#[serde(default)]` needs a fallible-free `Default`, which the
+/// foreign, `#[non_exhaustive]` [`ruoqa::consts::JobResult`] doesn't derive
+/// (and this crate can't add one under orphan rules), so this names the
+/// fallback explicitly instead.
+///
+/// Deliberately [`Unknown`](ruoqa::consts::JobResult::Unknown), not
+/// [`None`](ruoqa::consts::JobResult::None): openQA itself sends the string
+/// `"none"` for a genuinely pending job (that value deserializes straight
+/// into `JobResult::None`, no default involved), so this fallback is reserved
+/// for the field being *absent* from a malformed/truncated response — a
+/// distinct "we don't know" case this crate has no evidence to call `None`.
+fn default_job_result() -> ruoqa::consts::JobResult {
+    ruoqa::consts::JobResult::Unknown
 }
 
 /// One module within an openQA job.

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -10,22 +10,9 @@
 use mtui_types::{RequestKind, RequestReviewID};
 use serde::Deserialize;
 
-use super::client::OpenQAClient;
 use crate::error::OpenQAError;
-use crate::http::{MAX_API_BODY, read_body_capped, sanitize_url};
-
-/// Redact any URL userinfo from a displayable error before it reaches a log or
-/// an [`OpenQAError::Fetch`] value.
-///
-/// reqwest's `Error` `Display` appends `" for url ({url})"`. reqwest strips
-/// userinfo from the URL it stores, but this is the defensive backstop that
-/// honours [`OpenQAError::Fetch`]'s "never the raw URL" contract regardless of
-/// the error's source: [`sanitize_url`] scans the whole string and rewrites any
-/// `scheme://user:pass@host` substring to `scheme://***@host`, and is a no-op
-/// when no userinfo is present.
-fn redact(e: &impl std::fmt::Display) -> String {
-    sanitize_url(&e.to_string())
-}
+use crate::http::sanitize_url;
+use crate::openqa::client::redact;
 
 /// The openQA `distri` query parameter.
 ///
@@ -102,19 +89,15 @@ pub(crate) struct JobsResponse {
     pub jobs: Vec<Job>,
 }
 
-/// The shared connector state: the API client plus the resolved query params.
+/// The shared connector state: the ruoqa client plus the resolved query params.
 ///
-/// Computes the `distri`/`scope`/
-/// `latest`/`build` parameters once, from the [`RequestReviewID`] and incident
-/// name, and holds the [`OpenQAClient`] used to fetch jobs.
+/// Computes the `distri`/`scope`/`latest`/`build` parameters once, from the
+/// [`RequestReviewID`] and incident name, and holds the [`ruoqa::Client`] used
+/// to fetch jobs.
 #[derive(Debug, Clone)]
 pub struct OpenQABase {
-    client: OpenQAClient,
+    client: ruoqa::Client,
     params: Vec<(String, String)>,
-    host: String,
-    /// [`sanitize_url`]-redacted `host`, for logs/errors/display so a
-    /// credentialed base URL (`scheme://user:pass@host`) never leaks userinfo.
-    safe_host: String,
 }
 
 impl OpenQABase {
@@ -123,7 +106,11 @@ impl OpenQABase {
     /// The `build` parameter is
     /// `:{git|smelt}:{maintenance_id}:{incident_name}`, keyed on whether the
     /// request is [`RequestKind::Slfo`] (`git`) or otherwise (`smelt`).
-    pub fn new(client: OpenQAClient, rrid: &RequestReviewID, incident: &impl IncidentName) -> Self {
+    pub fn new(
+        client: ruoqa::Client,
+        rrid: &RequestReviewID,
+        incident: &impl IncidentName,
+    ) -> Self {
         let prefix = if rrid.kind == RequestKind::Slfo {
             "git"
         } else {
@@ -140,20 +127,18 @@ impl OpenQABase {
             ("latest".to_string(), "1".to_string()),
             ("build".to_string(), build),
         ];
-        let host = client.base_url().to_string();
-        let safe_host = sanitize_url(&host);
-        Self {
-            client,
-            params,
-            host,
-            safe_host,
-        }
+        Self { client, params }
     }
 
     /// The openQA instance host (base URL), used in pretty-printed output.
+    ///
+    /// Sourced from `ruoqa`'s own resolved `base_url`, which already carries
+    /// no userinfo: `ruoqa::config::resolve` reduces a URL to `host[:port]`
+    /// before parsing it, dropping any `user:pass@` outright rather than
+    /// merely redacting it for display.
     #[must_use]
     pub(crate) fn host(&self) -> &str {
-        &self.host
+        self.client.base_url().as_str()
     }
 
     /// Fetch jobs from the openQA instance (best-effort).
@@ -171,66 +156,43 @@ impl OpenQABase {
 
     /// Fetch jobs from the openQA instance, surfacing failures as `Err`.
     ///
-    /// The fallible sibling of [`get_jobs`](Self::get_jobs): a request-build,
-    /// transport, non-2xx, or malformed-body failure returns
-    /// [`OpenQAError::Fetch`] (with a URL-free description) instead of being
-    /// folded to `None`, so a caller can distinguish "unreachable" from
-    /// "empty". `Ok(vec![])` is a valid-but-empty response.
+    /// The fallible sibling of [`get_jobs`](Self::get_jobs): a transport,
+    /// non-2xx, or malformed-body failure returns [`OpenQAError::Fetch`]
+    /// (with a URL-free description) instead of being folded to `None`, so a
+    /// caller can distinguish "unreachable" from "empty". `Ok(vec![])` is a
+    /// valid-but-empty response.
     ///
     /// # Errors
     ///
     /// [`OpenQAError::Fetch`] on any fetch failure.
     pub async fn try_get_jobs(&self) -> Result<Vec<Job>, OpenQAError> {
-        tracing::debug!("Get data from openQA - {}", self.safe_host);
+        let safe_host = sanitize_url(self.host());
+        tracing::debug!("Get data from openQA - {safe_host}");
 
-        let param_refs: Vec<(&str, String)> = self
-            .params
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.clone()))
-            .collect();
-
-        let builder = self
+        let path = format!("/api/v1/jobs{}", build_query(&self.params));
+        let body: JobsResponse = self
             .client
-            .build_get("jobs", &param_refs)
-            .inspect_err(|e| {
-                tracing::error!("openQA request to {} failed: {}", self.safe_host, redact(e));
-            })?;
-
-        let response = builder.send().await.map_err(|e| {
-            tracing::error!(
-                "openQA request to {} failed: {}",
-                self.safe_host,
-                redact(&e)
-            );
-            OpenQAError::Fetch(redact(&e))
-        })?;
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::debug!("openQA returned an error status: {}", redact(&e));
-            OpenQAError::Fetch(redact(&e))
-        })?;
-
-        let bytes = read_body_capped(response, MAX_API_BODY)
+            .request_as(reqwest::Method::GET, &path, None)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "openQA request to {} failed: {}",
-                    self.safe_host,
-                    redact(&e)
-                );
+                tracing::error!("openQA request to {safe_host} failed: {}", redact(&e));
                 OpenQAError::Fetch(redact(&e))
             })?;
-        serde_json::from_slice::<JobsResponse>(&bytes)
-            .map(|body| body.jobs)
-            .map_err(|e| {
-                tracing::error!(
-                    "openQA request to {} failed: {}",
-                    self.safe_host,
-                    redact(&e)
-                );
-                OpenQAError::Fetch(redact(&e))
-            })
+        Ok(body.jobs)
     }
+}
+
+/// Renders `params` as a `?key=value&...` query string via `url`'s encoder
+/// (through the `reqwest::Url` re-export, so no direct `url` dependency is
+/// needed), or an empty string when `params` is empty.
+fn build_query(params: &[(String, String)]) -> String {
+    if params.is_empty() {
+        return String::new();
+    }
+    let mut url = reqwest::Url::parse("http://x").expect("fixed base URL always parses");
+    url.query_pairs_mut()
+        .extend_pairs(params.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    format!("?{}", url.query().unwrap_or_default())
 }
 
 #[cfg(test)]
@@ -306,30 +268,22 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn safe_host_redacts_url_credentials() {
-        use crate::http::{HttpClient, VerifyPolicy};
-        let http = HttpClient::new(VerifyPolicy::Default(true)).unwrap();
-        let client = OpenQAClient::new(
-            http,
+    fn host_drops_url_credentials_entirely() {
+        // Unlike the hand-rolled client this replaces, `ruoqa`'s
+        // `config::resolve` reduces a URL to `host[:port]` before parsing, so
+        // userinfo never survives into `base_url()` at all — not merely
+        // redacted for display, genuinely absent.
+        use crate::http::VerifyPolicy;
+        use crate::openqa::client::build_openqa_client;
+        let client = build_openqa_client(
+            VerifyPolicy::Default(true),
             "https://alice:s3cret@openqa.example.com",
-            crate::openqa::client::ApiCredentials::default(),
-        );
+        )
+        .unwrap();
         let base = OpenQABase::new(client, &rrid("Maintenance"), &MockIncident::new("bash"));
-        // The log-facing host never carries userinfo...
-        assert!(!base.safe_host.contains("s3cret"));
-        assert!(base.safe_host.contains("***"));
-        // ...but the functional host() keeps the raw URL for building requests.
-        assert!(base.host().contains("s3cret"));
-    }
-
-    #[test]
-    fn redact_strips_userinfo_from_error_display() {
-        // Mirrors reqwest's `... for url (scheme://user:pass@host)` shape.
-        let msg =
-            "error sending request for url (https://alice:s3cret@openqa.example.com/api/v1/jobs)";
-        let out = redact(&msg);
-        assert!(!out.contains("s3cret"), "leaked credential: {out}");
-        assert!(out.contains("***"), "missing redaction marker: {out}");
+        assert!(!base.host().contains("s3cret"));
+        assert!(!base.host().contains("alice"));
+        assert_eq!(base.host(), "https://openqa.example.com/");
     }
 
     #[test]
@@ -352,13 +306,9 @@ pub(crate) mod tests {
 
     /// A client pointed at an unroutable base URL, for unit tests that only
     /// exercise param building (never the network).
-    pub(crate) fn dummy_client() -> OpenQAClient {
-        use crate::http::{HttpClient, VerifyPolicy};
-        let http = HttpClient::new(VerifyPolicy::Default(true)).unwrap();
-        OpenQAClient::new(
-            http,
-            "https://openqa.example.com",
-            crate::openqa::client::ApiCredentials::default(),
-        )
+    pub(crate) fn dummy_client() -> ruoqa::Client {
+        use crate::http::VerifyPolicy;
+        use crate::openqa::client::build_openqa_client;
+        build_openqa_client(VerifyPolicy::Default(true), "https://openqa.example.com").unwrap()
     }
 }

--- a/crates/mtui-datasources/src/openqa/client.rs
+++ b/crates/mtui-datasources/src/openqa/client.rs
@@ -1,399 +1,139 @@
-//! The openQA REST API client, reproducing the auth contract of the
-//! third-party python `openqa_client` package on top of this crate's shared
-//! [`HttpClient`].
+//! Builds the [`ruoqa::Client`] used by the openQA connectors.
 //!
-//! `openqa_client.client.OpenQA_Client`'s wire contract is:
-//!
-//! 1. reads `key`/`secret` for the server from INI `client.conf` files under
-//!    `/etc/openqa` and `~/.config/openqa` (later files override earlier);
-//! 2. sends `Accept: json` and, when a key is configured, `X-API-Key`;
-//! 3. signs every request with an HMAC-SHA1 over `"{path}{microtime}"` where
-//!    `path` is the request path+query with openQA's quirk substitutions
-//!    (`%20` → `+`, `~` → `%7E`), emitting `X-API-Microtime` and `X-API-Hash`.
-//!
-//! This module rebuilds that contract with `reqwest` (via [`HttpClient`]) so
-//! mtui needs no python runtime and no third-party client. GET requests do
-//! not strictly require signing (openQA allows unauthenticated GETs), but the
-//! signature is always attached when a secret is configured, matching that
-//! contract.
-
-use std::collections::BTreeMap;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use hmac::{Hmac, KeyInit, Mac};
-use sha1::Sha1;
+//! `ruoqa` owns the whole signed-request contract (INI `client.conf` /
+//! `$OPENQA_CONFIG` discovery, HMAC-SHA1 `X-API-Hash`, retries, and
+//! same-origin-only redirects) that this module used to hand-roll. The only
+//! thing left here is wiring mtui's shared TLS/timeout policy into it: an
+//! injected, redirect-less, no-reqwest-retry `reqwest::Client` (see
+//! [`crate::http::HttpClient::openqa_transport`]), because `ruoqa` re-signs and redirects
+//! itself and would otherwise leak `X-API-Key`/`X-API-Hash` across an
+//! `Authorization`-stripping-only reqwest redirect.
 
 use crate::error::OpenQAError;
-use crate::http::HttpClient;
+#[cfg(test)]
+use crate::http::{HttpClient, VerifyPolicy};
+use crate::http::{MAX_API_BODY, sanitize_url};
 
-type HmacSha1 = Hmac<Sha1>;
-
-/// The API credentials resolved for one openQA server.
+/// Builds a [`ruoqa::Client`] for `base_url` with a fresh, single-use
+/// transport.
 ///
-/// Mirrors the `key`/`secret` pair `OpenQA_Client` reads from `client.conf`.
-/// Both may be empty, in which case only unauthenticated GET requests are
-/// possible (logged at debug, and the caller continues).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ApiCredentials {
-    /// The API key, sent as the `X-API-Key` header.
-    pub key: String,
-    /// The API secret, used to HMAC-sign each request. Empty means "no signing".
-    pub secret: String,
-}
-
-impl ApiCredentials {
-    /// Whether a secret is present (and thus requests can be signed).
-    #[must_use]
-    fn can_sign(&self) -> bool {
-        !self.secret.is_empty()
-    }
-
-    /// Resolve credentials for `server` from parsed `client.conf` sections.
-    ///
-    /// Tries the bare `server` section first, then the full `baseurl`
-    /// section, else empty credentials.
-    #[must_use]
-    pub fn resolve(sections: &ClientConf, server: &str, baseurl: &str) -> Self {
-        sections
-            .credentials(server)
-            .or_else(|| sections.credentials(baseurl))
-            .unwrap_or_default()
-    }
-}
-
-/// Parsed `client.conf` INI: a map of section name → key/value pairs.
+/// Test/fixture scaffolding only: every production call site
+/// (`Session::openqa_transport` and its `mtui-core` callers) builds the
+/// transport once and reuses it across hosts via
+/// [`build_openqa_client_with_transport`] directly, so the connection pool set
+/// up by D1's dedicated openQA transport is actually shared. Kept
+/// crate-internal so it can't be reached for that (wrong, pool-defeating)
+/// purpose from outside this crate.
 ///
-/// Only the minimal INI shape openQA uses is supported: `[section]` headers and
-/// `key = value` lines. Comments (`#`/`;`) and blank lines are ignored. This
-/// avoids pulling in a full INI dependency for a two-key file.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClientConf {
-    sections: BTreeMap<String, BTreeMap<String, String>>,
-}
-
-impl ClientConf {
-    /// The standard `client.conf` search paths, lowest precedence first.
-    ///
-    /// `("/etc/openqa", "~/.config/openqa")`; later files
-    /// override earlier ones for the same section/key.
-    #[must_use]
-    fn default_paths() -> Vec<PathBuf> {
-        let mut paths = vec![PathBuf::from("/etc/openqa/client.conf")];
-        if let Some(home) = directories::UserDirs::new().map(|d| d.home_dir().to_path_buf()) {
-            paths.push(home.join(".config/openqa/client.conf"));
-        }
-        paths
-    }
-
-    /// Read and merge the `default_paths`.
-    ///
-    /// Missing files are skipped; an unreadable or malformed file is logged at
-    /// `warn` and skipped, so a bad config never hard-fails a lookup.
-    #[must_use]
-    pub fn load() -> Self {
-        Self::load_from(&Self::default_paths())
-    }
-
-    /// Read and merge the given paths (lowest precedence first).
-    #[must_use]
-    fn load_from(paths: &[PathBuf]) -> Self {
-        let mut conf = Self::default();
-        for path in paths {
-            match std::fs::read_to_string(path) {
-                Ok(contents) => conf.merge(&Self::parse(&contents)),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    tracing::warn!("could not read openQA client.conf {}: {e}", path.display());
-                }
-            }
-        }
-        conf
-    }
-
-    /// Parse INI text into sections. Never fails: unparseable lines are skipped.
-    #[must_use]
-    fn parse(text: &str) -> Self {
-        let mut sections: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
-        let mut current: Option<String> = None;
-        for raw in text.lines() {
-            let line = raw.trim();
-            if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
-                continue;
-            }
-            if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-                let name = name.trim().to_string();
-                sections.entry(name.clone()).or_default();
-                current = Some(name);
-            } else if let Some((k, v)) = line.split_once('=')
-                && let Some(section) = &current
-            {
-                sections
-                    .entry(section.clone())
-                    .or_default()
-                    .insert(k.trim().to_string(), v.trim().to_string());
-            }
-        }
-        Self { sections }
-    }
-
-    /// Merge `other` into `self`, with `other`'s values winning on conflict.
-    fn merge(&mut self, other: &Self) {
-        for (section, kvs) in &other.sections {
-            let dst = self.sections.entry(section.clone()).or_default();
-            for (k, v) in kvs {
-                dst.insert(k.clone(), v.clone());
-            }
-        }
-    }
-
-    /// Look up `key`/`secret` for a section, if both are present.
-    #[must_use]
-    fn credentials(&self, section: &str) -> Option<ApiCredentials> {
-        let kvs = self.sections.get(section)?;
-        let key = kvs.get("key")?;
-        let secret = kvs.get("secret")?;
-        Some(ApiCredentials {
-            key: key.clone(),
-            secret: secret.clone(),
-        })
-    }
-}
-
-/// Apply openQA's path-encoding quirks before signing.
+/// # Errors
 ///
-/// Applies `path.replace("%20", "+").replace("~", "%7E")`. The input
-/// is the already-percent-encoded request path+query.
-#[must_use]
-fn encode_path_for_signing(path: &str) -> String {
-    path.replace("%20", "+").replace('~', "%7E")
+/// See [`build_openqa_client_with_transport`], plus [`OpenQAError::Http`] if
+/// the transport itself fails to build (e.g. an unreadable CA bundle).
+#[cfg(test)]
+pub(crate) fn build_openqa_client(
+    verify: VerifyPolicy,
+    base_url: &str,
+) -> Result<ruoqa::Client, OpenQAError> {
+    build_openqa_client_with_transport(HttpClient::openqa_transport(verify)?, base_url)
 }
 
-/// Compute the `X-API-Hash` for a request path and microtime.
+/// Builds a [`ruoqa::Client`] for `base_url`, injecting an already-built
+/// `transport` (see [`crate::http::HttpClient::openqa_transport`]).
 ///
-/// `apisecret` keys an HMAC-SHA1 over the concatenation `"{path}{microtime}"`,
-/// hex-encoded — the exact scheme in `openqa_client._add_auth_headers`.
-#[must_use]
-fn compute_api_hash(secret: &str, path: &str, microtime: &str) -> String {
-    let mut mac =
-        HmacSha1::new_from_slice(secret.as_bytes()).expect("HMAC accepts a key of any length");
-    mac.update(encode_path_for_signing(path).as_bytes());
-    mac.update(microtime.as_bytes());
-    hex::encode(mac.finalize().into_bytes())
-}
-
-/// The current time as a floating-point Unix timestamp string.
+/// Credentials are resolved by `ruoqa` itself from the standard
+/// `client.conf`/`$OPENQA_CONFIG` search path (see the crate docs), keyed on
+/// `base_url`'s host. mtui's own ruoqa-level retries are disabled
+/// (`max_retries(0)`): a flaky openQA is mtui's caller's problem to retry or
+/// fold to "no results" (see [`super::base::OpenQABase::get_jobs`]), not
+/// something to hide behind an opaque, cancellation-unaware retry loop.
 ///
-/// Mirrors python `str(time.time())`, used as `X-API-Microtime`. Returns
-/// [`OpenQAError::Clock`] if the system clock predates the Unix epoch.
-fn current_microtime() -> Result<String, OpenQAError> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| OpenQAError::Clock)?;
-    Ok(now.as_secs_f64().to_string())
-}
-
-/// A minimal openQA API client: base URL + credentials over an [`HttpClient`].
-#[derive(Debug, Clone)]
-pub struct OpenQAClient {
-    http: HttpClient,
-    /// The scheme+host base URL, e.g. `https://openqa.example.com`.
-    base_url: String,
-    credentials: ApiCredentials,
-}
-
-impl OpenQAClient {
-    /// Build a client for `base_url` (scheme+host) with the given
-    /// [`HttpClient`] and credentials.
-    #[must_use]
-    pub fn new(http: HttpClient, base_url: impl Into<String>, credentials: ApiCredentials) -> Self {
-        Self {
-            http,
-            base_url: base_url.into(),
-            credentials,
-        }
-    }
-
-    /// The base URL this client targets.
-    #[must_use]
-    pub(crate) fn base_url(&self) -> &str {
-        &self.base_url
-    }
-
-    /// Build a signed GET request to `/api/v1/{path}` with `params`.
-    ///
-    /// Builds the standard request shape: `Accept: json`, `X-API-Key` when a
-    /// key is set, and the `X-API-Microtime`/`X-API-Hash` pair when a secret is
-    /// set. The signature covers the request path+query (`/api/v1/{path}?...`).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`OpenQAError::Clock`] if the system clock predates the Unix
-    /// epoch.
-    pub(crate) fn build_get(
-        &self,
-        path: &str,
-        params: &[(&str, String)],
-    ) -> Result<reqwest::RequestBuilder, OpenQAError> {
-        let api_path = format!("/api/v1/{path}");
-
-        // Encode the query ourselves (reqwest's `.query()` needs the `query`
-        // feature, which pulls in default features we disable). Build the same
-        // string we sign so the signed path exactly equals the sent path.
-        let query = build_query_string(params);
-        let path_url = if query.is_empty() {
-            api_path.clone()
-        } else {
-            format!("{api_path}?{query}")
-        };
-        let url = format!("{}{path_url}", self.base_url);
-
-        let mut builder = self.http.inner().get(&url).header("Accept", "json");
-
-        if !self.credentials.key.is_empty() {
-            builder = builder.header("X-API-Key", self.credentials.key.clone());
-        }
-        if self.credentials.can_sign() {
-            let microtime = current_microtime()?;
-            let hash = compute_api_hash(&self.credentials.secret, &path_url, &microtime);
-            builder = builder
-                .header("X-API-Microtime", microtime)
-                .header("X-API-Hash", hash);
-        }
-        Ok(builder)
-    }
-}
-
-/// Build the percent-encoded `key=value&...` query string for signing.
+/// # Errors
 ///
-/// Uses `application/x-www-form-urlencoded` encoding to match reqwest's
-/// `.query()` wire form, so the signed path equals the sent path.
-fn build_query_string(params: &[(&str, String)]) -> String {
-    params
-        .iter()
-        .map(|(k, v)| {
+/// Returns [`OpenQAError::ClientBuild`] if `ruoqa` fails to build the client
+/// (a malformed `client.conf`, or an invalid `User-Agent`/API key).
+pub fn build_openqa_client_with_transport(
+    transport: reqwest::Client,
+    base_url: &str,
+) -> Result<ruoqa::Client, OpenQAError> {
+    ruoqa::ClientBuilder::new()
+        .server(base_url)
+        .http_client(transport)
+        .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
+        .max_response_bytes(MAX_API_BODY)
+        .build()
+        .map_err(|e| OpenQAError::ClientBuild(redact(&e)))
+}
+
+/// Redacts any URL userinfo from a [`ruoqa::Error`]'s rendered message before
+/// it reaches [`OpenQAError`].
+///
+/// Three of `ruoqa::Error`'s variants embed a `url::Url` in their `Display`:
+/// `Request`, `Connection`, and — the one path that can actually carry a
+/// *server-supplied* credential rather than mtui's own — `CrossOriginRedirect`,
+/// whose `to` comes straight from a `Location` header a malicious or
+/// misconfigured openQA instance controls. Each is rebuilt here with its
+/// URL(s) run through [`sanitize_url`] individually, rather than sanitizing
+/// the whole rendered string: `Display` for `CrossOriginRedirect` embeds
+/// *two* URLs, and [`sanitize_url`] only recognises a single bare
+/// `scheme://[user:pass@]host` shape — scanning the concatenated message finds
+/// the first URL (never credentialed here: it's `ruoqa`'s own request URL),
+/// authorises on it, and returns the *original, unmodified* string, silently
+/// skipping the second, credentialed one. Every other variant renders as-is:
+/// none of them embed a URL, per `ruoqa::error`'s source.
+pub(crate) fn redact(e: &ruoqa::Error) -> String {
+    match e {
+        ruoqa::Error::Request {
+            method,
+            url,
+            status,
+            ..
+        } => {
+            format!("{method} {} returned {status}", sanitize_url(url.as_str()))
+        }
+        ruoqa::Error::Connection { url, source } => {
             format!(
-                "{}={}",
-                urlencoding::encode(k),
-                urlencoding::encode(v).replace("%20", "+")
+                "failed to connect to {}: {}",
+                sanitize_url(url.as_str()),
+                sanitize_url(&source.to_string())
             )
-        })
-        .collect::<Vec<_>>()
-        .join("&")
+        }
+        ruoqa::Error::CrossOriginRedirect { from, to } => {
+            format!(
+                "refusing to follow redirect from {} to a different origin {}",
+                sanitize_url(from.as_str()),
+                sanitize_url(to.as_str())
+            )
+        }
+        other => other.to_string(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Also the regression pin for "`build_openqa_client_with_transport` never
+    /// calls `.tls()`/`.timeouts()`": either is a compile-time-silent, only-
+    /// fails-at-`build()` `Error::IncompatibleHttpClient` once an
+    /// `http_client` is injected (ruoqa's own contract, exercised directly in
+    /// `tests/openqa.rs::injected_transport_rejects_tls_override`/
+    /// `_timeouts_override`), so this assertion turning `Err` is what actually
+    /// catches a future edit re-adding either call here. Observed red: adding
+    /// `.tls(TlsMode::danger_accept_invalid_certs())` to
+    /// `build_openqa_client_with_transport` fails this assertion.
     #[test]
-    fn parse_reads_sections_and_keys() {
-        let conf = ClientConf::parse(
-            "# a comment\n\
-             [openqa.example.com]\n\
-             key = ABCDEF\n\
-             secret = 123456\n\
-             \n\
-             ; another\n\
-             [other]\n\
-             key = ZZZ\n\
-             secret = YYY\n",
-        );
-        let creds = conf.credentials("openqa.example.com").unwrap();
-        assert_eq!(creds.key, "ABCDEF");
-        assert_eq!(creds.secret, "123456");
-        let other = conf.credentials("other").unwrap();
-        assert_eq!(other.key, "ZZZ");
+    fn build_openqa_client_succeeds_with_default_verify() {
+        // No `client.conf` in this process's search path is assumed; a bad
+        // config would surface as `ClientBuild`, exercised via the
+        // integration suite instead (needs a real filesystem fixture).
+        let client = build_openqa_client(VerifyPolicy::Default(true), "openqa.example.com");
+        assert!(client.is_ok());
     }
 
-    #[test]
-    fn parse_skips_malformed_lines_without_failing() {
-        let conf = ClientConf::parse("garbage-without-section\n[s]\nkey=k\nsecret=s\nno-equals\n");
-        let creds = conf.credentials("s").unwrap();
-        assert_eq!(creds.key, "k");
-        assert_eq!(creds.secret, "s");
-    }
-
-    #[test]
-    fn credentials_needs_both_key_and_secret() {
-        let conf = ClientConf::parse("[s]\nkey=only\n");
-        assert!(conf.credentials("s").is_none());
-    }
-
-    #[test]
-    fn merge_later_paths_override_earlier() {
-        let mut base = ClientConf::parse("[s]\nkey=old\nsecret=old\n");
-        let over = ClientConf::parse("[s]\nkey=new\nsecret=new\n");
-        base.merge(&over);
-        let creds = base.credentials("s").unwrap();
-        assert_eq!(creds.key, "new");
-        assert_eq!(creds.secret, "new");
-    }
-
-    #[test]
-    fn resolve_prefers_server_then_baseurl_then_empty() {
-        let conf = ClientConf::parse(
-            "[openqa.example.com]\nkey=SRV\nsecret=srvsec\n\
-             [https://openqa.example.com]\nkey=URL\nsecret=urlsec\n",
-        );
-        // server section wins
-        let c = ApiCredentials::resolve(&conf, "openqa.example.com", "https://openqa.example.com");
-        assert_eq!(c.key, "SRV");
-        // fall back to baseurl section
-        let c2 = ApiCredentials::resolve(&conf, "missing", "https://openqa.example.com");
-        assert_eq!(c2.key, "URL");
-        // empty when neither present
-        let c3 = ApiCredentials::resolve(&conf, "missing", "https://also.missing");
-        assert_eq!(c3, ApiCredentials::default());
-    }
-
-    #[test]
-    fn encode_path_applies_openqa_quirks() {
-        assert_eq!(
-            encode_path_for_signing("/api/v1/jobs?a=x%20y~z"),
-            "/api/v1/jobs?a=x+y%7Ez"
-        );
-    }
-
-    #[test]
-    fn compute_api_hash_is_a_stable_known_vector() {
-        // Fixed inputs -> a deterministic HMAC-SHA1 hex digest, cross-checked
-        // against python: hmac.new(b"secret", b"/api/v1/jobs1000.0",
-        // hashlib.sha1).hexdigest(). This locks the signing scheme (key,
-        // message ordering, hex encoding) so an accidental change is caught.
-        let hash = compute_api_hash("secret", "/api/v1/jobs", "1000.0");
-        assert_eq!(hash, "f50340ce52ef5590362f4adf2eb03cf04aef7862");
-        assert_eq!(hash.len(), 40); // SHA-1 hex is 40 chars
-    }
-
-    #[test]
-    fn compute_api_hash_applies_path_quirks_before_signing() {
-        // "%20" and "~" in the path are rewritten before hashing, so a path
-        // carrying them must hash the same as its rewritten form.
-        let raw = compute_api_hash("s", "/api/v1/x?a=b%20c~d", "1.0");
-        let pre = compute_api_hash("s", "/api/v1/x?a=b+c%7Ed", "1.0");
-        assert_eq!(raw, pre);
-    }
-
-    #[test]
-    fn can_sign_reflects_secret_presence() {
-        assert!(!ApiCredentials::default().can_sign());
-        assert!(
-            ApiCredentials {
-                key: "k".into(),
-                secret: "s".into()
-            }
-            .can_sign()
-        );
-    }
-
-    #[test]
-    fn build_query_string_encodes_params() {
-        let q = build_query_string(&[
-            ("build", ":smelt:1:bash".to_string()),
-            ("latest", "1".to_string()),
-        ]);
-        assert!(q.contains("build=%3Asmelt%3A1%3Abash"));
-        assert!(q.contains("latest=1"));
-    }
+    // `redact` itself is exercised end-to-end against a *real*
+    // `ruoqa::Error::CrossOriginRedirect` (the one variant that can carry a
+    // server-supplied credential) in
+    // `tests/openqa.rs::try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location`:
+    // `ruoqa::Error`'s variants are `#[non_exhaustive]`, so this crate cannot
+    // construct one directly to unit-test `redact`'s match arms in isolation.
 }

--- a/crates/mtui-datasources/src/openqa/kernel.rs
+++ b/crates/mtui-datasources/src/openqa/kernel.rs
@@ -7,18 +7,19 @@
 use std::collections::BTreeMap;
 
 use mtui_types::{OpenQAResult, Test};
+use ruoqa::consts::JobResult as OqaJobResult;
 
 use super::base::{Job, OpenQABase};
 use crate::error::OpenQAError;
 use crate::http::sanitize_url;
 
 /// Job results that are excluded from the parsed test list (not real outcomes).
-const EXCLUDED_RESULTS: &[&str] = &[
-    "skipped",
-    "user_cancelled",
-    "incomplete",
-    "user_restarted",
-    "obsoleted",
+const EXCLUDED_RESULTS: &[OqaJobResult] = &[
+    OqaJobResult::Skipped,
+    OqaJobResult::UserCancelled,
+    OqaJobResult::Incomplete,
+    OqaJobResult::UserRestarted,
+    OqaJobResult::Obsoleted,
 ];
 
 /// Module names dropped from every parsed test's module map (boilerplate).
@@ -118,6 +119,7 @@ impl KernelOpenQA {
         Some(
             jobs.iter()
                 .filter(|j| j.clone_id.is_none())
+                .filter(|j| !EXCLUDED_RESULTS.contains(&j.result))
                 .map(|j| {
                     let modules: BTreeMap<String, String> = j
                         .modules
@@ -125,9 +127,8 @@ impl KernelOpenQA {
                         .filter(|m| !EXCLUDED_MODULES.contains(&m.name.as_str()))
                         .map(|m| (m.name.clone(), m.result.clone()))
                         .collect();
-                    Test::new(&j.test, &j.result, j.id, j.setting("ARCH"), modules)
+                    Test::new(&j.test, j.result.as_str(), j.id, j.setting("ARCH"), modules)
                 })
-                .filter(|t| !EXCLUDED_RESULTS.contains(&t.result.as_str()))
                 .collect(),
         )
     }
@@ -209,6 +210,14 @@ mod tests {
         OpenQABase::new(dummy_client(), &rrid, &MockIncident::new("bash"))
     }
 
+    /// Parses a wire-form result string (`"passed"`, `"skipped"`, ...) into
+    /// [`OqaJobResult`], for building test fixtures from the same literals the
+    /// old `String`-typed field took.
+    fn job_result(s: &str) -> OqaJobResult {
+        serde_json::from_value(serde_json::Value::String(s.to_owned()))
+            .expect("valid job-result fixture literal")
+    }
+
     fn job(
         id: i64,
         test: &str,
@@ -224,7 +233,7 @@ mod tests {
         Job {
             id,
             test: test.into(),
-            result: result.into(),
+            result: job_result(result),
             clone_id,
             settings,
             modules: modules

--- a/crates/mtui-datasources/src/openqa/mod.rs
+++ b/crates/mtui-datasources/src/openqa/mod.rs
@@ -7,9 +7,9 @@
 //!
 //! * [`base`] — the shared query-parameter build, job fetch, and the
 //!   [`IncidentName`] seam and [`Job`] model.
-//! * [`client`] — the REST client reproducing the `openqa_client` auth contract
-//!   (INI `client.conf`, `X-API-Key`, HMAC-SHA1 `X-API-Hash`) over this crate's
-//!   shared [`HttpClient`](crate::http::HttpClient).
+//! * [`client`] — builds the [`ruoqa::Client`] (signed-request auth,
+//!   `client.conf` discovery, retries) over this crate's shared TLS/timeout
+//!   policy.
 //! * [`kernel`] — the "kernel" workflow ([`KernelOpenQA`]): the LTP test matrix.
 //! * `install` — the install-job → log-filename map (`install_logfile_for`).
 
@@ -20,6 +20,6 @@ pub mod kernel;
 
 pub(crate) use base::OPENQA_INSTALL_DISTRI;
 pub use base::{IncidentName, Job, JobModule, OpenQABase};
-pub use client::{ApiCredentials, ClientConf, OpenQAClient};
+pub use client::build_openqa_client_with_transport;
 pub(crate) use install::install_logfile_for;
 pub use kernel::KernelOpenQA;

--- a/crates/mtui-datasources/src/oqa_search/search.rs
+++ b/crates/mtui-datasources/src/oqa_search/search.rs
@@ -19,6 +19,8 @@
 use std::collections::{BTreeSet, HashMap};
 
 use futures::stream::{self, StreamExt};
+use reqwest::Method;
+use ruoqa::consts::JobResult as OqaJobResult;
 use scraper::{Html, Selector};
 
 use crate::error::OqaSearchError;
@@ -48,6 +50,15 @@ async fn get_json(http: &HttpClient, url: &str) -> Result<serde_json::Value, Oqa
 async fn fetch_url_content(http: &HttpClient, url: &str) -> Result<String, OqaSearchError> {
     let bytes = http.get_bytes_capped(url, MAX_API_BODY).await?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// GET `path` (relative to `oqa`'s base URL) and return the parsed JSON body.
+///
+/// `ruoqa::Client::request` already parses the response and enforces the
+/// client's `max_response_bytes` cap, so — unlike [`get_json`] — there is no
+/// separate byte-fetch step.
+async fn oqa_request(oqa: &ruoqa::Client, path: &str) -> Result<serde_json::Value, OqaSearchError> {
+    Ok(oqa.request(Method::GET, path, None).await?)
 }
 
 // --- Incident info (Dashboard) ---
@@ -146,27 +157,30 @@ async fn fallback_build(
 ///
 /// Returns [`OqaSearchError::Http`] if openQA cannot be reached.
 pub async fn incident_jobs(
-    http: &HttpClient,
+    oqa: &ruoqa::Client,
     build: &str,
-    url_openqa: &str,
     include_obsoleted: bool,
 ) -> Result<Vec<JobResult>, OqaSearchError> {
     if build.is_empty() {
         return Ok(vec![]);
     }
     let encoded = urlencoding::encode(build);
-    let url = format!("{url_openqa}/api/v1/jobs?build={encoded}");
-    let data = get_json(http, &url).await?;
+    let data = oqa_request(oqa, &format!("/api/v1/jobs?build={encoded}")).await?;
     let jobs = data.get("jobs").and_then(|j| j.as_array());
     let Some(jobs) = jobs else {
         return Ok(vec![]);
     };
 
-    let openqa_trimmed = url_openqa.trim_end_matches('/');
+    let openqa_trimmed = oqa.base_url().as_str().trim_end_matches('/').to_owned();
     let mut rows: Vec<JobResult> = Vec::new();
     for job in jobs {
         let result = job.get("result").and_then(|r| r.as_str()).unwrap_or("");
-        if result == "obsoleted" && !include_obsoleted {
+        let is_obsoleted = job
+            .get("result")
+            .cloned()
+            .and_then(|v| serde_json::from_value::<OqaJobResult>(v).ok())
+            == Some(OqaJobResult::Obsoleted);
+        if is_obsoleted && !include_obsoleted {
             continue;
         }
         let settings = job.get("settings");
@@ -217,10 +231,9 @@ pub async fn incident_jobs(
 
 /// Fetch the full openQA job-group list for a host.
 async fn fetch_openqa_groups(
-    http: &HttpClient,
-    url_openqa: &str,
+    oqa: &ruoqa::Client,
 ) -> Result<Vec<serde_json::Value>, OqaSearchError> {
-    let data = get_json(http, &format!("{url_openqa}/api/v1/job_groups")).await?;
+    let data = oqa_request(oqa, "/api/v1/job_groups").await?;
     Ok(data.as_array().cloned().unwrap_or_default())
 }
 
@@ -329,34 +342,27 @@ fn get_group_id(groups: &[serde_json::Value], key: &str) -> Option<i64> {
 // --- openQA job lookups ---
 
 /// Browser-facing openQA overview URL.
-fn openqa_print_url(url_openqa: &str, version: &str, build: &str, group_id: i64) -> String {
+fn openqa_print_url(base_url: &str, version: &str, build: &str, group_id: i64) -> String {
     format!(
-        "{url_openqa}/tests/overview?distri=sle&version={version}&build={build}&groupid={group_id}"
+        "{base_url}/tests/overview?distri=sle&version={version}&build={build}&groupid={group_id}"
     )
 }
 
-/// API endpoint for filtered openQA jobs in a build. Returns `None` for an
-/// unknown state.
-fn openqa_build_url(
-    state: &str,
-    url_openqa: &str,
-    version: &str,
-    build: &str,
-    group_id: i64,
-) -> Option<String> {
+/// API path (relative to the client's base URL) for filtered openQA jobs in a
+/// build. Returns `None` for an unknown state.
+fn openqa_build_path(state: &str, version: &str, build: &str, group_id: i64) -> Option<String> {
     let suffix = oqa_query_string(state)?;
     Some(format!(
-        "{url_openqa}/api/v1/jobs/overview?distri=sle&version={version}&build={build}&groupid={group_id}{suffix}"
+        "/api/v1/jobs/overview?distri=sle&version={version}&build={build}&groupid={group_id}{suffix}"
     ))
 }
 
 /// Set of incident IDs being tested by an openQA job.
 async fn openqa_job_issues(
-    http: &HttpClient,
-    url_openqa: &str,
+    oqa: &ruoqa::Client,
     job_id: i64,
 ) -> Result<BTreeSet<i64>, OqaSearchError> {
-    let response = get_json(http, &format!("{url_openqa}/api/v1/jobs/{job_id}")).await?;
+    let response = oqa_request(oqa, &format!("/api/v1/jobs/{job_id}")).await?;
     let settings = response
         .get("job")
         .and_then(|j| j.get("settings"))
@@ -403,11 +409,10 @@ fn overview_len(value: &serde_json::Value) -> usize {
 
 /// Resolve PASSED / FAILED / RUNNING for one openQA build.
 async fn query_version_status(
-    http: &HttpClient,
+    oqa: &ruoqa::Client,
     version: &str,
     build: &str,
     group_id: i64,
-    url_openqa: &str,
 ) -> Result<VersionResult, OqaSearchError> {
     // Workaround: TERADATA jobs share the base version's URL.
     let version_oqa = if version == "12-SP3-TERADATA" {
@@ -416,18 +421,23 @@ async fn query_version_status(
         version
     };
 
-    let print_url = openqa_print_url(url_openqa, version_oqa, build, group_id);
+    // `ruoqa`'s resolved `base_url` always carries a trailing `/` (`Url`'s own
+    // normalisation); trim it so the browser URL doesn't double up the slash.
+    let base_url = oqa.base_url().as_str().trim_end_matches('/');
+    let print_url = openqa_print_url(base_url, version_oqa, build, group_id);
     // These states are always valid; the .expect documents that invariant.
-    let running_url = openqa_build_url("running", url_openqa, version_oqa, build, group_id)
+    let running_path = openqa_build_path("running", version_oqa, build, group_id)
         .expect("running is a valid state");
-    let failed_url = openqa_build_url("failed", url_openqa, version_oqa, build, group_id)
-        .expect("failed is a valid state");
+    let failed_path =
+        openqa_build_path("failed", version_oqa, build, group_id).expect("failed is a valid state");
 
     // The running and failed overview queries are independent; fetch them
     // concurrently. Both are always needed, and the failed>0 / running>0
     // precedence below is applied to the results, so ordering is unchanged.
-    let (running_results, failed_results) =
-        tokio::join!(get_json(http, &running_url), get_json(http, &failed_url));
+    let (running_results, failed_results) = tokio::join!(
+        oqa_request(oqa, &running_path),
+        oqa_request(oqa, &failed_path)
+    );
     let running_results = running_results?;
     let failed_results = failed_results?;
 
@@ -606,13 +616,12 @@ fn log_matches_package(log: &str, packages: &[String]) -> bool {
 /// recorded as a `failed` row with a note, so a flaky openQA cannot abort the
 /// command.
 pub async fn single_incidents(
-    http: &HttpClient,
+    oqa: &ruoqa::Client,
     build: &str,
     versions: &[String],
-    url_openqa: &str,
     max_parallel: usize,
 ) -> Vec<VersionResult> {
-    let groups = match fetch_openqa_groups(http, url_openqa).await {
+    let groups = match fetch_openqa_groups(oqa).await {
         Ok(g) => g,
         Err(e) => {
             tracing::error!("openQA job-group fetch failed: {e}");
@@ -631,11 +640,12 @@ pub async fn single_incidents(
         .map(|(idx, version)| (idx, version.clone(), get_group_id(&groups, version)))
         .collect();
     let build = build.to_owned();
-    let url_openqa = url_openqa.to_owned();
     let mut indexed: Vec<(usize, VersionResult)> = stream::iter(jobs)
         .map(|(idx, version, group_id)| {
             let build = build.clone();
-            let url_openqa = url_openqa.clone();
+            // `ruoqa::Client` is cheaply `Clone` (`Arc`-backed), matching
+            // `reqwest::Client`'s own clone-to-share-pool convention.
+            let oqa = oqa.clone();
             async move {
                 let Some(group_id) = group_id else {
                     let note = format!(
@@ -652,9 +662,7 @@ pub async fn single_incidents(
                         },
                     );
                 };
-                let row = match query_version_status(http, &version, &build, group_id, &url_openqa)
-                    .await
-                {
+                let row = match query_version_status(&oqa, &version, &build, group_id).await {
                     Ok(row) => row,
                     Err(e) => VersionResult {
                         version,
@@ -676,12 +684,11 @@ pub async fn single_incidents(
 
 /// Walk the last `days` days of aggregated builds for each group.
 pub async fn aggregated_updates(
-    http: &HttpClient,
+    oqa: &ruoqa::Client,
     incident_id: &str,
     versions: &[String],
     days: u32,
     groups_wanted: &[String],
-    url_openqa: &str,
     max_parallel: usize,
 ) -> Vec<GroupResult> {
     let filtered_versions: Vec<String> = versions
@@ -696,7 +703,7 @@ pub async fn aggregated_updates(
 
     let incident_id_int: Option<i64> = incident_id.parse().ok();
 
-    let groups = match fetch_openqa_groups(http, url_openqa).await {
+    let groups = match fetch_openqa_groups(oqa).await {
         Ok(g) => g,
         Err(e) => {
             tracing::error!("openQA job-group fetch failed: {e}");
@@ -733,20 +740,13 @@ pub async fn aggregated_updates(
                 .map(move |(vi, version)| (gi, vi, version.clone(), group_id))
         })
         .collect();
-    let url_openqa = url_openqa.to_owned();
     let mut scanned: Vec<(usize, usize, VersionResult)> = stream::iter(jobs)
         .map(|(gi, vi, version, group_id)| {
-            let url_openqa = url_openqa.clone();
+            let oqa = oqa.clone();
             async move {
-                let row = scan_aggregated_for_version(
-                    http,
-                    &version,
-                    days,
-                    group_id,
-                    incident_id_int,
-                    &url_openqa,
-                )
-                .await;
+                let row =
+                    scan_aggregated_for_version(&oqa, &version, days, group_id, incident_id_int)
+                        .await;
                 (gi, vi, row)
             }
         })
@@ -771,21 +771,20 @@ pub async fn aggregated_updates(
 
 /// Find the most recent aggregated build covering the incident.
 async fn scan_aggregated_for_version(
-    http: &HttpClient,
+    oqa: &ruoqa::Client,
     version: &str,
     days: u32,
     group_id: i64,
     incident_id: Option<i64>,
-    url_openqa: &str,
 ) -> VersionResult {
     let now = current_utc_date();
     for i in 0..days {
         let day = now - chrono::Duration::days(i64::from(i));
         let build = format!("{}-1", day.format("%Y%m%d"));
-        let Some(job_url) = openqa_build_url("all", url_openqa, version, &build, group_id) else {
+        let Some(job_path) = openqa_build_path("all", version, &build, group_id) else {
             continue;
         };
-        let jobs = match get_json(http, &job_url).await {
+        let jobs = match oqa_request(oqa, &job_path).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::debug!("aggregated query for {version}/{build} failed: {e}");
@@ -799,13 +798,13 @@ async fn scan_aggregated_for_version(
         let Some(job_id) = first.get("id").and_then(serde_json::Value::as_i64) else {
             continue;
         };
-        let issues = match openqa_job_issues(http, url_openqa, job_id).await {
+        let issues = match openqa_job_issues(oqa, job_id).await {
             Ok(i) => i,
             Err(_) => continue,
         };
 
         if incident_id.is_none() || incident_id.is_some_and(|id| issues.contains(&id)) {
-            return match query_version_status(http, version, &build, group_id, url_openqa).await {
+            return match query_version_status(oqa, version, &build, group_id).await {
                 Ok(row) => row,
                 Err(e) => VersionResult {
                     version: version.to_string(),

--- a/crates/mtui-datasources/tests/openqa.rs
+++ b/crates/mtui-datasources/tests/openqa.rs
@@ -5,9 +5,8 @@
 //! every failure into `None`, a well-formed response deserialises into jobs, and
 //! the signed request carries the `X-API-Key`/`X-API-Hash` auth headers.
 
+use mtui_datasources::VerifyPolicy;
 use mtui_datasources::openqa::base::{IncidentName, OpenQABase};
-use mtui_datasources::openqa::client::{ApiCredentials, OpenQAClient};
-use mtui_datasources::{HttpClient, VerifyPolicy};
 use mtui_types::RequestReviewID;
 use wiremock::matchers::{header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -19,11 +18,28 @@ impl IncidentName for Incident {
     }
 }
 
-fn base_for(server_uri: &str, creds: ApiCredentials) -> OpenQABase {
-    let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
-    let client = OpenQAClient::new(http, server_uri.to_string(), creds);
+/// Builds an [`OpenQABase`] against `server_uri`, with credentials taken from
+/// an isolated `config_paths` fixture directory (not the real filesystem), so
+/// tests are hermetic under the one-test-binary-per-crate convention.
+fn base_for(server_uri: &str, config_dir: &std::path::Path) -> OpenQABase {
+    let transport = mtui_datasources::HttpClient::openqa_transport(VerifyPolicy::Default(true))
+        .expect("transport builds");
+    let client = ruoqa::ClientBuilder::new()
+        .server(server_uri)
+        .http_client(transport)
+        .config_paths(vec![config_dir.join("client.conf")])
+        .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
+        .build()
+        .expect("ruoqa client builds");
     let rrid = RequestReviewID::parse("SUSE:Maintenance:1:1").unwrap();
     OpenQABase::new(client, &rrid, &Incident("bash"))
+}
+
+/// [`base_for`] against an empty (no `client.conf`) fixture directory, for
+/// tests that don't care about credentials.
+fn base_for_no_creds(server_uri: &str) -> OpenQABase {
+    let dir = tempfile::tempdir().unwrap();
+    base_for(server_uri, dir.path())
 }
 
 #[tokio::test]
@@ -47,7 +63,7 @@ async fn get_jobs_returns_parsed_jobs_on_success() {
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     let jobs = base.get_jobs().await.expect("Some(jobs)");
     assert_eq!(jobs.len(), 1);
     assert_eq!(jobs[0].id, 1);
@@ -64,7 +80,7 @@ async fn get_jobs_returns_none_on_error_status() {
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     assert!(base.get_jobs().await.is_none());
 }
 
@@ -78,14 +94,14 @@ async fn get_jobs_returns_none_on_malformed_body() {
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     assert!(base.get_jobs().await.is_none());
 }
 
 #[tokio::test]
 async fn get_jobs_returns_none_on_connection_failure() {
     // Point at a port with no listener: transport failure -> None.
-    let base = base_for("http://127.0.0.1:1", ApiCredentials::default());
+    let base = base_for_no_creds("http://127.0.0.1:1");
     assert!(base.get_jobs().await.is_none());
 }
 
@@ -99,18 +115,18 @@ async fn try_get_jobs_errs_on_error_status() {
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     assert!(base.try_get_jobs().await.is_err());
 }
 
 #[tokio::test]
 async fn try_get_jobs_error_never_leaks_url_credentials() {
     // A fetch failure against a credentialed base URL must never surface the
-    // userinfo in the error. `redact` (over reqwest's error Display) is the
-    // backstop even though reqwest also strips userinfo from its stored URL, so
-    // this asserts the end-to-end contract on both a transport and a status
-    // failure path.
-    let base = base_for("http://user:s3cret@127.0.0.1:1", ApiCredentials::default());
+    // userinfo in the error. ruoqa's own `config::resolve` already drops
+    // userinfo from the base URL before it reaches a request; `redact` is the
+    // defensive backstop over the whole rendered error.
+    let dir = tempfile::tempdir().unwrap();
+    let base = base_for("http://user:s3cret@127.0.0.1:1", dir.path());
     let err = base.try_get_jobs().await.unwrap_err().to_string();
     assert!(!err.contains("s3cret"), "error leaked credential: {err}");
 }
@@ -125,8 +141,39 @@ async fn try_get_jobs_ok_empty_on_valid_empty_body() {
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     assert!(base.try_get_jobs().await.unwrap().is_empty());
+}
+
+/// Drives `redact`'s backstop with a *real* `ruoqa::Error::CrossOriginRedirect`
+/// carrying a credentialed URL, rather than a hand-written string.
+///
+/// `ruoqa::config::resolve` drops userinfo from the *client's own* base URL
+/// before any request, but a `Location` header is server-controlled: a
+/// malicious or misconfigured openQA instance could redirect off-origin to a
+/// URL embedding `user:pass@`. ruoqa refuses to follow it (same-origin only)
+/// but its `Error::CrossOriginRedirect` embeds both URLs verbatim in
+/// `Display` — this is the one path that can actually put a credential into a
+/// `ruoqa::Error`, and the only test that previously exercised `redact` used a
+/// hand-written string instead of a real error, so it could not have caught a
+/// regression in `redact` itself. This one can: gutting `redact` to
+/// `e.to_string()` (dropping `sanitize_url`) turns this red.
+#[tokio::test]
+async fn try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/jobs"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("Location", "https://alice:s3cret@evil.example.com/x"),
+        )
+        .mount(&server)
+        .await;
+
+    let base = base_for_no_creds(&server.uri());
+    let err = base.try_get_jobs().await.unwrap_err().to_string();
+    assert!(!err.contains("s3cret"), "error leaked credential: {err}");
+    assert!(!err.contains("alice"), "error leaked credential: {err}");
 }
 
 #[tokio::test]
@@ -134,12 +181,12 @@ async fn request_carries_accept_and_query_params() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/v1/jobs"))
-        .and(header("Accept", "json"))
+        .and(header("Accept", "application/json"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"jobs": []})))
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     // Some(empty) — matched only if Accept header + path matched.
     assert_eq!(base.get_jobs().await.map(|j| j.len()), Some(0));
 }
@@ -156,11 +203,17 @@ async fn request_carries_auth_headers_when_credentials_present() {
         .mount(&server)
         .await;
 
-    let creds = ApiCredentials {
-        key: "MYKEY".to_string(),
-        secret: "MYSECRET".to_string(),
-    };
-    let base = base_for(&server.uri(), creds);
+    let dir = tempfile::tempdir().unwrap();
+    let conf = dir.path().join("client.conf");
+    std::fs::write(
+        &conf,
+        format!(
+            "[{}]\nkey = MYKEY\nsecret = MYSECRET\n",
+            strip_scheme(&server.uri())
+        ),
+    )
+    .unwrap();
+    let base = base_for(&server.uri(), dir.path());
     // Matches only if all three auth headers were present on the request.
     assert_eq!(base.get_jobs().await.map(|j| j.len()), Some(0));
 }
@@ -168,18 +221,101 @@ async fn request_carries_auth_headers_when_credentials_present() {
 #[tokio::test]
 async fn request_omits_auth_headers_without_credentials() {
     let server = MockServer::start().await;
-    // Reject any request that carries an X-API-Key by only matching its absence
-    // via a catch-all that requires the key -> mount a matcher that must NOT be
-    // hit. Instead: match plain requests and assert success.
     Mock::given(method("GET"))
         .and(path("/api/v1/jobs"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"jobs": []})))
         .mount(&server)
         .await;
 
-    let base = base_for(&server.uri(), ApiCredentials::default());
+    let base = base_for_no_creds(&server.uri());
     assert_eq!(base.get_jobs().await.map(|j| j.len()), Some(0));
+}
 
-    // No signed request was made (no secret) — verified structurally: an
-    // unauthenticated GET still succeeds against openQA.
+/// Credentials are also honored from `$OPENQA_CONFIG`, `#[serial]`-guarded
+/// since it mutates process-global environment state.
+#[tokio::test]
+#[serial_test::serial(openqa_config_env)]
+// `std::env::set_var`/`remove_var` are `unsafe` in edition 2024; the
+// `#[serial(openqa_config_env)]` guard makes the mutation exclusive.
+#[allow(unsafe_code)]
+async fn request_carries_auth_headers_from_openqa_config_env() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/jobs"))
+        .and(header("X-API-Key", "ENVKEY"))
+        .and(header_exists("X-API-Hash"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"jobs": []})))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("client.conf"),
+        format!(
+            "[{}]\nkey = ENVKEY\nsecret = ENVSECRET\n",
+            strip_scheme(&server.uri())
+        ),
+    )
+    .unwrap();
+
+    // SAFETY: serialised via `#[serial(openqa_config_env)]`.
+    unsafe { std::env::set_var("OPENQA_CONFIG", dir.path()) };
+    let transport =
+        mtui_datasources::HttpClient::openqa_transport(VerifyPolicy::Default(true)).unwrap();
+    let client = ruoqa::ClientBuilder::new()
+        .server(server.uri())
+        .http_client(transport)
+        .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
+        .build()
+        .unwrap();
+    // SAFETY: still inside the `#[serial(openqa_config_env)]` critical section.
+    unsafe { std::env::remove_var("OPENQA_CONFIG") };
+
+    let rrid = RequestReviewID::parse("SUSE:Maintenance:1:1").unwrap();
+    let base = OpenQABase::new(client, &rrid, &Incident("bash"));
+    assert_eq!(base.get_jobs().await.map(|j| j.len()), Some(0));
+}
+
+/// Pins the *upstream* contract this crate's `build_openqa_client_with_transport`
+/// depends on never having called `.tls()`/`.timeouts()`: combining either with
+/// an injected `http_client` is a runtime `Error::IncompatibleHttpClient`, not
+/// a compile error, so a `ruoqa` upgrade that loosened this would only surface
+/// as a mysterious runtime failure. This test exercises `ruoqa::ClientBuilder`
+/// directly (not mtui's wrapper, which never calls either) to record that
+/// contract explicitly. The regression guard for mtui's *own* code never
+/// re-adding either call is
+/// `openqa::client::tests::build_openqa_client_succeeds_with_default_verify`
+/// (in `src/openqa/client.rs`), which builds through the real wrapper.
+#[test]
+fn injected_transport_rejects_tls_override() {
+    let err = ruoqa::ClientBuilder::new()
+        .server("openqa.example.com")
+        .http_client(reqwest::Client::new())
+        .tls(ruoqa::TlsMode::danger_accept_invalid_certs())
+        .config_paths(vec![])
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ruoqa::Error::IncompatibleHttpClient { option: "tls" }
+    ));
+}
+
+#[test]
+fn injected_transport_rejects_timeouts_override() {
+    let err = ruoqa::ClientBuilder::new()
+        .server("openqa.example.com")
+        .http_client(reqwest::Client::new())
+        .timeouts(ruoqa::Timeouts::default())
+        .config_paths(vec![])
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ruoqa::Error::IncompatibleHttpClient { option: "timeouts" }
+    ));
+}
+
+fn strip_scheme(uri: &str) -> &str {
+    uri.split_once("://").map_or(uri, |(_, rest)| rest)
 }

--- a/crates/mtui-datasources/tests/oqa_search.rs
+++ b/crates/mtui-datasources/tests/oqa_search.rs
@@ -21,6 +21,22 @@ fn client() -> HttpClient {
     HttpClient::new(VerifyPolicy::Default(true)).expect("client builds")
 }
 
+/// A `ruoqa::Client` for the openQA-targeted entry points
+/// (`single_incidents`/`aggregated_updates`/`incident_jobs`), pointed at
+/// `server_uri` with credential discovery disabled (`config_paths(vec![])`)
+/// so tests are hermetic.
+fn oqa_client(server_uri: &str) -> ruoqa::Client {
+    let transport =
+        HttpClient::openqa_transport(VerifyPolicy::Default(true)).expect("transport builds");
+    ruoqa::ClientBuilder::new()
+        .server(server_uri)
+        .http_client(transport)
+        .config_paths(vec![])
+        .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
+        .build()
+        .expect("ruoqa client builds")
+}
+
 fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/oqa_search")
 }
@@ -60,10 +76,9 @@ async fn single_incidents_passed() {
         .await;
 
     let rows = single_incidents(
-        &client(),
+        &oqa_client(&server.uri()),
         ":12358:bash",
         &["15-SP5".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -104,10 +119,9 @@ async fn single_incidents_failed_counts_jobs() {
         .await;
 
     let rows = single_incidents(
-        &client(),
+        &oqa_client(&server.uri()),
         ":12358:bash",
         &["15-SP5".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -121,10 +135,9 @@ async fn single_incidents_unknown_version_records_note() {
     mount_job_groups(&server, vec![job_group(490, "SLE 15 SP5 Core Incidents")]).await;
 
     let rows = single_incidents(
-        &client(),
+        &oqa_client(&server.uri()),
         ":12358:bash",
         &["99-SP99".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -147,10 +160,9 @@ async fn single_incidents_teradata_uses_base_version_in_url() {
         .await;
 
     let rows = single_incidents(
-        &client(),
+        &oqa_client(&server.uri()),
         ":12358:bash",
         &["12-SP3-TERADATA".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -173,12 +185,11 @@ async fn aggregated_updates_skips_excluded_versions() {
     .await;
 
     let out = aggregated_updates(
-        &client(),
+        &oqa_client(&server.uri()),
         "12358",
         &["15-SP4-TERADATA".to_string(), "16.0".to_string()],
         5,
         &["core".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -229,12 +240,11 @@ async fn aggregated_updates_finds_matching_build() {
         .await;
 
     let out = aggregated_updates(
-        &client(),
+        &oqa_client(&server.uri()),
         "12358",
         &["15-SP5".to_string()],
         5,
         &["core".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -263,12 +273,11 @@ async fn aggregated_updates_missing_after_window() {
         .await;
 
     let out = aggregated_updates(
-        &client(),
+        &oqa_client(&server.uri()),
         "12358",
         &["15-SP5".to_string()],
         3,
         &["core".to_string()],
-        &server.uri(),
         4,
     )
     .await;
@@ -302,12 +311,11 @@ async fn aggregated_updates_preserves_group_and_version_order() {
         .await;
 
     let out = aggregated_updates(
-        &client(),
+        &oqa_client(&server.uri()),
         "12358",
         &["15-SP5".to_string(), "15-SP4".to_string()],
         2,
         &["core".to_string(), "cloud".to_string()],
-        &server.uri(),
         8,
     )
     .await;
@@ -598,7 +606,7 @@ async fn incident_jobs_drops_obsoleted_by_default() {
         .mount(&server)
         .await;
 
-    let rows = incident_jobs(&client(), ":git:5137:libica", &server.uri(), false)
+    let rows = incident_jobs(&oqa_client(&server.uri()), ":git:5137:libica", false)
         .await
         .expect("ok");
     let results: Vec<&str> = rows.iter().map(|r| r.result.as_str()).collect();
@@ -619,7 +627,7 @@ async fn incident_jobs_include_obsoleted() {
         })))
         .mount(&server)
         .await;
-    let rows = incident_jobs(&client(), ":b", &server.uri(), true)
+    let rows = incident_jobs(&oqa_client(&server.uri()), ":b", true)
         .await
         .expect("ok");
     assert_eq!(rows.len(), 1);
@@ -629,10 +637,36 @@ async fn incident_jobs_include_obsoleted() {
 #[tokio::test]
 async fn incident_jobs_empty_build_makes_no_request() {
     // A falsy build short-circuits with no HTTP call (no server needed).
-    let rows = incident_jobs(&client(), "", "https://openqa.invalid", false)
+    let rows = incident_jobs(&oqa_client("https://openqa.invalid"), "", false)
         .await
         .expect("ok");
     assert!(rows.is_empty());
+}
+
+/// `OqaSearchError`'s `From<ruoqa::Error>` conversion never leaks a credential
+/// embedded in a server-controlled `Location` header (a cross-origin
+/// redirect `ruoqa` refuses to follow but whose error message embeds both
+/// URLs verbatim). Mirrors
+/// `openqa.rs::try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location`
+/// for the `oqa_search` call sites migrated in Phase 2.
+#[tokio::test]
+async fn incident_jobs_error_never_leaks_a_credential_from_a_redirect_location() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/jobs"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .insert_header("Location", "https://alice:s3cret@evil.example.com/x"),
+        )
+        .mount(&server)
+        .await;
+
+    let err = incident_jobs(&oqa_client(&server.uri()), ":git:5137:libica", false)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(!err.contains("s3cret"), "error leaked credential: {err}");
+    assert!(!err.contains("alice"), "error leaked credential: {err}");
 }
 
 // --- Golden-fixture heuristic tests (parity with the vendored .matches) ---
@@ -746,7 +780,7 @@ async fn single_incidents_request_count_is_exact() {
         "15-SP4".to_string(),
         "12-SP5".to_string(),
     ];
-    let rows = single_incidents(&client(), ":12358:bash", &versions, &server.uri(), 4).await;
+    let rows = single_incidents(&oqa_client(&server.uri()), ":12358:bash", &versions, 4).await;
     assert_eq!(rows.len(), 3);
     assert!(rows.iter().all(|r| r.status == "passed"));
     // Output order matches the input order regardless of completion order.
@@ -796,7 +830,7 @@ async fn single_incidents_runs_versions_concurrently() {
     // bound. Sequential lower bound would be 8×delay = 800ms; bounded-parallel
     // (bound ≥ 4) is closer to ~2×delay. Assert well under the sequential bound.
     let start = std::time::Instant::now();
-    let rows = single_incidents(&client(), ":12358:bash", &versions, &server.uri(), 8).await;
+    let rows = single_incidents(&oqa_client(&server.uri()), ":12358:bash", &versions, 8).await;
     let elapsed = start.elapsed();
 
     assert_eq!(rows.len(), 4);
@@ -827,7 +861,7 @@ async fn single_incidents_respects_bound_of_one() {
     // delay), so serialised ≈ 2×delay while bound≥2 would be ≈ 1×delay. Assert
     // it takes at least the serialised lower bound.
     let start = std::time::Instant::now();
-    let rows = single_incidents(&client(), ":12358:bash", &versions, &server.uri(), 1).await;
+    let rows = single_incidents(&oqa_client(&server.uri()), ":12358:bash", &versions, 1).await;
     let elapsed = start.elapsed();
 
     assert_eq!(rows.len(), 2);

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -122,6 +122,16 @@ Defaults below are the built-in values.
 | `baremetal` | URL | `http://openqa.qam.suse.cz` | Baremetal openQA instance URL. |
 | `distri` | string | `sle` | openQA install `distri` parameter. |
 
+openQA API credentials (`key`/`secret`, used to sign requests with
+`X-API-Hash`) are **not** part of `mtui.toml`. They are read from the openQA
+project's own `client.conf` — an INI file with one `[host[:port]]` section per
+instance — searched at `/etc/openqa/client.conf` then
+`$XDG_CONFIG_HOME/openqa/client.conf` (or `~/.config/openqa/client.conf` when
+`$XDG_CONFIG_HOME` is unset), later files overriding earlier ones. Setting
+`$OPENQA_CONFIG` to a directory makes it the **only** path searched. An
+instance with no matching section (or no `client.conf` at all) is queried
+unauthenticated, which openQA permits for GET requests.
+
 ### `[gitea]`
 
 | Key | Type | Default | Meaning |


### PR DESCRIPTION
## Summary

Replaces mtui's hand-rolled openQA signed-request client with the [`ruoqa`](https://crates.io/crates/ruoqa) crate (crates.io, GPL-3.0-or-later, edition 2024, MSRV 1.96 — matching mtui), across three commits:

1. **`feat(datasources): replace the hand-rolled openQA client with ruoqa`** — deletes the INI `client.conf` reader, HMAC-SHA1 signer, and path-encoding quirks in `openqa/client.rs` (~350 of 399 lines), replacing them with a `ruoqa::Client` built over a dedicated redirect-less, no-reqwest-retry transport (`HttpClient::openqa_transport`) so it can share mtui's TLS/timeout policy without leaking `X-API-Key`/`X-API-Hash` across a reqwest-level cross-origin redirect.
2. **`feat(datasources): migrate oqa_search's openQA calls to ruoqa::Client`** — `openqa_jobs`/`openqa_overview` now authenticate against openQA (previously always unauthenticated, even with credentials configured).
3. **`feat(datasources): type openQA job results via ruoqa::consts::JobResult`** — `kernel.rs::EXCLUDED_RESULTS` and the obsoleted-job check are now enum matches instead of hand-copied string literals. `mtui_types::Test.result` stays `String` — `mtui-types` is the I/O-free crate and must not gain `ruoqa`/`reqwest`.

## User-visible changes (see CHANGELOG)

- `$OPENQA_CONFIG` and `$XDG_CONFIG_HOME/openqa/client.conf` are now honoured as `client.conf` search paths.
- A credentialed `openqa_instance` URL (`https://user:pass@host`) has the userinfo **dropped** when resolving the request target, not merely redacted for display.
- The unauthenticated `Accept` header changed from `json` to `application/json`.
- `openqa_jobs`/`openqa_overview` now authenticate when `client.conf` has credentials for the instance.

## Verification

- Full gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`, `cargo test --workspace`, `cargo test -p mtui-mcp -F mcp`, and both `--no-default-features`/`--all-features` builds.
- `rg -n 'compute_api_hash|encode_path_for_signing|struct ClientConf'` and `rg -n 'native-tls|openssl-sys' Cargo.lock` both return nothing; `cargo tree -p mtui-types` shows no `ruoqa`/`reqwest`.
- Patch coverage on touched files (`cargo llvm-cov -p mtui-datasources`): `openqa/client.rs` 97.4%, `openqa/base.rs` 97.1%, `error.rs` 100%, `http.rs` 98.1%, `oqa_search/search.rs` 91.8%.
- A regression test is observed **red** before every claimed fix: the HMAC signing golden vector against `ruoqa::auth` directly; the `IncompatibleHttpClient` pin (`build_openqa_client_with_transport` temporarily given `.tls(...)`); a wrong `client.conf` key against a wiremock instance requiring `X-API-Hash`.
- **Security-relevant fix caught by testing this migration, not the original implementation**: a first draft of the credential-redaction backstop sanitized a `ruoqa::Error`'s whole rendered message in one pass. A new test driving a real `ruoqa::Error::CrossOriginRedirect` (a mock server's `Location` header pointing off-origin to a `user:pass@` URL) caught it failing — the message embeds two URLs, and the sanitizer only recognises a single bare `scheme://[user:pass@]host` shape, so it authorised on the first (uncredentialed) URL and returned the original string unmodified, silently passing the credentialed second URL through. Fixed by sanitizing each `ruoqa::Error` variant's URL field individually rather than scanning the whole message.
- **Verified against the real `openqa.suse.de`** (with real credentials, not just wiremock): a signed `GET` succeeded end-to-end, and `OpenQABase::new(...)`'s exact production query shape (`build=:smelt:1:bash`, the colon-heavy pattern that was the specific wire-encoding risk of moving off the old `urlencoding`-based signer) round-tripped through `try_get_jobs()` with no signature or encoding rejection.

## Risks addressed

- **Redirect/credential safety**: the injected openQA transport is proven not to follow a cross-origin redirect itself (ruoqa owns that, same-origin only); no other datasource's redirect behaviour changed.
- **No second TLS stack**: reqwest 0.13's `default-tls = ["rustls"]`, so feature unification (`charset`, `http2`, `system-proxy` — ruoqa depends on `reqwest` with default features) adds no native-tls/openssl path. Cold `cargo build --workspace` delta: +4.6s (~10%).
- **Retries kept inert**: `max_retries(0)` on the ruoqa client — a flaky openQA is the caller's problem to retry/fold to "no results", not something to hide behind an opaque, cancellation-unaware retry loop.
