### PR TITLE
fix(testreport): report the patch's own exit status from the update templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,13 +144,40 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   failed transaction. As on every other host, a failed update check on these
   also drives the group-wide rollback downgrade, which they could not reach
   before.
-  SL Micro is judged on the command's output markers rather than its exit code:
-  its update template ends with a repo-cleanup loop, so the status the shell
-  reports is that loop's and not the patch's. RHEL/YUM is judged only on
-  whether the command ran: that key covers every RHEL version, `yum` is `dnf`
-  on RHEL 8/9, and mtui passes the whole package list to hosts that carry only
-  a subset — so neither a non-zero exit nor an `Error:` line (the template also
-  runs `yum repolist` in the same shell) reliably means the update failed.
+  SL Micro is judged on the command's output markers and on the patch's exit
+  code. RHEL/YUM is judged only
+  on whether the command ran: that key covers every RHEL version, `yum` is
+  `dnf` on RHEL 8/9, and mtui passes the whole package list to hosts that carry
+  only a subset — so neither a non-zero exit nor an `Error:` line (the template
+  also runs `yum repolist` in the same shell) reliably means the update failed.
+- An `update` whose patch command fails now fails the update, on both zypper
+  and SL Micro hosts, even when the patch's output is clean. The two update
+  templates are multi-line scripts run as a single remote command, and their
+  last line was the repo-cleanup loop — whose status is `0` whenever it finds
+  nothing to remove — so the shell reported that and discarded the
+  `zypper -n in -t patch` / `transactional-update -n pkg in -t patch` status
+  before anything could read it. Each template now captures the patch's own
+  status and exits with it, and the remote command text visible in `show_log`
+  transcripts changes accordingly.
+  The exit code is classified rather than compared against zero. `100`-`103`,
+  `106` and `107` are zypper's *informational* results and still pass — `102`
+  is "reboot needed", the routine outcome of patching a kernel, and `107` means
+  a package's `%post` script failed although the package itself is installed
+  and registered. (`103`, "restart needed", also passes: zypper installed the
+  patch that updates the package manager itself, and any *remaining* patches
+  need a second run — the post-patch `zypper patches` line in the transcript is
+  what shows those.) `104`, `4`, `5` and `8` report "package not found", ahead
+  of the output markers. Any other non-zero reports "Unknown Error", but only
+  when the markers recognise nothing — a locked stack, a dependency problem or
+  an RPM error keeps its own, more precise reason.
+  Without the informational carve-out a host that patched perfectly would fail
+  its check and fire the group-wide rollback downgrade, reverting every healthy
+  host in the group. A host carrying none of the update's products still
+  passes: the patch command is skipped rather than run with no operands.
+  On SL Micro the classification is in practice just "`0` passes": upstream
+  `transactional-update` absorbs zypper's status and returns only `0` or `1`,
+  so neither the informational codes nor the package-not-found ones can reach
+  the check on that key.
 - An `update` that timed out, or whose connection dropped part-way, is no
   longer reported as successful on **any** host. The update check had no
   equivalent of the downgrade check's "timed out or failed to run" gate, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,11 +145,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   also drives the group-wide rollback downgrade, which they could not reach
   before.
   SL Micro is judged on the command's output markers and on the patch's exit
-  code. RHEL/YUM is judged only
-  on whether the command ran: that key covers every RHEL version, `yum` is
-  `dnf` on RHEL 8/9, and mtui passes the whole package list to hosts that carry
-  only a subset — so neither a non-zero exit nor an `Error:` line (the template
-  also runs `yum repolist` in the same shell) reliably means the update failed.
+  code — and because `transactional-update` absorbs zypper's status and reports
+  a flat `1`, that key now fails on any non-zero exit, including failures that
+  are not the patch's own (an already-open transaction, a snapshot that could
+  not be created). RHEL/YUM is judged only on whether the command ran: that key
+  covers every RHEL version, `yum` is `dnf` on RHEL 8/9, and mtui passes the
+  whole package list to hosts that carry only a subset — so neither a non-zero
+  exit nor an `Error:` line (the template also runs `yum repolist` in the same
+  shell) reliably means the update failed.
 - An `update` whose patch command fails now fails the update, on both zypper
   and SL Micro hosts, even when the patch's output is clean. The two update
   templates are multi-line scripts run as a single remote command, and their
@@ -166,10 +169,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   and registered. (`103`, "restart needed", also passes: zypper installed the
   patch that updates the package manager itself, and any *remaining* patches
   need a second run — the post-patch `zypper patches` line in the transcript is
-  what shows those.) `104`, `4`, `5` and `8` report "package not found", ahead
-  of the output markers. Any other non-zero reports "Unknown Error", but only
-  when the markers recognise nothing — a locked stack, a dependency problem or
-  an RPM error keeps its own, more precise reason.
+  what shows those.) `104` reports "package not found" ahead of the output
+  markers. Every other failing code — `4`, `5`, `8` and anything else non-zero
+  — lets the markers speak first, so a locked stack, a dependency problem or an
+  RPM error keeps its own, more precise reason; with nothing recognised in the
+  output, `4`/`5`/`8` report "package not found" and the rest "Unknown Error".
   Without the informational carve-out a host that patched perfectly would fail
   its check and fire the group-wide rollback downgrade, reverting every healthy
   host in the group. A host carrying none of the update's products still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `transactional-update` absorbs zypper's status and returns only `0` or `1`,
   so neither the informational codes nor the package-not-found ones can reach
   the check on that key.
