### PR TITLE
Strip request URLs from reqwest errors at the HttpError boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,10 +311,17 @@ The `tests/` fixtures are the authority for these formats; treat them as golden.
   masked (`<set>`) by both `config show` and `config set` — never echo their
   value to the display buffer (it reaches terminal scrollback and MCP output).
   Configured datasource URLs may embed credentials (`scheme://user:pass@host`);
-  always run a URL through `mtui_datasources::sanitize_url` before logging it or
-  putting it in an error (it replaces userinfo with `***` while keeping the host
-  for diagnosis). The Gitea token travels in an `Authorization` header and is
-  never logged.
+  always run a URL through `sanitize_url` (crate-internal to `mtui-datasources`,
+  not a public export) before logging it or putting it in an error (it replaces
+  userinfo with `***` while keeping the host for diagnosis). Never render a
+  `reqwest::Error` directly — its `Display` appends the request URL verbatim, and
+  a redirect can put credentials back into it; `impl From<reqwest::Error> for
+  HttpError` strips the URL where reqwest errors enter the crate's hierarchy, so
+  convert first and add request context yourself. Outside `mtui-datasources`
+  `sanitize_url` is not reachable (it is crate-internal), so the rule there is:
+  never interpolate a datasource URL into a message at all — log the host alone,
+  or rely on the already-stripped error types. The Gitea token travels in an
+  `Authorization` header and is never logged.
 - Never add SSH password auth — MTUI is **pubkey-only by design**; preserve that.
 
 ## When adding or changing a command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,37 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   only `install`/`uninstall` reported a stranded `/var/lock/mtui.lock`; the
   other flows silently dropped the same outcome.
 
+### Security
+
+- Datasource errors and log lines no longer append the unredacted request URL
+  (#431). `reqwest`'s own error rendering ends in ` for url (<url>)`, and mtui
+  wrapped it in transparent error types, so the URL rode along wherever such an
+  error was rendered. It is now dropped where a `reqwest` error enters mtui's
+  error hierarchy, and log lines carry a sanitized URL (`https://***@host/…`) as
+  their context instead. What was affected:
+  - **Returned errors**: the OBS (`ObsError::Http`) and QEM-dashboard
+    (`QemDashboardError::Fetch`) types, plus TeReGen's `Fetch`, rendered the URL
+    to the user. Gitea's and Slack's `FailedCall` never embedded the transport
+    error, so their *errors* were already clean; openQA's path goes through
+    `ruoqa`, which already redacts URLs itself, and was never affected.
+  - **Log lines**: the OBS send failure (ERROR), the Gitea and Slack API-call
+    failures (WARN), TeReGen's GET and POST-regenerate failures (DEBUG), and the
+    testreport-log fetch failure (ERROR).
+  - **Credentials, not just URLs**: `reqwest` moves userinfo out of the first
+    request URL into an auth header, but `error_for_status` reports the
+    *redirect-followed* URL — so a `Location: https://user:pass@host/…` answered
+    with a non-2xx put the password into the error text verbatim.
+- Two mtui-formatted messages that interpolated a raw URL are now sanitized: the
+  OBS between-calls timeout (exhausting `[obs] request_timeout` against a
+  credentialed API URL printed that URL, password included) and the
+  `build_check log … unavailable` warning, which is emitted at the default log
+  level and builds its URL from the `[url] testreports` setting.
+- The OBS TLS-failure hint no longer names the username as the host it failed
+  to verify when the API URL carries credentials.
+- TLS-failure detail logs (OBS, Gitea, Slack, at DEBUG) now carry the
+  underlying certificate/IO cause instead of `reqwest`'s error kind plus URL,
+  which is both more actionable and URL-free by construction.
+
 ## [26.1.1] - 2026-07-27
 
 ### Added

--- a/crates/mtui-datasources/src/error.rs
+++ b/crates/mtui-datasources/src/error.rs
@@ -24,8 +24,18 @@ pub type Result<T> = std::result::Result<T, HttpError>;
 pub enum HttpError {
     /// A transport failure, a non-2xx HTTP status, or a client-build failure
     /// surfaced by `reqwest`.
+    ///
+    /// **Invariant: the wrapped error carries no URL.** It is stripped by
+    /// [`From<reqwest::Error>`](HttpError#impl-From<Error>-for-HttpError), so
+    /// no `#[error(transparent)]` chain over it can render one. The variant's
+    /// own `#[non_exhaustive]` makes that the *only* way to build it from
+    /// outside this crate (a bare `HttpError::Request(e)` there is `E0639`);
+    /// inside the crate it is convention, enforced by review, so construct it
+    /// via `?`, `.into()` or `HttpError::from` and never bare. Matching is
+    /// unaffected — `HttpError::Request(..)` stays a legal pattern everywhere.
     #[error(transparent)]
-    Request(#[from] reqwest::Error),
+    #[non_exhaustive]
+    Request(reqwest::Error),
 
     /// A user-configured CA bundle could not be read or parsed into
     /// certificates when building the HTTP client.
@@ -54,6 +64,22 @@ pub enum HttpError {
         /// else `None` (the cap tripped while streaming).
         seen: Option<u64>,
     },
+}
+
+impl From<reqwest::Error> for HttpError {
+    fn from(e: reqwest::Error) -> Self {
+        // #431: reqwest's `Display` appends the request URL verbatim
+        // (" for url (…)"), and `HttpError::Request` plus every `…Error::Http`
+        // over it are `#[error(transparent)]`, so that URL surfaces anywhere an
+        // error is rendered. It is not reliably credential-free either:
+        // `extract_authority` scrubs userinfo only from the URL the
+        // `RequestBuilder` was built with, while `Response::error_for_status`
+        // reports the *redirect-updated* URL, so a `Location` header can put
+        // `user:pass@host` straight back. Drop the URL where reqwest errors
+        // enter this crate's hierarchy; supplying request context is the call
+        // site's job, via `crate::http::sanitize_url`.
+        Self::Request(e.without_url())
+    }
 }
 
 /// Errors from loading and parsing a local `refhosts.yml` database.
@@ -400,6 +426,38 @@ mod tests {
             GiteaError::FailedCall("GET - /x".to_string())
                 .to_string()
                 .contains("GET - /x")
+        );
+    }
+
+    /// The #431 boundary: a `reqwest::Error` entering [`HttpError`] loses its
+    /// URL, so no `#[error(transparent)]` chain over
+    /// [`HttpError::Request`] can render it. Driven by a real transport error
+    /// (nothing listens on the loopback discard port, RFC 863) because the URL
+    /// is attached by reqwest's own send path, not by anything constructible
+    /// here.
+    #[tokio::test]
+    async fn reqwest_error_loses_its_url_at_the_http_error_boundary() {
+        let e = reqwest::Client::new()
+            .get("http://127.0.0.1:9/x")
+            .send()
+            .await
+            .expect_err("nothing listens on the discard port");
+        // Premise guard: if reqwest ever stops appending the URL, this test
+        // would pass vacuously and the boundary below would be untested.
+        assert!(
+            e.to_string().contains(" for url ("),
+            "premise gone: reqwest no longer appends the URL: {e}"
+        );
+
+        let msg = HttpError::from(e).to_string();
+        assert!(
+            !msg.contains(" for url ("),
+            "URL crossed the boundary: {msg}"
+        );
+        // The error *kind* must survive the strip — only the URL is dropped.
+        assert!(
+            msg.contains("error sending request"),
+            "kind was lost with the URL: {msg}"
         );
     }
 }

--- a/crates/mtui-datasources/src/gitea.rs
+++ b/crates/mtui-datasources/src/gitea.rs
@@ -33,10 +33,10 @@ use reqwest::Method;
 use serde_json::json;
 use tokio::sync::OnceCell;
 
-use crate::error::GiteaError;
+use crate::error::{GiteaError, HttpError};
 use crate::http::{
     HttpClient, MAX_API_BODY, VerifyPolicy, is_ssl_verification_error, read_body_capped,
-    resolve_verify, sanitize_url, ssl_verification_hint,
+    resolve_verify, sanitize_url, ssl_error_detail, ssl_verification_hint,
 };
 
 /// The default review group a [`Gitea`] client operates on behalf of.
