### PR TITLE
test(testreport): pin the SLFO packages envelope against a real metadata record

### DIFF
--- a/crates/mtui-testreport/src/metadata_parsers.rs
+++ b/crates/mtui-testreport/src/metadata_parsers.rs
@@ -141,7 +141,8 @@ pub struct MetadataEnvelope {
     /// Gitea commit hash.
     #[serde(default)]
     gitea_commit_hash: Option<String>,
-    /// Nested package map: `product -> ["pkg _ version", ...]`.
+    /// Nested package map: `product -> ["<name> <op> <version>", ...]`, e.g.
+    /// `{"standard": ["afterburn = 5.10.0.git73.b97f772-99999_stage.1.1"]}`.
     #[serde(default)]
     packages: Option<HashMap<String, Vec<String>>>,
     /// Update repository URLs.
@@ -180,8 +181,11 @@ impl JSONParser {
     ///   leaves the field `None`, degrading gracefully rather than panicking
     ///   on bad input);
     /// * scalar fields map straight through;
-    /// * each package entry `"pkg _ version"` is split on whitespace, taking the
-    ///   first token as the package name and the third as the version.
+    /// * each package entry `"<name> <op> <version>"` — real metadata ships
+    ///   `"afterburn = 5.10.0.git73.b97f772-99999_stage.1.1"` — is split on
+    ///   whitespace, taking the first token as the package name and the third
+    ///   as the version. The middle token is discarded, so the operator itself
+    ///   is not significant.
     fn parse(results: &mut TestReportBase, data: &MetadataEnvelope) {
         for id in data.jira.iter().flatten() {
             results.jira.insert(id.clone(), NO_DESCRIPTION.to_owned());
@@ -219,8 +223,8 @@ impl JSONParser {
         for (prod, pkgvers) in data.packages.iter().flatten() {
             let mut pkgs = HashMap::new();
             for entry in pkgvers {
-                // `"pkg _ version"`: first token is the package name, third
-                // the version, middle token discarded.
+                // `"<name> <op> <version>"`: first token is the package name,
+                // third the version, middle token discarded.
                 let mut tokens = entry.split_whitespace();
                 match (tokens.next(), tokens.next(), tokens.next()) {
                     (Some(pkg), Some(_), Some(ver)) => {

--- a/crates/mtui-testreport/tests/fixtures/metadata/slfo_metadata.json
+++ b/crates/mtui-testreport/tests/fixtures/metadata/slfo_metadata.json
@@ -1,0 +1,49 @@
+{
+    "SRCRPMs": [
+        "afterburn"
+    ],
+    "bugs": [
+        "1196972",
+        "1242665",
+        "1243850",
+        "1244199",
+        "1270175",
+        "1270483",
+        "1270555",
+        "1270651",
+        "1270787",
+        "1270817",
+        "1270886",
+        "1270949",
+        "1271348"
+    ],
+    "category": "security",
+    "generated_at": "2026-07-21T19:33:33+0200",
+    "id": "SUSE:SLFO:1.1:418286",
+    "jira": [],
+    "packager": "someone@suse.com",
+    "packages": {
+        "standard": [
+            "afterburn = 5.10.0.git73.b97f772-99999_stage.1.1",
+            "afterburn-dracut = 5.10.0.git73.b97f772-99999_stage.1.1"
+        ]
+    },
+    "product_composer": {
+        "afterburn": {
+            "media": [],
+            "pool_only": false,
+            "shipped": false
+        }
+    },
+    "products": [
+        "SL-Micro 6.1 (aarch64, ppc64le, s390x, x86_64)",
+        "SL-Micro-Extras 6.1 (aarch64, ppc64le, s390x, x86_64)"
+    ],
+    "rating": "important",
+    "repository": "http://download.suse.de/ibs/SUSE:/SLFO:/1.1:/Staging:/B/",
+    "rrid": "SUSE:SLFO:1.1:418286",
+    "testplatform": [
+        "base=SL-Micro(major=6,minor=1);arch=[aarch64,ppc64le,s390x,x86_64]",
+        "base=SL-Micro(major=6,minor=1);arch=[aarch64,ppc64le,s390x,x86_64];addon=SL-Micro-Extras(major=6,minor=1)"
+    ]
+}

--- a/crates/mtui-testreport/tests/lifecycle.rs
+++ b/crates/mtui-testreport/tests/lifecycle.rs
@@ -9,6 +9,7 @@
 //! load-failure path points at an empty `template_dir` so the internal `svn`
 //! checkout fails fast and the factory falls back to a [`NullReport`].
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use mtui_config::options::Config;
@@ -440,13 +441,6 @@ async fn make_testreport_falls_back_to_null_on_load_failure() {
 /// Returns nothing; the caller drives `make_testreport` against the
 /// template dir.
 fn make_slfo_checkout(root: &Path, rrid: &str, gitea_pr_api: &str, commit_hash: Option<&str>) {
-    let dir = root.join(rrid);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("log"),
-        format!("Testreport for {rrid}\n\n  x86_64 (reference host: refhost-a.example.com)\n"),
-    )
-    .unwrap();
     let hash_field = commit_hash
         .map(|h| format!(r#", "gitea_commit_hash": "{h}""#))
         .unwrap_or_default();
@@ -463,6 +457,31 @@ fn make_slfo_checkout(root: &Path, rrid: &str, gitea_pr_api: &str, commit_hash: 
             "testplatform": []
         }}"#
     );
+    make_slfo_checkout_with_metadata(root, rrid, &metadata);
+}
+
+/// The real `SUSE:SLFO:1.1:418286` metadata record, captured from TeReGen on
+/// 2026-08-11 with a single substitution (`packager`) and re-indented to match
+/// its golden sibling. Full provenance note sits on the same const in
+/// `tests/metadata_parsers.rs`.
+const SLFO_METADATA_JSON: &str = include_str!("fixtures/metadata/slfo_metadata.json");
+
+/// Places an SLFO checkout on disk for `rrid` — the `log` template plus a
+/// caller-supplied `metadata.json` body written verbatim.
+///
+/// [`make_slfo_checkout`] is this function plus a computed synthetic envelope,
+/// and delegates here, so the `log` literal lives in exactly one place. Callers
+/// that need a *captured* envelope (rather than the synthetic one the
+/// hash/update-source tests share — those must keep their `"packages": {}`,
+/// which is what makes them indifferent to package parsing) call this directly.
+fn make_slfo_checkout_with_metadata(root: &Path, rrid: &str, metadata: &str) {
+    let dir = root.join(rrid);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("log"),
+        format!("Testreport for {rrid}\n\n  x86_64 (reference host: refhost-a.example.com)\n"),
+    )
+    .unwrap();
     std::fs::write(dir.join("metadata.json"), metadata).unwrap();
 }
 
@@ -603,6 +622,76 @@ async fn make_testreport_slfo_1_1_obs_served_resolves_obs_source_and_slrepoparse
     assert!(
         repo.contains("/images/repo/"),
         "OBS-served 1.1 must use slrepoparse, got {repo}"
+    );
+}
+
+/// #397 T3 — the on-disk loader populates `base().packages` from a **real**
+/// SLFO `metadata.json`.
+///
+/// This is the **only** assertion in the crate on `base().packages` after
+/// `TestReport::read`: no unit test in `src` drives `read()` at all, and every
+/// other SLFO lifecycle test writes `"packages": {}` and asserts nothing about
+/// packages. So the specific thing added here is that the metadata a report
+/// loads from disk actually reaches `base().packages` with its values intact —
+/// not merely that `JSONParser` works when handed a string.
+///
+/// Modelled on the OBS-served 1.1 test above: the captured 1.1 record carries
+/// no `gitea_commit_hash`, so it resolves [`UpdateSource::Obs`] and the load
+/// needs neither a Gitea token nor a network call.
+///
+/// **Scope, stated honestly.** This proves the on-disk read path runs
+/// `JSONParser` over an SL report's metadata and keeps the real values. It does
+/// **not** prove host seeding: the production seeding call site
+/// (`Session::connect_one`) is private, and `Target::connect` hard-codes
+/// `SshConnection::connect` with no injectable seam, so no test can reach it.
+/// `slfo_real_fixture_seeds_packages_for_any_base_version` (in
+/// `tests/metadata_parsers.rs`) re-implements the `packages_for_map` half
+/// explicitly rather than pretending this test covers it.
+#[tokio::test]
+async fn make_testreport_slfo_real_metadata_populates_packages() {
+    let dashboard = MockServer::start().await;
+    mount_dashboard_with_install(&dashboard, "418286").await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    make_slfo_checkout_with_metadata(tmp.path(), SLFO_11_RRID, SLFO_METADATA_JSON);
+
+    // Deliberately no Gitea token: the captured record is OBS-served.
+    let mut config = cfg(tmp.path().to_path_buf());
+    point_dashboard(&mut config, &dashboard);
+    let update = UpdateID::parse(SLFO_11_RRID).unwrap();
+
+    let report = make_testreport(&update, config, UpdateKind::Auto, true, false, None).await;
+
+    assert!(report.is_loaded(), "the captured SLFO record must load");
+    assert_eq!(report.update_source(), UpdateSource::Obs);
+
+    let packages = &report.base().packages;
+    // A set, not a Vec: `packages` is a HashMap, so a Vec comparison would be
+    // order-dependent the moment a second key appeared — a flake where a clean
+    // failure belongs.
+    let products: HashSet<&str> = packages.keys().map(String::as_str).collect();
+    assert_eq!(
+        products,
+        HashSet::from(["standard"]),
+        "the loader must keep the real product key set: {packages:?}"
+    );
+    let standard = &packages["standard"];
+    assert_eq!(
+        standard["afterburn"], "5.10.0.git73.b97f772-99999_stage.1.1",
+        "{standard:?}"
+    );
+    assert_eq!(
+        standard["afterburn-dracut"], "5.10.0.git73.b97f772-99999_stage.1.1",
+        "{standard:?}"
+    );
+
+    // Secondary, and deliberately labelled as weak: `get_package_list` flattens
+    // *every* product and never consults `base_version`, so it would stay green
+    // under a total failure of the `"standard"` assumption. It shows only that
+    // the loader ran the parser at all — the assertions above are the claim.
+    assert_eq!(
+        report.get_package_list(),
+        vec!["afterburn", "afterburn-dracut"]
     );
 }
 

--- a/crates/mtui-testreport/tests/metadata_parsers.rs
+++ b/crates/mtui-testreport/tests/metadata_parsers.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 
 use mtui_config::options::Config;
+use mtui_testreport::testreport::packages_for_map;
 use mtui_testreport::{JSONParser, ReducedMetadataParser, TestReportBase, patchinfo_titles};
 
 /// A bare [`TestReportBase`] to parse into.
@@ -15,6 +16,26 @@ fn empty_report() -> TestReportBase {
 
 /// Golden fixture: `tests/fixtures/metadata/metadata.json`.
 const METADATA_JSON: &str = include_str!("fixtures/metadata/metadata.json");
+
+/// Real-metadata fixture: `tests/fixtures/metadata/slfo_metadata.json`.
+///
+/// Captured from TeReGen's `metadata.json` for `SUSE:SLFO:1.1:418286` on
+/// 2026-08-11. Every field value is **field-for-field** identical to the fetched
+/// record except one substitution: `packager` was replaced with
+/// `someone@suse.com` (a value already used by the lifecycle fixtures) so a
+/// named individual's address is not published in a public repo.
+///
+/// The file is **not** a byte-for-byte copy: the record arrives as a single
+/// ~950-byte line and was re-serialized here (4-space indent, keys sorted, one
+/// array element per line) to match its golden sibling `metadata.json`. Anyone
+/// diffing this against a fresh fetch will see a whole-file reformat — that is
+/// the pretty-printing, not tampering. Compare parsed values, not bytes.
+///
+/// Do not "tidy" any value in it. The whole point of the fixture is that the
+/// domain values are observed rather than guessed: #396 shipped a synthetic
+/// SLFO probe that guessed the map key wrong, and only a real record settles it
+/// (#397).
+const SLFO_METADATA_JSON: &str = include_str!("fixtures/metadata/slfo_metadata.json");
 
 #[test]
 fn reduced_metadata_parser_parses_hosts_jira_bugs() {
@@ -182,7 +203,7 @@ fn json_parser_parse_maps_every_field() {
         "id": "test_id",
         "gitea_pr": "test_gitea_pr",
         "gitea_pr_api": "test_gitea_pr_api",
-        "packages": {"test_prod": ["test_pkg 1.0 1.0"]},
+        "packages": {"test_prod": ["test_pkg 1.0 2.0"]},
         "repositories": ["test_repo"]
     }"#;
 
@@ -203,7 +224,10 @@ fn json_parser_parse_maps_every_field() {
     assert_eq!(report.realid.as_deref(), Some("test_id"));
     assert_eq!(report.giteapr.as_deref(), Some("test_gitea_pr"));
     assert_eq!(report.giteaprapi.as_deref(), Some("test_gitea_pr_api"));
-    assert_eq!(report.packages["test_prod"]["test_pkg"], "1.0");
+    // The two tokens after the name must differ: with `"test_pkg 1.0 1.0"` this
+    // assertion could not tell version-from-token[1] from version-from-token[2],
+    // so it passed under a parser that read the wrong one.
+    assert_eq!(report.packages["test_prod"]["test_pkg"], "2.0");
     assert_eq!(report.repositories, HashSet::from(["test_repo".to_owned()]));
 }
 
@@ -399,6 +423,11 @@ fn patchinfo_titles_malformed_is_empty() {
 /// sub-map behind — that state makes `base.packages` non-empty while the
 /// flattened package list is empty, defeating every "anything to install?"
 /// guard downstream.
+///
+/// Key-agnostic and separator-agnostic by design: the parser never inspects
+/// either, so the odd `_` separator is a deliberate probe of that, not a claim
+/// that metadata ships one. See `json_parser_parses_slfo_real_fixture` for the
+/// real shape.
 #[test]
 fn json_parser_drops_products_with_no_parsable_entries() {
     let mut results = TestReportBase::new(Config::default());
@@ -417,6 +446,11 @@ fn json_parser_drops_products_with_no_parsable_entries() {
 
 /// One- and two-token entries are dropped (now loudly); three-plus-token
 /// entries keep parsing as first=name, third=version.
+///
+/// The middle token is *discarded*, so an entry's separator is not significant
+/// — the deliberately odd `_` below is the point of the probe, not a claim
+/// about the wire format. Real metadata ships `=`
+/// (`json_parser_parses_slfo_real_fixture`).
 #[test]
 fn json_parser_drops_short_entries_keeps_three_plus() {
     let mut results = TestReportBase::new(Config::default());
@@ -444,22 +478,154 @@ fn json_parser_empty_packages_envelope_yields_empty_map() {
     assert!(results.packages.is_empty());
 }
 
-/// A populated SLFO-shaped envelope parses end-to-end (#396's incident used
-/// SUSE:SLFO:1.1:418286 / SL-Micro 6.1 / afterburn — the only domain values
-/// used here). Synthetic: real-fixture coverage remains #397, NOT closed here.
+/// #397 T1 — the **real** `SUSE:SLFO:1.1:418286` envelope parses, pinning the
+/// observed shape of an SLFO `packages` map: a single `"standard"` key.
+///
+/// **Only the key is new.** The rest of the entry grammar — `=` as the
+/// separator, the version as the *third* token — was already pinned against
+/// captured data by `json_parser_parses_golden_fixture`, whose golden
+/// `metadata.json` ships `"sle-module-python2-release = 15.3-150300.59.4.1"`
+/// and is asserted by whole-map equality. #397 adds nothing there; the version
+/// assertions below are belt-and-braces. What no test carried before is a real
+/// record keyed `"standard"`, and that key is what makes `packages_for_map`'s
+/// single-key branch the live path for SLFO (see
+/// `slfo_real_fixture_seeds_packages_for_any_base_version`).
+///
+/// **What the key-set assertion is not.** It cannot detect TeReGen changing
+/// shape upstream: production copies the JSON key verbatim (no normalisation
+/// anywhere), so `results.packages.keys()` is definitionally this checked-in
+/// file's own keys. A static fixture observes nothing about a live service. Its
+/// real value is that it pins *this* record — swapping the fixture for a
+/// different update, or losing a field on the way through the parser, fails
+/// loudly here instead of silently weakening everything downstream. That is
+/// what the `rrid` assertion and the version assertions are for too.
 #[test]
-fn slfo_populated_envelope_parses() {
-    let mut results = TestReportBase::new(Config::default());
-    JSONParser::parse_str(
-        &mut results,
-        r#"{
-            "rrid": "SUSE:SLFO:1.1:418286",
-            "packages": {"6.1": ["afterburn _ 5.9.0-1", "afterburn-dracut _ 5.9.0-1"]}
-        }"#,
-    )
-    .unwrap();
-    assert_eq!(results.packages["6.1"].len(), 2);
-    // The flattened list feeds prepare's pre-flight; it must be non-empty.
-    let flat: Vec<&String> = results.packages.values().flat_map(|m| m.keys()).collect();
-    assert_eq!(flat.len(), 2, "{flat:?}");
+fn json_parser_parses_slfo_real_fixture() {
+    let mut results = empty_report();
+    JSONParser::parse_str(&mut results, SLFO_METADATA_JSON).expect("real SLFO metadata parses");
+
+    // The whole key set rather than a `contains_key`, so the fixture is pinned
+    // to exactly what was captured — see the note above on what that does and
+    // does not prove.
+    let products: HashSet<&str> = results.packages.keys().map(String::as_str).collect();
+    assert_eq!(
+        products,
+        HashSet::from(["standard"]),
+        "the captured SLFO record is keyed \"standard\" and nothing else: {:?}",
+        results.packages
+    );
+
+    let standard = &results.packages["standard"];
+    assert_eq!(standard.len(), 2, "{standard:?}");
+    // Versions, not just names: a parser that took the *second* token would
+    // still produce both names, with "=" as their version.
+    for name in ["afterburn", "afterburn-dracut"] {
+        assert_eq!(
+            standard[name], "5.10.0.git73.b97f772-99999_stage.1.1",
+            "wrong version parsed for {name}"
+        );
+    }
+
+    // The rest of the envelope comes from the same record, so a fixture swapped
+    // for a different update would not quietly keep passing.
+    assert_eq!(
+        results.rrid.as_ref().map(ToString::to_string).as_deref(),
+        Some("SUSE:SLFO:1.1:418286")
+    );
+}
+
+/// #397 T2 — the load-bearing one: the **real** fixture, driven through
+/// `packages_for_map`, seeds a host whose `base_version` is deliberately *not*
+/// a key in the map. Product-agnosticism is the entire point of the
+/// single-`"standard"`-key branch, so a `base_version` that coincidentally
+/// matched a key would disarm the test.
+///
+/// `SL-Micro` / `6.1` is taken from the fixture itself, not minted and not
+/// borrowed from another test's hand-built input: the captured record's
+/// `products` line reads `SL-Micro 6.1 (aarch64, ppc64le, s390x, x86_64)` and
+/// its `testplatform` line `base=SL-Micro(major=6,minor=1);…`. `6.1` is
+/// therefore exactly what a host running this update reports as its
+/// `base_version`.
+///
+/// This is the first test to connect the parser, `packages_for_map`, and a real
+/// envelope: the `"standard"` branch was previously exercised only by a
+/// hand-built single-key map, and every downstream consumer test hand-seeds its
+/// target instead.
+#[test]
+fn slfo_real_fixture_seeds_packages_for_any_base_version() {
+    let mut results = empty_report();
+    JSONParser::parse_str(&mut results, SLFO_METADATA_JSON).expect("real SLFO metadata parses");
+    assert!(
+        !results.packages.contains_key("6.1"),
+        "precondition: the base_version must not be a map key, or the \"standard\" \
+         branch is not what is under test: {:?}",
+        results.packages
+    );
+
+    let pkgs = packages_for_map(&results.packages, "6.1");
+
+    // Sorted test-side. `packages_for_map` happens to sort, but leaning on that
+    // would turn a dropped `sort_by` into a ~50% flake instead of a clean
+    // failure — the order is not what this test is about.
+    let mut names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["afterburn", "afterburn-dracut"], "{names:?}");
+    // `required` too, not just the names: seeding with `required = None` leaves
+    // the names intact while the before/after version checks lose their
+    // baseline entirely.
+    for p in &pkgs {
+        assert_eq!(
+            p.required().map(ToString::to_string).as_deref(),
+            Some("5.10.0.git73.b97f772-99999_stage.1.1"),
+            "required version must be seeded for {}",
+            p.name
+        );
+    }
+}
+
+/// #397 T2b — pins the `map.len() == 1` half of `packages_for_map`'s guard,
+/// which the existing single-key test cannot: its map has exactly one key, so
+/// `map.len() == 1 && map.contains_key("standard")` and a weakened
+/// `map.contains_key("standard")` behave identically there.
+///
+/// Hand-built on purpose, and **not** a claim about a real shape: the records
+/// we captured ship `"standard"` alone (n is small — this says nothing about
+/// what SLFO can emit). It is a guard-shape probe — if such a map ever
+/// appeared, the base-version branch must win, because `"standard"` only means
+/// "product-agnostic" when it is the whole map. Its values are ones the tree
+/// already carries.
+#[test]
+fn packages_for_map_second_product_key_disables_standard_branch() {
+    let map: HashMap<String, HashMap<String, String>> = HashMap::from([
+        (
+            "standard".to_owned(),
+            HashMap::from([(
+                "afterburn".to_owned(),
+                "5.10.0.git73.b97f772-99999_stage.1.1".to_owned(),
+            )]),
+        ),
+        (
+            "15-SP6".to_owned(),
+            HashMap::from([("hplip".to_owned(), "3.26.4-150600.4.12.1".to_owned())]),
+        ),
+    ]);
+
+    let pkgs = packages_for_map(&map, "15-SP6");
+
+    let mut names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        vec!["hplip"],
+        "a second product key must fall through to the base-version branch"
+    );
+    // Versions too. Asserting names alone is exactly the weakness this file's
+    // other tests warn about: it survives a mutation that seeds no `required`,
+    // and the base-version branch has to seed one just as the `"standard"`
+    // branch does.
+    assert_eq!(
+        pkgs[0].required().map(ToString::to_string).as_deref(),
+        Some("3.26.4-150600.4.12.1"),
+        "the base-version branch must seed required too"
+    );
 }


### PR DESCRIPTION
Closes #397.

## What the evidence says

#397 asked for a real SLFO `metadata.json` and left two questions open. Both are
now answered from observed records, fetched from TeReGen for two independent
updates — `SUSE:SLFO:1.1:418286` (the one #396 named) and a current
`SUSE:SLFO:1.2:6766`:

```json
"packages": {
    "standard": [
        "afterburn = 5.10.0.git73.b97f772-99999_stage.1.1",
        "afterburn-dracut = 5.10.0.git73.b97f772-99999_stage.1.1"
    ]
}
```

1. **Entries are exactly three whitespace tokens**, `<name> = <version>` — the
   parser's strict form is right, with `=` as the discarded middle token.
2. **The map is keyed `standard`**, and nothing else — so `packages_for_map`'s
   single-key branch is the live path for SLFO, and seeding does reach hosts.

Both assumptions hold, so this is **not** a hidden #396 root cause and **no
production behaviour changes**. It is the coverage the issue asked for, plus the
correction of a belief the tree was encoding.

To be precise about what was and was not already covered: the `=` form and
version-is-token[2] were **already** pinned against real data by the Maintenance
golden, which asserts whole-map equality on a captured record. The genuinely
unpinned things were the **`standard` key**, the `map.len() == 1` half of the
guard, and any assertion at all on `base().packages` after `TestReport::read`.

## The belief that was wrong

`slfo_populated_envelope_parses` landed with #396 as an explicitly synthetic
probe (its own doc said real-fixture coverage remained #397) and guessed *both*
halves wrong: key `6.1`, separator `_`. So the tree held two irreconcilable
claims — `packages_for_map`'s doc saying SLFO ⇒ `standard`, and that test saying
SLFO ⇒ `6.1`. It is retargeted onto the observed shape.

The `_` came from the envelope rustdoc writing `"pkg _ version"`, which is
Rust's *ignored-binding* notation for the discarded token; read as a wire format
it says SLFO ships underscores. Second commit fixes the notation.

## What is pinned, and what is not

| test | pins |
|---|---|
| `json_parser_parses_slfo_real_fixture` | the real key set (whole set, not `contains_key`) and both real versions |
| `slfo_real_fixture_seeds_packages_for_any_base_version` | real fixture → `packages_for_map` with a `base_version` deliberately absent from the map; asserts `required()`, not just names |
| `packages_for_map_second_product_key_disables_standard_branch` | the `map.len() == 1` half of the guard |
| `make_testreport_slfo_real_metadata_populates_packages` | the on-disk loader keeps the real values through `TestReport::read` |

Two deliberate restraints:

- **`get_package_list()` is only a labelled secondary assertion.** The issue
  suggests asserting it is non-empty; it flattens every product and never
  consults `base_version`, so it stays green under a total failure of the
  `standard` assumption. Resting the case on it would have been another check
  that cannot fail.
- **Host seeding is not claimed.** `Session::connect_one` is private and
  `Target::connect` hard-codes `SshConnection::connect` with no injectable seam,
  so no test can reach the production seeding call site. The `packages_for_map`
  half is re-implemented explicitly instead, and the test doc says so rather
  than implying coverage that does not exist.

## Mutation evidence

Every new assertion has a mutation applied to production code, observed red, and
reverse-restored. Two worth naming:

- Dropping `map.len() == 1` from `packages_for_map`'s guard leaves the **entire
  264-test lib suite green** — the existing single-key test cannot distinguish it,
  because its map has one key either way. The new probe is the only thing in the
  workspace that catches it.
- Clearing `base().packages` right after the loader's `parse_str` reddens the new
  lifecycle test **alone**, which is what isolates its added coverage from the
  eleven pre-existing SLFO lifecycle tests.

Also fixed along the way: a pre-existing probe in the same file used the same
value for an entry's second and third token, so it could not distinguish
version-from-second-token from version-from-third.

## Fixture provenance

`crates/mtui-testreport/tests/fixtures/metadata/slfo_metadata.json` is
**field-for-field** the captured record with **one** substitution: `packager` →
`someone@suse.com`, the address the lifecycle fixtures already use, so a named
individual's address is not published. Nothing under test depends on it. Say the
word if you would rather have it verbatim — the existing golden fixture already
ships a real address and a real IBS URL, so either is consistent with precedent.

Field-for-field, not byte-for-byte: the record arrives from TeReGen as a single
~950-byte line, and the fixture is re-serialized with sorted keys and 4-space
indent to match its golden sibling. Every *value* is byte-identical; the file is
not. So a diff against a fresh re-fetch is reformatting, not tampering. The
in-tree provenance note on the const says the same.

Every other value — RRID, products, packages, testplatform, repository, bugs,
SRCRPMs, product_composer — is the real record, unedited.