+- `install` no longer fails when a package's `%post` script did. zypper exits
+  `107` (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) in that case — an *informational*
+  code meaning the packages "were successfully unpacked to disk and are
+  registered in the rpm database" — but the install check's success set stopped
+  at `106`, so a routine kernel or dracut scriptlet hiccup was reported as
+  "Unknown Error".
 - An `update` that timed out, or whose connection dropped part-way, is no
   longer reported as successful on **any** host. The update check had no
   equivalent of the downgrade check's "timed out or failed to run" gate, so a

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -839,9 +839,9 @@ async fn prepare_body(
     // exit codes only — never from the stderr rule `host_command_failures`
     // also applies, because `transactional-update` writes progress to stderr
     // on a *successful* run and skipping such a host's reboot would leave its
-    // healthy staged snapshot silently inert. Unlike update's multi-line
-    // script, the prepare templates are single commands, so the recorded exit
-    // code is genuinely the prepare command's own.
+    // healthy staged snapshot silently inert. The prepare templates are single
+    // commands, so the recorded exit code is genuinely the prepare command's
+    // own.
     //
     // The check verdicts are seeded too, but they are inert for the hosts that
     // matter today: `prepare_check` has no ("slmicro", true) entry, and only
@@ -2764,10 +2764,10 @@ mod tests {
 
     /// A transactional SL-Micro target whose commands answer with `stderr`.
     ///
-    /// The update check for `("slmicro", true)` is deliberately judged on the
-    /// output markers rather than the exit code — the slmicro update template
-    /// ends with a repo-cleanup loop that masks the patch's status — so a
-    /// stderr marker is the signal a genuinely failing patch leaves behind.
+    /// The update check for `("slmicro", true)` reads the stdout/stderr markers
+    /// *and* the exit code; this fixture exercises the marker half, so it
+    /// answers exit `0` and leaves the failure signal entirely in `stderr` —
+    /// which is also the shape of the failure the exit code alone would miss.
     fn slmicro_target_with_stderr(hostname: &str, stderr: &str) -> (Target, MockConnection) {
         let conn = MockConnection::new(hostname)
             .with_default(CommandLog::new("", "", stderr, 0, 0))
@@ -3251,17 +3251,78 @@ mod tests {
         );
     }
 
+    /// The rendered zypper `update` command for `("15", false)` — the exact
+    /// string a `MockConnection` must be keyed on to script the *patch's* exit
+    /// code rather than every command's.
+    fn zypper_patch_command(packages: &[String]) -> String {
+        WorkflowRegistry::default()
+            .doer(Role::Update, "15", false)
+            .expect("zypper has an updater")
+            .render_command(
+                &[
+                    ("repa", repa_for("42", "7").as_str()),
+                    ("packages", quote_args(packages).as_str()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .expect("safe substitution never fails")
+    }
+
+    /// A SLES 15 target whose *patch command specifically* answers `exit`.
+    ///
+    /// Every other command answers cleanly. This is the fixture shape the
+    /// exit-code rules require: the update template now captures the patch's
+    /// status and re-exits with it, so an exit code scripted via `with_default`
+    /// would be one on *every* command — a state no shell produces, and one
+    /// that keeps a test green with the patch fan-out deleted, because the
+    /// check then reads the repo refresh's snapshot instead.
+    ///
+    /// The default stdout is a resolvable version line so the rollback
+    /// downgrade's version probe succeeds and a rollback, if one is routed,
+    /// actually renders an `--oldpackage` command. Without that, "assert no
+    /// rollback happened" would pass however the failure was routed.
+    fn sles_target_with_patch_exit(
+        hostname: &str,
+        packages: &[String],
+        exit: i16,
+    ) -> (Target, MockConnection, String) {
+        let patch = zypper_patch_command(packages);
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", "pkg-a = 1.0-1\n", "", 0, 0))
+            .with_response(
+                patch.clone(),
+                CommandLog::new(patch.clone(), "", "", exit, 0),
+            );
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        (t, handle, patch)
+    }
+
     #[tokio::test]
     async fn perform_update_keeps_repos_on_check_failure() {
-        // exit 104 on the updater command ⇒ the update check flags "package not
+        // exit 104 on the patch command ⇒ the update check flags "package not
         // found"; the flow must NOT issue a repo-remove (repos kept for retry).
-        let (t, handle) = sles_target_with_exit("h1", "", 104);
+        //
+        // The 104 is scripted onto the patch alone. It used to ride on
+        // `with_default`, i.e. on every command — which the shell could not
+        // produce even before #400 (the script's status was the cleanup loop's)
+        // and cannot produce now either (it is the patch's).
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+        let (t, handle, patch) = sles_target_with_patch_exit("h1", &packages, 104);
         let mut group = HostsGroup::new(vec![t], false);
 
         // A recording repo so we can assert no Remove followed the Add.
         let repo = RecordingRepo::default();
-        let report = report_with_rrid();
-        let packages = report.get_package_list();
 
         // Drive perform_update with the recording repo as the SetRepo hook by
         // calling the module fn directly (SlReport delegates to it).
@@ -3277,10 +3338,14 @@ mod tests {
             &mut Vec::new(),
         )
         .await;
-        assert!(
-            matches!(res, Err(UpdateFailure::Check(_))),
-            "a check failure returns Err(Check): {res:?}"
-        );
+        let Err(UpdateFailure::Check(e)) = res else {
+            panic!("a failed patch returns Err(Check): {res:?}");
+        };
+        // The reason, not just the variant: `Check` is reached by every marker
+        // too, so asserting the variant alone would not show that the *exit
+        // code* was read.
+        assert_eq!(e.reason, "package not found");
+        assert_eq!(e.host.as_deref(), Some("h1"));
 
         let ops = repo.ops.lock().unwrap().clone();
         assert!(ops.contains(&RepoOp::Add), "repo add must run: {ops:?}");
@@ -3288,8 +3353,66 @@ mod tests {
             !ops.contains(&RepoOp::Remove),
             "on failure the repos are kept (no Remove): {ops:?}"
         );
-        // The updater command was still attempted.
-        assert!(handle.commands().iter().any(|c| c.contains(":p=42:7")));
+        // The verdict must come from the patch, so the patch must have run.
+        let cmds = handle.commands();
+        assert!(
+            cmds.contains(&patch),
+            "the patch command must have been dispatched: {cmds:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_update_passes_a_host_that_only_needs_a_reboot() {
+        // The carve-out that makes reading the exit code safe at all, asserted
+        // where the blast radius lives. zypper exits 102
+        // (`ZYPPER_EXIT_INF_REBOOT_NEEDED`) after patching a kernel — the
+        // routine outcome of the thing mtui exists to do. Under a bare `!= 0`
+        // rule that host would fail its check, and a check failure hands
+        // `perform_update_with_rollback` the *whole* group: it removes every
+        // host's issue repos, downgrades every host, and rewrites the report's
+        // before/after version slots. One host's healthy 102 would revert the
+        // fleet.
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+        let packages = report.get_package_list();
+        let (t1, h1, patch) = sles_target_with_patch_exit("h1", &packages, 102);
+        let (t2, h2, _) = sles_target_with_patch_exit("h2", &packages, 0);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let res = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await;
+
+        // Not vacuous: the 102 was actually delivered, and to the patch.
+        assert!(
+            h1.commands().contains(&patch),
+            "the patch command must have been dispatched: {:?}",
+            h1.commands()
+        );
+        assert!(
+            res.is_ok(),
+            "exit 102 is 'reboot needed', not a failure: {res:?}"
+        );
+        // And nothing was rolled back. `perform_update_with_rollback` hands the
+        // downgrade the *whole* group, so the healthy peer is where a false
+        // failure shows up as collateral damage — h2 is asserted **first** for
+        // exactly that reason. The fixture answers the version probe with a
+        // parseable line, so a rollback that did run would render
+        // `--oldpackage` here.
+        //
+        // Two assertions rather than a loop over both hosts: in a loop the
+        // first host to fail hides the other, and the peer host is the one this
+        // test exists for.
+        assert!(
+            !h2.commands().iter().any(|c| c.contains("--oldpackage")),
+            "the healthy peer h2 must not be rolled back on h1's behalf: {:?}",
+            h2.commands()
+        );
+        assert!(
+            !h1.commands().iter().any(|c| c.contains("--oldpackage")),
+            "h1 must not be rolled back: {:?}",
+            h1.commands()
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -40,6 +40,19 @@
 //! receive, and lets the patch itself use a quoted `"$@"` instead of a bare
 //! unquoted expansion.
 //!
+//! # The residual: a refresh that fails silently
+//!
+//! `zypper -n refresh` is **not** guarded, and the empty-list no-op above is
+//! what makes that a real gap: if the issue repo is unreachable or its key is
+//! untrusted, the refresh fails, `zypper -n patches` matches no row, the guard
+//! skips the patch and the script exits `0`. An update that installed nothing
+//! passes its check. Deferred rather than fixed, because `refresh` returns `4`
+//! whether one repository failed or all of them did, so its status cannot tell
+//! "the issue repo went missing" from "an unrelated stale repo did" — and
+//! failing on the latter would abort updates on refhosts that would have
+//! patched correctly, which is routine on QAM refhosts. Closing it needs a
+//! check that the *issue* repo specifically is present, not a status test.
+//!
 //! Two constraints on the text:
 //!
 //! * every `$` meant for the remote shell is written `$$`
@@ -599,7 +612,11 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // then splits it into zero words, and the patch runs with **no
             // operands** — the very case the guard exists to prevent. Its
             // status is real now, so the package manager's complaint about its
-            // own arguments becomes "Unknown Error" and a group-wide rollback.
+            // own arguments reaches the check as a failure instead of being
+            // masked — as which reason depends on the code and the transcript
+            // (the stub's `8` reads as "RPM Error" when it writes `Error:` to
+            // stderr, "package not found" when it does not), which is why this
+            // asserts on the exit status rather than on a reason string.
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
                 let code = run_script(&cmds, &stubs, 8, 0, BLANK_PATCH_ROW, "");

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -8,6 +8,59 @@
 //!
 //! Each template's leading newline keeps the first command off the prompt line
 //! in the transcript `show_log` prints.
+//!
+//! # The exit status the zypper / slmicro scripts report
+//!
+//! Both are multi-line scripts run as **one** remote `exec`, so the shell's
+//! last-command-wins rule decides what the update check gets to inspect. Left
+//! alone that is the trailing repo-cleanup loop's status — `0` whenever the
+//! loop body never runs — and a genuinely failed patch reported success.
+//!
+//! So the patch's own status is captured into `$mtui_status` on the line after
+//! the patch, before the post-state `zypper -n patches | grep` can clobber
+//! `$?`, and the script ends with `exit $mtui_status`. The two commands after
+//! the patch stay: the `grep` is transcript signal, and the cleanup loop is
+//! real work. Neither may decide the verdict — an `update` check failure fires
+//! the **group-wide** rollback downgrade, so a cosmetic `zypper -n rr` hiccup
+//! would revert every healthy host in the group.
+//!
+//! The patch list is captured into `$mtui_patches` first so the empty case is
+//! distinguishable: a host carrying none of the update's products is a no-op,
+//! not a failure, and running the patch command with no operands would make the
+//! package manager complain about its own arguments — a status that is now
+//! real. That verdict is unchanged; only the way it is reached is.
+//!
+//! The emptiness test is `set -- $mtui_patches` followed by `[ "$#" -gt 0 ]`,
+//! **not** `[ -n "$mtui_patches" ]`. The two differ on a list of whitespace:
+//! `-n` calls it non-empty, but the unquoted expansion that follows splits it
+//! into *zero* words, so the patch would run with no operands after all — the
+//! precise case the guard exists to prevent, and one the awk can produce from a
+//! matching row whose second `|` field is blank. Going through the positional
+//! parameters makes the guard test what the patch command will actually
+//! receive, and lets the patch itself use a quoted `"$@"` instead of a bare
+//! unquoted expansion.
+//!
+//! Two constraints on the text:
+//!
+//! * every `$` meant for the remote shell is written `$$`
+//!   (`$$mtui_status`, `$$?`, `$$(`, `$$#`, `$$@`, `$$r`). A bare `$?` happens
+//!   to survive [`SubstMode::Safe`] today, but `$$` is the documented escape
+//!   and the only form that stays correct if the mode is ever tightened. The
+//!   awk field refs (`print $2`) stay bare — that is the tested convention.
+//!   Shell variables are `mtui_`-prefixed *and* `$$`-escaped, so no future
+//!   `$name` template variable can silently expand one away.
+//! * the literal token `zypper` stays in `ZYPPER_UPDATE`: the *zypper* update
+//!   check gates its exit-code rules on the command text containing it
+//!   (`checks::update::zypper`), so losing it there would silently disable
+//!   them. `SLM_UPDATE` carries the token too, via its `zypper -n lr` /
+//!   `patches` lines, but nothing depends on that —
+//!   `checks::update::transactional_update` deliberately has no such gate.
+//!
+//! One portability note, pre-existing and unchanged: `/$repa\>/` uses `\>`,
+//! which is a **GNU-awk** word-boundary operator. The SUSE hosts these run on
+//! ship gawk. Other awks degrade it to a literal `>`, which matters only to the
+//! tests below — they execute this text under the *build host's* awk, and pick
+//! a stub row that matches under either reading.
 
 use crate::update_workflow::actions::{ActionCommands, SubstMode};
 
@@ -19,24 +72,44 @@ yum -y update $packages
 ";
 
 /// zypper update command.
+///
+/// See the module docs for why the patch's status is captured rather than left
+/// to the shell's last-command-wins rule.
 const ZYPPER_UPDATE: &str = r#"
 export LANG=
 zypper -n lr -puU
 zypper -n refresh
 zypper -n patches | grep $repa
-zypper -n in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_patches=$$(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_status=0
+set -- $$mtui_patches
+if [ "$$#" -gt 0 ]; then
+  zypper -n in -l -y -t patch "$$@"
+  mtui_status=$$?
+fi
 zypper -n patches | grep $repa
 zypper -n lr | awk -F "|" '/$repa\>/ { print $2; }' | while read r; do zypper -n rr $$r; done
+exit $$mtui_status
 "#;
 
 /// slmicro update command.
+///
+/// See the module docs for why the patch's status is captured rather than left
+/// to the shell's last-command-wins rule.
 const SLM_UPDATE: &str = r#"
 export LANG=
 zypper -n lr -puU
 zypper -n patches | grep $repa
-transactional-update -n pkg in -l -y -t patch $(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_patches=$$(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_status=0
+set -- $$mtui_patches
+if [ "$$#" -gt 0 ]; then
+  transactional-update -n pkg in -l -y -t patch "$$@"
+  mtui_status=$$?
+fi
 zypper -n patches | grep $repa
 zypper -n lr | awk -F "|" '/$repa\>/ { print $2; }' | while read r; do zypper -n rr $$r; done
+exit $$mtui_status
 "#;
 
 fn yum() -> ActionCommands {
@@ -104,6 +177,67 @@ mod tests {
         // Discriminating: `"{{ print $2; }}"` *contains* `"{ print $2; }"`, so
         // the assertion above alone would also pass on the old doubled form.
         assert!(!rendered.contains("{{"), "{rendered}");
+        assert_status_comes_from_the_patch(
+            "zypper",
+            &rendered,
+            ":p=1:2",
+            "zypper -n in -l -y -t patch",
+        );
+    }
+
+    /// The `$$`-escaping and status-capture contract, asserted on the
+    /// **rendered** text rather than the source constant — a `$` that was meant
+    /// for the remote shell but written bare still *looks* right in the source.
+    ///
+    /// `patch` is the patch command's leading text, so the shape being pinned
+    /// is that nothing at all sits between the patch and the capture of its
+    /// status.
+    fn assert_status_comes_from_the_patch(name: &str, rendered: &str, repa: &str, patch: &str) {
+        // The single discriminating check on the escaping: after substitution
+        // no `$$` may survive. Every `$$` in these templates is an escape for
+        // the remote shell, so one left doubled is one the shell would read as
+        // its own PID.
+        assert!(
+            !rendered.contains("$$"),
+            "{name}: an unresolved `$$` reached the remote shell: {rendered}"
+        );
+        // The patch list is captured before the patch so the empty case is
+        // distinguishable.
+        assert!(
+            rendered.contains("mtui_patches=$(zypper -n patches | awk -F \"|\""),
+            "{name}: the patch list must be captured first: {rendered}"
+        );
+        // Guarded on the *word count*, not on the string being non-empty: a
+        // whitespace-only list is `-n`-true but splits to zero words, which
+        // would run the patch with no operands after all.
+        assert!(
+            rendered.contains("set -- $mtui_patches\nif [ \"$#\" -gt 0 ]; then\n"),
+            "{name}: the patch must be guarded on the split word count: {rendered}"
+        );
+        // Nothing between the patch and the capture of its status: the
+        // post-state `grep` two lines down would otherwise clobber `$?`.
+        assert!(
+            rendered.contains(&format!("  {patch} \"$@\"\n  mtui_status=$?\n")),
+            "{name}: the patch's status must be captured on the very next line: {rendered}"
+        );
+        // Everything after the patch, as one contiguous block anchored to the
+        // end of the script. `contains` would prove only presence: the
+        // repo-cleanup loop moved *above* the `if` still contains, but removes
+        // the issue repos before the patch can resolve against them. This pins
+        // that the post-state `grep` (the command whose `$?`-clobbering
+        // motivates the whole fix) and the cleanup loop are still there, still
+        // in that order, still after the patch — and that `exit` is last.
+        let tail = format!(
+            "fi\nzypper -n patches | grep {repa}\nzypper -n lr | awk -F \"|\" '/{repa}\\>/ {{ print $2; }}' | while read r; do zypper -n rr $r; done\nexit $mtui_status\n"
+        );
+        assert!(
+            rendered.ends_with(&tail),
+            "{name}: the script must end with grep, cleanup loop, exit — in that order.\nwant tail:\n{tail}\ngot:\n{rendered}"
+        );
+        // The other half of the contract — that `checks::update::zypper`'s
+        // `zypper`-token gate still fires on this text — is pinned in that
+        // module, by feeding it the rendered template. Asserting the token
+        // here would only pin the template against itself.
     }
 
     #[test]
@@ -124,11 +258,363 @@ mod tests {
         assert!(rendered.contains("transactional-update -n pkg in -l -y -t patch"));
         assert!(rendered.contains("{ print $2; }"));
         assert!(!rendered.contains("{{"), "{rendered}");
+        assert_status_comes_from_the_patch(
+            "slmicro",
+            &rendered,
+            ":p=1:2",
+            "transactional-update -n pkg in -l -y -t patch",
+        );
+    }
+
+    #[test]
+    fn yum_is_untouched_by_the_status_capture() {
+        // `YUM_UPDATE`'s last line *is* `yum -y update`, so its status was
+        // never masked and there is nothing to fix. The yum check's narrow
+        // did-it-run verdict rests on a different argument entirely (one key
+        // for every RHEL version, `yum` is `dnf` on 8/9, and mtui hands the
+        // host the update's whole package list) — extending the capture here
+        // would be a new, unargued rule on a transcript it was never written
+        // for.
+        let rendered = updater("YUM", false)
+            .expect("yum updater")
+            .render_command(&vars("", "p1 p2"))
+            .unwrap();
+        assert!(!rendered.contains("mtui_status"), "{rendered}");
+        assert!(
+            rendered.trim_end().ends_with("yum -y update p1 p2"),
+            "{rendered}"
+        );
     }
 
     #[test]
     fn unknown_key_is_none() {
         assert!(updater("99", false).is_none());
         assert!(updater("slmicro", false).is_none());
+    }
+
+    /// Executes the *rendered* update scripts under a real `/bin/sh`, with stub
+    /// `zypper` / `transactional-update` executables first on `PATH`.
+    ///
+    /// The subject of this module is shell semantics — which command's status
+    /// the script reports — and no mock can express that: `MockConnection` keys
+    /// on the whole command string and scripts one exit code per command, so
+    /// "the patch failed but the last line succeeded" is a state it cannot
+    /// produce. A check-level test that simply passes `exitcode: 1` proves the
+    /// classifier, not the script.
+    ///
+    /// The stubs append to a sentinel file on every invocation, so a test can
+    /// assert the patch actually ran (or actually did not). Without that, a
+    /// `PATH` mistake would make the script a no-op and every assertion here
+    /// vacuous.
+    #[cfg(unix)]
+    mod rendered_script {
+        use std::ffi::OsString;
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::path::Path;
+        use std::process::Command;
+
+        use super::*;
+
+        /// The `$repa` selector the scripts are rendered with.
+        const REPA: &str = ":p=42:7";
+
+        /// A `zypper -n patches` row: `|`-field 2 is the patch name the awk in
+        /// the template extracts, and field 1 carries [`REPA`] immediately
+        /// followed by `>`.
+        ///
+        /// That `>` is deliberate and load-bearing for portability. The
+        /// template's regex is `/:p=42:7\>/`, and `\>` is a **GNU-awk**
+        /// word-boundary operator; other awks (macOS ships BWK awk, and this
+        /// job also runs there) degrade an unknown escape to the literal
+        /// character. A row containing `:p=42:7>` satisfies **both** readings:
+        /// gawk sees a word boundary after `7` because `>` is a non-word
+        /// character, and a non-GNU awk sees the literal `>`. Verified against
+        /// gawk and against `gawk --traditional`, which reproduces the non-GNU
+        /// reading. `the_stub_rows_match_under_this_hosts_awk` re-checks it on
+        /// whatever awk actually runs, so a third dialect fails loudly with an
+        /// explanation instead of silently extracting nothing.
+        const PATCH_ROW: &str =
+            "issue-:p=42:7>repo | patch-alpha | security | important | --- | needed";
+
+        /// A `zypper -n patches` row whose second field is **whitespace**.
+        ///
+        /// `[ -n "$mtui_patches" ]` calls this non-empty while the unquoted
+        /// expansion that follows splits it into zero words — the reason the
+        /// guard counts split words instead.
+        const BLANK_PATCH_ROW: &str = "issue-:p=42:7>repo |    | security";
+
+        /// A `zypper -n lr` row the repo-cleanup loop matches, so the loop body
+        /// (`zypper -n rr`) actually runs and its status can be controlled.
+        const REPO_ROW: &str = "1 | issue-:p=42:7>repo | Yes | Yes";
+
+        /// The stub `zypper`. Every call in both templates is
+        /// `zypper -n <subcommand> …`, so `$2` discriminates.
+        ///
+        /// Note this means `zypper -n lr -puU` also lands in the `lr)` arm;
+        /// harmless, since its output is not piped anywhere.
+        ///
+        /// Every arm records its invocation. The `patches`/`lr` probes matter
+        /// as much as the patch: without them "the patch never ran" — the
+        /// assertion the empty-list case rests on — is also what a broken
+        /// `PATH` produces, and the test would pass with no stubs at all.
+        const ZYPPER_STUB: &str = r#"#!/bin/sh
+printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran"
+case "$2" in
+patches)
+    if [ -n "$MTUI_STUB_PATCH_ROW" ]; then printf '%s\n' "$MTUI_STUB_PATCH_ROW"; fi
+    ;;
+lr)
+    if [ -n "$MTUI_STUB_REPO_ROW" ]; then printf '%s\n' "$MTUI_STUB_REPO_ROW"; fi
+    ;;
+rr)
+    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/cleanup.ran"
+    exit "$MTUI_STUB_CLEANUP_EXIT"
+    ;;
+in)
+    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran"
+    exit "$MTUI_STUB_PATCH_EXIT"
+    ;;
+esac
+exit 0
+"#;
+
+        /// The stub `transactional-update`: the slmicro patch command, and the
+        /// only thing that binary is called for in `SLM_UPDATE`.
+        const TU_STUB: &str = r#"#!/bin/sh
+printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran"
+exit "$MTUI_STUB_PATCH_EXIT"
+"#;
+
+        /// A temp dir holding the stub executables plus the sentinel files they
+        /// append to.
+        struct Stubs {
+            dir: tempfile::TempDir,
+            path: OsString,
+        }
+
+        impl Stubs {
+            fn new() -> Self {
+                let dir = tempfile::tempdir().expect("tempdir");
+                write_exe(dir.path(), "zypper", ZYPPER_STUB);
+                write_exe(dir.path(), "transactional-update", TU_STUB);
+                // Keep the inherited PATH behind the stubs: the templates also
+                // call the real `awk` and `grep`.
+                let mut path = dir.path().as_os_str().to_owned();
+                if let Some(inherited) = std::env::var_os("PATH") {
+                    path.push(":");
+                    path.push(inherited);
+                }
+                Self { dir, path }
+            }
+
+            /// The lines the patch stub appended, one per invocation.
+            fn patch_invocations(&self) -> Vec<String> {
+                sentinel(&self.dir.path().join("patch.ran"))
+            }
+
+            /// The lines the `zypper -n rr` cleanup stub appended.
+            fn cleanup_invocations(&self) -> Vec<String> {
+                sentinel(&self.dir.path().join("cleanup.ran"))
+            }
+
+            /// Every `zypper` subcommand the stub saw, in order.
+            ///
+            /// The liveness signal for the cases whose headline assertion is a
+            /// *negative* ("the patch never ran"): that is equally what an
+            /// empty `PATH` produces, so a case asserting it must also show the
+            /// script reached the stub at all.
+            fn probe_invocations(&self) -> Vec<String> {
+                sentinel(&self.dir.path().join("probe.ran"))
+            }
+        }
+
+        fn write_exe(dir: &Path, name: &str, body: &str) {
+            let p = dir.join(name);
+            fs::write(&p, body).expect("write stub");
+            fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).expect("chmod stub");
+        }
+
+        fn sentinel(p: &Path) -> Vec<String> {
+            fs::read_to_string(p)
+                .unwrap_or_default()
+                .lines()
+                .map(ToOwned::to_owned)
+                .collect()
+        }
+
+        /// The two templates whose exit status must be the patch's.
+        fn templates() -> Vec<(&'static str, ActionCommands)> {
+            vec![("zypper", zypper()), ("slmicro", slmicro())]
+        }
+
+        /// Renders `cmds` and runs it under `/bin/sh -c`, returning the script's
+        /// own exit status.
+        ///
+        /// `patch_row` empty means the update matches no patch on this host;
+        /// `repo_row` empty means the cleanup loop finds nothing to remove (its
+        /// body never runs, so the loop's status is `0` — the masking the whole
+        /// issue is about).
+        fn run_script(
+            cmds: &ActionCommands,
+            stubs: &Stubs,
+            patch_exit: i32,
+            cleanup_exit: i32,
+            patch_row: &str,
+            repo_row: &str,
+        ) -> i32 {
+            let rendered = cmds
+                .render_command(&vars(REPA, "pkg-a"))
+                .expect("safe substitute never fails");
+            let out = Command::new("/bin/sh")
+                .arg("-c")
+                .arg(&rendered)
+                .env("PATH", &stubs.path)
+                .env("MTUI_STUB_DIR", stubs.dir.path())
+                .env("MTUI_STUB_PATCH_EXIT", patch_exit.to_string())
+                .env("MTUI_STUB_CLEANUP_EXIT", cleanup_exit.to_string())
+                .env("MTUI_STUB_PATCH_ROW", patch_row)
+                .env("MTUI_STUB_REPO_ROW", repo_row)
+                .output()
+                .expect("run rendered script under /bin/sh");
+            out.status
+                .code()
+                .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status))
+        }
+
+        #[test]
+        fn the_stub_rows_match_under_this_hosts_awk() {
+            // The portability guard for every case below. The template's
+            // `/$repa\>/` is GNU-awk syntax; this runs the *production*
+            // expression, through the host's real awk, against the stub rows,
+            // and asserts the patch name comes back out.
+            //
+            // Without this, a host whose awk reads `\>` a third way would fail
+            // the other cases with "the patch stub must have run" — true but
+            // wildly misleading. Here it fails with the actual cause. It is a
+            // hard failure, not a skip: a skip would be a green result on a
+            // host where the acceptance tests proved nothing, which is the
+            // shape of every false-green in this repo's history.
+            let prog = format!("awk -F \"|\" '/{REPA}\\>/ {{ print $2; }}'");
+            let out = Command::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("printf '%s\\n' \"$1\" | {prog}"))
+                .arg("sh")
+                .arg(PATCH_ROW)
+                .output()
+                .expect("run the template's awk under /bin/sh");
+            let got = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+            assert_eq!(
+                got,
+                "patch-alpha",
+                "this host's awk does not extract the patch name from the stub row.\n\
+                 The template uses `\\>` (a GNU-awk word-boundary operator); the stub row \
+                 carries `{REPA}>` so that gawk (word boundary before a non-word `>`) and a \
+                 non-GNU awk (literal `>`) both match. This awk reads it a third way, so the \
+                 acceptance cases below would report 'the patch stub must have run' instead of \
+                 the real cause.\nprogram: {prog}\nrow: {PATCH_ROW}\nstderr: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        #[test]
+        fn a_failed_patch_fails_the_script_even_when_the_cleanup_succeeds() {
+            // The bug in #400: the script's last line is the repo-cleanup loop,
+            // whose status is `0` whenever its body never runs. The patch's
+            // non-zero status was discarded before anything could read it, so
+            // a genuinely failed patch reported success.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let code = run_script(&cmds, &stubs, 8, 0, PATCH_ROW, "");
+                assert_eq!(
+                    stubs.patch_invocations().len(),
+                    1,
+                    "{name}: the patch stub must have run, or this test is vacuous"
+                );
+                assert!(
+                    stubs.cleanup_invocations().is_empty(),
+                    "{name}: no repo row, so the cleanup loop body must not run"
+                );
+                assert_eq!(code, 8, "{name}: the script must report the patch's status");
+            }
+        }
+
+        #[test]
+        fn a_failing_cleanup_does_not_fail_a_successful_patch() {
+            // The other direction, and the reason a bare "report the last
+            // command's status" would be wrong: the repo cleanup is cosmetic,
+            // and an update check failure fires the *group-wide* rollback
+            // downgrade, reverting every healthy host in the group.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let code = run_script(&cmds, &stubs, 0, 3, PATCH_ROW, REPO_ROW);
+                assert_eq!(
+                    stubs.patch_invocations().len(),
+                    1,
+                    "{name}: the patch stub must have run, or this test is vacuous"
+                );
+                assert_eq!(
+                    stubs.cleanup_invocations().len(),
+                    1,
+                    "{name}: the cleanup loop body must have run and failed"
+                );
+                assert_eq!(
+                    code, 0,
+                    "{name}: a cosmetic cleanup hiccup must not fail the update"
+                );
+            }
+        }
+
+        #[test]
+        fn an_empty_patch_list_skips_the_patch_and_succeeds() {
+            // A host carrying none of the update's products is a no-op, not a
+            // failure. Running the patch command with no operands would make
+            // the package manager complain about its own arguments, and that
+            // status would now be real.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let code = run_script(&cmds, &stubs, 8, 0, "", "");
+                // Liveness first. The headline assertion here is a *negative*,
+                // and an empty `PATH` produces exactly the same observation —
+                // so show the script actually reached the stub.
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "patches"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: with no matching patch the patch command must not run: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert_eq!(code, 0, "{name}: a host with nothing to patch passes");
+            }
+        }
+
+        #[test]
+        fn a_whitespace_only_patch_list_skips_the_patch_and_succeeds() {
+            // The gap `[ -n "$mtui_patches" ]` left. A matching `zypper
+            // patches` row whose second `|` field is blank makes the awk emit
+            // whitespace: `-n` calls that non-empty, the unquoted expansion
+            // then splits it into zero words, and the patch runs with **no
+            // operands** — the very case the guard exists to prevent. Its
+            // status is real now, so the package manager's complaint about its
+            // own arguments becomes "Unknown Error" and a group-wide rollback.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let code = run_script(&cmds, &stubs, 8, 0, BLANK_PATCH_ROW, "");
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "patches"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: a whitespace-only list must not run the patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert_eq!(code, 0, "{name}: nothing to patch is not a failure");
+            }
+        }
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/install.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/install.rs
@@ -12,11 +12,15 @@ use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed}
 /// The three exit-code sets are the same ones
 /// [`classify_exit`](super::classify_exit) expresses for the `update` check,
 /// but they are spelled out inline here because this check interleaves them
-/// with its stderr markers in a different order (the markers sit *between* the
-/// package-not-found set and the "Unknown Error" fallback, where `update` gives
-/// them first refusal on the fallback). Folding this onto the shared helper is
-/// a behaviour-preserving refactor only if that ordering is preserved
-/// exactly — worth doing on its own, not as a rider.
+/// with its stderr markers in a different order: the markers sit *between* the
+/// package-not-found set and the "Unknown Error" fallback, where `update` now
+/// gives them first refusal on everything except `104`. So the same transcript
+/// can read differently across the two checks — an exit `5` carrying
+/// `System management is locked` is "package not found" here and "update stack
+/// locked" there, pinned on both sides so the divergence stays deliberate.
+/// Folding this onto the shared helper is a behaviour-preserving refactor only
+/// if that ordering is preserved exactly — worth doing on its own, not as a
+/// rider.
 ///
 /// # Errors
 ///
@@ -103,6 +107,31 @@ mod tests {
             let err = zypper(args("", "", code)).unwrap_err();
             assert_eq!(err.reason, "package not found");
             assert_eq!(err.host.as_deref(), Some("h1"));
+        }
+    }
+
+    #[test]
+    fn the_not_found_set_still_outranks_the_markers_here() {
+        // The install check keeps its own ordering: the whole `104 | 4 | 5 | 8`
+        // set short-circuits ahead of the stderr markers, where the `update`
+        // check now lets them speak first on everything but `104`. So the same
+        // transcript reads differently across the two, deliberately — pinned
+        // here and in `update`'s `only_104_outranks_the_markers` so neither
+        // side can drift without a test saying so.
+        //
+        // Every other fixture in this module passes an empty transcript, which
+        // is why hoisting the marker block above the set used to break nothing.
+        for (stdout, stderr, code) in [
+            ("", "System management is locked", 5),
+            ("", "A ZYpp transaction is already in progress.", 4),
+            ("", "Error: something", 8),
+            ("choose (c): c", "", 4),
+        ] {
+            let err = zypper(args(stdout, stderr, code)).unwrap_err();
+            assert_eq!(
+                err.reason, "package not found",
+                "install exit {code} must outrank its markers"
+            );
         }
     }
 

--- a/crates/mtui-testreport/src/update_workflow/checks/install.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/install.rs
@@ -9,15 +9,24 @@ use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed}
 
 /// The zypper install check.
 ///