@@ -393,12 +393,17 @@ impl Gitea {
         let response = match builder.send().await {
             Ok(r) => r,
             Err(e) => {
-                if is_ssl_verification_error(&e) {
+                // Never render the raw `reqwest::Error`; convert first (#431).
+                let ssl = is_ssl_verification_error(&e);
+                let e = HttpError::from(e);
+                if ssl {
                     let host = host_of(url);
                     tracing::error!("{}", ssl_verification_hint(host.as_deref()));
-                    tracing::debug!("Gitea TLS error detail: {e}");
+                    tracing::debug!("Gitea TLS error detail: {}", ssl_error_detail(&e));
                 } else {
-                    tracing::warn!("API call to Gitea failed: {e}");
+                    // On this arm the sanitized URL is the line's only host
+                    // context, reqwest's having been dropped.
+                    tracing::warn!("API call to Gitea {} failed: {e}", sanitize_url(url));
                 }
                 return Err(GiteaError::FailedCall(format!(
                     "{method} - {}",

--- a/crates/mtui-datasources/src/http.rs
+++ b/crates/mtui-datasources/src/http.rs
@@ -12,9 +12,16 @@
 //!   preference into the effective [`VerifyPolicy`].
 //! - [`HttpClient`] builds one `reqwest::Client` with a fixed timeout + verify
 //!   posture. Verification is **on by default for every call site.**
-//! - `is_ssl_verification_error` / `ssl_verification_hint` give a short,
-//!   actionable message for the internal-CA hosts (openqa.suse.de,
-//!   dashboard.qam.suse.de, ...) instead of a raw transport error.
+//! - `is_ssl_verification_error` / `ssl_verification_hint` /
+//!   `ssl_error_detail` give a short, actionable message for the internal-CA
+//!   hosts (openqa.suse.de, dashboard.qam.suse.de, ...) instead of a raw
+//!   transport error.
+//! - URL redaction has three legs, in order of load-bearing-ness (#431): the
+//!   primary one is the strip at the [`HttpError`] conversion boundary, which
+//!   most call sites (teregen, the QEM dashboard) rely on and nothing else;
+//!   `sanitize_url` is for interpolating a request URL into a message as
+//!   context; and `root_cause` reaches past an error layer whose own `Display`
+//!   may embed a URL, for a detail line.
 //!
 //! ## Client construction and verify precedence
 //!
@@ -315,7 +322,9 @@ fn load_ca_bundle(path: &Path) -> Result<Vec<reqwest::Certificate>> {
         path: path.display().to_string(),
         source,
     })?;
-    reqwest::Certificate::from_pem_bundle(&pem).map_err(HttpError::Request)
+    // `HttpError::from`, never the bare variant: the URL strip lives in the
+    // conversion (see the variant's invariant).
+    reqwest::Certificate::from_pem_bundle(&pem).map_err(HttpError::from)
 }
 
 /// Return `true` if `err` is (or was caused by) a TLS certificate-verification
@@ -401,6 +410,50 @@ pub(crate) fn sanitize_url(url: &str) -> String {
 /// If `s` contains an `@`, return the slice after the last one; else `None`.
 fn rest_after_at(s: &str) -> Option<&str> {
     s.rsplit_once('@').map(|(_, after)| after)
+}
+
+/// The DEBUG-level detail line accompanying [`ssl_verification_hint`]: the
+/// deepest cause of `e`, or `e`'s own `Display` when it has no source.
+///
+/// Taking [`HttpError`] rather than `&dyn Error` is the point: it makes "the
+/// error has already crossed the conversion boundary" a compile-time
+/// precondition, so neither branch can render a URL (#431). `HttpError::Request`
+/// is `#[error(transparent)]`, so `source()` forwards past reqwest's own
+/// `Display` straight to the rustls/IO cause — which is also the actionable
+/// part, reqwest's `Display` saying only "error sending request".
+#[must_use]
+pub(crate) fn ssl_error_detail(e: &HttpError) -> String {
+    root_cause(e).unwrap_or_else(|| e.to_string())
+}
+
+/// Walks `e`'s source chain to the deepest cause, deliberately skipping `e`
+/// itself (whose `Display` may embed a URL — reqwest's appends the request URL,
+/// `ruoqa::Error::Connection`'s renders a redacted one), and returns it through
+/// [`sanitize_url`] as a backstop.
+///
+/// That backstop handles a **single** embedded URL only: `sanitize_url` parses
+/// one `scheme://[userinfo@]host` and silently no-ops on a second one in the
+/// same string. It is a safety net for an unexpected layer, not a substitute
+/// for stripping at the boundary.
+///
+/// Returns `None` if `e` carries no source at all, so callers fall back to the
+/// outer error's own `Display`. A self-referential source chain is bounded like
+/// [`is_ssl_verification_error`]'s walk, though not identically: that one
+/// inspects at most 65 links, this one advances at most 66 times past the first
+/// source. Either bound only has to terminate. (The openQA copy this was hoisted
+/// from had no bound at all.)
+#[must_use]
+pub(crate) fn root_cause(e: &dyn std::error::Error) -> Option<String> {
+    let mut deepest = e.source()?;
+    let mut seen = 0usize;
+    while let Some(next) = deepest.source() {
+        if seen > 64 {
+            break;
+        }
+        seen += 1;
+        deepest = next;
+    }
+    Some(sanitize_url(&deepest.to_string()))
 }
 
 /// The system's CA bundle path, or `None` when none is found.
@@ -666,6 +719,111 @@ mod tests {
         let out = sanitize_url("alice:s3cret@host.example/x");
         assert_eq!(out, "***@host.example/x");
         assert!(!out.contains("s3cret"));
+    }
+
+    #[derive(Debug)]
+    struct Leaf(&'static str);
+    impl std::fmt::Display for Leaf {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+    impl std::error::Error for Leaf {}
+
+    #[derive(Debug)]
+    struct Wrapper {
+        source: Box<dyn std::error::Error>,
+    }
+    impl std::fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "wrapper")
+        }
+    }
+    impl std::error::Error for Wrapper {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(self.source.as_ref())
+        }
+    }
+
+    /// Two-deep chain: `root_cause` must sanitize the deepest message.
+    /// Deleting the `sanitize_url` call in `root_cause` turns this red.
+    #[test]
+    fn root_cause_sanitizes_the_deepest_message() {
+        let e = Wrapper {
+            source: Box::new(Leaf("boom https://alice:s3cret@h/x")),
+        };
+        assert_eq!(root_cause(&e).as_deref(), Some("boom https://***@h/x"));
+    }
+
+    /// Three-deep chain: `root_cause` must return the *deepest* message, not
+    /// an intermediate one. Changing `root_cause` to stop at the first
+    /// `source()` instead of walking to the end turns this red.
+    #[test]
+    fn root_cause_returns_the_deepest_not_the_intermediate() {
+        let e = Wrapper {
+            source: Box::new(Wrapper {
+                source: Box::new(Leaf("deepest")),
+            }),
+        };
+        assert_eq!(root_cause(&e).as_deref(), Some("deepest"));
+    }
+
+    /// An error with no source at all yields `None`, so callers fall back to
+    /// the outer error's own (already-redacted) `Display`.
+    #[test]
+    fn root_cause_is_none_without_a_source() {
+        assert_eq!(root_cause(&Leaf("no source here")), None);
+    }
+
+    /// Driven by a *real* `HttpError` rather than a synthetic chain, because
+    /// the property under test is a property of the real one: `Request` is
+    /// `#[error(transparent)]`, so `source()` forwards past reqwest's own
+    /// `Display` — the layer that carries the URL — to the transport cause
+    /// underneath. Nothing listens on the loopback discard port (RFC 863).
+    #[tokio::test]
+    async fn ssl_error_detail_reports_the_transport_cause_without_a_url() {
+        let e: HttpError = reqwest::Client::new()
+            .get("http://127.0.0.1:9/x")
+            .send()
+            .await
+            .expect_err("connection refused")
+            .into();
+
+        let detail = ssl_error_detail(&e);
+        assert!(
+            !detail.contains(" for url ("),
+            "detail rendered reqwest's URL: {detail}"
+        );
+        // The recovered cause is the actionable half; `e`'s own Display is only
+        // "error sending request", which is why the walk exists at all.
+        assert!(
+            detail.to_lowercase().contains("connection refused"),
+            "detail lost the transport cause: {detail}"
+        );
+        assert_ne!(
+            detail,
+            e.to_string(),
+            "detail must reach past the outer error, not echo it"
+        );
+    }
+
+    /// A self-referential source chain must terminate rather than hang; the
+    /// hop guard bounds the walk as `is_ssl_verification_error`'s does.
+    #[test]
+    fn root_cause_terminates_on_a_cyclic_chain() {
+        #[derive(Debug)]
+        struct SelfRef;
+        impl std::fmt::Display for SelfRef {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "cycle")
+            }
+        }
+        impl std::error::Error for SelfRef {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&SelfRef)
+            }
+        }
+        assert_eq!(root_cause(&SelfRef).as_deref(), Some("cycle"));
     }
 
     /// [`HttpClient::openqa_transport`] must not follow a redirect: a

