### PR TITLE
prepare/update refuse metadata-empty reports; export stops claiming never-checked packages are absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   block with no recorded version data keeps its `=> PASSED/FAILED` placeholder
   — and `export` prints `WARNING: no package version data recorded for
   <host>...` on the display — instead of flipping to PASSED; a genuine version
-  regression still flips FAILED even when other packages are unverified.
+  regression still flips FAILED even when other packages are unverified. A
+  version query that never answered for a package is no longer recorded as
+  "not installed" either — it renders as not-checked, and the update
+  workflow's package check now warns about it separately from a
+  confirmed-missing package.
 - The QEM dashboard incident lookup for an OBS-served `SUSE:SLFO:1.1` update
   used to key on the maintenance id (`1.1`), so mtui queried
   `/api/incidents/1.1` instead of an actual incident number — a request that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   given bare `filename`) instead of naming a file on the server's filesystem
   that a remote client cannot create (#434). Oversize payloads are refused
   rather than truncated; the REPL `put` command is unchanged.
+- `prepare` no longer reports success while doing nothing (#396): a loaded
+  report whose metadata names no package versions now fails the command (REPL
+  and MCP) with a diagnosis instead of printing `prepare completed on ...`; a
+  host the prepare fan-out could not build a command for now fails the flow by
+  name; and an empty package list inside the flow logs a warning (parity with
+  `downgrade`). Metadata package entries that do not parse as
+  `<name> <op> <version>`, and products left with no parsable entries, are
+  logged and dropped instead of silently vanishing, and connecting a host
+  whose base product matches no metadata packages now warns that before/after
+  version checks cannot run.
+- Exported testreports no longer claim a package "is not installed" when its
+  version was never checked (#396): a never-observed before/after version
+  renders as `package <name>: not checked (no version data recorded)`; a host
+  block with no recorded version data keeps its `=> PASSED/FAILED` placeholder
+  — and `export` prints `WARNING: no package version data recorded for
+  <host>...` on the display — instead of flipping to PASSED; a genuine version
+  regression still flips FAILED even when other packages are unverified.
 - The QEM dashboard incident lookup for an OBS-served `SUSE:SLFO:1.1` update
   used to key on the maintenance id (`1.1`), so mtui queried
   `/api/incidents/1.1` instead of an actual incident number — a request that

--- a/crates/mtui-core/src/commands/export.rs
+++ b/crates/mtui-core/src/commands/export.rs
@@ -136,6 +136,18 @@ impl Command for Export {
             let hosts = select_names(session.targets(), args, false)
                 .map_err(|e| CommandError::Other(e.to_string()))?;
             let results = manual_hosts(session, &hosts);
+            // #396: a host block exported with no recorded package data keeps
+            // the scaffold's own (unverified) lines — say so on the surface the
+            // operator/MCP client actually sees, not only in the tracing log.
+            for host in &results {
+                if host.packages.is_empty() {
+                    session.display.println(&format!(
+                        "WARNING: no package version data recorded for {}; its install \
+                         result was left unverified",
+                        host.hostname
+                    ));
+                }
+            }
             let overview = session.metadata().openqa().overview.clone();
             (Some((hosts, results)), overview)
         } else {
@@ -459,6 +471,58 @@ mod tests {
         assert!(session.metadata().openqa().auto.is_some());
         let written = std::fs::read_to_string(&path).unwrap();
         assert!(written.contains("## export MTUI:"));
+    }
+
+    /// #396: a host exported with no recorded package version data must be
+    /// flagged on the operator-visible surface (display/MCP), not only in the
+    /// tracing log — its block is left unverified in the report.
+    #[tokio::test]
+    async fn manual_warns_about_unverified_hosts_on_display() {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        session.metadata_mut().base_mut().workflow = Workflow::Manual;
+        let server = dashboard_server("1").await;
+        session.config.qem_dashboard_api = format!("{}/api", server.uri());
+        session.config.openqa_instance = server.uri();
+        let dir = tempfile::tempdir().unwrap();
+        session.config.template_dir = dir.path().to_path_buf();
+        let path = dir.path().join("template.txt");
+        std::fs::write(&path, "source code change review:\n").unwrap();
+
+        let args = matches(&Export, &["-f", path.to_str().unwrap()]);
+        Export.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(
+            out.contains("WARNING: no package version data recorded for h1"),
+            "{out}"
+        );
+    }
+
+    /// Negative control for the #396 WARNING: a host WITH recorded package
+    /// data must not be flagged — kills the warn-unconditionally mutant.
+    #[tokio::test]
+    async fn manual_does_not_warn_when_package_data_recorded() {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        session.metadata_mut().base_mut().workflow = Workflow::Manual;
+        for t in session.targets_mut().targets_mut() {
+            t.set_packages(vec![mtui_types::package::Package::new("bash")]);
+        }
+        let server = dashboard_server("1").await;
+        session.config.qem_dashboard_api = format!("{}/api", server.uri());
+        session.config.openqa_instance = server.uri();
+        let dir = tempfile::tempdir().unwrap();
+        session.config.template_dir = dir.path().to_path_buf();
+        let path = dir.path().join("template.txt");
+        std::fs::write(&path, "source code change review:\n").unwrap();
+
+        let args = matches(&Export, &["-f", path.to_str().unwrap()]);
+        Export.call(&mut session, &args).await.unwrap();
+
+        assert!(
+            !buf.contents().contains("WARNING: no package version data"),
+            "{}",
+            buf.contents()
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-core/src/commands/export.rs
+++ b/crates/mtui-core/src/commands/export.rs
@@ -9,6 +9,7 @@ use mtui_testreport::{
     AutoExport, DenyOverwrite, ExportContext, FileList, KernelExport, ManualExport, ManualHost,
 };
 use mtui_types::Workflow;
+use mtui_types::package::VersionCheck;
 
 use super::support::{
     add_hosts_arg, build_auto_openqa, build_incident, named_hosts, require_update, select_names,
@@ -136,11 +137,18 @@ impl Command for Export {
             let hosts = select_names(session.targets(), args, false)
                 .map_err(|e| CommandError::Other(e.to_string()))?;
             let results = manual_hosts(session, &hosts);
-            // #396: a host block exported with no recorded package data keeps
-            // the scaffold's own (unverified) lines — say so on the surface the
-            // operator/MCP client actually sees, not only in the tracing log.
+            // #396/#437: a host block exported with no recorded package data —
+            // or seeded packages the version query never answered for at all —
+            // keeps the scaffold's own (unverified) lines. Say so on the
+            // surface the operator/MCP client actually sees, not only in the
+            // tracing log.
             for host in &results {
-                if host.packages.is_empty() {
+                let unverified = host.packages.is_empty()
+                    || host.packages.iter().all(|p| {
+                        *p.before_check() == VersionCheck::NotChecked
+                            && *p.after_check() == VersionCheck::NotChecked
+                    });
+                if unverified {
                     session.display.println(&format!(
                         "WARNING: no package version data recorded for {}; its install \
                          result was left unverified",
@@ -498,6 +506,34 @@ mod tests {
         );
     }
 
+    /// #437: a host seeded with packages the version query never answered for
+    /// at all must still be flagged — the `packages.is_empty()` check alone
+    /// missed this, reachable when a host dies between seed and check.
+    #[tokio::test]
+    async fn manual_warns_about_seeded_but_unchecked_hosts_on_display() {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        session.metadata_mut().base_mut().workflow = Workflow::Manual;
+        for t in session.targets_mut().targets_mut() {
+            t.set_packages(vec![mtui_types::package::Package::new("bash")]);
+        }
+        let server = dashboard_server("1").await;
+        session.config.qem_dashboard_api = format!("{}/api", server.uri());
+        session.config.openqa_instance = server.uri();
+        let dir = tempfile::tempdir().unwrap();
+        session.config.template_dir = dir.path().to_path_buf();
+        let path = dir.path().join("template.txt");
+        std::fs::write(&path, "source code change review:\n").unwrap();
+
+        let args = matches(&Export, &["-f", path.to_str().unwrap()]);
+        Export.call(&mut session, &args).await.unwrap();
+
+        let out = buf.contents();
+        assert!(
+            out.contains("WARNING: no package version data recorded for h1"),
+            "{out}"
+        );
+    }
+
     /// Negative control for the #396 WARNING: a host WITH recorded package
     /// data must not be flagged — kills the warn-unconditionally mutant.
     #[tokio::test]
@@ -505,7 +541,9 @@ mod tests {
         let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
         session.metadata_mut().base_mut().workflow = Workflow::Manual;
         for t in session.targets_mut().targets_mut() {
-            t.set_packages(vec![mtui_types::package::Package::new("bash")]);
+            let mut pkg = mtui_types::package::Package::new("bash");
+            pkg.set_before(Some("5.1-1")).unwrap();
+            t.set_packages(vec![pkg]);
         }
         let server = dashboard_server("1").await;
         session.config.qem_dashboard_api = format!("{}/api", server.uri());

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -800,7 +800,13 @@ mod mcp_nonempty_success_guard {
                 (s, b, argv(&["true"]))
             }
             "update" => {
-                let (s, b) = hosts();
+                // Seed one package: the #396 pre-flight refuses a report whose
+                // metadata names no package versions.
+                let (mut s, b) = hosts();
+                s.metadata_mut().base_mut().packages.insert(
+                    "standard".to_owned(),
+                    std::collections::HashMap::from([("pkg-a".to_owned(), "1.0".to_owned())]),
+                );
                 (s, b, argv(&["--noprepare"]))
             }
             "install" => {
@@ -812,7 +818,12 @@ mod mcp_nonempty_success_guard {
                 (s, b, argv(&["pkg"]))
             }
             "prepare" => {
-                let (s, b) = hosts();
+                // Seeded for the same #396 pre-flight as `update` above.
+                let (mut s, b) = hosts();
+                s.metadata_mut().base_mut().packages.insert(
+                    "standard".to_owned(),
+                    std::collections::HashMap::from([("pkg-a".to_owned(), "1.0".to_owned())]),
+                );
                 (s, b, argv(&["-u"]))
             }
             "downgrade" => {

--- a/crates/mtui-core/src/commands/prepare.rs
+++ b/crates/mtui-core/src/commands/prepare.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgAction, ArgMatches};
 use super::perform::{PerformOp, drive};
 use super::support::{add_hosts_arg, complete_fanout};
 use crate::command::{Command, Scope};
-use crate::error::CommandResult;
+use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
 /// Installs missing packages and updates existing packages.
@@ -74,7 +74,22 @@ impl Command for Prepare {
     }
 
     async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
+        // Not-loaded first, so the refusal below can honestly say "the loaded
+        // report" (#396 review).
+        let _rrid = crate::commands::support::require_update(session)?;
         let packages = session.metadata().get_package_list();
+        // #396: a report whose metadata names no package versions would sail
+        // through the flow (repo add/refresh, zero installs) and print
+        // `prepare completed on <hosts>` — an unqualified success an MCP
+        // client cannot distinguish from a prepared host. Refuse up front.
+        if packages.is_empty() {
+            return Err(CommandError::Other(
+                "the loaded report names no package versions, so prepare has nothing to \
+                 install; refusing to report success — check `list_packages -w` and the \
+                 report metadata"
+                    .to_owned(),
+            ));
+        }
         drive(
             session,
             args,
@@ -96,6 +111,16 @@ mod tests {
         empty_session, matches, session_with_failing_perform, session_with_hosts,
     };
     use crate::error::CommandError;
+
+    /// Seeds one package version on the loaded fixture report: the #396
+    /// pre-flight refuses a report whose metadata names none, and these tests
+    /// drive the paths past that guard.
+    fn seed_package(session: &mut crate::session::Session) {
+        session.metadata_mut().base_mut().packages.insert(
+            "standard".to_owned(),
+            std::collections::HashMap::from([("pkg-a".to_owned(), "1.0".to_owned())]),
+        );
+    }
 
     #[test]
     fn complete_offers_own_flags_target_and_hosts() {
@@ -124,6 +149,7 @@ mod tests {
     #[tokio::test]
     async fn over_loaded_report_succeeds() {
         let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        seed_package(&mut session);
         let args = matches(&Prepare, &["-u"]);
         Prepare.call(&mut session, &args).await.unwrap();
         assert_eq!(session.targets().names(), vec!["h1"]);
@@ -137,10 +163,29 @@ mod tests {
     #[tokio::test]
     async fn failure_errors_and_names_host() {
         let (mut session, buf) = session_with_failing_perform("SUSE:Maintenance:1:1", &["h1"]);
+        seed_package(&mut session);
         let args = matches(&Prepare, &[]);
         let err = Prepare.call(&mut session, &args).await.unwrap_err();
         assert!(matches!(err, CommandError::Other(m) if m.contains("h1")));
         assert!(!buf.contents().contains("completed"), "{}", buf.contents());
+    }
+
+    /// #396 headline: a loaded report whose metadata names no package
+    /// versions must REFUSE, not print `prepare completed on h1`.
+    #[tokio::test]
+    async fn empty_package_list_errors_instead_of_success() {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        let args = matches(&Prepare, &[]);
+        let err = Prepare.call(&mut session, &args).await.unwrap_err();
+        assert!(
+            matches!(&err, CommandError::Other(m) if m.contains("names no package")),
+            "{err:?}"
+        );
+        assert!(
+            !buf.contents().contains("completed"),
+            "no success line: {}",
+            buf.contents()
+        );
     }
 
     #[tokio::test]
@@ -148,6 +193,7 @@ mod tests {
         // Loaded report but no hosts: passes the requires_update guard, then the
         // empty selection yields NoRefhostsDefined.
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &[], "ok");
+        seed_package(&mut session);
         let args = matches(&Prepare, &[]);
         let err = Prepare.call(&mut session, &args).await.unwrap_err();
         assert!(matches!(err, CommandError::NoRefhostsDefined));
@@ -160,6 +206,12 @@ mod tests {
         let (mut session, _buf) = empty_session();
         let args = matches(&Prepare, &[]);
         let err = Prepare.call(&mut session, &args).await.unwrap_err();
+        // The not-loaded guard outranks the #396 empty-metadata refusal, so
+        // the message never claims a report is loaded when none is.
+        assert!(
+            matches!(&err, CommandError::Other(m) if m.contains("Metadata not loaded")),
+            "{err:?}"
+        );
         assert!(matches!(err, CommandError::Other(_)));
     }
 }

--- a/crates/mtui-core/src/commands/update.rs
+++ b/crates/mtui-core/src/commands/update.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgAction, ArgMatches};
 use super::perform::{PerformOp, drive};
 use super::support::{add_hosts_arg, complete_fanout};
 use crate::command::{Command, Scope};
-use crate::error::CommandResult;
+use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
 /// Applies the testing update to the target hosts.
@@ -63,6 +63,20 @@ impl Command for Update {
 
     async fn call(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
         tracing::info!("Updating");
+        // Not-loaded first, so the refusal below can honestly say "the loaded
+        // report" (#396 review).
+        let _rrid = crate::commands::support::require_update(session)?;
+        // #396: like `prepare`, an update over a report whose metadata names no
+        // package versions would dispatch an empty package list and print an
+        // unqualified success. Refuse up front.
+        if session.metadata().get_package_list().is_empty() {
+            return Err(CommandError::Other(
+                "the loaded report names no package versions, so update has nothing to \
+                 install; refusing to report success — check `list_packages -w` and the \
+                 report metadata"
+                    .to_owned(),
+            ));
+        }
         let noprepare = args.get_flag("noprepare");
         let newpackage = args.get_flag("newpackage");
         // Upstream fires a desktop toast on both outcomes (`prompt.notify_user`);
@@ -98,6 +112,15 @@ mod tests {
     };
     use crate::error::CommandError;
 
+    /// Seeds one package version on the loaded fixture report — the #396
+    /// pre-flight refuses a report whose metadata names none.
+    fn seed_package(session: &mut crate::session::Session) {
+        session.metadata_mut().base_mut().packages.insert(
+            "standard".to_owned(),
+            std::collections::HashMap::from([("pkg-a".to_owned(), "1.0".to_owned())]),
+        );
+    }
+
     #[test]
     fn complete_offers_own_flags_target_and_hosts() {
         let (session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "linux");
@@ -125,6 +148,7 @@ mod tests {
     #[tokio::test]
     async fn over_loaded_report_succeeds() {
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        seed_package(&mut session);
         let args = matches(&Update, &["--noprepare"]);
         Update.call(&mut session, &args).await.unwrap();
         assert_eq!(session.targets().names(), vec!["h1"]);
@@ -134,6 +158,7 @@ mod tests {
     async fn success_fires_finished_notification() {
         use std::sync::{Arc, Mutex};
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        seed_package(&mut session);
         let seen = Arc::new(Mutex::new(Vec::<(String, bool)>::new()));
         let sink = Arc::clone(&seen);
         session.set_notify_sink(Box::new(move |msg: &str, err: bool| {
@@ -151,6 +176,7 @@ mod tests {
     async fn no_notification_when_sink_unset() {
         // Headless (no sink): notify_user is a no-op, the command still succeeds.
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        seed_package(&mut session);
         let args = matches(&Update, &["--noprepare"]);
         assert!(!session.notify_user("probe", false));
         Update.call(&mut session, &args).await.unwrap();
@@ -162,6 +188,7 @@ mod tests {
         // The report's perform_update returns Err ⇒ the command must surface the
         // failure (Err result) and fire exactly one *error*-class toast.
         let (mut session, _buf) = session_with_failing_update("SUSE:Maintenance:1:1", &["h1"]);
+        seed_package(&mut session);
         let seen = Arc::new(Mutex::new(Vec::<(String, bool)>::new()));
         let sink = Arc::clone(&seen);
         session.set_notify_sink(Box::new(move |msg: &str, err: bool| {
@@ -176,11 +203,26 @@ mod tests {
         assert!(seen[0].1, "failure toast must be error-class");
     }
 
+    /// #396: an update over a metadata-empty report refuses instead of
+    /// dispatching an empty package list and printing success.
+    #[tokio::test]
+    async fn empty_package_list_errors_instead_of_success() {
+        let (mut session, buf) = session_with_hosts("SUSE:Maintenance:1:1", &["h1"], "ok");
+        let args = matches(&Update, &[]);
+        let err = Update.call(&mut session, &args).await.unwrap_err();
+        assert!(
+            matches!(&err, CommandError::Other(m) if m.contains("names no package")),
+            "{err:?}"
+        );
+        assert!(!buf.contents().contains("completed"), "{}", buf.contents());
+    }
+
     #[tokio::test]
     async fn no_hosts_is_no_refhosts_defined() {
         // Loaded report but no hosts: passes the requires_update guard, then the
         // empty selection yields NoRefhostsDefined.
         let (mut session, _buf) = session_with_hosts("SUSE:Maintenance:1:1", &[], "ok");
+        seed_package(&mut session);
         let args = matches(&Update, &[]);
         let err = Update.call(&mut session, &args).await.unwrap_err();
         assert!(matches!(err, CommandError::NoRefhostsDefined));

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -1013,7 +1013,17 @@ impl Session {
                 let base_version = target.system().get_base().version.clone();
                 let seeded =
                     mtui_testreport::testreport::packages_for_map(package_meta, &base_version);
-                if !seeded.is_empty() {
+                if seeded.is_empty() {
+                    // #396: a host whose base product matches no metadata
+                    // packages tracks nothing — before/after version checks
+                    // cannot run and export has nothing to verify. Say so
+                    // instead of skipping silently.
+                    warn!(
+                        host = %host, base_version = %base_version,
+                        "report metadata names no packages for this host's base product; \
+                         package list not seeded — version checks cannot run"
+                    );
+                } else {
                     target.set_packages(seeded);
                     target.query_versions().await;
                 }

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -43,6 +43,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::error::{HostError, Result};
 
+use mtui_types::package::VersionCheck;
 use mtui_types::system::System;
 
 use super::actions::{self, Command, RunCommand};
@@ -908,14 +909,18 @@ impl HostsGroup {
     /// * **post** (`post == true`): record `current` as the package's `after`
     ///   version (leaving `before` as captured on the pre-pass).
     ///
-    /// and emit the four warnings:
+    /// and emit the warnings:
     ///
     /// * *too recent* — pre-update installed version is already `>=` the required
     ///   version,
     /// * *not updated* — `after == before` on the post-pass,
     /// * *below required* — post-update version is `<` the required version,
-    /// * *missing* — the package is not installed (`before` is `None`), collected
-    ///   and logged once per host.
+    /// * *missing* — the package's before check is
+    ///   [`VersionCheck::NotInstalled`] (a query ran and found it not
+    ///   installed), collected and logged once per host,
+    /// * *unchecked* — the before check is [`VersionCheck::NotChecked`] (the
+    ///   version query never answered for it), logged separately since it is a
+    ///   different operator action than a confirmed-missing package.
     ///
     /// The packages must already be [`seeded`](Target::set_packages) with their
     /// `required` versions.
@@ -970,20 +975,22 @@ impl HostsGroup {
             let hostname = target.hostname().to_owned();
 
             let mut not_installed: Vec<String> = Vec::new();
+            let mut unchecked: Vec<String> = Vec::new();
             for pkg in target.packages_mut() {
                 let required = pkg.required().cloned();
-                let current = pkg.current().cloned();
+                let current_check = pkg.current_check().clone();
                 if post {
-                    pkg.set_after_version(current.clone());
+                    pkg.set_after_check(current_check);
                 } else {
-                    pkg.set_before_version(current.clone());
+                    pkg.set_before_check(current_check);
                 }
                 let before = pkg.before().cloned();
                 let after = if post { pkg.after().cloned() } else { None };
 
-                match &before {
-                    None => not_installed.push(pkg.name.clone()),
-                    Some(before_v) => {
+                match pkg.before_check() {
+                    VersionCheck::NotInstalled => not_installed.push(pkg.name.clone()),
+                    VersionCheck::NotChecked => unchecked.push(pkg.name.clone()),
+                    VersionCheck::Installed(before_v) => {
                         if let Some(req) = &required
                             && before_v >= req
                         {
@@ -1019,6 +1026,12 @@ impl HostsGroup {
                 tracing::warn!(
                     host = %hostname, packages = %not_installed.join(", "),
                     "these packages are missing"
+                );
+            }
+            if !unchecked.is_empty() {
+                tracing::warn!(
+                    host = %hostname, packages = %unchecked.join(", "),
+                    "the version query never answered for these packages"
                 );
             }
         }
@@ -3092,6 +3105,27 @@ mod tests {
         let mut g = HostsGroup::new(vec![t], false);
 
         g.package_check(false).await;
+        let before_check = g.get("h1").unwrap().packages()[0].before_check().clone();
         assert!(g.get("h1").unwrap().packages()[0].before().is_none());
+        // #437: an rpm "is not installed" line is a real observation of
+        // absence, not the ambiguous "never checked" state.
+        assert_eq!(before_check, VersionCheck::NotInstalled);
+    }
+
+    /// #437: a package the version query never mentions at all must be
+    /// distinguished from one it reports absent.
+    #[tokio::test]
+    async fn package_check_marks_unqueried_package_as_unchecked() {
+        use mtui_types::package::Package;
+
+        let mut pkg = Package::new("baz");
+        pkg.set_required(Some("1.0-1")).unwrap();
+        let mut t = host_with_rpm_output("h1", "");
+        t.set_packages(vec![pkg]);
+        let mut g = HostsGroup::new(vec![t], false);
+
+        g.package_check(false).await;
+        let before_check = g.get("h1").unwrap().packages()[0].before_check().clone();
+        assert_eq!(before_check, VersionCheck::NotChecked);
     }
 }

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -67,7 +67,7 @@ use std::path::{Path, PathBuf};
 use mtui_config::Config;
 use mtui_types::enums::TargetState;
 use mtui_types::hostlog::{CommandLog, HostLog};
-use mtui_types::package::Package;
+use mtui_types::package::{Package, VersionCheck};
 use mtui_types::system::{System, SystemProduct};
 
 #[cfg(feature = "shell")]
@@ -767,11 +767,13 @@ impl Target {
     }
 
     /// Queries the installed versions of the tracked packages and records them
-    /// as each package's `current` version.
+    /// as each package's `current` check.
     ///
     /// Runs the
     /// [`PackageQuerier`] over `self.packages` and sets `current` from the
-    /// result (`None` when the package is not installed). A no-op when no
+    /// result: [`VersionCheck::NotInstalled`] when the query ran and found the
+    /// package not installed, [`VersionCheck::NotChecked`] when the query
+    /// never answered for it at all (#437). A no-op when no
     /// packages are tracked. Only meaningful for an
     /// [`Enabled`](TargetState::Enabled) host; other states record nothing, as
     /// their `run` does not touch a live connection.
@@ -782,7 +784,11 @@ impl Target {
         }
         let versions = PackageQuerier::new(self).versions(&names).await;
         for pkg in &mut self.packages {
-            pkg.set_current_version(versions.get(&pkg.name).cloned().flatten());
+            let check = match versions.get(&pkg.name) {
+                Some(v) => VersionCheck::from(v.clone()),
+                None => VersionCheck::NotChecked,
+            };
+            pkg.set_current_check(check);
         }
     }
 
@@ -2316,7 +2322,11 @@ mod tests {
             0,
         ));
         let mut t = enabled_with(conn);
-        t.set_packages(vec![Package::new("bash"), Package::new("foo")]);
+        t.set_packages(vec![
+            Package::new("bash"),
+            Package::new("foo"),
+            Package::new("baz"),
+        ]);
         t.query_versions().await;
 
         let by_name: std::collections::HashMap<_, _> =
@@ -2325,7 +2335,10 @@ mod tests {
             by_name["bash"].current(),
             Some(&RPMVersion::parse("5.1-1").unwrap())
         );
-        assert_eq!(by_name["foo"].current(), None);
+        // #437: the query answered "not installed" for foo (NotInstalled) but
+        // never mentioned baz at all (NotChecked) — the two must stay distinct.
+        assert_eq!(by_name["foo"].current_check(), &VersionCheck::NotInstalled);
+        assert_eq!(by_name["baz"].current_check(), &VersionCheck::NotChecked);
     }
 
     #[tokio::test]

--- a/crates/mtui-hosts/src/target/package_querier.rs
+++ b/crates/mtui-hosts/src/target/package_querier.rs
@@ -15,15 +15,21 @@ use tracing::warn;
 use super::Target;
 
 /// Extracts the package name from the rpm-style `package X is not installed`
-/// line, or `None` when the line is not that shape. The corresponding dpkg
-/// output (`no packages found matching X`) is reported on stderr and does not
-/// appear in the stdout line loop, so it needs no matcher here.
+/// line, or `None` when the line is not that shape.
 ///
 /// Matches the rpm `package (.*) is not installed` line exactly: the name
 /// is everything between the fixed prefix and suffix.
 fn not_installed_name(line: &str) -> Option<&str> {
     line.strip_prefix("package ")
         .and_then(|rest| rest.strip_suffix(" is not installed"))
+}
+
+/// Extracts the package name from dpkg-query's `no packages found matching X`
+/// stderr line, or `None` when the line is not that shape. Matched loosely
+/// (`contains`, not an exact prefix) since the `dpkg-query: ` lead-in is only
+/// documented, not pinned against a real binary.
+fn dpkg_not_found_name(line: &str) -> Option<&str> {
+    line.split("no packages found matching ").nth(1)
 }
 
 /// Adapter that runs `rpm -q` / `dpkg-query` on a [`Target`] and parses the
@@ -84,6 +90,17 @@ impl<'a> PackageQuerier<'a> {
                     });
                 })
                 .or_insert(Some(new_ver));
+        }
+        if is_ubuntu {
+            // dpkg-query reports an absent package on stderr, not stdout —
+            // without this, a genuinely-absent .deb would look identical to
+            // one the query never answered about.
+            let errors = self.target.lasterr().to_owned();
+            for line in errors.lines() {
+                if let Some(name) = dpkg_not_found_name(line) {
+                    pkgs.entry(name.trim().to_owned()).or_insert(None);
+                }
+            }
         }
         pkgs
     }
@@ -184,5 +201,28 @@ mod tests {
         let mut q = PackageQuerier::new(&mut t);
         let _ = q.versions(&["bash".to_owned()]).await;
         assert!(mock.commands().iter().any(|c| c.starts_with("dpkg-query")));
+    }
+
+    #[tokio::test]
+    async fn dpkg_not_found_on_stderr_maps_to_none() {
+        let mock = MockConnection::new("h1").with_default(CommandLog::new(
+            "",
+            "",
+            "dpkg-query: no packages found matching foo\n",
+            0,
+            0,
+        ));
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(mock));
+        t.set_system(
+            mtui_types::system::System::new(
+                mtui_types::system::SystemProduct::new("ubuntu", "22.04", "x86_64"),
+                Default::default(),
+                false,
+            ),
+            false,
+        );
+        let mut q = PackageQuerier::new(&mut t);
+        let map = q.versions(&["foo".to_owned()]).await;
+        assert_eq!(map["foo"], None);
     }
 }

--- a/crates/mtui-testreport/src/export/manual.rs
+++ b/crates/mtui-testreport/src/export/manual.rs
@@ -98,6 +98,9 @@ impl ManualExport {
     /// host.
     fn host_installog_to_template(&self, target: &str) -> Vec<String> {
         let Some(host) = self.results.iter().find(|h| h.hostname == target) else {
+            // #396: an empty install log for a host nobody collected data for
+            // must at least say so, not just silently write nothing.
+            tracing::warn!("no install log recorded for {target}; exporting an empty log");
             return Vec::new();
         };
 
@@ -224,8 +227,22 @@ impl ManualExport {
                 continue;
             };
 
-            // For before/after: track whether any package went un-updated.
+            // #396: with no recorded package data there is nothing honest to
+            // write — leave the scaffold's own lines and its undecided
+            // `=> PASSED/FAILED` marker in place rather than flipping a
+            // verdict over unverified content.
+            if host.packages.is_empty() {
+                tracing::warn!(
+                    "no package version data recorded for {hostname}; leaving its \
+                     install result unverified (scaffold lines and => PASSED/FAILED kept)"
+                );
+                continue;
+            }
+
+            // For before/after: track whether any package went un-updated,
+            // and whether any slot was never checked at all (#396).
             let mut failed = false;
+            let mut unverified = false;
             for state in ["before", "after"] {
                 let state_line = format!("{state}:\n");
                 let Some(pos) = self
@@ -243,13 +260,20 @@ impl ManualExport {
 
                 for package in &host.packages {
                     let name = &package.name;
-                    let version = match state {
-                        "before" => package.before(),
-                        _ => package.after(),
+                    let (version, observed) = match state {
+                        "before" => (package.before(), package.before_observed()),
+                        _ => (package.after(), package.after_observed()),
                     };
-                    let new_line = match version {
-                        Some(v) => format!("\t{name}-{v}\n"),
-                        None => format!("\tpackage {name} is not installed\n"),
+                    // #396: `None` never-observed must not become the positive
+                    // claim "is not installed" — only an actual observation of
+                    // absence may say that.
+                    let new_line = match (version, observed) {
+                        (Some(v), _) => format!("\t{name}-{v}\n"),
+                        (None, true) => format!("\tpackage {name} is not installed\n"),
+                        (None, false) => {
+                            unverified = true;
+                            format!("\tpackage {name}: not checked (no version data recorded)\n")
+                        }
                     };
                     if index < self.ctx.template.len()
                         && self.ctx.template[index].contains(name.as_str())
@@ -278,11 +302,25 @@ impl ManualExport {
 
             // Flip the verdict placeholder, bounded by this host's comment line
             // or the next host block, so an already-set verdict is preserved.
+            // Precedence (#396): a genuine regression flips FAILED even when
+            // other packages are unverified; an unverified block with no
+            // failure keeps the undecided placeholder rather than claiming
+            // PASSED over content nobody checked.
+            if !failed && unverified {
+                tracing::warn!(
+                    "installation test result on {hostname} left undecided: some package \
+                     versions were never checked (run `update`, or `prepare` plus a \
+                     version check, before exporting)"
+                );
+            }
             for j in index..self.ctx.template.len() {
                 let line = &self.ctx.template[j];
                 if line.contains("PASSED/FAILED") {
-                    self.ctx.template[j] =
-                        if failed { "=> FAILED\n" } else { "=> PASSED\n" }.to_string();
+                    if failed {
+                        self.ctx.template[j] = "=> FAILED\n".to_string();
+                    } else if !unverified {
+                        self.ctx.template[j] = "=> PASSED\n".to_string();
+                    }
                     break;
                 }
                 if line.starts_with("comment:") || line.contains("reference host:") {
@@ -347,6 +385,101 @@ mod tests {
             "\n",
             "comment: (none)\n",
         ]
+    }
+
+    /// #396: a never-observed slot must render "not checked", never the
+    /// positive claim "is not installed", and the block must not flip PASSED.
+    #[test]
+    fn install_results_says_not_checked_for_unobserved() {
+        // Package::new with no set_* calls: nothing was ever observed.
+        let mut ex = ManualExport::new(
+            ctx(&host_block()),
+            vec![host(vec![Package::new("bash")])],
+            None,
+            None,
+        );
+        ex.fillup_hosts_to_template();
+        let body = ex.ctx.template.concat();
+        assert!(
+            body.contains("package bash: not checked (no version data recorded)"),
+            "{body}"
+        );
+        assert!(!body.contains("bash is not installed"), "{body}");
+        assert!(
+            body.contains("=> PASSED/FAILED\n"),
+            "undecided placeholder kept: {body}"
+        );
+        assert!(
+            !body.contains("=> PASSED\n"),
+            "must not claim PASSED: {body}"
+        );
+    }
+
+    /// Observed-absent (a real `None` observation) keeps the classic wording.
+    #[test]
+    fn install_results_keeps_is_not_installed_for_observed_absent() {
+        let mut ex = ManualExport::new(
+            ctx(&host_block()),
+            vec![host(vec![pkg("bash", None, None)])],
+            None,
+            None,
+        );
+        ex.fillup_hosts_to_template();
+        let body = ex.ctx.template.concat();
+        assert!(body.contains("package bash is not installed"), "{body}");
+        assert!(!body.contains("not checked"), "{body}");
+    }
+
+    /// #396: a genuine regression still flips FAILED even when another package
+    /// is unverified — unverified must never hide a failure.
+    #[test]
+    fn install_results_failed_wins_over_unverified() {
+        let mut ex = ManualExport::new(
+            ctx(&host_block()),
+            vec![host(vec![
+                pkg("bash", Some("2"), Some("2")),
+                Package::new("zsh"),
+            ])],
+            None,
+            None,
+        );
+        ex.fillup_hosts_to_template();
+        let body = ex.ctx.template.concat();
+        assert!(body.contains("=> FAILED\n"), "{body}");
+        // The mixed block renders BOTH line kinds side by side.
+        assert!(body.contains("\tbash-2\n"), "{body}");
+        assert!(
+            body.contains("package zsh: not checked (no version data recorded)"),
+            "{body}"
+        );
+    }
+
+    /// #396: a host with NO recorded package data keeps the scaffold verbatim —
+    /// including its undecided verdict — instead of flipping PASSED over
+    /// content nobody verified.
+    #[test]
+    fn install_results_skips_empty_host_block() {
+        let scaffold = vec![
+            "system1 (reference host: h1)\n",
+            "before:\n",
+            "\tpackage bash is not installed\n",
+            "after:\n",
+            "\tpackage bash is not installed\n",
+            "\n",
+            "=> PASSED/FAILED\n",
+            "\n",
+            "comment: (none)\n",
+        ];
+        let mut ex = ManualExport::new(ctx(&scaffold), vec![host(vec![])], None, None);
+        ex.fillup_hosts_to_template();
+        let body = ex.ctx.template.concat();
+        assert!(
+            body.contains("=> PASSED/FAILED\n"),
+            "scaffold verdict kept: {body}"
+        );
+        assert!(!body.contains("=> PASSED\n"), "no invented PASSED: {body}");
+        // The scaffold's own (unverified) lines are left untouched.
+        assert_eq!(body.matches("is not installed").count(), 2, "{body}");
     }
 
     #[test]

--- a/crates/mtui-testreport/src/export/manual.rs
+++ b/crates/mtui-testreport/src/export/manual.rs
@@ -18,7 +18,7 @@ use std::sync::LazyLock;
 use mtui_datasources::OpenQAOverviewResult;
 use mtui_datasources::qem_dashboard::dashboard_openqa::DashboardAutoOpenQA;
 use mtui_types::hostlog::HostLog;
-use mtui_types::package::Package;
+use mtui_types::package::{Package, VersionCheck};
 use regex::Regex;
 
 use super::base::{ExportContext, OverwritePrompt};
@@ -260,17 +260,19 @@ impl ManualExport {
 
                 for package in &host.packages {
                     let name = &package.name;
-                    let (version, observed) = match state {
-                        "before" => (package.before(), package.before_observed()),
-                        _ => (package.after(), package.after_observed()),
+                    let check = match state {
+                        "before" => package.before_check(),
+                        _ => package.after_check(),
                     };
-                    // #396: `None` never-observed must not become the positive
-                    // claim "is not installed" — only an actual observation of
-                    // absence may say that.
-                    let new_line = match (version, observed) {
-                        (Some(v), _) => format!("\t{name}-{v}\n"),
-                        (None, true) => format!("\tpackage {name} is not installed\n"),
-                        (None, false) => {
+                    // #396: an unchecked slot must not become the positive
+                    // claim "is not installed" — only a check that ran and
+                    // found nothing may say that.
+                    let new_line = match check {
+                        VersionCheck::Installed(v) => format!("\t{name}-{v}\n"),
+                        VersionCheck::NotInstalled => {
+                            format!("\tpackage {name} is not installed\n")
+                        }
+                        VersionCheck::NotChecked => {
                             unverified = true;
                             format!("\tpackage {name}: not checked (no version data recorded)\n")
                         }

--- a/crates/mtui-testreport/src/metadata_parsers.rs
+++ b/crates/mtui-testreport/src/metadata_parsers.rs
@@ -23,7 +23,7 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use regex::Regex;
 use serde::Deserialize;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::testreport::TestReportBase;
 
@@ -222,20 +222,49 @@ impl JSONParser {
                 // `"pkg _ version"`: first token is the package name, third
                 // the version, middle token discarded.
                 let mut tokens = entry.split_whitespace();
-                if let (Some(pkg), Some(_), Some(ver)) =
-                    (tokens.next(), tokens.next(), tokens.next())
-                {
-                    // Package names are interpolated into root remote commands.
-                    // Reject anything that is not a valid RPM name at ingestion
-                    // (lenient-load: log and skip, never hard-fail the load).
-                    if let Err(e) = PackageSpec::parse(pkg) {
-                        error!(package = %pkg, error = %e, "skipping invalid package name in metadata");
-                        continue;
+                match (tokens.next(), tokens.next(), tokens.next()) {
+                    (Some(pkg), Some(_), Some(ver)) => {
+                        if tokens.next().is_some() {
+                            warn!(
+                                product = %prod, entry = %entry,
+                                "package entry has trailing tokens; using the first as name and third as version"
+                            );
+                        }
+                        // Package names are interpolated into root remote
+                        // commands. Reject anything that is not a valid RPM
+                        // name at ingestion (lenient-load: log and skip, never
+                        // hard-fail the load).
+                        if let Err(e) = PackageSpec::parse(pkg) {
+                            error!(package = %pkg, error = %e, "skipping invalid package name in metadata");
+                            continue;
+                        }
+                        pkgs.insert(pkg.to_owned(), ver.to_owned());
                     }
-                    pkgs.insert(pkg.to_owned(), ver.to_owned());
+                    // One- and two-token entries used to vanish with no trace
+                    // (#396): the sibling invalid-name arm logs, so must this.
+                    _ => error!(
+                        product = %prod, entry = %entry,
+                        "skipping unparsable package entry in metadata (expected \"<name> <op> <version>\")"
+                    ),
                 }
             }
+            // An empty sub-map must not be inserted: it makes `base.packages`
+            // non-empty while the flattened `get_package_list()` is empty,
+            // defeating every "is anything to install?" guard downstream (#396).
+            if pkgs.is_empty() {
+                error!(
+                    product = %prod,
+                    "metadata names this product but no package entry was parsable; dropping the empty entry"
+                );
+                continue;
+            }
             packages.insert(prod.clone(), pkgs);
+        }
+        if data.packages.iter().flatten().count() > 0 && packages.is_empty() {
+            warn!(
+                "metadata carries no parsable package versions; prepare/downgrade have nothing \
+                 to install and before/after version checks cannot run"
+            );
         }
         results.packages = packages;
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -279,7 +279,10 @@ enum PrepareFailure {
     /// installed and the update's premise is broken — the update aborts.
     DidNotRun(UpdateError),
     /// Prepare ran and one or more hosts reported trouble from the package
-    /// manager. Warn and continue.
+    /// manager. Warn and continue. Also carries #396's per-host
+    /// no-command-built failures: `update` intentionally warns there because
+    /// `build_update_maps` re-detects the unresolved-key cause moments later
+    /// and aborts with `MissingUpdater`.
     HostReported(UpdateError),
     /// A cancellation checkpoint, not a failure.
     Cancelled(UpdateError),
@@ -782,6 +785,16 @@ async fn prepare_body(
     let mut dispatched: BTreeSet<String> = BTreeSet::new();
     let mut inert: BTreeSet<String> = BTreeSet::new();
 
+    // Parity with perform_downgrade: an empty list is not a host failure, but
+    // it must never be a silent success either — only the issue repositories
+    // were touched (#396). Above the branch so the `installed_only` path (zero
+    // loop iterations) warns too; the operator-facing refusal lives in the
+    // `prepare`/`update` command pre-flights, this covers embedded callers
+    // (the update flow's newpackage prepare).
+    if pkgs.is_empty() {
+        warn!("no packages to prepare");
+    }
+
     let mut cancelled_at: Option<usize> = None;
     if installed_only {
         // Conditional per-package install — inherently one package at a time.
@@ -846,6 +859,28 @@ async fn prepare_body(
     // entry for one host would push `aggregate_failures` out of its
     // single-failure verbatim branch into the summary, which drops `host` to
     // `None` and breaks callers that read it.
+    // A host the fan-out never reached must fail by name, not ride the
+    // group's success (#396): `build_prepare_map` drops a host whose release
+    // key does not resolve or whose template does not render (e.g. no
+    // installed-only variant), and nothing else records that. Skipped when the
+    // flow was cancelled before the first fan-out (nothing was expected to
+    // dispatch) and when the list was empty (the warn above owns that case).
+    if !pkgs.is_empty() && cancelled_at != Some(0) {
+        for target in targets.targets() {
+            if target.state() != mtui_types::TargetState::Enabled {
+                continue;
+            }
+            let host = target.hostname();
+            if !dispatched.contains(host) {
+                inert.insert(host.to_owned());
+                failures.push(UpdateError::new(
+                    "no prepare command could be built for this host; nothing was installed",
+                    host.to_owned(),
+                ));
+            }
+        }
+    }
+
     let named: BTreeSet<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
     for host in &inert {
         if !named.contains(host) {
@@ -936,6 +971,7 @@ fn build_prepare_map(
     let mut map = BTreeMap::new();
     for target in targets.targets() {
         let Some((release, transactional)) = host_key(target) else {
+            error!(host = %target.hostname(), "prepare: host release key unresolved; no command built");
             continue;
         };
         let Some(doer) = resolve_doer(registry, Role::Prepare, &release, transactional) else {
@@ -952,6 +988,15 @@ fn build_prepare_map(
         };
         if let Some(cmd) = rendered {
             map.insert(target.hostname().to_owned(), cmd);
+        } else {
+            // A dropped render (error, or a family with no installed-only
+            // variant) leaves the host out of the fan-out; the dispatch
+            // accounting in `prepare_body` turns that into a named failure,
+            // this log says why (#396).
+            error!(
+                host = %target.hostname(), release = %release,
+                "prepare: no command rendered for this host; nothing will be installed on it"
+            );
         }
     }
     map
@@ -1318,8 +1363,14 @@ async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<Str
     for target in targets.targets_mut() {
         let hostname = target.hostname().to_owned();
         for pkg in target.packages_mut() {
-            let after = pkg.after().cloned();
-            pkg.set_before_version(after);
+            // #396: rotate value AND honesty — a never-observed after slot
+            // must not become an "observed" before slot, or a standalone
+            // downgrade (no prior update) exports "is not installed" for a
+            // slot nobody ever checked.
+            if pkg.after_observed() {
+                let after = pkg.after().cloned();
+                pkg.set_before_version(after);
+            }
             let current = pkg.current().cloned();
             pkg.set_after_version(current);
             if let (Some(current), Some(required)) = (pkg.current(), pkg.required())
@@ -3778,6 +3829,57 @@ mod tests {
         assert!(
             !fired.iter().any(|c| c.contains("systemctl reboot")),
             "a host with nothing staged must not be rebooted: {fired:?}"
+        );
+    }
+
+    /// #396: a host `build_prepare_map` drops (unresolvable release key, so
+    /// no command is ever built for it) must fail the prepare BY NAME instead
+    /// of riding the group's success while the other host does the work.
+    #[tokio::test]
+    async fn perform_prepare_fails_a_host_no_command_was_built_for() {
+        let (good, good_handle) = slmicro_target("h1", "", 0);
+        // h2: enabled but with no parsed system -> host_key resolves nothing.
+        let bad_conn = MockConnection::new("h2").with_default(CommandLog::new("", "", "", 0, 0));
+        let bad_handle = bad_conn.clone();
+        let bad = Target::with_connection("h2", TargetState::Enabled, Box::new(bad_conn));
+        let mut group = HostsGroup::new(vec![good, bad], false);
+
+        let res = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["afterburn".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        let err = res.expect_err("the dropped host must fail the flow");
+        // Robust attribution: a single failure keeps its host verbatim; a
+        // second (h1-blaming) entry would collapse `host` to `None` via the
+        // aggregate summary.
+        assert_eq!(err.host.as_deref(), Some("h2"), "{err}");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no prepare command could be built"),
+            "cause stated: {msg}"
+        );
+        // Mock-level proof: the dropped host was never sent ANY command —
+        // being both dispatched-to and reported not-installed would be #396's
+        // dishonesty inverted.
+        assert!(
+            bad_handle.commands().is_empty(),
+            "{:?}",
+            bad_handle.commands()
+        );
+        // The healthy host still received its prepare command.
+        assert!(
+            good_handle
+                .commands()
+                .iter()
+                .any(|c| c.contains("transactional-update") && c.contains("afterburn")),
+            "{:?}",
+            good_handle.commands()
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1368,8 +1368,10 @@ async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<Str
             // "checked, not installed", or a standalone downgrade (no prior
             // update) exports "is not installed" for a slot nobody looked at.
             pkg.set_before_check(pkg.after_check().clone());
-            let current = pkg.current().cloned();
-            pkg.set_after_version(current);
+            // #437: same for `current` -> `after` — a host the re-query never
+            // answered for must not land in `after` as "checked, not
+            // installed" either.
+            pkg.set_after_check(pkg.current_check().clone());
             if let (Some(current), Some(required)) = (pkg.current(), pkg.required())
                 && current >= required
             {
@@ -2671,6 +2673,28 @@ mod tests {
             "an unchecked after slot must not rotate in as an observation"
         );
         assert_eq!(p.after().map(ToString::to_string).as_deref(), Some("0.9-1"));
+    }
+
+    /// #437: a host the re-query never answers about for a package must
+    /// rotate `current` into `after` as `NotChecked`, not the ambiguous
+    /// "checked, not installed" that a plain-`Option` rotation would produce.
+    #[tokio::test]
+    async fn downgrade_verdict_rotation_keeps_an_unqueried_current_unchecked() {
+        // Empty stdout: the mock rpm query never mentions "pkg-a" at all.
+        let (mut t, _h) = sles_target("h1", "");
+        let mut pkg = mtui_types::package::Package::new("pkg-a");
+        pkg.set_required(Some("1.5-1")).unwrap();
+        t.set_packages(vec![pkg]);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let _ = downgrade_verdict(&mut group).await;
+
+        let p = &group.get("h1").unwrap().packages()[0];
+        assert_eq!(
+            p.after_check(),
+            &VersionCheck::NotChecked,
+            "an unqueried current must not rotate in as an observation"
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1363,14 +1363,11 @@ async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<Str
     for target in targets.targets_mut() {
         let hostname = target.hostname().to_owned();
         for pkg in target.packages_mut() {
-            // #396: rotate value AND honesty — a never-observed after slot
-            // must not become an "observed" before slot, or a standalone
-            // downgrade (no prior update) exports "is not installed" for a
-            // slot nobody ever checked.
-            if pkg.after_observed() {
-                let after = pkg.after().cloned();
-                pkg.set_before_version(after);
-            }
+            // #396: rotate the whole check, not just its version — a
+            // never-checked after slot must not land in the before slot as
+            // "checked, not installed", or a standalone downgrade (no prior
+            // update) exports "is not installed" for a slot nobody looked at.
+            pkg.set_before_check(pkg.after_check().clone());
             let current = pkg.current().cloned();
             pkg.set_after_version(current);
             if let (Some(current), Some(required)) = (pkg.current(), pkg.required())
@@ -1749,6 +1746,7 @@ mod tests {
     use mtui_hosts::{HostsGroup, MockConnection, Target};
     use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
+    use mtui_types::package::VersionCheck;
     use mtui_types::system::{System, SystemProduct};
 
     use super::*;
@@ -2648,6 +2646,31 @@ mod tests {
             Some("1.5-1")
         );
         assert_eq!(p.after().map(ToString::to_string).as_deref(), Some("1.5-1"));
+    }
+
+    #[tokio::test]
+    async fn downgrade_verdict_rotation_keeps_an_unchecked_slot_unchecked() {
+        // #396: on a standalone downgrade there was no prior `update`, so the
+        // after slot was never checked. Rotating it into the before slot must
+        // carry that across — turning it into "checked, not installed" would
+        // make the export claim the package was absent before a rollback
+        // nobody measured.
+        let (mut t, _h) = sles_target("h1", "pkg-a 0.9-1\n");
+        let mut pkg = mtui_types::package::Package::new("pkg-a");
+        pkg.set_required(Some("1.5-1")).unwrap();
+        assert_eq!(pkg.after_check(), &VersionCheck::NotChecked);
+        t.set_packages(vec![pkg]);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let _ = downgrade_verdict(&mut group).await;
+
+        let p = &group.get("h1").unwrap().packages()[0];
+        assert_eq!(
+            p.before_check(),
+            &VersionCheck::NotChecked,
+            "an unchecked after slot must not rotate in as an observation"
+        );
+        assert_eq!(p.after().map(ToString::to_string).as_deref(), Some("0.9-1"));
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/tests/metadata_parsers.rs
+++ b/crates/mtui-testreport/tests/metadata_parsers.rs
@@ -394,3 +394,72 @@ fn patchinfo_titles_malformed_is_empty() {
         .expect("write patchinfo");
     assert!(patchinfo_titles(dir.path()).is_empty());
 }
+
+/// #396: a product whose entries all fail to parse must NOT leave an empty
+/// sub-map behind — that state makes `base.packages` non-empty while the
+/// flattened package list is empty, defeating every "anything to install?"
+/// guard downstream.
+#[test]
+fn json_parser_drops_products_with_no_parsable_entries() {
+    let mut results = TestReportBase::new(Config::default());
+    JSONParser::parse_str(
+        &mut results,
+        r#"{"packages": {"6.1": ["afterburn 5.9.0"], "other": ["afterburn _ 5.9.0-1"]}}"#,
+    )
+    .unwrap();
+    assert!(
+        !results.packages.contains_key("6.1"),
+        "two-token-only product must be dropped: {:?}",
+        results.packages
+    );
+    assert_eq!(results.packages["other"]["afterburn"], "5.9.0-1");
+}
+
+/// One- and two-token entries are dropped (now loudly); three-plus-token
+/// entries keep parsing as first=name, third=version.
+#[test]
+fn json_parser_drops_short_entries_keeps_three_plus() {
+    let mut results = TestReportBase::new(Config::default());
+    JSONParser::parse_str(
+        &mut results,
+        r#"{"packages": {"6.1": [
+            "solo",
+            "afterburn 5.9.0",
+            "afterburn-dracut _ 5.9.0-1",
+            "four _ 1.2.3 extra"
+        ]}}"#,
+    )
+    .unwrap();
+    let m = &results.packages["6.1"];
+    assert_eq!(m.len(), 2, "{m:?}");
+    assert_eq!(m["afterburn-dracut"], "5.9.0-1");
+    assert_eq!(m["four"], "1.2.3", "trailing tokens tolerated, third wins");
+}
+
+/// An empty packages envelope stays an empty map (no placeholder products).
+#[test]
+fn json_parser_empty_packages_envelope_yields_empty_map() {
+    let mut results = TestReportBase::new(Config::default());
+    JSONParser::parse_str(&mut results, r#"{"packages": {}}"#).unwrap();
+    assert!(results.packages.is_empty());
+}
+
+/// A populated SLFO-shaped envelope parses end-to-end (#396's incident used
+/// SUSE:SLFO:1.1:418286 / SL-Micro 6.1 / afterburn — the only domain values
+/// used here). Synthetic: real-fixture coverage remains #397, NOT closed here.
+#[test]
+fn slfo_populated_envelope_parses() {
+    let mut results = TestReportBase::new(Config::default());
+    JSONParser::parse_str(
+        &mut results,
+        r#"{
+            "rrid": "SUSE:SLFO:1.1:418286",
+            "packages": {"6.1": ["afterburn _ 5.9.0-1", "afterburn-dracut _ 5.9.0-1"]}
+        }"#,
+    )
+    .unwrap();
+    assert_eq!(results.packages["6.1"].len(), 2);
+    // The flattened list feeds prepare's pre-flight; it must be non-empty.
+    let flat: Vec<&String> = results.packages.values().flat_map(|m| m.keys()).collect();
+    assert_eq!(flat.len(), 2, "{flat:?}");
+}

--- a/crates/mtui-types/src/package.rs
+++ b/crates/mtui-types/src/package.rs
@@ -28,6 +28,12 @@ pub struct Package {
     after: Option<RPMVersion>,
     required: Option<RPMVersion>,
     current: Option<RPMVersion>,
+    /// Whether a before-version observation was ever recorded (#396): a `None`
+    /// [`before`](Package::before) with this set means *observed absent*, not
+    /// *never checked* — export must render the two differently.
+    before_observed: bool,
+    /// The after-side counterpart of [`before_observed`](Package::before_observed).
+    after_observed: bool,
 }
 
 impl Package {
@@ -40,7 +46,23 @@ impl Package {
             after: None,
             required: None,
             current: None,
+            before_observed: false,
+            after_observed: false,
         }
+    }
+
+    /// Whether a before-version observation was ever recorded — `None` from
+    /// [`before`](Package::before) then means "observed absent", not "never
+    /// checked".
+    #[must_use]
+    pub fn before_observed(&self) -> bool {
+        self.before_observed
+    }
+
+    /// The after-side counterpart of [`before_observed`](Package::before_observed).
+    #[must_use]
+    pub fn after_observed(&self) -> bool {
+        self.after_observed
     }
 
     /// The version of the package before an update, if known.
@@ -77,6 +99,7 @@ impl Package {
     /// as "clear" and never errors.
     pub fn set_before(&mut self, ver: Option<&str>) -> crate::error::Result<()> {
         self.before = parse_opt(ver)?;
+        self.before_observed = true;
         Ok(())
     }
 
@@ -86,6 +109,7 @@ impl Package {
     /// See [`set_before`](Package::set_before).
     pub fn set_after(&mut self, ver: Option<&str>) -> crate::error::Result<()> {
         self.after = parse_opt(ver)?;
+        self.after_observed = true;
         Ok(())
     }
 
@@ -98,14 +122,18 @@ impl Package {
         Ok(())
     }
 
-    /// Sets the [`before`](Package::before) version directly.
+    /// Sets the [`before`](Package::before) version directly, recording that
+    /// an observation was made (even a `None` one — observed absent).
     pub fn set_before_version(&mut self, ver: Option<RPMVersion>) {
         self.before = ver;
+        self.before_observed = true;
     }
 
-    /// Sets the [`after`](Package::after) version directly.
+    /// Sets the [`after`](Package::after) version directly, recording that an
+    /// observation was made (even a `None` one — observed absent).
     pub fn set_after_version(&mut self, ver: Option<RPMVersion>) {
         self.after = ver;
+        self.after_observed = true;
     }
 
     /// Sets the [`current`](Package::current) version directly.
@@ -147,8 +175,30 @@ impl std::hash::Hash for Package {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
+
+    use super::*;
+
+    /// #396: setting a `None` version still counts as an observation —
+    /// "observed absent" and "never checked" must stay distinguishable.
+    #[test]
+    fn set_version_none_counts_as_observed() {
+        let mut p = Package::new("bash");
+        assert!(!p.before_observed() && !p.after_observed());
+        p.set_before_version(None);
+        assert!(p.before_observed());
+        assert!(!p.after_observed());
+        p.set_after_version(None);
+        assert!(
+            p.after_observed(),
+            "set_after_version must mark the observation"
+        );
+        let mut p = Package::new("bash2");
+        p.set_after(None).unwrap();
+        assert!(p.after_observed());
+        assert!(!p.before_observed());
+        assert!(p.before().is_none() && p.after().is_none());
+    }
 
     #[test]
     fn new_has_name_and_no_versions() {

--- a/crates/mtui-types/src/package.rs
+++ b/crates/mtui-types/src/package.rs
@@ -8,11 +8,12 @@
 //!
 //! Each version field is stored as a single typed representation, with
 //! fallible setters that parse a `&str` rather than silently storing an
-//! unparsed string. `before` and `after` are [`VersionCheck`]s, not
-//! `Option<`[`RPMVersion`]`>`: those two are *measured* on a target, so they
-//! must be able to say "checked, not installed" and "never checked" apart
-//! (#396). `required` (declared by the update metadata) and `current` stay
-//! plain options.
+//! unparsed string. `before`, `after` and `current` are all [`VersionCheck`]s,
+//! not `Option<`[`RPMVersion`]`>`: all three are *measured* on a target, so
+//! they must be able to say "checked, not installed" and "never checked" apart
+//! (#396, #437 — a host the version query never reached must not read the
+//! same as one it confirmed the package absent on). `required` (declared by
+//! the update metadata, never measured) stays a plain option.
 //!
 //! A `Package` hashes and compares **by name only**, so it can live in a
 //! name-keyed set regardless of its version fields.
@@ -30,7 +31,7 @@ pub struct Package {
     before: VersionCheck,
     after: VersionCheck,
     required: Option<RPMVersion>,
-    current: Option<RPMVersion>,
+    current: VersionCheck,
 }
 
 /// The outcome of checking one of a package's versions on a target.
@@ -90,7 +91,7 @@ impl Package {
             before: VersionCheck::NotChecked,
             after: VersionCheck::NotChecked,
             required: None,
-            current: None,
+            current: VersionCheck::NotChecked,
         }
     }
 
@@ -130,9 +131,18 @@ impl Package {
     }
 
     /// The version currently installed on a target, if known.
+    ///
+    /// `None` covers both "checked, not installed" and "never checked" — use
+    /// [`current_check`](Package::current_check) when the difference matters.
     #[must_use]
     pub fn current(&self) -> Option<&RPMVersion> {
-        self.current.as_ref()
+        self.current.version()
+    }
+
+    /// The current-version check, including whether it ran at all.
+    #[must_use]
+    pub fn current_check(&self) -> &VersionCheck {
+        &self.current
     }
 
     /// Sets the [`before`](Package::before) version from an optional string,
@@ -191,9 +201,17 @@ impl Package {
         self.after = check;
     }
 
-    /// Sets the [`current`](Package::current) version directly.
+    /// Sets the [`current`](Package::current) version directly, recording a
+    /// completed check — `None` is *observed absent*, not *never checked*.
     pub fn set_current_version(&mut self, ver: Option<RPMVersion>) {
-        self.current = ver;
+        self.current = ver.into();
+    }
+
+    /// Sets the [`current`](Package::current) check outcome directly,
+    /// including [`NotChecked`](VersionCheck::NotChecked) — the version
+    /// query never having answered for this package at all (#437).
+    pub fn set_current_check(&mut self, check: VersionCheck) {
+        self.current = check;
     }
 }
 
@@ -308,6 +326,23 @@ mod tests {
         assert_eq!(p.current().unwrap(), &RPMVersion::parse("3.0-1").unwrap());
         p.set_current_version(None);
         assert!(p.current().is_none());
+    }
+
+    /// #437: `current` carries the same tri-state as `before`/`after` — a
+    /// version query that never answered for a package must not read the
+    /// same as one that confirmed it absent.
+    #[test]
+    fn current_check_distinguishes_unchecked_from_not_installed() {
+        let mut p = Package::new("bash");
+        assert_eq!(p.current_check(), &VersionCheck::NotChecked);
+        p.set_current_check(VersionCheck::NotInstalled);
+        assert_eq!(p.current_check(), &VersionCheck::NotInstalled);
+        assert!(p.current().is_none());
+        p.set_current_version(Some(RPMVersion::parse("3.0-1").unwrap()));
+        assert_eq!(
+            p.current_check(),
+            &VersionCheck::Installed(RPMVersion::parse("3.0-1").unwrap())
+        );
     }
 
     #[test]

--- a/crates/mtui-types/src/package.rs
+++ b/crates/mtui-types/src/package.rs
@@ -6,10 +6,13 @@
 //! by the update metadata, and the [`current`](Package::current) version actually
 //! installed on a target.
 //!
-//! Each version field is stored as a single typed representation —
-//! `Option<`[`RPMVersion`]`>` — with fallible setters that parse a `&str`.
-//! Passing an empty string or `None` clears the field, rather than silently
-//! storing an unparsed string.
+//! Each version field is stored as a single typed representation, with
+//! fallible setters that parse a `&str` rather than silently storing an
+//! unparsed string. `before` and `after` are [`VersionCheck`]s, not
+//! `Option<`[`RPMVersion`]`>`: those two are *measured* on a target, so they
+//! must be able to say "checked, not installed" and "never checked" apart
+//! (#396). `required` (declared by the update metadata) and `current` stay
+//! plain options.
 //!
 //! A `Package` hashes and compares **by name only**, so it can live in a
 //! name-keyed set regardless of its version fields.
@@ -24,16 +27,58 @@ use crate::rpmver::RPMVersion;
 pub struct Package {
     /// The package name.
     pub name: String,
-    before: Option<RPMVersion>,
-    after: Option<RPMVersion>,
+    before: VersionCheck,
+    after: VersionCheck,
     required: Option<RPMVersion>,
     current: Option<RPMVersion>,
-    /// Whether a before-version observation was ever recorded (#396): a `None`
-    /// [`before`](Package::before) with this set means *observed absent*, not
-    /// *never checked* — export must render the two differently.
-    before_observed: bool,
-    /// The after-side counterpart of [`before_observed`](Package::before_observed).
-    after_observed: bool,
+}
+
+/// The outcome of checking one of a package's versions on a target.
+///
+/// `Option<RPMVersion>` cannot carry this: it has no way to say *why* it is
+/// empty, and "the check ran and the package was absent" and "no check ever
+/// ran" are different facts the export must render differently (#396). Keeping
+/// both in one field means the value and the fact that it was measured cannot
+/// drift apart.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum VersionCheck {
+    /// No check has run — the version is simply unknown.
+    #[default]
+    NotChecked,
+    /// A check ran and found the package not installed.
+    NotInstalled,
+    /// A check ran and found this version installed.
+    Installed(RPMVersion),
+}
+
+impl VersionCheck {
+    /// The version found, or `None` when the package was absent or unchecked.
+    #[must_use]
+    pub fn version(&self) -> Option<&RPMVersion> {
+        match self {
+            Self::Installed(v) => Some(v),
+            Self::NotChecked | Self::NotInstalled => None,
+        }
+    }
+
+    /// Whether a check ran at all — `false` only for
+    /// [`NotChecked`](VersionCheck::NotChecked).
+    #[must_use]
+    pub fn is_checked(&self) -> bool {
+        !matches!(self, Self::NotChecked)
+    }
+}
+
+impl From<Option<RPMVersion>> for VersionCheck {
+    /// Records the result of a check that ran: `None` is *observed absent*,
+    /// never *unchecked*. Only [`VersionCheck::default`] produces
+    /// [`NotChecked`](VersionCheck::NotChecked).
+    fn from(ver: Option<RPMVersion>) -> Self {
+        match ver {
+            Some(v) => Self::Installed(v),
+            None => Self::NotInstalled,
+        }
+    }
 }
 
 impl Package {
@@ -42,39 +87,40 @@ impl Package {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            before: None,
-            after: None,
+            before: VersionCheck::NotChecked,
+            after: VersionCheck::NotChecked,
             required: None,
             current: None,
-            before_observed: false,
-            after_observed: false,
         }
     }
 
-    /// Whether a before-version observation was ever recorded — `None` from
-    /// [`before`](Package::before) then means "observed absent", not "never
-    /// checked".
+    /// The before-version check, including whether it ran at all.
     #[must_use]
-    pub fn before_observed(&self) -> bool {
-        self.before_observed
+    pub fn before_check(&self) -> &VersionCheck {
+        &self.before
     }
 
-    /// The after-side counterpart of [`before_observed`](Package::before_observed).
+    /// The after-side counterpart of [`before_check`](Package::before_check).
     #[must_use]
-    pub fn after_observed(&self) -> bool {
-        self.after_observed
+    pub fn after_check(&self) -> &VersionCheck {
+        &self.after
     }
 
-    /// The version of the package before an update, if known.
+    /// The version of the package before an update, if one was found.
+    ///
+    /// `None` covers both "checked, not installed" and "never checked" — use
+    /// [`before_check`](Package::before_check) when the difference matters.
     #[must_use]
     pub fn before(&self) -> Option<&RPMVersion> {
-        self.before.as_ref()
+        self.before.version()
     }
 
-    /// The version of the package after an update, if known.
+    /// The version of the package after an update, if one was found.
+    ///
+    /// See [`before`](Package::before) on what `None` does and does not say.
     #[must_use]
     pub fn after(&self) -> Option<&RPMVersion> {
-        self.after.as_ref()
+        self.after.version()
     }
 
     /// The version required by the update metadata, if known.
@@ -89,17 +135,17 @@ impl Package {
         self.current.as_ref()
     }
 
-    /// Sets the [`before`](Package::before) version from an optional string.
-    ///
-    /// `None` (or an empty string) clears the field.
+    /// Sets the [`before`](Package::before) version from an optional string,
+    /// recording a completed check either way: `None` (or an empty string)
+    /// stores [`NotInstalled`](VersionCheck::NotInstalled), not
+    /// [`NotChecked`](VersionCheck::NotChecked).
     ///
     /// # Errors
     /// Returns [`RpmVersionParseError`](crate::error::RpmVersionParseError) only
     /// for a non-empty string that fails to parse. An empty string is treated
-    /// as "clear" and never errors.
+    /// as "checked, absent" and never errors.
     pub fn set_before(&mut self, ver: Option<&str>) -> crate::error::Result<()> {
-        self.before = parse_opt(ver)?;
-        self.before_observed = true;
+        self.before = parse_opt(ver)?.into();
         Ok(())
     }
 
@@ -108,8 +154,7 @@ impl Package {
     /// # Errors
     /// See [`set_before`](Package::set_before).
     pub fn set_after(&mut self, ver: Option<&str>) -> crate::error::Result<()> {
-        self.after = parse_opt(ver)?;
-        self.after_observed = true;
+        self.after = parse_opt(ver)?.into();
         Ok(())
     }
 
@@ -122,18 +167,28 @@ impl Package {
         Ok(())
     }
 
-    /// Sets the [`before`](Package::before) version directly, recording that
-    /// an observation was made (even a `None` one — observed absent).
+    /// Sets the [`before`](Package::before) version directly, recording a
+    /// completed check — `None` is *observed absent*, not *never checked*.
     pub fn set_before_version(&mut self, ver: Option<RPMVersion>) {
-        self.before = ver;
-        self.before_observed = true;
+        self.before = ver.into();
     }
 
-    /// Sets the [`after`](Package::after) version directly, recording that an
-    /// observation was made (even a `None` one — observed absent).
+    /// Sets the [`after`](Package::after) version directly, recording a
+    /// completed check — `None` is *observed absent*, not *never checked*.
     pub fn set_after_version(&mut self, ver: Option<RPMVersion>) {
-        self.after = ver;
-        self.after_observed = true;
+        self.after = ver.into();
+    }
+
+    /// Sets the [`before`](Package::before) check outcome directly, including
+    /// [`NotChecked`](VersionCheck::NotChecked).
+    pub fn set_before_check(&mut self, check: VersionCheck) {
+        self.before = check;
+    }
+
+    /// Sets the [`after`](Package::after) check outcome directly, including
+    /// [`NotChecked`](VersionCheck::NotChecked).
+    pub fn set_after_check(&mut self, check: VersionCheck) {
+        self.after = check;
     }
 
     /// Sets the [`current`](Package::current) version directly.
@@ -142,7 +197,12 @@ impl Package {
     }
 }
 
-/// Parses an optional version string, treating `None`/empty as "clear".
+/// Parses an optional version string, treating `None`/empty as "no version".
+///
+/// The before/after setters feed the result through
+/// [`VersionCheck::from`], which reads that as *checked, not installed*;
+/// [`required`](Package::required) keeps it as a plain absent value, since
+/// metadata declares a requirement rather than observing one.
 fn parse_opt(ver: Option<&str>) -> crate::error::Result<Option<RPMVersion>> {
     match ver {
         Some(v) if !v.is_empty() => Ok(Some(RPMVersion::parse(v)?)),
@@ -179,25 +239,33 @@ mod tests {
 
     use super::*;
 
-    /// #396: setting a `None` version still counts as an observation —
-    /// "observed absent" and "never checked" must stay distinguishable.
+    /// #396: setting a `None` version records a check that found nothing —
+    /// `NotInstalled` and `NotChecked` must stay distinguishable, and both
+    /// must keep reading as `None` through [`Package::before`]/[`Package::after`].
     #[test]
-    fn set_version_none_counts_as_observed() {
+    fn set_version_none_is_not_installed_not_unchecked() {
         let mut p = Package::new("bash");
-        assert!(!p.before_observed() && !p.after_observed());
+        assert_eq!(p.before_check(), &VersionCheck::NotChecked);
+        assert_eq!(p.after_check(), &VersionCheck::NotChecked);
         p.set_before_version(None);
-        assert!(p.before_observed());
-        assert!(!p.after_observed());
-        p.set_after_version(None);
-        assert!(
-            p.after_observed(),
-            "set_after_version must mark the observation"
+        assert_eq!(p.before_check(), &VersionCheck::NotInstalled);
+        assert_eq!(
+            p.after_check(),
+            &VersionCheck::NotChecked,
+            "setting one side must not mark the other"
         );
+        p.set_after_version(None);
+        assert_eq!(p.after_check(), &VersionCheck::NotInstalled);
+        assert!(p.before().is_none() && p.after().is_none());
+
         let mut p = Package::new("bash2");
         p.set_after(None).unwrap();
-        assert!(p.after_observed());
-        assert!(!p.before_observed());
-        assert!(p.before().is_none() && p.after().is_none());
+        assert_eq!(p.after_check(), &VersionCheck::NotInstalled);
+        assert_eq!(p.before_check(), &VersionCheck::NotChecked);
+        p.set_after(Some("2.0-1")).unwrap();
+        assert!(p.after_check().is_checked() && p.after().is_some());
+        p.set_after_check(VersionCheck::NotChecked);
+        assert!(!p.after_check().is_checked() && p.after().is_none());
     }
 
     #[test]

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -110,6 +110,16 @@ Feature updates often add packages that only exist in the test-update repository
 so `prepare` can't install them yet. Run `update --newpackage` to install the new
 packages right after the update applies.
 
+## Why does `prepare` (or `update`) refuse to run?
+
+When the loaded report's metadata names no package versions, `prepare` and
+`update` refuse with an error instead of printing an unqualified success over
+a no-op (#396) — an empty-metadata report used to produce
+`prepare completed on <hosts>` while installing nothing. Check
+`list_packages -w` and the report metadata; a host the fan-out cannot build a
+command for (unresolvable release, no matching template) likewise fails the
+run by name.
+
 ## How do I control what `prepare` installs?
 
 `prepare` has three switches:

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -176,6 +176,16 @@ host, the same destination the REPL `put` uses. `filename` must be a bare name
 outright: truncating an upload would corrupt it. Any host failure fails the
 call with the host named.
 
+## Command behaviour notes
+
+- The `prepare` tool fails — instead of reporting success — when the loaded
+  report's metadata names no package versions, and when no prepare command
+  could be built for a connected host (#396). Automation keying on `prepare`'s
+  success no longer sees a false positive on a metadata-empty report.
+- `export` emits `WARNING: no package version data recorded for <host>...`
+  lines in its tool output when a host has no recorded package data and its
+  install-result block was therefore left unverified in the report.
+
 ## Testreport editing tools
 
 Five hand-written tools operate on the loaded test report's checkout, replacing


### PR DESCRIPTION
Closes #396.

## Summary

On `SUSE:SLFO:1.1:418286`, `prepare` reported success while installing nothing, and `export` then claimed the installed packages were absent. Root cause (established during #433's investigation, refuting the wrong-repo-layout hypothesis): the metadata envelope's packages either failed to parse or were empty, every silent-drop site on the chain converted "did nothing" into `Ok`, and export rendered never-observed state as a positive absence claim.

This fixes the whole chain, in causal order:

- **Parser**: unparsable package entries are logged and dropped (previously vanished); a product with no parsable entries no longer leaves an empty sub-map that defeats the `get_package_list()` guards; trailing tokens warn.
- **Prepare/update commands**: refuse up front on a report naming no package versions — no more `prepare completed on <hosts>` over a no-op (REPL and MCP). Not-loaded is checked first so the refusal never claims a report is loaded when none is.
- **Prepare flow**: a host `build_prepare_map` drops (unresolvable release, failed render) fails the run **by name** with mock-level proof it received no command; empty lists warn on every path.
- **Observation honesty** (`mtui-types`): `Package::{before,after}` are now a three-state `VersionCheck` — `NotChecked` / `NotInstalled` / `Installed(RPMVersion)` — so "checked, absent" and "never checked" are distinguishable; `required`/`current` stay plain options, and `before()`/`after()` keep their `Option<&RPMVersion>` signature. The `downgrade` rotation moves the whole check, so "never checked" survives it.
- **Export**: never-checked renders `package <name>: not checked (no version data recorded)`; a host with no recorded data keeps the scaffold and its `=> PASSED/FAILED` placeholder (never flips PASSED over unverified content); FAILED outranks unverified; `export` prints an operator-visible `WARNING:` line per unverified host (with a negative control pinning it doesn't fire for verified hosts).

## Review

Three read-only adversarial reviewers (false-success remnants / test vacuity / contracts) ran over the uncommitted tree; every finding was fixed before the commits were created — including two they rated medium: the guard-order bug (refusal claiming "the loaded report" with none loaded) and the downgrade rotation stamping a never-checked slot as checked. The one *confirmed non-regression*: `package_check` stamps observations unconditionally, so real update-flow exports keep saying "is not installed" for genuinely-absent packages — "not checked" appears only when no check ever ran.

## Testing

- Full gate: fmt, clippy `-D warnings`, workspace tests, `-p mtui-mcp -F mcp`, rustdoc gate, typos.
- Six red-first proofs, each observed failing against the mutated fix (with the test observably *running* — one initial "0 passed" false-negative was caught and re-proven against the right harness) and restored with `MUTANT`-marker greps.
- New pins: prepare/update refusal (+ no-success negative), per-host dispatch accounting (attribution via `err.host`, not substring), parser drop/keep matrix, the `VersionCheck` state machine across all four setters, four export-honesty tests plus the mixed-block both-line-kinds pin, export WARNING presence *and* absence.

## Known residuals (documented, out of scope)

- `package_check` can stamp "observed absent" when the *version query itself* never answered (host died between fan-out and check) — a pre-existing seam `VersionCheck` cannot see; noted for #397's fixture work.
- `export`'s WARNING covers the no-data-at-all host; a host with seeded-but-never-observed packages is visible in the report body ("not checked" lines + kept placeholder) but not as a display WARNING.
- The unreachable-cancel inventory log and #400/#406 interactions are sibling-issue scope.



---

**Review round 2 (2026-08-10).** Rebased onto `ae8b91db` (the #434 merge conflicted in `CHANGELOG.md` and `docs/src/mcp.md`; both resolved by keeping each side's entries), and @mimi1vx's point about the two `*_observed` booleans is addressed in `9a38923`: the flag beside the option became one field with three states (`VersionCheck`). The value and the fact that it was measured can no longer drift apart, and the downgrade rotation's guard is gone — moving the whole check carries "never checked" across on its own. `downgrade_verdict_rotation_keeps_an_unchecked_slot_unchecked` pins that, and fails against the naive value-only rotation.
