### PR TITLE
chore(deps): update ruoqa to 0.1.4 (+ full cargo update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- An unreachable openQA instance now reports the actual transport failure
+  (e.g. `"...: Connection refused (os error 61)"`) instead of restating the
+  request URL (`"...: error sending request for url (http://.../api/v1/jobs)"`).
 - MCP calls passing a list to a repeatable single-value flag (e.g. `approve`
   with two `group`s) no longer fail to parse: the reconstructed argv now
   repeats the flag before every element instead of emitting it once for the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -399,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,9 +674,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+checksum = "64f383fe92a826d3b1a3c18e0cb791bef22948931b4909f6781adea466ede5e8"
 dependencies = [
  "clap",
  "roff",
@@ -1032,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -1304,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs_io"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
 dependencies = [
  "encoding_rs",
 ]
@@ -1625,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1650,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
+checksum = "7c92814c286f45b5ed1498ce9547bc9637b473eba7037f8aee6a4d5a3c1e051c"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -1863,7 +1869,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2055,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2152,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2184,9 +2190,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags",
  "libc",
@@ -3341,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3362,7 +3368,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3476,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "ruoqa"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6931448e1649502f2f4476333d816d07a459aad6c5786d26746a5fb4813b4cbc"
+checksum = "22e2366733a0e88dbab896d700e161ce43efe35acb96001235eb76d5acff4294"
 dependencies = [
  "bytes",
  "hmac",
@@ -3596,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "russh-sftp"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+checksum = "9de67aace74530a29086db0671fa200c470a58eb380081f28ad512ffb0c5356b"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3917,7 +3923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb49c0aa8a5bb88c00b833c11bae50d1611fb89e01336f53b05f7c643b1c883"
 dependencies = [
  "annotate-snippets",
- "base64",
+ "base64 0.23.1",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",
@@ -5396,7 +5402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,12 @@ reqwest = { version = "0.13", features = ["json", "rustls"], default-features = 
 # `client.conf`/$OPENQA_CONFIG credential discovery, retries, and redirect
 # restriction, replacing mtui's own hand-rolled implementation. reqwest 0.13.4
 # on both sides so `ClientBuilder::http_client` shares mtui's connection pool.
-ruoqa = "0.1.3"
+# "0.1.4" is a floor, not a preference: mtui depends on its userinfo
+# redaction in `Error::Request`/`Error::Connection`/`Error::CrossOriginRedirect`
+# Display and in `config::resolve`'s bare-authority stripping
+# (crates/mtui-datasources/src/openqa/client.rs), and a resolver allowed to
+# pick 0.1.3 would silently reintroduce the leak.
+ruoqa = "0.1.4"
 # HMAC-SHA1, for the OpenSSH hashed known_hosts test helper (mtui-hosts dev-dep);
 # not used for openQA auth any more (ruoqa owns that).
 hmac = "0.13"

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -110,8 +110,10 @@ pub enum RefhostError {
 /// `#[non_exhaustive]` and covers eleven distinct failure modes (bad status,
 /// transport, TLS, config, redirect limits, ...); every one collapses onto
 /// [`Fetch`](Self::Fetch)/[`ClientBuild`](Self::ClientBuild) via the
-/// `openqa::client` module's `redact` helper, which strips any URL userinfo
-/// before the message reaches this type.
+/// `openqa::client` module's `describe` helper. Userinfo cannot reach these
+/// messages: `ruoqa` >= 0.1.4 redacts it at every `Display` site and drops it
+/// in `config::resolve`, and `describe` never renders a `reqwest::Error`
+/// directly.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum OpenQAError {
@@ -121,13 +123,14 @@ pub enum OpenQAError {
     Http(#[from] HttpError),
 
     /// The `ruoqa` client itself failed to build: a malformed `client.conf`,
-    /// invalid TLS setup, or an incompatible builder combination. Carries a
-    /// sanitized description (never the raw URL).
+    /// invalid TLS setup, or an incompatible builder combination. Userinfo
+    /// cannot reach this message (see the module-level doc above).
     #[error("openQA client could not be built: {0}")]
     ClientBuild(String),
 
     /// A jobs fetch failed: a transport error, a non-2xx status, or a malformed
-    /// response body. Carries a sanitized description (never the raw URL).
+    /// response body. Userinfo cannot reach this message (see the
+    /// module-level doc above).
     #[error("openQA jobs fetch failed: {0}")]
     Fetch(String),
 }
@@ -279,13 +282,12 @@ impl From<HttpError> for OqaSearchError {
 }
 
 impl From<ruoqa::Error> for OqaSearchError {
-    /// Routed through the `openqa::client` module's `redact` helper first:
-    /// `ruoqa::Error` can embed a `url::Url` (`Request`/`Connection`/
-    /// `CrossOriginRedirect`),
-    /// and this crate's contract is that a fetch failure never carries a raw
-    /// URL (which could embed a credentialed openQA instance URL).
+    /// Routed through the `openqa::client` module's `describe` helper first:
+    /// this crate's contract is that a fetch failure never carries a raw URL
+    /// (which could embed a credentialed openQA instance URL) — see the
+    /// [`OpenQAError`] module-level doc for why that's guaranteed.
     fn from(source: ruoqa::Error) -> Self {
-        Self::Http(crate::openqa::client::redact(&source))
+        Self::Http(crate::openqa::client::describe(&source))
     }
 }
 

--- a/crates/mtui-datasources/src/openqa/base.rs
+++ b/crates/mtui-datasources/src/openqa/base.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::error::OpenQAError;
 use crate::http::sanitize_url;
-use crate::openqa::client::redact;
+use crate::openqa::client::describe;
 
 /// The openQA `distri` query parameter.
 ///
@@ -191,8 +191,8 @@ impl OpenQABase {
             .request_as(reqwest::Method::GET, &path, None)
             .await
             .map_err(|e| {
-                tracing::error!("openQA request to {safe_host} failed: {}", redact(&e));
-                OpenQAError::Fetch(redact(&e))
+                tracing::error!("openQA request to {safe_host} failed: {}", describe(&e));
+                OpenQAError::Fetch(describe(&e))
             })?;
         Ok(body.jobs)
     }

--- a/crates/mtui-datasources/src/openqa/client.rs
+++ b/crates/mtui-datasources/src/openqa/client.rs
@@ -61,51 +61,43 @@ pub fn build_openqa_client_with_transport(
         .retry(ruoqa::RetryPolicy::default().max_retries(0).deadline(None))
         .max_response_bytes(MAX_API_BODY)
         .build()
-        .map_err(|e| OpenQAError::ClientBuild(redact(&e)))
+        .map_err(|e| OpenQAError::ClientBuild(describe(&e)))
 }
 
-/// Redacts any URL userinfo from a [`ruoqa::Error`]'s rendered message before
-/// it reaches [`OpenQAError`].
-///
-/// Three of `ruoqa::Error`'s variants embed a `url::Url` in their `Display`:
-/// `Request`, `Connection`, and — the one path that can actually carry a
-/// *server-supplied* credential rather than mtui's own — `CrossOriginRedirect`,
-/// whose `to` comes straight from a `Location` header a malicious or
-/// misconfigured openQA instance controls. Each is rebuilt here with its
-/// URL(s) run through [`sanitize_url`] individually, rather than sanitizing
-/// the whole rendered string: `Display` for `CrossOriginRedirect` embeds
-/// *two* URLs, and [`sanitize_url`] only recognises a single bare
-/// `scheme://[user:pass@]host` shape — scanning the concatenated message finds
-/// the first URL (never credentialed here: it's `ruoqa`'s own request URL),
-/// authorises on it, and returns the *original, unmodified* string, silently
-/// skipping the second, credentialed one. Every other variant renders as-is:
-/// none of them embed a URL, per `ruoqa::error`'s source.
-pub(crate) fn redact(e: &ruoqa::Error) -> String {
+/// Renders a [`ruoqa::Error`] for [`OpenQAError`]: userinfo cannot reach this
+/// message — `ruoqa` >= 0.1.4 redacts it at every `Display` site
+/// (`Request`/`Connection`/`CrossOriginRedirect` all render via its
+/// `RedactedUrl`) and drops it in `config::resolve`, and this function never
+/// renders a `reqwest::Error` directly (see [`root_cause`]).
+pub(crate) fn describe(e: &ruoqa::Error) -> String {
     match e {
-        ruoqa::Error::Request {
-            method,
-            url,
-            status,
-            ..
-        } => {
-            format!("{method} {} returned {status}", sanitize_url(url.as_str()))
-        }
-        ruoqa::Error::Connection { url, source } => {
-            format!(
-                "failed to connect to {}: {}",
-                sanitize_url(url.as_str()),
-                sanitize_url(&source.to_string())
-            )
-        }
-        ruoqa::Error::CrossOriginRedirect { from, to } => {
-            format!(
-                "refusing to follow redirect from {} to a different origin {}",
-                sanitize_url(from.as_str()),
-                sanitize_url(to.as_str())
-            )
-        }
+        // `Connection`'s Display is just "failed to connect to
+        // <redacted-url>" — ruoqa redacts the URL but drops the transport
+        // cause entirely. Recover it from the source chain: rendering the
+        // `reqwest::Error` itself would append an unredacted `for url (...)`
+        // (reqwest-0.13.4/src/error.rs:280).
+        ruoqa::Error::Connection { source, .. } => match root_cause(source) {
+            Some(cause) => format!("{e}: {cause}"),
+            None => e.to_string(),
+        },
+        // Every other variant already interpolates its own source
+        // (`Config`/`Tls`/`Parse`) or carries none.
         other => other.to_string(),
     }
+}
+
+/// Walks `e`'s source chain to the deepest cause, deliberately skipping `e`
+/// itself (whose `Display` may be unredacted — see [`describe`]), and returns
+/// it through [`sanitize_url`] as a backstop against a future layer embedding
+/// a URL.
+///
+/// Returns `None` if `e` carries no source at all.
+fn root_cause(e: &dyn std::error::Error) -> Option<String> {
+    let mut deepest = e.source()?;
+    while let Some(next) = deepest.source() {
+        deepest = next;
+    }
+    Some(sanitize_url(&deepest.to_string()))
 }
 
 #[cfg(test)]
@@ -130,10 +122,64 @@ mod tests {
         assert!(client.is_ok());
     }
 
-    // `redact` itself is exercised end-to-end against a *real*
-    // `ruoqa::Error::CrossOriginRedirect` (the one variant that can carry a
-    // server-supplied credential) in
-    // `tests/openqa.rs::try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location`:
+    // `describe` itself is exercised end-to-end against a *real*
+    // `ruoqa::Error::Connection`/`CrossOriginRedirect` in `tests/openqa.rs`:
     // `ruoqa::Error`'s variants are `#[non_exhaustive]`, so this crate cannot
-    // construct one directly to unit-test `redact`'s match arms in isolation.
+    // construct one directly to unit-test `describe`'s match arms in
+    // isolation. `root_cause` has no such restriction, since it walks a
+    // plain `&dyn Error`.
+
+    #[derive(Debug)]
+    struct Leaf(&'static str);
+    impl std::fmt::Display for Leaf {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+    impl std::error::Error for Leaf {}
+
+    #[derive(Debug)]
+    struct Wrapper {
+        source: Box<dyn std::error::Error>,
+    }
+    impl std::fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "wrapper")
+        }
+    }
+    impl std::error::Error for Wrapper {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(self.source.as_ref())
+        }
+    }
+
+    /// Two-deep chain: `root_cause` must sanitize the deepest message.
+    /// Deleting the `sanitize_url` call in `root_cause` turns this red.
+    #[test]
+    fn root_cause_sanitizes_the_deepest_message() {
+        let e = Wrapper {
+            source: Box::new(Leaf("boom https://alice:s3cret@h/x")),
+        };
+        assert_eq!(root_cause(&e).as_deref(), Some("boom https://***@h/x"));
+    }
+
+    /// Three-deep chain: `root_cause` must return the *deepest* message, not
+    /// an intermediate one. Changing `root_cause` to stop at the first
+    /// `source()` instead of walking to the end turns this red.
+    #[test]
+    fn root_cause_returns_the_deepest_not_the_intermediate() {
+        let e = Wrapper {
+            source: Box::new(Wrapper {
+                source: Box::new(Leaf("deepest")),
+            }),
+        };
+        assert_eq!(root_cause(&e).as_deref(), Some("deepest"));
+    }
+
+    /// An error with no source at all yields `None`, so callers fall back to
+    /// the outer error's own (already-redacted) `Display`.
+    #[test]
+    fn root_cause_is_none_without_a_source() {
+        assert_eq!(root_cause(&Leaf("no source here")), None);
+    }
 }

--- a/crates/mtui-datasources/tests/openqa.rs
+++ b/crates/mtui-datasources/tests/openqa.rs
@@ -119,14 +119,19 @@ async fn try_get_jobs_errs_on_error_status() {
     assert!(base.try_get_jobs().await.is_err());
 }
 
+/// The `http://user:pass@host` form was already stripped of userinfo by
+/// `ruoqa::config::resolve`'s `netloc()` branch before 0.1.4 existed, so a
+/// credential there could never have regressed — it never reaches a request.
+/// The *bare-authority* form (no scheme, e.g. `alice:s3cret@host`) skips that
+/// branch and reached `Url::parse` untouched in 0.1.3, only gaining a strip
+/// in 0.1.4 (`config::resolve`'s post-parse `username()`/`password()`
+/// check). `describe` no longer sanitizes the URL itself — that's `ruoqa`'s
+/// job now — so this is the one assertion in this file that turns red on a
+/// `ruoqa 0.1.3` downgrade.
 #[tokio::test]
-async fn try_get_jobs_error_never_leaks_url_credentials() {
-    // A fetch failure against a credentialed base URL must never surface the
-    // userinfo in the error. ruoqa's own `config::resolve` already drops
-    // userinfo from the base URL before it reaches a request; `redact` is the
-    // defensive backstop over the whole rendered error.
+async fn try_get_jobs_error_never_leaks_a_bare_authority_credential() {
     let dir = tempfile::tempdir().unwrap();
-    let base = base_for("http://user:s3cret@127.0.0.1:1", dir.path());
+    let base = base_for("user:s3cret@127.0.0.1:1", dir.path());
     let err = base.try_get_jobs().await.unwrap_err().to_string();
     assert!(!err.contains("s3cret"), "error leaked credential: {err}");
 }
@@ -145,19 +150,17 @@ async fn try_get_jobs_ok_empty_on_valid_empty_body() {
     assert!(base.try_get_jobs().await.unwrap().is_empty());
 }
 
-/// Drives `redact`'s backstop with a *real* `ruoqa::Error::CrossOriginRedirect`
+/// Drives `ruoqa`'s own redaction with a *real* `Error::CrossOriginRedirect`
 /// carrying a credentialed URL, rather than a hand-written string.
 ///
 /// `ruoqa::config::resolve` drops userinfo from the *client's own* base URL
 /// before any request, but a `Location` header is server-controlled: a
 /// malicious or misconfigured openQA instance could redirect off-origin to a
-/// URL embedding `user:pass@`. ruoqa refuses to follow it (same-origin only)
-/// but its `Error::CrossOriginRedirect` embeds both URLs verbatim in
-/// `Display` — this is the one path that can actually put a credential into a
-/// `ruoqa::Error`, and the only test that previously exercised `redact` used a
-/// hand-written string instead of a real error, so it could not have caught a
-/// regression in `redact` itself. This one can: gutting `redact` to
-/// `e.to_string()` (dropping `sanitize_url`) turns this red.
+/// URL embedding `user:pass@`. ruoqa refuses to follow it (same-origin only),
+/// and (>= 0.1.4) redacts both URLs in `Error::CrossOriginRedirect`'s
+/// `Display` itself. Pins the exact `***` marker, not just credential
+/// absence: a `ruoqa 0.1.3` downgrade renders both URLs verbatim, turning
+/// this red.
 #[tokio::test]
 async fn try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location() {
     let server = MockServer::start().await;
@@ -172,8 +175,45 @@ async fn try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location() 
 
     let base = base_for_no_creds(&server.uri());
     let err = base.try_get_jobs().await.unwrap_err().to_string();
-    assert!(!err.contains("s3cret"), "error leaked credential: {err}");
-    assert!(!err.contains("alice"), "error leaked credential: {err}");
+    assert!(
+        err.ends_with("to a different origin https://***@evil.example.com/x"),
+        "expected the redacted redirect target, got: {err}"
+    );
+}
+
+/// Risk 2 backstop: a connection-failure message must never contain
+/// reqwest's own `Display` suffix (`" for url (...)"`,
+/// reqwest-0.13.4/src/error.rs:280) — that would leak the request URL
+/// unredacted, bypassing `ruoqa`'s own `Connection` redaction entirely.
+/// Swapping `root_cause(source)` for `source.to_string()` in `describe`
+/// turns this red.
+#[tokio::test]
+async fn try_get_jobs_connection_failure_never_leaks_reqwests_own_url_suffix() {
+    let base = base_for_no_creds("http://127.0.0.1:1");
+    let err = base.try_get_jobs().await.unwrap_err().to_string();
+    assert!(
+        !err.contains(" for url ("),
+        "leaked reqwest's own unredacted Display: {err}"
+    );
+}
+
+/// Risk 1: the message still carries a real transport cause, not just the
+/// redacted URL — dropping `root_cause`'s recovered cause in `describe`
+/// turns this red. Deliberately doesn't pin the OS-specific errno text (61
+/// on macOS, 111 on Linux).
+#[tokio::test]
+async fn try_get_jobs_connection_failure_message_carries_a_transport_cause() {
+    let base = base_for_no_creds("http://127.0.0.1:1");
+    let err = base.try_get_jobs().await.unwrap_err().to_string();
+    assert!(
+        err.contains("failed to connect to http://127.0.0.1:1/api/v1/jobs"),
+        "unexpected message shape: {err}"
+    );
+    let cause = err.rsplit_once(": ").map_or("", |(_, c)| c);
+    assert!(
+        !cause.is_empty(),
+        "expected a non-empty cause after the URL, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/crates/mtui-datasources/tests/oqa_search.rs
+++ b/crates/mtui-datasources/tests/oqa_search.rs
@@ -646,7 +646,9 @@ async fn incident_jobs_empty_build_makes_no_request() {
 /// `OqaSearchError`'s `From<ruoqa::Error>` conversion never leaks a credential
 /// embedded in a server-controlled `Location` header (a cross-origin
 /// redirect `ruoqa` refuses to follow but whose error message embeds both
-/// URLs verbatim). Mirrors
+/// URLs). `ruoqa` >= 0.1.4 redacts both itself; pins the exact `***` marker,
+/// not just credential absence, so a `ruoqa 0.1.3` downgrade (raw URLs) turns
+/// this red. Mirrors
 /// `openqa.rs::try_get_jobs_error_never_leaks_a_credential_from_a_redirect_location`
 /// for the `oqa_search` call sites migrated in Phase 2.
 #[tokio::test]
@@ -665,8 +667,10 @@ async fn incident_jobs_error_never_leaks_a_credential_from_a_redirect_location()
         .await
         .unwrap_err()
         .to_string();
-    assert!(!err.contains("s3cret"), "error leaked credential: {err}");
-    assert!(!err.contains("alice"), "error leaked credential: {err}");
+    assert!(
+        err.ends_with("to a different origin https://***@evil.example.com/x"),
+        "expected the redacted redirect target, got: {err}"
+    );
 }
 
 // --- Golden-fixture heuristic tests (parity with the vendored .matches) ---


### PR DESCRIPTION
## Summary

Full `cargo update` (13 releases behind) plus the `ruoqa` 0.1.4 security fix
(`fix(security): redact URL userinfo from errors, logs, and Debug output`),
and the follow-up rework this makes possible in `mtui-datasources`'
openQA error handling.

Implements `plans/ruoqa-0.1.4-update.md` in full.

## Commits

1. **`chore(deps)`** — `cargo update` (no `--workspace`): 14 packages
   updated (`ruoqa` 0.1.3→0.1.4, `russh-sftp` 2.3.0→2.4.0, `base64 0.23.1`
   added, 11 others). No movement on the held-back `rmcp`/`matchit`/
   `sandogasa-rpmvercmp`. Raises the `ruoqa` floor to `"0.1.4"` — a floor,
   not a preference: mtui now depends on its userinfo redaction, so a
   resolver allowed to pick 0.1.3 would silently reintroduce the leak this
   bump fixes.

2. **`fix(datasources)`** — `ruoqa` ≥ 0.1.4 now redacts URL userinfo at
   every `Display` site itself, which made mtui's own
   `openqa::client::redact` a stale, silently-drifting reimplementation of
   ruoqa's three format strings (and its `Connection` arm rendered
   `reqwest::Error`'s own `Display` directly — the very leak vector it was
   trying to scrub afterwards). `redact` is replaced with `describe`, a
   single-arm renderer that recovers the transport cause `ruoqa`'s
   redacted `Connection` message now drops, via a new `root_cause` helper
   that walks the error's source chain without ever rendering
   `reqwest::Error`'s own `Display`. The three pre-existing "never leaks a
   credential" tests were absence-only (one was already unfalsifiable
   under 0.1.3, per its own comment) and are reworked into positive
   ruoqa-contract pins, plus new Risk-1 (cause preserved) / Risk-2 (no raw
   reqwest URL leak) tests.

## Verification

- **Regression tests observed red before green**: downgraded to `ruoqa
  0.1.3` — the bare-authority test and both redirect tests went red as
  predicted; hand-broke `root_cause` (dropped `sanitize_url`, stopped at
  the first source instead of the deepest) and the `describe`→`root_cause`
  wiring — each mutation's target test went red. All restored to green.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` and `--all-features`
- `ssh_integration.rs` sftp/append tests green under `russh-sftp` 2.4.0
- `rg redact crates/mtui-datasources` returns nothing (identifier fully retired)
- CHANGELOG updated: the openQA fetch-failure message now reports the
  actual transport cause instead of restating the request URL.

## Breaking changes

None. The openQA fetch-failure error message text changes (documented in
CHANGELOG.md), which is the intended user-facing fix.