--- a/crates/mtui-datasources/src/obs/client.rs
+++ b/crates/mtui-datasources/src/obs/client.rs
@@ -23,9 +23,10 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use reqwest::{Method, RequestBuilder};
 
+use crate::error::HttpError;
 use crate::http::{
     HttpClient, MAX_API_BODY, VerifyPolicy, is_ssl_verification_error, read_body_capped,
-    sanitize_url, ssl_verification_hint,
+    sanitize_url, ssl_error_detail, ssl_verification_hint,
 };
 use crate::obs::errors::ObsError;
 
@@ -175,7 +176,8 @@ impl ObsClient {
     fn check_budget(&self, url: &str) -> Result<(), ObsError> {
         if Instant::now() > self.deadline {
             return Err(ObsError::Timeout(format!(
-                "OBS operation exceeded its between-calls time budget before {url}"
+                "OBS operation exceeded its between-calls time budget before {}",
+                sanitize_url(url)
             )));
         }
         Ok(())
@@ -207,14 +209,17 @@ impl ObsClient {
         builder: RequestBuilder,
     ) -> Result<reqwest::Response, ObsError> {
         builder.send().await.map_err(|e| {
-            if is_ssl_verification_error(&e) {
+            // Never render the raw `reqwest::Error`; convert first (#431).
+            let ssl = is_ssl_verification_error(&e);
+            let e = HttpError::from(e);
+            if ssl {
                 let host = host_of(url);
                 tracing::error!("{}", ssl_verification_hint(host.as_deref()));
-                tracing::debug!("OBS TLS error detail: {e}");
+                tracing::debug!("OBS TLS error detail: {}", ssl_error_detail(&e));
             } else {
                 tracing::error!("OBS {method} {} failed: {e}", sanitize_url(url));
             }
-            ObsError::Http(e.into())
+            ObsError::Http(e)
         })
     }
 
@@ -375,13 +380,18 @@ fn build_query_string(params: &[(&str, String)]) -> String {
         .join("&")
 }
 
-/// Extract the host (authority without any port) from an `scheme://host[:port]/…`
-/// URL, for the TLS-failure hint. Returns `None` if the shape is unexpected.
+/// Extract the host (authority without any port) from an
+/// `scheme://[userinfo@]host[:port]/…` URL, for the TLS-failure hint. Returns
+/// `None` if the shape is unexpected.
+///
+/// Any userinfo is dropped first: without that, a credentialed API base makes
+/// the hint name the *username* as the host it failed to verify (#431).
 ///
 /// Mirrors the same helper in [`crate::gitea`].
 fn host_of(url: &str) -> Option<String> {
     let rest = url.split_once("://")?.1;
     let authority = rest.split(['/', '?', '#']).next()?;
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
     let host = authority.split(':').next()?;
     (!host.is_empty()).then(|| host.to_string())
 }
@@ -431,6 +441,21 @@ mod tests {
             Some("api.suse.de")
         );
         assert_eq!(host_of("not a url"), None);
+    }
+
+    /// Userinfo is not the host: without the strip, `host_of` returns the
+    /// *username*, which `ssl_verification_hint` then names as the server the
+    /// operator failed to verify (#431).
+    #[test]
+    fn host_of_ignores_userinfo() {
+        assert_eq!(
+            host_of("https://user:pass@h.example/x").as_deref(),
+            Some("h.example")
+        );
+        assert_eq!(
+            host_of("https://token@h.example:443/x").as_deref(),
+            Some("h.example")
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-datasources/src/obs/preconditions.rs
+++ b/crates/mtui-datasources/src/obs/preconditions.rs
@@ -16,6 +16,7 @@ use regex::Regex;
 
 use mtui_types::RequestReviewID;
 
+use crate::error::HttpError;
 use crate::http::{HttpClient, MAX_API_BODY, VerifyPolicy, read_body_capped, sanitize_url};
 
 /// Capture the whole trimmed `SUMMARY:` value, not just the first token, so a
@@ -62,7 +63,12 @@ pub(crate) async fn fetch_testreport_log(
     let response = match client.inner().get(&url).send().await {
         Ok(response) => response,
         Err(e) => {
-            tracing::error!("could not fetch testreport {safe_url}: {e}");
+            // Convert first: a raw `reqwest::Error` would append the *un*safe
+            // URL right next to the sanitized one (#431).
+            tracing::error!(
+                "could not fetch testreport {safe_url}: {}",
+                HttpError::from(e)
+            );
             return None;
         }
     };

--- a/crates/mtui-datasources/src/openqa/client.rs
+++ b/crates/mtui-datasources/src/openqa/client.rs
@@ -12,7 +12,7 @@
 use crate::error::OpenQAError;
 #[cfg(test)]
 use crate::http::{HttpClient, VerifyPolicy};
-use crate::http::{MAX_API_BODY, sanitize_url};
+use crate::http::{MAX_API_BODY, root_cause};
 
 /// Builds a [`ruoqa::Client`] for `base_url` with a fresh, single-use
 /// transport.
@@ -86,20 +86,6 @@ pub(crate) fn describe(e: &ruoqa::Error) -> String {
     }
 }
 
-/// Walks `e`'s source chain to the deepest cause, deliberately skipping `e`
-/// itself (whose `Display` may be unredacted — see [`describe`]), and returns
-/// it through [`sanitize_url`] as a backstop against a future layer embedding
-/// a URL.
-///
-/// Returns `None` if `e` carries no source at all.
-fn root_cause(e: &dyn std::error::Error) -> Option<String> {
-    let mut deepest = e.source()?;
-    while let Some(next) = deepest.source() {
-        deepest = next;
-    }
-    Some(sanitize_url(&deepest.to_string()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,60 +112,6 @@ mod tests {
     // `ruoqa::Error::Connection`/`CrossOriginRedirect` in `tests/openqa.rs`:
     // `ruoqa::Error`'s variants are `#[non_exhaustive]`, so this crate cannot
     // construct one directly to unit-test `describe`'s match arms in
-    // isolation. `root_cause` has no such restriction, since it walks a
-    // plain `&dyn Error`.
-
-    #[derive(Debug)]
-    struct Leaf(&'static str);
-    impl std::fmt::Display for Leaf {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-    impl std::error::Error for Leaf {}
-
-    #[derive(Debug)]
-    struct Wrapper {
-        source: Box<dyn std::error::Error>,
-    }
-    impl std::fmt::Display for Wrapper {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "wrapper")
-        }
-    }
-    impl std::error::Error for Wrapper {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            Some(self.source.as_ref())
-        }
-    }
-
-    /// Two-deep chain: `root_cause` must sanitize the deepest message.
-    /// Deleting the `sanitize_url` call in `root_cause` turns this red.
-    #[test]
-    fn root_cause_sanitizes_the_deepest_message() {
-        let e = Wrapper {
-            source: Box::new(Leaf("boom https://alice:s3cret@h/x")),
-        };
-        assert_eq!(root_cause(&e).as_deref(), Some("boom https://***@h/x"));
-    }
-
-    /// Three-deep chain: `root_cause` must return the *deepest* message, not
-    /// an intermediate one. Changing `root_cause` to stop at the first
-    /// `source()` instead of walking to the end turns this red.
-    #[test]
-    fn root_cause_returns_the_deepest_not_the_intermediate() {
-        let e = Wrapper {
-            source: Box::new(Wrapper {
-                source: Box::new(Leaf("deepest")),
-            }),
-        };
-        assert_eq!(root_cause(&e).as_deref(), Some("deepest"));
-    }
-
-    /// An error with no source at all yields `None`, so callers fall back to
-    /// the outer error's own (already-redacted) `Display`.
-    #[test]
-    fn root_cause_is_none_without_a_source() {
-        assert_eq!(root_cause(&Leaf("no source here")), None);
-    }
+    // isolation. `root_cause` has no such restriction, since it walks a plain
+    // `&dyn Error` — its own unit tests live with it in `crate::http`.
 }

--- a/crates/mtui-datasources/src/oqa_search/search.rs
+++ b/crates/mtui-datasources/src/oqa_search/search.rs
@@ -24,7 +24,7 @@ use ruoqa::consts::JobResult as OqaJobResult;
 use scraper::{Html, Selector};
 
 use crate::error::OqaSearchError;
-use crate::http::{HttpClient, MAX_API_BODY};
+use crate::http::{HttpClient, MAX_API_BODY, sanitize_url};
 
 use super::heuristics::{
     AGGREGATED_EXCLUDED_VERSIONS, AGGREGATED_GROUPS_TERMS, AGGREGATED_NAME_MAP, EXCLUDED_GROUPS,
@@ -879,7 +879,14 @@ pub async fn build_checks(
                     let log_text = match fetch_url_content(http, &log_url).await {
                         Ok(t) => t,
                         Err(e) => {
-                            tracing::warn!("build_check log {log_url} unavailable: {e}");
+                            // `log_url` is built from the `[url] testreports`
+                            // config, which is taken verbatim and may embed
+                            // credentials — and this is WARN, i.e. visible by
+                            // default (#431).
+                            tracing::warn!(
+                                "build_check log {} unavailable: {e}",
+                                sanitize_url(&log_url)
+                            );
                             return (
                                 idx,
                                 BuildCheckResult {

--- a/crates/mtui-datasources/src/qem_dashboard/client.rs
+++ b/crates/mtui-datasources/src/qem_dashboard/client.rs
@@ -102,9 +102,10 @@ impl QemDashboardClient {
     ///
     /// The fallible sibling of [`get`](Self::get): a transport error, a non-2xx
     /// status, or a malformed JSON body returns [`QemDashboardError::Fetch`]
-    /// (with a URL-free description) instead of being folded to `None`, so a
-    /// caller can distinguish "unreachable" from "empty". A valid-but-`null`
-    /// body is `Ok(None)`.
+    /// instead of being folded to `None`, so a caller can distinguish
+    /// "unreachable" from "empty". A valid-but-`null` body is `Ok(None)`. The
+    /// description is URL-free because the URL is stripped where the
+    /// `reqwest::Error` becomes an [`HttpError`](crate::HttpError) (#431).
     async fn try_get(&self, path: &str) -> Result<Option<Value>, QemDashboardError> {
         let url = format!("{}/{}", self.apiurl, path.trim_start_matches('/'));
         let bytes = self

--- a/crates/mtui-datasources/src/slack.rs
+++ b/crates/mtui-datasources/src/slack.rs
@@ -29,10 +29,10 @@ use reqwest::Method;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::error::SlackError;
+use crate::error::{HttpError, SlackError};
 use crate::http::{
     HttpClient, MAX_API_BODY, VerifyPolicy, is_ssl_verification_error, read_body_capped,
-    resolve_verify, sanitize_url, ssl_verification_hint,
+    resolve_verify, sanitize_url, ssl_error_detail, ssl_verification_hint,
 };
 
 /// Maximum `conversations.replies` pages walked before giving up.
@@ -266,11 +266,16 @@ impl Slack {
         let response = match builder.send().await {
             Ok(r) => r,
             Err(e) => {
-                if is_ssl_verification_error(&e) {
+                // Never render the raw `reqwest::Error`; convert first (#431).
+                let ssl = is_ssl_verification_error(&e);
+                let e = HttpError::from(e);
+                if ssl {
                     tracing::error!("{}", ssl_verification_hint(None));
-                    tracing::debug!("Slack TLS error detail: {e}");
+                    tracing::debug!("Slack TLS error detail: {}", ssl_error_detail(&e));
                 } else {
-                    tracing::warn!("API call to Slack failed: {e}");
+                    // On this arm the sanitized URL is the line's only host
+                    // context, reqwest's having been dropped.
+                    tracing::warn!("API call to Slack {} failed: {e}", sanitize_url(&url));
                 }
                 return Err(SlackError::FailedCall(format!(
                     "{method} - {}",

--- a/crates/mtui-datasources/src/teregen.rs
+++ b/crates/mtui-datasources/src/teregen.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use mtui_config::Config;
 use serde_json::{Value, json};
 
-use crate::error::TeReGenError;
+use crate::error::{HttpError, TeReGenError};
 use crate::http::{
     HTTP_TIMEOUT, HttpClient, MAX_API_BODY, VerifyPolicy, read_body_capped, resolve_verify,
 };
@@ -84,8 +84,8 @@ impl TeReGen {
     ///
     /// # Errors
     ///
-    /// Returns [`HttpError`](crate::error::HttpError) if the shared HTTP client
-    /// cannot be built (e.g. a configured CA bundle cannot be read).
+    /// Returns [`HttpError`] if the shared HTTP client cannot be built (e.g. a
+    /// configured CA bundle cannot be read).
     pub fn new(config: &Config, apiurl: &str) -> crate::Result<Self> {
         let verify: VerifyPolicy = resolve_verify(
             VerifyPolicy::Default(true),
@@ -123,17 +123,21 @@ impl TeReGen {
             url.push_str(&qs);
         }
         let request = self.http.inner().get(&url).timeout(HTTP_TIMEOUT.1);
+        // Both arms convert before logging: a raw `reqwest::Error` renders the
+        // request URL verbatim, and `error_for_status`'s carries the
+        // *redirect-followed* URL, which can hold credentials a `Location`
+        // header put back (#431).
         let response = match request.send().await {
             Ok(r) => r,
             Err(e) => {
-                tracing::debug!("TeReGen GET {path} failed: {e}");
+                tracing::debug!("TeReGen GET {path} failed: {}", HttpError::from(e));
                 return None;
             }
         };
         let response = match response.error_for_status() {
             Ok(r) => r,
             Err(e) => {
-                tracing::debug!("TeReGen GET {path} failed: {e}");
+                tracing::debug!("TeReGen GET {path} failed: {}", HttpError::from(e));
                 return None;
             }
         };
@@ -156,9 +160,11 @@ impl TeReGen {
     /// GET `path`, surfacing failures as `Err`.
     ///
     /// The fallible sibling of [`get`](Self::get): a transport failure, a
-    /// non-2xx status, or invalid JSON returns [`TeReGenError::Fetch`] (with a
-    /// URL-free description) instead of being folded to `None`, so a caller can
-    /// distinguish "unreachable" from a genuinely-empty successful response.
+    /// non-2xx status, or invalid JSON returns [`TeReGenError::Fetch`] instead
+    /// of being folded to `None`, so a caller can distinguish "unreachable"
+    /// from a genuinely-empty successful response. The description is URL-free
+    /// because every `reqwest::Error` is converted to [`HttpError`] — which
+    /// strips the URL — before it is stringified (#431).
     async fn try_get(&self, path: &str, query: &[(&str, String)]) -> Result<Value, TeReGenError> {
         let mut url = format!("{}/{}", self.base, path.trim_start_matches('/'));
         let qs = build_query_string(query);
@@ -168,10 +174,12 @@ impl TeReGen {
         }
         let request = self.http.inner().get(&url).timeout(HTTP_TIMEOUT.1);
         let response = request.send().await.map_err(|e| {
+            let e = HttpError::from(e);
             tracing::debug!("TeReGen GET {path} failed: {e}");
             TeReGenError::Fetch(e.to_string())
         })?;
         let response = response.error_for_status().map_err(|e| {
+            let e = HttpError::from(e);
             tracing::debug!("TeReGen GET {path} failed: {e}");
             TeReGenError::Fetch(e.to_string())
         })?;
@@ -291,7 +299,12 @@ impl TeReGen {
         {
             Ok(r) => r,
             Err(e) => {
-                tracing::debug!("TeReGen POST regenerate {rrid} failed: {e}");
+                // Convert before logging: reqwest's Display appends the request
+                // URL (#431).
+                tracing::debug!(
+                    "TeReGen POST regenerate {rrid} failed: {}",
+                    HttpError::from(e)
+                );
                 return None;
             }
         };
@@ -482,9 +495,97 @@ mod tests {
 
     const RRID: &str = "SUSE:SLFO:1.2:5702";
 
+    /// A base URL where nothing listens, so a request fails inside `send`
+    /// rather than on a status — the arm wiremock cannot reach.
+    const CLOSED_PORT: &str = "http://127.0.0.1:1";
+
     fn client(server: &MockServer) -> TeReGen {
         let http = HttpClient::new(VerifyPolicy::Default(false)).unwrap();
         TeReGen::with_client(http, &server.uri())
+    }
+
+    /// A client pointed at [`CLOSED_PORT`].
+    fn unreachable_client() -> TeReGen {
+        let http = HttpClient::new(VerifyPolicy::Default(false)).unwrap();
+        TeReGen::with_client(http, CLOSED_PORT)
+    }
+
+    thread_local! {
+        /// The active capture buffer for this thread, if any. Events on a
+        /// thread with no active capture are dropped.
+        static SINK: std::cell::RefCell<Option<Vec<String>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// Install — once per test binary — a permissive **global** subscriber that
+    /// forwards every event into the calling thread's [`SINK`].
+    ///
+    /// Deliberately global rather than `tracing::subscriber::set_default`'s
+    /// thread-local: `tracing` caches callsite *interest* process-wide, so a
+    /// callsite first reached from a thread with no subscriber is cached as
+    /// `Interest::never()` and stays silent for every later capture. With
+    /// tests running in parallel that is a race — it made
+    /// `regenerate_none_when_unreachable` fail ~30% of runs with "no line in
+    /// capture" while the code under test was correct. A subscriber that is
+    /// always installed keeps interest pinned to `always`; scoping moves to the
+    /// thread-local sink instead.
+    fn install_capture_subscriber() {
+        use std::fmt::Write as _;
+        use std::sync::OnceLock;
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+        use tracing_subscriber::registry::Registry;
+
+        struct CaptureLayer;
+        struct MessageVisitor(String);
+        impl Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    let _ = write!(self.0, "{value:?}");
+                }
+            }
+        }
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                SINK.with(|s| {
+                    if let Some(buf) = s.borrow_mut().as_mut() {
+                        let mut v = MessageVisitor(String::new());
+                        event.record(&mut v);
+                        buf.push(v.0);
+                    }
+                });
+            }
+        }
+
+        static ONCE: OnceLock<()> = OnceLock::new();
+        ONCE.get_or_init(|| {
+            let _ = tracing::subscriber::set_global_default(Registry::default().with(CaptureLayer));
+        });
+    }
+
+    /// Capture the `message` field of every tracing event emitted by `f` on
+    /// this thread. See [`install_capture_subscriber`] for why the subscriber
+    /// is global and only the sink is scoped.
+    async fn capture_logs<F, Fut>(f: F) -> String
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        install_capture_subscriber();
+        SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+        f().await;
+        SINK.with(|s| s.borrow_mut().take())
+            .unwrap_or_default()
+            .join("\n")
+    }
+
+    /// The `TeReGen GET … failed` line matching `needle`, or a panic naming the
+    /// whole capture — so an assertion can never pass because the line the test
+    /// is about was never emitted.
+    fn failure_line<'a>(logs: &'a str, needle: &str) -> &'a str {
+        logs.lines()
+            .find(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("no {needle:?} line in capture: {logs}"))
     }
 
     // --- reads: best-effort JSON decode ---
@@ -509,6 +610,26 @@ mod tests {
             .mount(&server)
             .await;
         assert_eq!(client(&server).info(RRID).await, None);
+    }
+
+    /// A wiremock server can only produce a *status*, so `get`'s `send` arm is
+    /// otherwise never executed. Drives it, and pins that the log line it emits
+    /// carries no reqwest URL (#431).
+    #[tokio::test]
+    async fn get_swallows_transport_failure_without_logging_a_url() {
+        let mut out = Some(json!({}));
+        let logs = capture_logs(|| async {
+            out = unreachable_client().info(RRID).await;
+        })
+        .await;
+        assert_eq!(out, None);
+
+        let line = failure_line(&logs, "TeReGen GET");
+        assert!(!line.contains(" for url ("), "log rendered the URL: {line}");
+        assert!(
+            line.contains("error sending request"),
+            "log lost the failure kind: {line}"
+        );
     }
 
     #[tokio::test]
@@ -748,8 +869,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn updates_errs_on_transport_failure() {
-        // A non-2xx status surfaces as Err, distinct from an empty queue.
+    async fn updates_errs_on_error_status() {
+        // A non-2xx status surfaces as Err, distinct from an empty queue. This
+        // is `try_get`'s `error_for_status` arm — the transport arm is a
+        // separate case below, since a mock server cannot refuse a connection.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/updates"))
@@ -761,6 +884,31 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, TeReGenError::Fetch(_)));
+    }
+
+    /// `try_get`'s `send` arm: both the log line and the `Fetch` string it
+    /// bakes must be free of reqwest's URL (#431).
+    #[tokio::test]
+    async fn updates_errs_on_transport_failure_without_a_url() {
+        let mut err = None;
+        let logs = capture_logs(|| async {
+            err = unreachable_client()
+                .updates(&UpdatesQuery::default())
+                .await
+                .err();
+        })
+        .await;
+
+        let Some(TeReGenError::Fetch(msg)) = &err else {
+            panic!("expected TeReGenError::Fetch, got {err:?}");
+        };
+        assert!(!msg.contains(" for url ("), "error rendered the URL: {msg}");
+        assert!(
+            msg.contains("error sending request"),
+            "error lost the failure kind: {msg}"
+        );
+        let line = failure_line(&logs, "TeReGen GET");
+        assert!(!line.contains(" for url ("), "log rendered the URL: {line}");
     }
 
     #[tokio::test]
@@ -847,10 +995,23 @@ mod tests {
     #[tokio::test]
     async fn regenerate_none_when_unreachable() {
         // No server: point the client at a closed port so the POST fails to
-        // connect, mapping a connection error to None.
-        let http = HttpClient::new(VerifyPolicy::Default(false)).unwrap();
-        let c = TeReGen::with_client(http, "http://127.0.0.1:1");
-        assert_eq!(c.regenerate(RRID, false, false).await, None);
+        // connect, mapping a connection error to None. The POST send arm is
+        // reachable no other way — every other `regenerate` test drives a
+        // status, not a transport failure.
+        let mut out = Some(json!({}));
+        let logs = capture_logs(|| async {
+            out = unreachable_client().regenerate(RRID, false, false).await;
+        })
+        .await;
+        assert_eq!(out, None);
+
+        // #431: the line must not carry reqwest's ` for url (…)`.
+        let line = failure_line(&logs, "POST regenerate");
+        assert!(!line.contains(" for url ("), "log rendered the URL: {line}");
+        assert!(
+            line.contains("error sending request"),
+            "log lost the failure kind: {line}"
+        );
     }
 
     // --- wait_for_template ---

--- a/crates/mtui-datasources/tests/gitea.rs
+++ b/crates/mtui-datasources/tests/gitea.rs
@@ -11,8 +11,9 @@
 //! comment snapshot) is modelled by one mounted GET plus one mounted POST —
 //! exactly the states each case sets up.
 
+use super::log_capture::capture_logs;
 use mtui_datasources::gitea::{Gitea, assign_marker};
-use mtui_datasources::{HttpClient, VerifyPolicy};
+use mtui_datasources::{GiteaError, HttpClient, VerifyPolicy};
 use serde_json::json;
 use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -626,50 +627,22 @@ async fn explicit_user_skips_token_owner_lookup() {
     assert!(body.contains("assigned to user: carol"), "{body}");
 }
 
-/// Capture the `message` field of every tracing event emitted by `f`.
+/// The origin guard refuses a credentialed PR URL *before* any request is sent,
+/// and both the refusal log and the resulting error are sanitized.
 ///
-/// A thread-local subscriber (`with_default`) works here because `#[tokio::test]`
-/// drives a current-thread runtime, so the awaited request's events fire on this
-/// thread. Mirrors the capture helper in `obs_oscrc`.
-async fn capture_logs<F, Fut>(f: F) -> String
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = ()>,
-{
-    use std::fmt::Write as _;
-    use std::sync::{Arc, Mutex};
-    use tracing::field::{Field, Visit};
-    use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-    use tracing_subscriber::registry::Registry;
-
-    struct CaptureLayer(Arc<Mutex<Vec<String>>>);
-    struct MessageVisitor(String);
-    impl Visit for MessageVisitor {
-        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-            if field.name() == "message" {
-                let _ = write!(self.0, "{value:?}");
-            }
-        }
-    }
-    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
-        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-            let mut v = MessageVisitor(String::new());
-            event.record(&mut v);
-            self.0.lock().unwrap().push(v.0);
-        }
-    }
-
-    let records = Arc::new(Mutex::new(Vec::new()));
-    let sub = Registry::default().with(CaptureLayer(records.clone()));
-    let guard = tracing::subscriber::set_default(sub);
-    f().await;
-    drop(guard);
-    records.lock().unwrap().join("\n")
-}
-
+/// This never reaches the transport, so it is no evidence about transport-error
+/// rendering; that arm is covered by
+/// `transport_failure_log_carries_no_reqwest_url` below.
 #[tokio::test]
-async fn request_logs_and_error_redact_url_credentials() {
+async fn credentialed_pr_url_is_refused_before_send_and_redacted() {
     let server = MockServer::start().await;
+    // "Before send" is half the claim, so assert it: any request at all would
+    // mean the guard ran too late.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(0)
+        .mount(&server)
+        .await;
 
     // Embed `user:s3cret@` credentials in the target authority. A userinfo-
     // bearing PR URL is refused by the origin guard *before* any request is
@@ -691,12 +664,20 @@ async fn request_logs_and_error_redact_url_credentials() {
     .expect("gitea client builds");
 
     let mut err = String::new();
+    let mut kind_is_untrusted_origin = false;
     let logs = capture_logs(|| async {
         let e = client.assignee().await.unwrap_err();
+        kind_is_untrusted_origin = matches!(e, GiteaError::UntrustedOrigin(_));
         err = format!("{e}");
     })
     .await;
 
+    // "Refused by the origin guard" is the other half: a transport failure
+    // would also produce a credential-free message, for the wrong reason.
+    assert!(
+        kind_is_untrusted_origin,
+        "expected GiteaError::UntrustedOrigin, got {err}"
+    );
     // Neither the captured debug/warn logs nor the surfaced error leak the
     // password, but the host is preserved for diagnosis.
     assert!(!logs.contains("s3cret"), "logs leaked credential: {logs}");
@@ -704,6 +685,41 @@ async fn request_logs_and_error_redact_url_credentials() {
     assert!(
         logs.contains("***@"),
         "logs missing redaction marker: {logs}"
+    );
+}
+
+/// #431: the *transport* arm, which the origin-guard case above never reaches.
+/// Rendering the raw `reqwest::Error` appended its unredacted request URL
+/// (` for url (…)`); the line must carry mtui's own sanitized URL instead.
+///
+/// A credentialed URL cannot be driven here: the origin guard rejects userinfo
+/// in the configured base *and* in every request URL before send, so for Gitea
+/// the enforceable invariant is URL disclosure, not credential disclosure.
+#[tokio::test]
+async fn transport_failure_log_carries_no_reqwest_url() {
+    // Loopback discard port (RFC 863): userinfo-free and `http` on loopback, so
+    // the origin guard trusts it and the request actually reaches `send`, where
+    // nothing is listening.
+    let client = gitea_with_trust("http://127.0.0.1:9", "http://127.0.0.1:9");
+
+    let logs = capture_logs(|| async {
+        client.assignee().await.expect_err("connection refused");
+    })
+    .await;
+
+    // Anti-vacuity: this line only exists on the transport arm, so finding it
+    // proves the origin guard did not short-circuit the request.
+    let failure = logs
+        .lines()
+        .find(|l| l.starts_with("API call to Gitea"))
+        .unwrap_or_else(|| panic!("transport arm never ran: {logs}"));
+    assert!(
+        !failure.contains(" for url ("),
+        "log rendered reqwest's URL: {failure}"
+    );
+    assert!(
+        failure.contains("127.0.0.1:9"),
+        "log lost its URL context: {failure}"
     );
 }
 

--- a/crates/mtui-datasources/tests/http_client.rs
+++ b/crates/mtui-datasources/tests/http_client.rs
@@ -46,8 +46,12 @@ async fn get_bytes_raises_on_http_error_status() {
         .expect_err("404 is an error");
 
     // reqwest surfaces the non-2xx as a status error wrapped in HttpError.
+    // Braced `{ .. }`, not `(_)`: the variant is `#[non_exhaustive]` so no crate
+    // outside this one can build it and bypass the URL strip (#431), and that
+    // also makes its tuple-pattern form unnameable here. Matching stays
+    // possible via the braced form, which is what this pins.
     assert!(
-        matches!(err, mtui_datasources::HttpError::Request(_)),
+        matches!(err, mtui_datasources::HttpError::Request { .. }),
         "expected HttpError::Request, got {err:?}"
     );
 }
@@ -172,4 +176,52 @@ async fn body_too_large_error_message_carries_no_url() {
     let msg = err.to_string();
     assert!(msg.contains("42"), "message names the limit: {msg}");
     assert!(!msg.contains("http"), "message must not leak a URL: {msg}");
+}
+
+/// #431, the credential vector: reqwest scrubs userinfo out of the URL only at
+/// `RequestBuilder` construction (`extract_authority` moves it into a Basic-auth
+/// header), and never again. A `Location` header therefore puts credentials
+/// straight back into the `Response`'s URL — which `error_for_status` copies
+/// verbatim into its `reqwest::Error` — so a hostile or compromised datasource
+/// can force mtui to render `user:pass@host` out of a plain non-2xx.
+///
+/// The failure must stay a failure: only the URL is dropped, not the status.
+#[tokio::test]
+async fn credentialed_redirect_target_never_reaches_a_status_error() {
+    let target = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/moved"))
+        .respond_with(ResponseTemplate::new(404))
+        // The redirect hop must actually be served: if a future reqwest stripped
+        // userinfo from a `Location`, the credential half of this test would go
+        // vacuous rather than fail.
+        .expect(1)
+        .mount(&target)
+        .await;
+
+    let entry = MockServer::start().await;
+    let location = target.uri().replace("http://", "http://alice:s3cret@");
+    Mock::given(method("GET"))
+        .and(path("/start"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("Location", format!("{location}/moved")),
+        )
+        .expect(1)
+        .mount(&entry)
+        .await;
+
+    let err = client()
+        .get_bytes(&format!("{}/start", entry.uri()))
+        .await
+        .expect_err("the redirect target answers 404");
+
+    let msg = err.to_string();
+    let dbg = format!("{err:?}");
+    assert!(!msg.contains("s3cret"), "error leaked credential: {msg}");
+    assert!(!dbg.contains("s3cret"), "debug leaked credential: {dbg}");
+    assert!(!msg.contains(" for url ("), "error rendered the URL: {msg}");
+    assert!(
+        msg.contains("404"),
+        "the status must survive the URL strip: {msg}"
+    );
 }

--- a/crates/mtui-datasources/tests/it.rs
+++ b/crates/mtui-datasources/tests/it.rs
@@ -4,11 +4,16 @@
 //! (see `autotests = false` + `[[test]] name = "it"` in Cargo.toml) so the
 //! crate + its heavy deps are linked once, not once per file. Add new
 //! integration tests as a module here, not as a new top-level `tests/*.rs`.
+//!
+//! `log_capture` is shared test support rather than a test module: it installs
+//! one process-global tracing subscriber, which cannot be done per file.
 
 #[path = "gitea.rs"]
 mod gitea;
 #[path = "http_client.rs"]
 mod http_client;
+#[path = "log_capture.rs"]
+mod log_capture;
 #[path = "obs_auth.rs"]
 mod obs_auth;
 #[path = "obs_client.rs"]

--- a/crates/mtui-datasources/tests/log_capture.rs
+++ b/crates/mtui-datasources/tests/log_capture.rs
@@ -1,0 +1,81 @@
+//! Shared tracing-capture helper for the integration suite.
+//!
+//! One copy for the whole `it` binary, because the subscriber it installs is
+//! **global** and `set_global_default` succeeds only once per process.
+//!
+//! ## Why global rather than `tracing::subscriber::set_default`
+//!
+//! `tracing` caches callsite *interest* process-wide. A callsite first reached
+//! from a thread with no subscriber installed is cached as `Interest::never()`
+//! and then stays silent for every later capture, no matter which subscriber is
+//! active — and a thread-local default does not invalidate that cache. With
+//! libtest running tests in parallel, whether a given callsite was "poisoned"
+//! before a capturing test reached it is a race, so a log assertion fails (or,
+//! worse, passes vacuously) depending on test order.
+//!
+//! A subscriber that is always installed keeps interest pinned to `always`.
+//! Scoping moves to a thread-local sink: events on a thread with no active
+//! capture are dropped, so concurrent tests cannot see each other's lines.
+
+use std::cell::RefCell;
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use tracing_subscriber::registry::Registry;
+
+thread_local! {
+    /// The active capture buffer for this thread, if any.
+    static SINK: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+}
+
+struct CaptureLayer;
+
+struct MessageVisitor(String);
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.0, "{value:?}");
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        SINK.with(|s| {
+            if let Some(buf) = s.borrow_mut().as_mut() {
+                let mut v = MessageVisitor(String::new());
+                event.record(&mut v);
+                buf.push(v.0);
+            }
+        });
+    }
+}
+
+/// Install the forwarding subscriber once for this test binary.
+fn install() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        // A pre-existing global default (another harness, a future test)
+        // is not an error here: the capture simply yields nothing, which the
+        // callers' anti-vacuity panics report loudly.
+        let _ = tracing::subscriber::set_global_default(Registry::default().with(CaptureLayer));
+    });
+}
+
+/// Capture the `message` field of every tracing event emitted by `f` on this
+/// thread, newline-joined.
+pub async fn capture_logs<F, Fut>(f: F) -> String
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    install();
+    SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+    f().await;
+    SINK.with(|s| s.borrow_mut().take())
+        .unwrap_or_default()
+        .join("\n")
+}

--- a/crates/mtui-datasources/tests/obs_client.rs
+++ b/crates/mtui-datasources/tests/obs_client.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use super::log_capture::capture_logs;
 use mtui_datasources::VerifyPolicy;
 use mtui_datasources::obs::{NoAuth, ObsClient, ObsError};
 use wiremock::matchers::{header, method, path};
@@ -167,46 +168,6 @@ async fn transport_error_maps_to_http_variant() {
     assert!(matches!(err, ObsError::Http(_)), "got {err:?}");
 }
 
-/// Capture the `message` field of every tracing event emitted by `f`.
-///
-/// A thread-local subscriber works under `#[tokio::test]`'s current-thread
-/// runtime. Mirrors the capture helper in `obs_oscrc`/`gitea`.
-async fn capture_logs<F, Fut>(f: F) -> String
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = ()>,
-{
-    use std::fmt::Write as _;
-    use std::sync::{Arc as StdArc, Mutex};
-    use tracing::field::{Field, Visit};
-    use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-    use tracing_subscriber::registry::Registry;
-
-    struct CaptureLayer(StdArc<Mutex<Vec<String>>>);
-    struct MessageVisitor(String);
-    impl Visit for MessageVisitor {
-        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-            if field.name() == "message" {
-                let _ = write!(self.0, "{value:?}");
-            }
-        }
-    }
-    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
-        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-            let mut v = MessageVisitor(String::new());
-            event.record(&mut v);
-            self.0.lock().unwrap().push(v.0);
-        }
-    }
-
-    let records = StdArc::new(Mutex::new(Vec::new()));
-    let sub = Registry::default().with(CaptureLayer(records.clone()));
-    let guard = tracing::subscriber::set_default(sub);
-    f().await;
-    drop(guard);
-    records.lock().unwrap().join("\n")
-}
-
 #[tokio::test]
 async fn logs_and_api_error_redact_url_credentials() {
     let server = MockServer::start().await;
@@ -242,5 +203,104 @@ async fn logs_and_api_error_redact_url_credentials() {
     assert!(
         logs.contains("***@"),
         "logs missing redaction marker: {logs}"
+    );
+}
+
+/// #431: a real *transport* failure (not an API status) must not put reqwest's
+/// own `Display` — which appends ` for url (…)` verbatim — into either the log
+/// stream or the returned `ObsError`, whose `Http` variant is transparent down
+/// to `reqwest::Error`.
+///
+/// OBS has no origin guard, so a credentialed API base reaches `send`; that is
+/// what makes this the datasource where the credential path is actually
+/// reachable. reqwest strips first-hop userinfo into a Basic-auth header
+/// (`RequestBuilder::new` → `extract_authority`), so the password is already
+/// absent from the error URL — the `s3cret` assertions are belt-and-braces, and
+/// the substring that is genuinely red without the fix is `" for url ("`.
+#[tokio::test]
+async fn transport_error_logs_and_error_carry_no_reqwest_url() {
+    // Loopback discard port (RFC 863): nothing listens, so `send` fails.
+    let client = ObsClient::new(
+        "http://alice:s3cret@127.0.0.1:9",
+        Duration::from_secs(180),
+        VerifyPolicy::Default(true),
+        Arc::new(NoAuth),
+    )
+    .expect("client builds");
+
+    let mut err = String::new();
+    let mut dbg = String::new();
+    let logs = capture_logs(|| async {
+        let e = client
+            .get("request/1", &[])
+            .await
+            .expect_err("connection refused is an error");
+        err = format!("{e}");
+        dbg = format!("{e:?}");
+    })
+    .await;
+
+    // Assert on the *failure* line specifically. The unconditional pre-send
+    // debug line already carries a sanitized URL, so a whole-capture anchor
+    // would stay green even if this line were deleted outright. The selector
+    // names mtui's own line exactly: `capture_logs` records every event on the
+    // thread, including hyper's pool chatter, whose content varies with
+    // connection state.
+    let failure = logs
+        .lines()
+        .find(|l| l.starts_with("OBS GET") && l.contains("failed:"))
+        .unwrap_or_else(|| panic!("the transport-failure arm never ran: {logs}"));
+    assert!(
+        !failure.contains(" for url ("),
+        "log rendered reqwest's URL: {failure}"
+    );
+    assert!(
+        !failure.contains("s3cret"),
+        "log leaked credential: {failure}"
+    );
+    // Dropping reqwest's URL must not leave the operator with no host at all.
+    assert!(
+        failure.contains("***@127.0.0.1"),
+        "log lost its sanitized URL context: {failure}"
+    );
+
+    assert!(
+        !err.contains(" for url ("),
+        "error rendered reqwest's URL: {err}"
+    );
+    assert!(!err.contains("s3cret"), "error leaked credential: {err}");
+    assert!(!dbg.contains("s3cret"), "debug leaked credential: {dbg}");
+    // Positive anchor: only the URL is dropped, never the failure kind — an
+    // over-stripping conversion must not pass this test.
+    assert!(
+        err.contains("error sending request"),
+        "error lost the failure kind: {err}"
+    );
+}
+
+/// #431: the between-calls budget message interpolated the raw URL, so an
+/// exhausted budget against a credentialed base leaked the password verbatim —
+/// the one site where the credential (not merely the URL) was reachable.
+#[tokio::test]
+async fn budget_timeout_message_redacts_url_credentials() {
+    let client = ObsClient::new(
+        "http://alice:s3cret@127.0.0.1:9",
+        Duration::from_secs(0),
+        VerifyPolicy::Default(true),
+        Arc::new(NoAuth),
+    )
+    .expect("client builds");
+
+    let err = client
+        .get("request/1", &[])
+        .await
+        .expect_err("exhausted budget aborts");
+    let ObsError::Timeout(msg) = &err else {
+        panic!("expected ObsError::Timeout, got {err:?}");
+    };
+    assert!(!msg.contains("s3cret"), "timeout leaked credential: {msg}");
+    assert!(
+        msg.contains("***@127.0.0.1"),
+        "timeout dropped the URL context: {msg}"
     );
 }

--- a/crates/mtui-datasources/tests/oqa_search.rs
+++ b/crates/mtui-datasources/tests/oqa_search.rs
@@ -9,6 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
+use super::log_capture::capture_logs;
 use mtui_datasources::oqa_search::search::{
     aggregated_updates, build_checks, extract_test_results, get_incident_info, incident_jobs,
     single_incidents, summarize_test_results,
@@ -872,5 +873,51 @@ async fn single_incidents_respects_bound_of_one() {
     assert!(
         elapsed >= delay + delay / 2,
         "bound=1 should serialise the two versions, took {elapsed:?}",
+    );
+}
+
+/// #431: `build_checks` builds its log URLs from `[url] testreports`, which is
+/// taken from config verbatim (no validation strips userinfo), so a credentialed
+/// value reaches this WARN — visible at the *default* log level, unlike the
+/// DEBUG-only leaks elsewhere.
+#[tokio::test]
+async fn build_check_log_failure_warns_without_the_credential() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(BUILD_CHECKS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_string(HTML_INDEX))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // The log itself is deliberately not mounted: wiremock answers 404, so
+    // `fetch_url_content` fails and the warn arm runs.
+
+    let url_qam = server.uri().replace("http://", "http://alice:s3cret@");
+    let mut out = Vec::new();
+    let logs = capture_logs(|| async {
+        out = build_checks(
+            &client(),
+            "Maintenance",
+            "12358",
+            199773,
+            &["bash".to_string()],
+            &url_qam,
+            None,
+            4,
+        )
+        .await;
+    })
+    .await;
+
+    // Anti-vacuity: the unavailable-log arm is what produced these rows.
+    assert_eq!(out.len(), 2, "the index must yield two matching logs");
+    let line = logs
+        .lines()
+        .find(|l| l.contains("build_check log"))
+        .unwrap_or_else(|| panic!("the unavailable-log arm never ran: {logs}"));
+    assert!(!line.contains("s3cret"), "warn leaked credential: {line}");
+    assert!(
+        line.contains("***@127.0.0.1"),
+        "warn lost its sanitized URL context: {line}"
     );
 }

--- a/crates/mtui-datasources/tests/slack.rs
+++ b/crates/mtui-datasources/tests/slack.rs
@@ -7,6 +7,7 @@
 //! sequence of differing responses to the same endpoint is expressed with
 //! `expect`-scoped mounts or by matching on the request body.
 
+use super::log_capture::capture_logs;
 use mtui_datasources::slack::Slack;
 use mtui_datasources::{HttpClient, SlackError, VerifyPolicy};
 use serde_json::json;
@@ -362,4 +363,39 @@ async fn non_json_body_is_a_failed_call_not_a_panic() {
         slack_for(&server).auth_test().await,
         Err(SlackError::FailedCall(_))
     ));
+}
+
+/// #431: the transport arm must not render the raw `reqwest::Error`, whose
+/// `Display` appends the unredacted request URL (` for url (…)`); the line
+/// carries mtui's own sanitized URL instead.
+///
+/// A credentialed base cannot be driven here: `is_token_safe_url` rejects
+/// userinfo at construction, so for Slack the enforceable invariant is URL
+/// disclosure, not credential disclosure.
+#[tokio::test]
+async fn transport_failure_log_carries_no_reqwest_url() {
+    // Loopback discard port (RFC 863): accepted by the token-safety guard, and
+    // nothing is listening, so the request fails inside `send`.
+    let http = HttpClient::new(VerifyPolicy::Default(true)).expect("client builds");
+    let client = Slack::with_client(http, "xoxb-test".to_owned(), "http://127.0.0.1:9")
+        .expect("slack client builds");
+
+    let logs = capture_logs(|| async {
+        client.auth_test().await.expect_err("connection refused");
+    })
+    .await;
+
+    // Anti-vacuity: this line only exists on the transport arm.
+    let failure = logs
+        .lines()
+        .find(|l| l.starts_with("API call to Slack"))
+        .unwrap_or_else(|| panic!("transport arm never ran: {logs}"));
+    assert!(
+        !failure.contains(" for url ("),
+        "log rendered reqwest's URL: {failure}"
+    );
+    assert!(
+        failure.contains("127.0.0.1:9"),
+        "log lost its URL context: {failure}"
+    );
 }


### PR DESCRIPTION
Closes #431.

## What actually leaked (the issue's premise, corrected by measurement)

The issue's mechanism was reqwest's Display appending the raw request URL through the doubly-transparent `HttpError::Request` chain. That is real, but narrower than filed: reqwest itself strips first-hop userinfo into a Basic-auth header at builder construction, so a plain connect failure never carried a credential — only the URL. The two vectors that *do* carry credentials, both confirmed empirically:

- **A redirect `Location` is never re-stripped**, and `error_for_status` reports the redirect-updated URL. `302 → http://user:pass@host/moved` followed by a `404` rendered `HTTP status client error (404 Not Found) for url (http://user:pass@…/moved)` into every transparent wrapper. Pinned by the new `http_client` test through `HttpClient::get_bytes` (the shared path behind the QEM dashboard, refhosts download and openQA log fetch; TeReGen's `error_for_status` reaches it identically). On a *transport* failure the redirect target does not reach the error (reqwest only updates it on the Ok branch) — so the test pins the status-error shape, the one that was observably red.
- **Two sites interpolated mtui's own URL raw**: OBS `check_budget`'s timeout message, and oqa_search's `build_check log … unavailable` warn — the latter derives from `[url] testreports`, which accepts userinfo and is not otherwise validated, and logs at WARN, visible at the default level.

## The fix

**Boundary strip.** `HttpError::Request` loses `#[from]`; a hand-written `From<reqwest::Error>` applies `without_url()`. Display, Debug and the `source()` chain are all URL-free past the boundary (verified against reqwest 0.13.4's internals), so the five transparent enums, the string-baking conversion sites (`OqaSearchError`, `TeReGenError::Fetch`, `QemDashboardError::Fetch`, `RefhostError`), and every downstream `CommandError::Other` interpolation — which reach the REPL, tracing, and MCP tool output verbatim — are safe without per-site discipline. `#[non_exhaustive]` sits on the variant itself, so constructing it around the strip is a compile error outside the crate. The error kind and status text survive; the new tests pin that they do.

**Convert-before-render.** Every site that rendered a raw `reqwest::Error` now converts first: the OBS/Gitea/Slack/TeReGen send closures (all five TeReGen sites, including the `regenerate` POST arm) and the testreport-log precondition fetch. TLS-detail lines switch to a new `ssl_error_detail(&HttpError)` — the actual rustls/io cause via a hoisted, hop-capped `root_cause`, instead of reqwest's kind+URL line; the `&HttpError` signature makes "convert first" compiler-enforced at those sites. Gitea/Slack transport warns gain a sanitized URL (reqwest's unredacted one was the only host context those lines had).

**Two OBS bugs.** `check_budget` sanitizes its URL (verbatim credential leak), and `host_of` now strips userinfo — it previously reported the *username* as the host in the TLS hint, despite claiming to mirror the Gitea helper that gets this right.

## Guard reality for Gitea/Slack (deviation from the issue's acceptance)

The acceptance asked for credentialed real-transport tests against all three clients. Gitea refuses userinfo on both the configured base (construction fails) and every request URL pre-send; Slack refuses a credentialed base at construction. A credential therefore cannot reach their send paths at all — the origin guards are the first line of defense, and the enforceable transport-arm invariant there is URL non-disclosure, which the tests pin against the captured log line. OBS has no origin guard and got the full credentialed treatment. The previously-named redaction test in `tests/gitea.rs` was an origin-guard refusal test wearing a transport-test name; it is renamed to what it pins and now asserts the refusal (`.expect(0)` + `UntrustedOrigin`).

## Tests

Every new assertion was observed red first (unfixed code or a single-line marked mutant), with the run demonstrably executing the test; proofs cover the boundary strip, the kind surviving the strip, the redirect-status credential, each send-path log line, `host_of`, the timeout message, the oqa_search warn, and a hang-proof for the `root_cause` hop cap. Log-line tests locate their specific line before asserting, so an arm that never ran panics instead of passing vacuously.

Along the way the shared thread-local `capture_logs` test helper turned out to be racy — tracing caches callsite interest process-wide, so a callsite first hit on a subscriber-less thread is cached `never` and silently empties later captures (measured 5/12 failing; `rebuild_interest_cache` still raced 6/20). Replaced by one shared `log_capture` helper (global permissive subscriber, thread-local sink; 20/20 clean). That race is exactly the shape that makes negative log assertions pass vacuously, which is why the line-locating anchors matter.

## Residuals (deliberately out of scope)

- `hyper-util`'s connection-pool DEBUG lines print the pooled authority including userinfo from a hostile redirect; reachable via `set_log_level debug` / `RUST_LOG=debug` since the level directives carry no third-party carve-out. Follow-up issue to add `hyper_util=info,hyper=info,reqwest=info` to the default directives.
- `BuildCheckResult.url` stores the same unsanitized oqa_search URL into report output — changing report content is a different decision from fixing a log line.
- `mtui-testreport`'s downloader logs `{remote}` raw, but the value provably cannot carry userinfo (ruoqa reduces the base to host:port); host/path disclosure only.
- The three TLS-branch call sites of `ssl_error_detail` remain untestable without a real failing TLS handshake (pre-existing; the helper and its inputs are unit-tested).
- `sanitize_url` remains single-URL-only; it is now applied per-URL everywhere, never over a whole message, and `root_cause`'s backstop documents the limit.

## Process

Planned from a three-scout survey of the leak surface (the full render-site inventory, the reqwest/ruoqa internals, and the test-harness constraints), implemented, then three independent read-only adversarial reviews (leak-completeness, test-vacuity, contracts) over the uncommitted tree; all eleven findings — including the fifth TeReGen site two reviewers found independently and the oqa_search WARN leak — were fixed before the first commit was created.