+/// The three exit-code sets are the same ones
+/// [`classify_exit`](super::classify_exit) expresses for the `update` check,
+/// but they are spelled out inline here because this check interleaves them
+/// with its stderr markers in a different order (the markers sit *between* the
+/// package-not-found set and the "Unknown Error" fallback, where `update` gives
+/// them first refusal on the fallback). Folding this onto the shared helper is
+/// a behaviour-preserving refactor only if that ordering is preserved
+/// exactly — worth doing on its own, not as a rider.
+///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "package not found", "update stack
 /// locked", "RPM Error", "Dependency Error", or "Unknown Error" depending on
 /// the exit code and stderr/stdout markers. Exit codes `0, 100, 101, 102,
-/// 103, 106` are success. This check surfaces no [`Diagnostic`]s (only
+/// 103, 106, 107` are success. This check surfaces no [`Diagnostic`]s (only
 /// `update` does).
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if matches!(args.exitcode, 0 | 100 | 101 | 102 | 103 | 106) {
+    if matches!(args.exitcode, 0 | 100 | 101 | 102 | 103 | 106 | 107) {
         return Ok(Vec::new());
     }
     if matches!(args.exitcode, 104 | 4 | 5 | 8) {
@@ -74,7 +83,13 @@ mod tests {
 
     #[test]
     fn success_exit_codes_pass() {
-        for code in [0, 100, 101, 102, 103, 106] {
+        // `107` (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) is in the list because
+        // `man zypper` puts it in the informational band: "Installation
+        // basically succeeded, but some of the packages %post install scripts
+        // returned an error. These packages were successfully unpacked to disk
+        // and are registered in the rpm database". It was missing, so a
+        // routine `%posttrans` hiccup failed the install.
+        for code in [0, 100, 101, 102, 103, 106, 107] {
             assert!(
                 zypper(args("", "", code)).is_ok(),
                 "code {code} should pass"

--- a/crates/mtui-testreport/src/update_workflow/checks/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/mod.rs
@@ -114,9 +114,35 @@ pub(crate) enum ExitClass {
     /// The transaction committed: `0`, plus the informational `100`, `101`,
     /// `102`, `103`, `106` and `107`.
     Success,
-    /// `104`, `4`, `5`, `8` — the verdict "package not found".
+    /// `104`, `4`, `5`, `8` — the verdict "package not found". Only `104`
+    /// literally means that; see [`classify_exit`] for why the other three
+    /// share the class, and the `update` check for why they no longer share
+    /// its message when the transcript can say more.
     PackageNotFound,
-    /// Any other non-zero status, including `105` (aborted on a signal).
+    /// `-1`, mtui's own sentinel: the command never produced a status at all.
+    ///
+    /// Its own variant rather than a member of [`Unknown`], because the two
+    /// mean opposite things — an unrecognised status is a patch that ran and
+    /// failed, `-1` is a host mtui never reached. As a member of [`Unknown`] it
+    /// told the operator "Unknown Error" about a host that was never contacted,
+    /// which is not a vaguer diagnosis but a wrong one.
+    ///
+    /// What it does **not** change is the rollback. The group-wide downgrade is
+    /// vetoed by `never_ran` in `reports::update_flow`, which keys on the
+    /// target's recorded `lastexit()` being `-1` and never on the class or the
+    /// reason a check produced — so a `-1` host skipped the rollback under the
+    /// old fallthrough too. This variant fixes what the operator is told, not
+    /// where the flow goes.
+    ///
+    /// The variant also makes the distinction structural: the one `match` on
+    /// this enum ([`classify_exit`]'s caller) is exhaustive, so removing this
+    /// arm is a compile error rather than a silent fallthrough. That holds only
+    /// for exhaustive matchers — a caller writing `_ =>` still compiles.
+    ///
+    /// [`Unknown`]: ExitClass::Unknown
+    NotRun,
+    /// Any other non-zero status except `-1`, including `105` (aborted on a
+    /// signal).
     Unknown,
 }
 
@@ -130,19 +156,25 @@ pub(crate) enum ExitClass {
 /// The `104 | 4 | 5 | 8` grouping is the install check's, reproduced exactly:
 /// only `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) literally means "capability not
 /// found", while `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`.
-/// The label is inaccurate for three of the four, but the reason strings are a
-/// stable contract callers match on, so one exit code must not carry two
-/// different verdicts across two checks. The grouping is preserved rather than
-/// re-derived.
+/// The grouping is preserved rather than re-derived, so that one exit code
+/// cannot be sorted into two different classes by two checks. What a check
+/// then *says* about the three inaccurate members is its own decision: the
+/// `update` check lets the transcript name them where it can (see
+/// `classified` there).
 ///
-/// `-1` is **not** classified here: it is mtui's own "never ran to completion"
-/// sentinel, not a status any package manager returned, and it must keep its
-/// distinct reason so the flow can veto the rollback for a host it never
-/// reached (`not_run` in [`update`]).
+/// `-1` classifies as [`NotRun`], not [`Unknown`]. It is mtui's own "never ran
+/// to completion" sentinel rather than a status a package manager returned, so
+/// it must keep its own reason: an operator reading "Unknown Error" about a
+/// host mtui never contacted has been told the wrong thing. The gate that
+/// normally catches it first is `not_run` in [`update`].
+///
+/// [`NotRun`]: ExitClass::NotRun
+/// [`Unknown`]: ExitClass::Unknown
 pub(crate) fn classify_exit(exitcode: i32) -> ExitClass {
     match exitcode {
         0 | 100 | 101 | 102 | 103 | 106 | 107 => ExitClass::Success,
         104 | 4 | 5 | 8 => ExitClass::PackageNotFound,
+        -1 => ExitClass::NotRun,
         _ => ExitClass::Unknown,
     }
 }
@@ -214,13 +246,19 @@ mod tests {
     }
 
     #[test]
-    fn the_never_ran_sentinel_is_not_classified_as_a_package_problem() {
+    fn the_never_ran_sentinel_gets_its_own_class() {
         // `-1` is mtui's own "timed out / connection lost / not connected"
         // sentinel. It reaches the classifier only if a caller forgets its
         // `not_run` gate, and it must not be mistaken for a status a package
         // manager returned — the flow vetoes the group-wide rollback for a
         // host it never reached, and only the distinct reason string carries
         // that.
-        assert_eq!(classify_exit(-1), ExitClass::Unknown);
+        //
+        // It used to fall through to `Unknown`, which reported a host mtui
+        // never contacted as a failed patch — the wrong diagnosis, though not
+        // (as it would be easy to assume) a wrong rollback: `never_ran` in
+        // `reports::update_flow` vetoes the group-wide downgrade from the
+        // target's `lastexit()`, not from anything a check returns.
+        assert_eq!(classify_exit(-1), ExitClass::NotRun);
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/mod.rs
@@ -85,6 +85,68 @@ pub struct CheckArgs<'a> {
 /// stable reason string otherwise.
 pub type CheckFn = Box<dyn Fn(CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> + Send + Sync>;
 
+/// What a package manager's exit status says about the run.
+///
+/// zypper's status is not a boolean. Quoting `man zypper` (verified against
+/// zypper 1.14.98): *"Codes below 100 denote an error, codes above 100 provide
+/// a specific information, 0 represents a normal successful run."* The
+/// informational band is therefore **100-107**, not 100-106 — and *"specific
+/// information"* is not the same as *"the transaction committed"*. Two members
+/// of the band are not successes:
+///
+/// * `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) — the requested capability was
+///   not found, so nothing was installed. Classified [`PackageNotFound`].
+/// * `105` (`ZYPPER_EXIT_ON_SIGNAL`) — *"Returned upon exiting after receiving
+///   a SIGINT or SIGTERM"*, i.e. aborted mid-flight. Classified [`Unknown`].
+///
+/// Getting the band's *extent* wrong is not academic: `107`
+/// (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) sat outside it in the first version of
+/// this enum, which made a routine kernel/dracut `%posttrans` hiccup a failed
+/// update — and an `update` check failure fires the **group-wide** rollback
+/// downgrade, reverting every host in the group, not just the one that
+/// reported. `102` ("reboot needed") is the same shape: the routine result of
+/// patching a kernel.
+///
+/// [`PackageNotFound`]: ExitClass::PackageNotFound
+/// [`Unknown`]: ExitClass::Unknown
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExitClass {
+    /// The transaction committed: `0`, plus the informational `100`, `101`,
+    /// `102`, `103`, `106` and `107`.
+    Success,
+    /// `104`, `4`, `5`, `8` — the verdict "package not found".
+    PackageNotFound,
+    /// Any other non-zero status, including `105` (aborted on a signal).
+    Unknown,
+}
+
+/// Classifies a zypper-family exit status.
+///
+/// This is the one place the classification lives for the `update` check; the
+/// install check ([`install`]) still spells the same three sets out inline,
+/// interleaved with its stderr markers, and is left alone rather than being
+/// bent into this shape (see the note there).
+///
+/// The `104 | 4 | 5 | 8` grouping is the install check's, reproduced exactly:
+/// only `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) literally means "capability not
+/// found", while `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`.
+/// The label is inaccurate for three of the four, but the reason strings are a
+/// stable contract callers match on, so one exit code must not carry two
+/// different verdicts across two checks. The grouping is preserved rather than
+/// re-derived.
+///
+/// `-1` is **not** classified here: it is mtui's own "never ran to completion"
+/// sentinel, not a status any package manager returned, and it must keep its
+/// distinct reason so the flow can veto the rollback for a host it never
+/// reached (`not_run` in [`update`]).
+pub(crate) fn classify_exit(exitcode: i32) -> ExitClass {
+    match exitcode {
+        0 | 100 | 101 | 102 | 103 | 106 | 107 => ExitClass::Success,
+        104 | 4 | 5 | 8 => ExitClass::PackageNotFound,
+        _ => ExitClass::Unknown,
+    }
+}
+
 /// Shared diagnostic-log helper: logs a "command failed" event before each
 /// raised `UpdateError`.
 fn log_failed(args: CheckArgs<'_>) {
@@ -95,4 +157,70 @@ fn log_failed(args: CheckArgs<'_>) {
         stderr = args.stderr,
         "command failed"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn informational_codes_are_success() {
+        // The whole reason the update check can read an exit code at all.
+        //
+        // `102` is "reboot needed" after a kernel patch — routine, not a
+        // failure. `107` is `ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`, which
+        // `man zypper` describes as "Installation basically succeeded, but
+        // some of the packages %post install scripts returned an error. These
+        // packages were successfully unpacked to disk and are registered in
+        // the rpm database" — a kernel/dracut/systemd `%posttrans` returning
+        // non-zero is routine, and it is the *last* code in the informational
+        // band, which is where it got missed the first time.
+        //
+        // Each of these failing would fire the group-wide rollback downgrade.
+        for code in [0, 100, 101, 102, 103, 106, 107] {
+            assert_eq!(
+                classify_exit(code),
+                ExitClass::Success,
+                "exit {code} must be a success"
+            );
+        }
+    }
+
+    #[test]
+    fn package_not_found_codes() {
+        for code in [104, 4, 5, 8] {
+            assert_eq!(
+                classify_exit(code),
+                ExitClass::PackageNotFound,
+                "exit {code} must be package-not-found"
+            );
+        }
+    }
+
+    #[test]
+    fn other_non_zero_codes_are_unknown() {
+        // `99` sits just below the informational band and `108` just above it.
+        // `105` (`ZYPPER_EXIT_ON_SIGNAL`) sits *inside* the band's numeric
+        // range without being a success: "Returned upon exiting after
+        // receiving a SIGINT or SIGTERM", i.e. the transaction was aborted
+        // part-way. Being in the band is not the same as having committed.
+        for code in [1, 2, 3, 6, 7, 99, 105, 108, 255] {
+            assert_eq!(
+                classify_exit(code),
+                ExitClass::Unknown,
+                "exit {code} must be unknown"
+            );
+        }
+    }
+
+    #[test]
+    fn the_never_ran_sentinel_is_not_classified_as_a_package_problem() {
+        // `-1` is mtui's own "timed out / connection lost / not connected"
+        // sentinel. It reaches the classifier only if a caller forgets its
+        // `not_run` gate, and it must not be mistaken for a status a package
+        // manager returned — the flow vetoes the group-wide rollback for a
+        // host it never reached, and only the distinct reason string carries
+        // that.
+        assert_eq!(classify_exit(-1), ExitClass::Unknown);
+    }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -29,10 +29,11 @@ use crate::update_workflow::checks::{
 /// either would fire the **group-wide** rollback downgrade and revert every
 /// healthy host in the group.
 ///
-/// An unrecognised non-zero status gives the stdout/stderr [`markers`] first
-/// refusal — "update stack locked", "Dependency Error" and "RPM Error" name
-/// the failure, where "Unknown Error" only says there was one — so the
-/// fallback fires solely on a clean transcript.
+/// Every failing status except `104` and the `-1` sentinel gives the
+/// stdout/stderr [`markers`] first refusal — "update stack locked",
+/// "Dependency Error" and "RPM Error" name the failure, where "Unknown Error"
+/// and "package not found" only say there was one — so a class label is
+/// reported solely on a clean transcript.
 ///
 /// The classification is gated on the command text containing `zypper`, which
 /// is inert in production (this check is only registered for keys whose
@@ -43,9 +44,10 @@ use crate::update_workflow::checks::{
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run" (exit `-1`), "package not found" (exit `104`, `4`, `5`,
-/// `8`), "update stack locked", "Dependency Error", "RPM Error", or "Unknown
-/// Error" (any other non-zero exit with a clean transcript). The informational
+/// failed to run" (exit `-1`), "package not found" (exit `104` always; `4`,
+/// `5`, `8` on a clean transcript), "update stack locked", "Dependency Error",
+/// "RPM Error", or "Unknown Error" (any other non-zero exit with a clean
+/// transcript). The informational
 /// exits (`100`-`103`, `106`, `107`) and the two recognised output sections
 /// ("Additional rpm output", "not supported by its vendor") do not fail the
 /// check; `106` additionally logs a warning, and the two sections are returned
@@ -99,6 +101,18 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// after logging `zypper: nothing to update`), so a clean exit does not
 /// distinguish "patched" from "had nothing to patch".
 ///
+/// **The cost of that, stated deliberately rather than left implicit.** Because
+/// only `0` and `1` can arrive and `1` is `Unknown`, this key went from "never
+/// fails on an exit code" to "fails on any non-zero one" — and a failed update
+/// check fires the **group-wide** rollback, downgrading and rebooting every
+/// host in the group, not only this one. `transactional-update` flattens
+/// failures that are not the patch's into that same `1`: an already-open
+/// transaction, a snapshot that could not be created or deleted. Those are
+/// genuine failures of the operation mtui asked for, and the alternative —
+/// keeping the old silence — reports a failed patch as a successful update,
+/// which is the bug this check exists to close. Judged the worse of the two,
+/// with the blast radius understood.
+///
 /// Unlike [`zypper`] this is not gated on a token in the command text: the
 /// slmicro template contains both `zypper` and `transactional-update`, so a
 /// token guard here would only add a second way for the rule to silently stop
@@ -127,40 +141,55 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// Applies [`classify_exit`] to a patch status, interleaved with the
 /// stdout/stderr [`markers`].
 ///
-/// The interleaving is the whole content of this function: `PackageNotFound`
-/// is a named verdict and returns straight away, while `Unknown` lets the
+/// The interleaving is the whole content of this function: `104` is a named
+/// verdict and returns straight away, while every other failing status lets the
 /// markers speak first, because "update stack locked" is a diagnosis and
-/// "Unknown Error" is an admission. A success status still runs the markers —
-/// a dependency prompt (`(c): c`) leaves the transaction unfinished with a
-/// perfectly clean exit status.
+/// "Unknown Error" — or "package not found" on a code that means neither — is
+/// an admission. A success status still runs the markers too: a dependency
+/// prompt (`(c): c`) leaves the transaction unfinished with a perfectly clean
+/// exit status.
 ///
 /// Two consequences of that ordering, both deliberate and neither obvious:
 ///
-/// * The `PackageNotFound` arm **skips the markers**. Its set is
-///   `104 | 4 | 5 | 8`, and only `104` actually means "capability not found" —
-///   `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`. So an exit
-///   `5` carrying `System management is locked` on stderr now reports "package
-///   not found" where the marker rule alone would have reported the lock. The
-///   set and its reason string are a frozen contract shared with the install
-///   check (an exit code must not carry two verdicts across two checks), so the
-///   inaccurate label stays; what it costs is a less precise reason on three
-///   codes, never a missed failure.
+/// * **Only `104` skips the markers.** The class is `104 | 4 | 5 | 8`, and only
+///   `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) actually means "capability not
+///   found" — `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`,
+///   i.e. the package *was* found and the transaction failed. `8` with `Error:`
+///   on stderr is the likeliest status for a genuinely failed patch, and `5`
+///   with `System management is locked` for a busy update stack; letting the
+///   not-found label outrank the markers replaced both headline diagnoses with
+///   a message that is not merely vaguer but wrong. So the three defer to the
+///   markers, and keep "package not found" only when the transcript is clean.
+///
+///   The class itself is still the install check's, unsplit — the sorting is
+///   shared so an exit code cannot land in two classes, while the *message* is
+///   this check's to choose. Nothing branches on these strings (they are
+///   rendered, logged and asserted on, never matched), and on `update` the
+///   three used to reach no verdict at all, falling through to the markers, so
+///   there is no earlier behaviour for the short-circuit to have preserved.
 /// * `103` (`ZYPPER_EXIT_INF_RESTART_NEEDED`) is a success even though zypper
 ///   means "the patch that updates the package manager itself was installed,
 ///   run the command again to install the *remaining* patches". Those remaining
 ///   patches are not installed. Inherited from the install check's set and left
-///   identical for the same contract reason; the post-state
+///   identical so the two keys cannot drift; the post-state
 ///   `zypper -n patches | grep $repa` in the template is what surfaces it in
 ///   the transcript.
 ///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "package not found", "update stack
-/// locked", "Dependency Error", "RPM Error", or "Unknown Error".
+/// locked", "Dependency Error", "RPM Error", "Unknown Error", or — only if a
+/// caller reaches here without its [`not_run`] gate — "update command timed out
+/// or failed to run".
 fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     match classify_exit(args.exitcode) {
         ExitClass::Success => markers(args),
+        ExitClass::PackageNotFound if args.exitcode == 104 => {
+            log_failed(args);
+            Err(UpdateError::new("package not found", args.hostname))
+        }
         ExitClass::PackageNotFound => {
+            markers(args)?;
             log_failed(args);
             Err(UpdateError::new("package not found", args.hostname))
         }
@@ -169,6 +198,13 @@ fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
             log_failed(args);
             Err(UpdateError::new("Unknown Error", args.hostname))
         }
+        // Unreachable through either check — both gate on `not_run` first — but
+        // a class rather than a fallthrough, so a caller that forgets cannot
+        // report a host mtui never reached as a failed patch. Deliberately the
+        // same error the gate raises, which makes the gate's removal
+        // behaviour-preserving on this path; the gate stays because it is the
+        // cheaper check and reads at the top of each key.
+        ExitClass::NotRun => Err(not_run_error(args)),
     }
 }
 
@@ -224,13 +260,22 @@ fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// failed to run".
 fn not_run(args: CheckArgs<'_>) -> Result<(), UpdateError> {
     if args.exitcode == -1 {
-        log_failed(args);
-        return Err(UpdateError::new(
-            "update command timed out or failed to run",
-            args.hostname,
-        ));
+        return Err(not_run_error(args));
     }
     Ok(())
+}
+
+/// The `-1` verdict, in one place.
+///
+/// Built here rather than at each site so [`not_run`] and [`classified`]'s
+/// [`ExitClass::NotRun`] arm cannot drift into two spellings of the same
+/// sentinel. The flow's veto of the group-wide rollback keys on `lastexit()`
+/// being `-1`, not on this string; what the string decides is what the operator
+/// is told the host's failure *was*, which for a host mtui never reached must
+/// not read as a package problem.
+fn not_run_error(args: CheckArgs<'_>) -> UpdateError {
+    log_failed(args);
+    UpdateError::new("update command timed out or failed to run", args.hostname)
 }
 
 /// The stdout/stderr classification shared by every update check.
@@ -263,9 +308,17 @@ fn markers(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
         return Err(UpdateError::new("update stack locked", args.hostname));
     }
     if args.stdout.contains("(c): c") {
+        // Carries `command` and `stderr` as well as `stdout`, matching the
+        // sibling branches' `log_failed` record. Without them this branch was
+        // the one marker that left no forensic trace of the command — invisible
+        // while it could only follow a success or an unrecognised status, but
+        // reachable now on `4`/`5`/`8`, which are the codes an operator is most
+        // likely to be investigating.
         tracing::error!(
             host = args.hostname,
+            command = args.stdin,
             stdout = args.stdout,
+            stderr = args.stderr,
             "unresolved dependency problem. please resolve manually"
         );
         return Err(UpdateError::new("Dependency Error", args.hostname));
@@ -580,8 +633,10 @@ mod tests {
     #[test]
     fn package_not_found_codes_on_both_zypper_keys() {
         // The `104 | 4 | 5 | 8` grouping is the install check's, reproduced
-        // exactly: the reason strings are a contract callers match on, so one
-        // exit code must not carry two verdicts across two checks.
+        // exactly, so an exit code cannot be sorted into two different classes
+        // by two checks. The transcripts here are clean, which is when the
+        // class label is also the message; see `only_104_outranks_the_markers`
+        // for what the three inaccurate members say when it is not.
         for code in [104, 4, 5, 8] {
             let err = zypper(args("zypper -n in -t patch", "", "", code)).unwrap_err();
             assert_eq!(err.reason, "package not found", "zypper exit {code}");
@@ -627,24 +682,62 @@ mod tests {
     }
 
     #[test]
-    fn package_not_found_outranks_the_markers() {
-        // The other half of `classified`'s ordering, and the half nothing
-        // pinned: every other not-found fixture has empty stdout *and* stderr,
-        // so inserting `markers(args)?` at the top of that arm passed the whole
-        // suite. These carry a marker AND a not-found exit code, so they can
-        // only pass if the exit code is consulted first.
-        //
-        // This is also where the `104 | 4 | 5 | 8` grouping shows its cost: an
-        // exit `5` is `ERR_PRIVILEGES`, not a missing package, so a locked
-        // stack under it is reported as "package not found". Deliberate — the
-        // reason strings are a contract shared with the install check.
+    fn only_104_outranks_the_markers() {
+        // `104` is the one member of its class that literally means "capability
+        // not found", and the one whose verdict a marker cannot improve on: it
+        // short-circuits even with a marker present.
         let err = zypper(args("zypper", "", "System management is locked", 104)).unwrap_err();
-        assert_eq!(err.reason, "package not found");
+        assert_eq!(err.reason, "package not found", "104 outranks the marker");
+
+        // `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT` — the
+        // package was found and the transaction failed. These three are the
+        // headline real-world patch failures, so the transcript names them
+        // rather than the class label. Restoring the blanket short-circuit
+        // turns every one of these into "package not found".
+        let err = zypper(args("zypper", "", "System management is locked", 5)).unwrap_err();
+        assert_eq!(err.reason, "update stack locked", "5 + lock marker");
+        let err = zypper(args(
+            "zypper",
+            "",
+            "A ZYpp transaction is already in progress.",
+            4,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "update stack locked", "4 + ZYpp marker");
         let err = zypper(args("zypper", "(c): c", "", 4)).unwrap_err();
-        assert_eq!(err.reason, "package not found");
+        assert_eq!(err.reason, "Dependency Error", "4 + dependency prompt");
         let err =
             transactional_update(args("transactional-update", "", "Error: boom", 8)).unwrap_err();
-        assert_eq!(err.reason, "package not found");
+        assert_eq!(err.reason, "RPM Error", "8 + rpm marker");
+
+        // What the three say on a *clean* transcript is already pinned by
+        // `package_not_found_codes_on_both_zypper_keys`, which passes empty
+        // stdout and stderr for all four codes. Repeating it here would
+        // constrain nothing the marker cases above do not.
+    }
+
+    #[test]
+    fn the_never_ran_class_cannot_be_read_as_a_package_failure() {
+        // Unreachable through `zypper`/`transactional_update`, which gate on
+        // `not_run` first — so this calls `classified` directly, which is the
+        // only way to prove the arm exists and says the right thing. Before
+        // `ExitClass::NotRun`, `-1` fell through to `Unknown`, and a host mtui
+        // never contacted was reported as a failed patch. (Not as a *rolled
+        // back* one: `never_ran` in `reports::update_flow` reads the target's
+        // `lastexit()`, so the group-wide downgrade was skipped either way.)
+        let err = classified(args("zypper", "", "", -1)).unwrap_err();
+        assert_eq!(err.reason, "update command timed out or failed to run");
+
+        // Both routes to the sentinel give the operator the same string — the
+        // point of `not_run_error`. This cannot detect the gate's removal
+        // (the arm produces the identical error, by design); what it pins is
+        // that the two never drift apart.
+        for reached in [
+            zypper(args("zypper", "", "", -1)),
+            transactional_update(args("transactional-update", "", "", -1)),
+        ] {
+            assert_eq!(reached.unwrap_err().reason, err.reason);
+        }
     }
 
     #[test]

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -9,59 +9,100 @@
 //! alongside. Lock / dependency / RPM failures still raise [`UpdateError`].
 
 use crate::update_workflow::UpdateError;
-use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed};
+use crate::update_workflow::checks::{
+    CheckArgs, CheckFn, Diagnostic, ExitClass, classify_exit, log_failed,
+};
 
 /// The zypper update check.
+///
+/// The exit code reaching here **is the patch's own**: the update template
+/// captures `$?` on the line after the patch, before the post-state `grep` and
+/// the repo-cleanup loop can clobber it, and ends with `exit $mtui_status`
+/// (see [`crate::update_workflow::actions::update`]). So the status is
+/// classified, by [`classify_exit`] — the same three sets the install check
+/// uses, in one place.
+///
+/// The informational carve-out is the load-bearing part, not the failure rule:
+/// zypper exits `102` ("reboot needed") after patching a kernel and `107` when
+/// a package's `%post` script failed but the package is installed and
+/// registered — both routine outcomes of the thing mtui exists to do. Failing
+/// either would fire the **group-wide** rollback downgrade and revert every
+/// healthy host in the group.
+///
+/// An unrecognised non-zero status gives the stdout/stderr [`markers`] first
+/// refusal — "update stack locked", "Dependency Error" and "RPM Error" name
+/// the failure, where "Unknown Error" only says there was one — so the
+/// fallback fires solely on a clean transcript.
+///
+/// The classification is gated on the command text containing `zypper`, which
+/// is inert in production (this check is only registered for keys whose
+/// updater is the zypper template, and that template's `zypper` token is
+/// pinned by a test) but preserves the long-standing rule that these codes are
+/// only read as zypper's when the transcript is zypper's.
 ///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run" (exit `-1`), "package not found" (zypper exit `104`),
-/// "update stack locked", "Dependency Error", or "RPM Error"
-/// depending on the exit code and stderr/stdout markers. Warnings
-/// (exit `106`, "Additional rpm output", "not supported by its vendor") do not
-/// fail the check; the two output sections are returned as [`Diagnostic`]s for
-/// the caller to render.
-///
-/// Note this check does **not** treat an unrecognised non-zero exit as a
-/// failure: the zypper update template ends with the same repo-cleanup loop
-/// that masks the patch status on `slmicro` (see [`transactional_update`]), so
-/// the code reaching here is not the patch's either. It is judged on the
-/// markers, the `-1` never-ran sentinel, and the two exit codes zypper is
-/// known to surface.
+/// failed to run" (exit `-1`), "package not found" (exit `104`, `4`, `5`,
+/// `8`), "update stack locked", "Dependency Error", "RPM Error", or "Unknown
+/// Error" (any other non-zero exit with a clean transcript). The informational
+/// exits (`100`-`103`, `106`, `107`) and the two recognised output sections
+/// ("Additional rpm output", "not supported by its vendor") do not fail the
+/// check; `106` additionally logs a warning, and the two sections are returned
+/// as [`Diagnostic`]s for the caller to render.
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
-    if args.stdin.contains("zypper") && args.exitcode == 104 {
-        log_failed(args);
-        return Err(UpdateError::new("package not found", args.hostname));
+    if !args.stdin.contains("zypper") {
+        return markers(args);
     }
-    if args.stdin.contains("zypper") && args.exitcode == 106 {
+    if args.exitcode == 106 {
         tracing::warn!(
             host = args.hostname,
             stderr = args.stderr,
             "zypper returns exitcode 106"
         );
     }
-    markers(args)
+    classified(args)
 }
 
 /// The transactional-update (`slmicro`) update check.
 ///
-/// Deliberately has **no exit-code rule beyond the
-/// [`not_run`] sentinel**, because `lastexit()` does not carry the patch
-/// command's status on this key: the `slmicro` update template is a multi-line
-/// script executed as a single remote `exec`, and its last line is the
-/// `zypper -n lr | … | while read r; do zypper -n rr $r; done` repo-cleanup
-/// loop. The shell therefore reports *that loop's* status — which is `0`
-/// whenever the loop body never runs — and discards the
-/// `transactional-update -n pkg in … -t patch` status entirely.
+/// Judged on the exit code as well as the markers. The slmicro update template
+/// captures the `transactional-update -n pkg in … -t patch` status into a
+/// variable and exits with it, so `lastexit()` is the patch's status and not
+/// the trailing repo-cleanup loop's — which was `0` whenever the loop body
+/// never ran, and let a failed patch report success.
 ///
-/// Judging this key on the exit code would be wrong in both directions: a
-/// failed patch still exits `0`, and a hiccup in the cosmetic repo cleanup
-/// would be reported as a failed update — which, because an `update` check
-/// failure routes the **group-wide** rollback downgrade, would roll back the
-/// whole fleet over a no-op. The stdout/stderr markers below are unaffected by
-/// the masking and are what this key is judged on.
+/// It shares zypper's classifier ([`classify_exit`]), and in practice that
+/// reduces to "`0` passes, anything else fails", because
+/// **`transactional-update` does not propagate zypper's exit code** — it
+/// absorbs it. Verified against upstream `openSUSE/transactional-update`,
+/// `sbin/transactional-update.in` @ `aee1e1b5` (v6.1.3): the zypper status is
+/// captured into `RETVAL` (`:1197`), tested against a hardcoded tolerance list
+/// of `0 | 102 | 103 | (106 unless dup)` (`:1214`), and otherwise turned into a
+/// flat `EXITCODE=1` (`:1232`). `RETVAL` is never assigned to `EXITCODE` and
+/// never reaches the single `exit $EXITCODE` (`:1505`). The documented exit
+/// status (`man/transactional-update.8.xml`) is only `0`, `1` and `2`, and `2`
+/// comes solely from the `apply` command, which this template does not use.
+/// The behaviour is identical across every tag from v2.28.3 to v6.1.3.
+///
+/// So on this key the informational carve-out and the `PackageNotFound` arm
+/// are both **inert**: `102`/`103`/`106` are already mapped to `0` upstream,
+/// and `104`/`4`/`5`/`8` all collapse to `1`. Only `0` and `1` can arrive.
+/// The shared classifier is used anyway rather than a hand-written `!= 0`, so
+/// this key cannot drift away from the zypper one, and so a future
+/// `transactional-update` that *did* propagate would be classified correctly
+/// from the day it started to.
+///
+/// One consequence worth knowing when reading a transcript: `0` is also what
+/// `pkg in` returns when its dry run finds nothing to do (`quit 0` at `:1192`,
+/// after logging `zypper: nothing to update`), so a clean exit does not
+/// distinguish "patched" from "had nothing to patch".
+///
+/// Unlike [`zypper`] this is not gated on a token in the command text: the
+/// slmicro template contains both `zypper` and `transactional-update`, so a
+/// token guard here would only add a second way for the rule to silently stop
+/// firing.
 ///
 /// The markers carry one residual exposure, accepted as a decision rather
 /// than an oversight: the `Error:` rule reads stderr from the whole `exec`,
@@ -76,10 +117,59 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run", "update stack locked", "Dependency Error", or "RPM Error".
+/// failed to run", "package not found", "update stack locked", "Dependency
+/// Error", "RPM Error", or "Unknown Error".
 fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
-    markers(args)
+    classified(args)
+}
+
+/// Applies [`classify_exit`] to a patch status, interleaved with the
+/// stdout/stderr [`markers`].
+///
+/// The interleaving is the whole content of this function: `PackageNotFound`
+/// is a named verdict and returns straight away, while `Unknown` lets the
+/// markers speak first, because "update stack locked" is a diagnosis and
+/// "Unknown Error" is an admission. A success status still runs the markers —
+/// a dependency prompt (`(c): c`) leaves the transaction unfinished with a
+/// perfectly clean exit status.
+///
+/// Two consequences of that ordering, both deliberate and neither obvious:
+///
+/// * The `PackageNotFound` arm **skips the markers**. Its set is
+///   `104 | 4 | 5 | 8`, and only `104` actually means "capability not found" —
+///   `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`. So an exit
+///   `5` carrying `System management is locked` on stderr now reports "package
+///   not found" where the marker rule alone would have reported the lock. The
+///   set and its reason string are a frozen contract shared with the install
+///   check (an exit code must not carry two verdicts across two checks), so the
+///   inaccurate label stays; what it costs is a less precise reason on three
+///   codes, never a missed failure.
+/// * `103` (`ZYPPER_EXIT_INF_RESTART_NEEDED`) is a success even though zypper
+///   means "the patch that updates the package manager itself was installed,
+///   run the command again to install the *remaining* patches". Those remaining
+///   patches are not installed. Inherited from the install check's set and left
+///   identical for the same contract reason; the post-state
+///   `zypper -n patches | grep $repa` in the template is what surfaces it in
+///   the transcript.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "package not found", "update stack
+/// locked", "Dependency Error", "RPM Error", or "Unknown Error".
+fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    match classify_exit(args.exitcode) {
+        ExitClass::Success => markers(args),
+        ExitClass::PackageNotFound => {
+            log_failed(args);
+            Err(UpdateError::new("package not found", args.hostname))
+        }
+        ExitClass::Unknown => {
+            markers(args)?;
+            log_failed(args);
+            Err(UpdateError::new("Unknown Error", args.hostname))
+        }
+    }
 }
 
 /// The yum update check.
@@ -386,19 +476,23 @@ mod tests {
     }
 
     #[test]
-    fn transactional_update_ignores_the_masked_exit_code() {
-        // The slmicro template's last line is the repo-cleanup loop, so
-        // `lastexit()` is that loop's status, not the patch's. Judging this
-        // key on the exit code would roll the whole group back over a cosmetic
-        // cleanup hiccup, so a non-zero code with clean output must pass.
-        let diags = transactional_update(args("transactional-update -n pkg in", "all good", "", 1))
-            .expect("a masked non-zero exit must not fail the transactional check");
-        assert!(diags.is_empty());
+    fn transactional_update_fails_on_an_unrecognised_non_zero_exit() {
+        // The inverse of the rule this check used to carry. The slmicro
+        // template now captures the patch's own status and exits with it, so a
+        // non-zero code with clean output is a failed patch, not the trailing
+        // repo-cleanup loop's status.
+        let err = transactional_update(args("transactional-update -n pkg in", "all good", "", 1))
+            .expect_err("a failed patch with clean output must fail the check");
+        assert_eq!(err.reason, "Unknown Error");
+        assert_eq!(err.host.as_deref(), Some("h1"));
     }
 
     #[test]
     fn transactional_update_still_catches_the_markers() {
-        // What it *is* judged on: the markers survive the exit-code masking.
+        // The other half of the verdict. Each of these carries exit `0`, which
+        // is exactly the shape the exit-code rule cannot see: a
+        // `transactional-update` that ran, reported a problem in its output,
+        // and still returned success.
         let err = transactional_update(args(
             "transactional-update -n pkg in",
             "",
@@ -444,10 +538,131 @@ mod tests {
     }
 
     #[test]
-    fn zypper_does_not_fail_on_an_unrecognised_non_zero_exit() {
-        // The zypper template ends with the same masking cleanup loop, so a
-        // bare `!= 0` rule here would be a false failure — and would fire the
-        // group-wide rollback. Only -1, 104 and the markers judge this key.
-        assert!(zypper(args("zypper -n in -t patch", "all good", "", 7)).is_ok());
+    fn zypper_fails_on_an_unrecognised_non_zero_exit() {
+        // The inverse of the rule this check used to carry. The zypper
+        // template captures the patch's status and exits with it, so an
+        // unrecognised non-zero code is the patch's verdict and not the
+        // trailing repo-cleanup loop's.
+        let err = zypper(args("zypper -n in -t patch", "all good", "", 7))
+            .expect_err("a failed patch with clean output must fail the check");
+        assert_eq!(err.reason, "Unknown Error");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn informational_exit_codes_pass_on_both_zypper_keys() {
+        // The carve-out that makes the exit-code rule safe to switch on at
+        // all. `102` is "reboot needed" — the routine result of patching a
+        // kernel — `100`/`101` are "(security) updates available", which a
+        // patch run leaves behind whenever the host carries more than this
+        // update, and `107` is "the package is installed and registered but
+        // its %post script failed". Failing any of them would fire the
+        // group-wide rollback downgrade and revert every healthy host in the
+        // group.
+        //
+        // The whole informational band is listed here, not a sample: the
+        // classifier's own test and this one are the two places a code can be
+        // forgotten, and `107` was in fact missing from the band on the first
+        // pass.
+        for code in [0, 100, 101, 102, 103, 106, 107] {
+            assert!(
+                zypper(args("zypper -n in -t patch", "all good", "", code)).is_ok(),
+                "zypper must pass on informational exit {code}"
+            );
+            assert!(
+                transactional_update(args("transactional-update -n pkg in", "all good", "", code))
+                    .is_ok(),
+                "transactional-update must pass on informational exit {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn package_not_found_codes_on_both_zypper_keys() {
+        // The `104 | 4 | 5 | 8` grouping is the install check's, reproduced
+        // exactly: the reason strings are a contract callers match on, so one
+        // exit code must not carry two verdicts across two checks.
+        for code in [104, 4, 5, 8] {
+            let err = zypper(args("zypper -n in -t patch", "", "", code)).unwrap_err();
+            assert_eq!(err.reason, "package not found", "zypper exit {code}");
+            let err = transactional_update(args("transactional-update -n pkg in", "", "", code))
+                .unwrap_err();
+            assert_eq!(
+                err.reason, "package not found",
+                "transactional-update exit {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_rendered_update_templates_reach_the_exit_code_rules() {
+        // `zypper`'s classification is gated on the literal token `zypper`
+        // appearing in the command text. That gate and the template are two
+        // separate files, so this feeds the check the *real* rendered template
+        // — the only way the coupling can be pinned. Asserting the token
+        // inside the template's own test would pin it against itself.
+        let vars = [("repa", ":p=42:7"), ("packages", "pkg-a")];
+        for (key, transactional, check) in [
+            (
+                "15",
+                false,
+                Box::new(zypper) as Box<dyn Fn(CheckArgs<'_>) -> _>,
+            ),
+            ("slmicro", true, Box::new(transactional_update)),
+        ] {
+            let rendered = crate::update_workflow::actions::update::updater(key, transactional)
+                .expect("both keys have an updater")
+                .render_command(&vars.into_iter().collect())
+                .expect("safe substitution never fails");
+
+            let err = check(args(&rendered, "", "", 104)).unwrap_err();
+            assert_eq!(err.reason, "package not found", "{key}");
+            let err = check(args(&rendered, "", "", 7)).unwrap_err();
+            assert_eq!(err.reason, "Unknown Error", "{key}");
+            assert!(
+                check(args(&rendered, "", "", 102)).is_ok(),
+                "{key}: 102 is 'reboot needed'"
+            );
+        }
+    }
+
+    #[test]
+    fn package_not_found_outranks_the_markers() {
+        // The other half of `classified`'s ordering, and the half nothing
+        // pinned: every other not-found fixture has empty stdout *and* stderr,
+        // so inserting `markers(args)?` at the top of that arm passed the whole
+        // suite. These carry a marker AND a not-found exit code, so they can
+        // only pass if the exit code is consulted first.
+        //
+        // This is also where the `104 | 4 | 5 | 8` grouping shows its cost: an
+        // exit `5` is `ERR_PRIVILEGES`, not a missing package, so a locked
+        // stack under it is reported as "package not found". Deliberate — the
+        // reason strings are a contract shared with the install check.
+        let err = zypper(args("zypper", "", "System management is locked", 104)).unwrap_err();
+        assert_eq!(err.reason, "package not found");
+        let err = zypper(args("zypper", "(c): c", "", 4)).unwrap_err();
+        assert_eq!(err.reason, "package not found");
+        let err =
+            transactional_update(args("transactional-update", "", "Error: boom", 8)).unwrap_err();
+        assert_eq!(err.reason, "package not found");
+    }
+
+    #[test]
+    fn markers_outrank_the_unknown_error_fallback() {
+        // "Unknown Error" only says a run failed; the markers say why. A
+        // failing patch that also reports a locked stack must keep the
+        // diagnosis, on both keys — this is what the ordering inside
+        // `classified` buys, and a fallback placed before the markers would
+        // silently replace every named reason with "Unknown Error".
+        let err = zypper(args("zypper", "", "System management is locked", 1)).unwrap_err();
+        assert_eq!(err.reason, "update stack locked");
+        let err = zypper(args("zypper", "(c): c", "", 1)).unwrap_err();
+        assert_eq!(err.reason, "Dependency Error");
+        let err = zypper(args("zypper", "", "Error: boom", 1)).unwrap_err();
+        assert_eq!(err.reason, "RPM Error");
+
+        let err =
+            transactional_update(args("transactional-update", "", "Error: boom", 1)).unwrap_err();
+        assert_eq!(err.reason, "RPM Error");
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -46,13 +46,17 @@ pub(crate) type WorkflowKey = (String, bool);
 ///
 /// Its
 /// `Display` renders `"{host}: {reason}"` when a host is
-/// present, otherwise just `"{reason}"`. The `reason` strings are stable
-/// contract values consumed by callers ("package not found", "update stack
-/// locked", "RPM Error", "Dependency Error", "Unknown Error", "Unspecified
-/// Error").
+/// present, otherwise just `"{reason}"`. The `reason` strings are diagnoses
+/// shown to an operator and asserted on by tests ("package not found", "update
+/// stack locked", "RPM Error", "Dependency Error", "Unknown Error",
+/// "Unspecified Error"); no code branches on them, so a check is free to pick
+/// the most accurate one for a given transcript. What *is* a contract is the
+/// `UpdateFailure` variant a failure routes to, which decides whether the
+/// group is rolled back.
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub struct UpdateError {
-    /// The failure reason (a stable, contract short string).
+    /// The failure reason: a short diagnosis for the operator, not a value
+    /// callers match on (see the type doc).
     pub(crate) reason: String,
     /// The host the command ran on, if known.
     pub(crate) host: Option<String>,


### PR DESCRIPTION
Closes #400.

## The bug

`ZYPPER_UPDATE` and `SLM_UPDATE` are multi-line scripts run as one remote
command. Their last line is the repo-cleanup loop, whose status is `0` whenever
it finds nothing to remove — so the shell reported that, and the patch's status
was discarded before anything could read it. A patch that genuinely failed with
clean output passed the update check. (The post-state `zypper patches | grep`
clobbers `$?` even before the loop does.)

This is long-standing upstream behaviour, not a port regression: the Python
templates are byte-identical, trailing loop and all.

## The fix

Each template captures the patch's status on the line *after* the patch and
exits with it. The patch list is captured first and the patch runs only when
that list holds at least one word, so a host carrying none of the update's
products is a no-op rather than a package manager complaining about its own
arguments — a status that is now real.

The emptiness test is `set -- $mtui_patches` + `[ "$#" -gt 0 ]`, **not**
`[ -n "$mtui_patches" ]`: the latter is true for a list of whitespace, which
then word-splits to nothing and runs the patch with no operands. That was caught
in review, measured, and is covered by a test.

## The safety argument — please read this part

An `update` check failure drives the **group-wide** rollback downgrade: it is
handed the whole `HostsGroup` with no filtering, removes every host's issue
repos, downgrades every host, reboots the transactional ones, and rewrites the
report's version slots. A false failure therefore reverts hosts that did
everything right. So the check classifies the status instead of comparing it
against zero:

| codes | verdict |
|---|---|
| `0`, `100`, `101`, `102`, `103`, `106`, `107` | pass |
| `104`, `4`, `5`, `8` | "package not found" |
| any other non-zero | "Unknown Error", *unless* an output marker names it more precisely |

`102` is "reboot needed" — the routine outcome of patching a kernel.

**`107` was missing from that set in my first draft, and the review caught it.**
It is `ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`: a package's `%post` script failed
although the package itself was, per the man page, "successfully unpacked to
disk and registered in the rpm database". It would have failed the check and
rolled back the fleet over a scriptlet hiccup. The second commit fixes the
identical omission in the *install* check, where it is a live bug today.

The template change and the check change are one commit deliberately: a template
reporting the real status while the check still lacked the carve-out would newly
fail every host that merely needs a reboot.

## Two things I want your call on

1. **`4`/`5`/`8` report "package not found".** That grouping is inherited
   verbatim from the install check, and the reason strings are a stable contract,
   so I kept it rather than let one exit code carry two verdicts across two
   checks. But it is now on the *primary* failure path instead of dormant, and
   the label misdiagnoses: `8` is `ERR_COMMIT` (the most likely status for the
   failure this issue is about) and `5` is `ERR_PRIVILEGES`. Splitting them means
   minting a reason string. Happy to do it if you'd rather.
2. **`103` passes.** `RESTART_NEEDED` means zypper installed the patch that
   updates the package manager itself and *remaining* patches need a second run —
   so mtui reports the update applied while some patches were not installed.
   Inherited from the install check; the post-patch `zypper patches` line in the
   transcript is what shows them. Flagging because this change advertises it.

## SL Micro

The classification is in practice just "`0` passes". Upstream
`transactional-update` captures zypper's status, tolerance-tests it, and flattens
everything else to `EXITCODE=1` — it returns only `0` or `1`, verified against
`openSUSE/transactional-update` @ `aee1e1b5` (v6.1.3) and unchanged across nine
tags. So neither the informational codes nor the package-not-found ones can reach
the check on that key. This started as an inference and was checked rather than
assumed; the doc says so with the citation.

## Testing

The acceptance test renders each template and executes it under a real `/bin/sh`
with stub `zypper` / `transactional-update` executables on `PATH`, because the
suite's `MockConnection` scripts one exit code per command and cannot model the
shell's last-command-wins rule — the entire subject of this issue. Each case was
observed red against the old template first:

* patch exits 8, cleanup exits 0 → script must exit 8 (**before: 0** — the bug);
* patch exits 0, cleanup exits 3 → script must exit 0 (a cosmetic cleanup hiccup
  must not fail an update and revert the group);
* empty and whitespace-only patch lists → patch never invoked, script exits 0.

The stubs record their invocations so the tests cannot pass by never running
anything. A separate test asserts the fixture rows match under *this host's* awk,
so a non-GNU awk fails loudly with the real cause rather than silently skipping —
the template's `\>` is a gawk extension and the macOS CI leg runs these tests.

## Residuals, deliberately not fixed here

* The command substitution's own failure is discarded: a failed `zypper refresh`
  or a missing repo yields an empty patch list, skips the patch, and reports
  success having installed nothing. Same class as this bug, one step upstream —
  filed separately rather than widening a change that already moves the rollback
  boundary.
* `#[cfg(unix)]` on the shell tests: they vanish on a non-unix builder with a
  green `ok`.
* `perform_update_aggregates_multiple_host_failures_and_keeps_repos` still
  scripts its exit code via `with_default`.
