### PR TITLE
fix(testreport): fail an update whose host could not work out what to patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   nothing to remove — so the shell reported that and discarded the
   `zypper -n in -t patch` / `transactional-update -n pkg in -t patch` status
   before anything could read it. Each template now captures the patch's own
-  status and exits with it, and the remote command text visible in `show_log`
+  status and exits with it — unless it never got as far as the patch, which is
+  the entry below — and the remote command text visible in `show_log`
   transcripts changes accordingly.
   The exit code is classified rather than compared against zero. `100`-`103`,
   `106` and `107` are zypper's *informational* results and still pass — `102`
@@ -182,6 +183,48 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `transactional-update` absorbs zypper's status and returns only `0` or `1`,
   so neither the informational codes nor the package-not-found ones can reach
   the check on that key.
+- An `update` on a host that could not work out **what** to patch is no longer
+  reported as a successful update (#447). Both zypper templates decide whether
+  to patch from `zypper -n patches` and the `awk` that filters its output, and a
+  failure of either — exit `6` on a host with no repositories, `7` on a locked
+  ZYpp stack, an unreadable rpmdb, an `awk` that is broken or missing — produced
+  an *empty* patch list, which is indistinguishable from the legitimate "this
+  host carries none of the update's products". The patch was then skipped and
+  the script exited `0`, so mtui reported an update it had never installed.
+  Both are now captured with their own status read before anything can
+  overwrite it; the script prints
+  `mtui: could not determine what to patch: <command> exited <status>` and exits
+  with that command's own status. The check reads that line ahead of the
+  exit-code rules — the two statuses share one numeric space, so nothing else
+  could tell them apart — and reports the new reason **"could not determine
+  what to patch"**, which an operator (or an MCP client) sees instead of
+  "Unknown Error" or "package not found".
+  **Only exit `0` counts as an answer here**, deliberately narrower than the
+  rule the patch's own status is read against: `106`
+  ("some repository had to be disabled temporarily") is routine for a *patch*,
+  but on the listing step it may mean the disabled repository was the update's
+  own, in which case the missing patch would go unnoticed. The cost is that a
+  host carrying an unrelated stale or unreachable repository can now fail its
+  update with "could not determine what to patch" rather than patching; the
+  remedy is to fix or remove that repository. A host carrying none of the
+  update's products still passes — an empty list reached with a `0` status is an
+  answer, not a failure — and so does an update repo that was simply never
+  added, which zypper reports as a perfectly good list without the update's
+  rows.
+  `zypper -n refresh` is **not** judged: it returns the same status whether one
+  repository failed to refresh or all of them did, so on a refhost with an
+  unrelated broken repo it cannot distinguish a fatal problem from a routine
+  one. A refresh failure that really does hide the update surfaces on the
+  listing step instead.
+  Such a host fails the update but does **not** trigger the group-wide rollback
+  downgrade: it never ran a patch, so there is nothing half-applied to repair,
+  and rolling back would revert every healthy host in the group. A run mixing
+  one such host with a genuine check failure still rolls back, on behalf of the
+  host the rollback can actually repair; a run mixing one with a host the flow
+  lost (a timeout, a dropped connection) does not roll back at all, where it
+  previously did — neither host is one a downgrade could repair.
+  The remote command text changes again, so `show_log` transcripts change with
+  it.
 - `install` no longer fails when a package's `%post` script did. zypper exits
   `107` (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) in that case — an *informational*
   code meaning the packages "were successfully unpacked to disk and are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,18 +199,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   could tell them apart — and reports the new reason **"could not determine
   what to patch"**, which an operator (or an MCP client) sees instead of
   "Unknown Error" or "package not found".
-  **Only exit `0` counts as an answer here**, deliberately narrower than the
-  rule the patch's own status is read against: `106`
-  ("some repository had to be disabled temporarily") is routine for a *patch*,
-  but on the listing step it may mean the disabled repository was the update's
-  own, in which case the missing patch would go unnoticed. The cost is that a
-  host carrying an unrelated stale or unreachable repository can now fail its
-  update with "could not determine what to patch" rather than patching; the
-  remedy is to fix or remove that repository. A host carrying none of the
-  update's products still passes — an empty list reached with a `0` status is an
-  answer, not a failure — and so does an update repo that was simply never
-  added, which zypper reports as a perfectly good list without the update's
-  rows.
+  **Exit `0` counts as an answer here, and `106` only while the update's own
+  repository is still listed** — deliberately narrower than the rule the
+  patch's own status is read against. `106` ("some repository had to be
+  disabled temporarily") is routine for a *patch*, but on the listing step it
+  may mean the disabled repository was the update's own, in which case the
+  missing patch would go unnoticed. zypper raises it for any skipped
+  repository without saying which, so instead of judging the status the script
+  asks `zypper -n lr` whether the update's repository is there: if it is, the
+  skipped one was somebody else's and the update proceeds with a note in the
+  transcript; if it is not, the listing cannot be trusted and the update fails.
+  A refhost carrying an unrelated stale or unreachable repository therefore
+  keeps patching, as it does today. A host carrying none of the update's
+  products still passes — an empty list reached with a `0` status is an answer,
+  not a failure — and so does an update repo that was simply never added, which
+  zypper reports as a perfectly good list without the update's rows.
   `zypper -n refresh` is **not** judged: it returns the same status whether one
   repository failed to refresh or all of them did, so on a refhost with an
   unrelated broken repo it cannot distinguish a fatal problem from a routine

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -455,7 +455,13 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         // vanish on the other — and they are the declared routing contract,
         // not a detail of who reads them today.
         aggregate.probe_failed = failures.iter().all(|e| e.probe_failed);
-        aggregate.cancelled = failures.iter().all(|e| e.cancelled);
+        // `cancelled` is deliberately NOT propagated here. Every cancellation
+        // in this module is an early `return Err`, so no cancelled error ever
+        // reaches a `failures` vec — the line would be dead, and if it ever
+        // became live it would newly route a multi-failure aggregate to
+        // `CommandError::Cancelled`, letting a cancel mask a real host failure
+        // that merely coincided with it. That is a behaviour change, not part
+        // of this fix.
         Err(aggregate)
     }
 }
@@ -2532,6 +2538,10 @@ mod tests {
             "one host that did dispatch a patch clears the flag: {mixed:?}"
         );
 
+        // `cancelled` is deliberately not summarised. Every cancellation in
+        // this module is an early `return Err`, so no cancelled error reaches
+        // a `failures` vec; propagating it here would be dead code that, were
+        // it ever reached, would let a cancel mask a coincident real failure.
         let cancelled = aggregate_failures(
             "update",
             vec![
@@ -2541,8 +2551,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            cancelled.is_cancelled(),
-            "a summary of cancellations is still a cancellation: {cancelled:?}"
+            !cancelled.is_cancelled(),
+            "aggregation must not mint a cancel verdict: {cancelled:?}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -39,13 +39,21 @@ use crate::update_workflow::{CheckProvider, DoerProvider, Role, UpdateError, Wor
 /// built by [`build_update_maps`] (`(commands, reboot)`).
 type UpdateMaps = (BTreeMap<String, String>, BTreeMap<String, String>);
 
-/// Why an update did not apply — distinguishes a *check* failure (packages may be
-/// half-applied, so roll back) from a *config* failure (a concrete target has no
-/// updater doer, so nothing was installed and there is nothing to roll back).
+/// Why an update did not apply.
 ///
-/// Both map to a single [`UpdateError`] at the command boundary; the distinction
-/// exists only so [`perform_update_with_rollback`] rolls back on `Check` and
-/// skips rollback on `MissingUpdater`.
+/// The variants exist to answer exactly one question — **can a group-wide
+/// downgrade repair any host that failed?** — because that is what
+/// [`perform_update_with_rollback`] has to decide, and the rollback reverts
+/// *every* host in the group, not just the one that reported. `Check` and
+/// `RebootNotTaken` answer yes and roll back; every other variant answers no
+/// and re-surfaces the error untouched.
+///
+/// "No" is not one situation, and the variants keep the differences because an
+/// operator needs them: nothing was ever installed (`MissingUpdater`,
+/// `Prepare`, `Cancelled`, `ProbeFailed`), or something may well have been
+/// installed but the flow cannot reach the host to undo it (`Reboot`), or it is
+/// unknown whether anything was (`NotRun`). All of them collapse to a single
+/// [`UpdateError`] at the command boundary.
 #[derive(Debug, PartialEq, Eq)]
 pub enum UpdateFailure {
     /// One or more hosts failed the `updater` check after the command ran.
@@ -115,10 +123,34 @@ pub enum UpdateFailure {
     /// of a verdict. The host's state is unknown, not known-bad; it needs
     /// eyes on it, not an automated second transaction.
     ///
-    /// Only used when **every** failed host is in that state; a run mixing a
-    /// real check failure with a lost host still rolls back, on behalf of the
-    /// host the rollback can genuinely repair.
+    /// Used when **no** failed host is one the rollback could repair: every
+    /// one of them is `-1`, or a mix of `-1` and
+    /// [`ProbeFailed`](Self::ProbeFailed) hosts (`-1` is the more
+    /// conservative of the two labels, and its "state unknown" claim is true
+    /// of at least one host in such a run). A run mixing either with a real
+    /// check failure still rolls back, on behalf of the host the rollback can
+    /// genuinely repair.
     NotRun(UpdateError),
+    /// The update command ran on every host that failed, and each reported
+    /// that it could not work out what to patch — so none of them dispatched
+    /// a patch (`checks::update`'s `probe_failure`).
+    ///
+    /// Skips the rollback, and for a *stronger* reason than
+    /// [`NotRun`](Self::NotRun)'s: this is not the absence of a verdict but a
+    /// definite one. The host said it never patched, so its packages are
+    /// exactly what they were before the flow started. There is nothing
+    /// half-applied for a downgrade to repair, and the rollback is group-wide
+    /// — running it would revert every healthy peer over a probe that broke on
+    /// one host.
+    ///
+    /// It is the operator's `zypper` view that needs attention (a host with no
+    /// repositories, a ZYpp lock, a broken awk), not the host's package state.
+    ///
+    /// Only used when **every** failed host is in that state. A run mixing one
+    /// with a `-1` host is labelled [`NotRun`](Self::NotRun) — also
+    /// non-rolling, and the more conservative of the two claims, since one host
+    /// in such a run really is in an unknown state.
+    ProbeFailed(UpdateError),
 }
 
 /// Drives [`perform_update`] from a concrete report, reading the package list
@@ -167,9 +199,12 @@ where
 /// that did not take effect on a host still reachable
 /// ([`UpdateFailure::RebootNotTaken`]).
 ///
-/// A `MissingUpdater` failure installed nothing, so it re-surfaces without a
-/// rollback attempt. The rollback is best-effort ([`perform_downgrade`] returns
-/// `()`), so it can never bury the original update error.
+/// Every other failure installed nothing — no updater for a host's key, a
+/// prepare that could not run, a cancel before dispatch, a host the flow lost,
+/// or a host that could not determine what to patch — so each re-surfaces
+/// without a rollback attempt. The rollback is best-effort
+/// ([`perform_downgrade`] returns `()`), so it can never bury the original
+/// update error.
 pub async fn perform_update_with_rollback<R>(
     report: &R,
     targets: &mut HostsGroup,
@@ -212,6 +247,17 @@ where
             // group-wide downgrade cannot repair them and would only revert
             // the healthy ones.
             error!(error = %e, "update failed");
+            Err(e)
+        }
+        Err(UpdateFailure::ProbeFailed(e)) => {
+            // Every failed host reported that it could not work out what to
+            // patch, so none of them ran a patch: there is nothing
+            // half-applied for a downgrade to undo, and the rollback is
+            // group-wide — it would revert every healthy peer over a probe
+            // that broke on one host. The test repos are kept, as on any
+            // failure, so the operator can look at the repo state the probe
+            // complained about.
+            error!(error = %e, "update failed: could not determine what to patch");
             Err(e)
         }
         Err(UpdateFailure::Check(e) | UpdateFailure::RebootNotTaken(e)) => {
@@ -396,11 +442,21 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         let mut hosts: Vec<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
         hosts.sort();
         let detail: Vec<String> = failures.iter().map(ToString::to_string).collect();
-        Err(UpdateError::reason_only(format!(
+        let mut aggregate = UpdateError::reason_only(format!(
             "{op} failed on {} ({})",
             hosts.join(", "),
             detail.join("; ")
-        )))
+        ));
+        // The typed flags survive the summary. `all`, not `any`: each says
+        // something about *the run*, and a summary that claimed "no patch was
+        // dispatched" while one host had dispatched one would be worse than no
+        // claim at all. The single-failure path above returns the error
+        // verbatim, so without this the flags would exist on one path and
+        // vanish on the other — and they are the declared routing contract,
+        // not a detail of who reads them today.
+        aggregate.probe_failed = failures.iter().all(|e| e.probe_failed);
+        aggregate.cancelled = failures.iter().all(|e| e.cancelled);
+        Err(aggregate)
     }
 }
 
@@ -1605,9 +1661,12 @@ async fn remove_test_repos(targets: &mut HostsGroup, report: &dyn SetRepo) {
 /// host's reboot took effect — reconnecting is not sufficient, since a host can
 /// answer without ever having gone down. Otherwise `Err` with the aggregated
 /// failure: a check failure (packages may be half-applied) is
-/// [`UpdateFailure::Check`] and **suppresses the reboot entirely** — unless
-/// every failed host's command never completed (`lastexit()` of `-1`), which
-/// is [`UpdateFailure::NotRun`] and skips the rollback; a reboot
+/// [`UpdateFailure::Check`] and **suppresses the reboot entirely** — unless no
+/// failed host is one a rollback could repair, which is
+/// [`UpdateFailure::ProbeFailed`] when every one of them reported that it
+/// could not determine what to patch and [`UpdateFailure::NotRun`] when the
+/// command never completed there (`lastexit()` of `-1`); both skip the
+/// rollback. A reboot
 /// failure is [`UpdateFailure::Reboot`] when the host is unreachable and
 /// [`UpdateFailure::RebootNotTaken`] when every failed host is still reachable,
 /// which is what decides whether the group-wide rollback runs. A single failure is returned verbatim; more than
@@ -1659,20 +1718,35 @@ async fn update_run_phase(
         // left of it for the package-manager lock. All three veto the
         // rollback — `UpdateFailure::NotRun` carries the full argument.
         //
-        // `all`, not `any`, for the same reason as the reboot arm: a run that
-        // mixes a lost host with a genuine check failure still rolls back, on
-        // behalf of the host the rollback can actually repair.
-        let never_ran = failures.iter().all(|e| {
-            e.host
-                .as_deref()
-                .and_then(|h| targets.get(h))
-                .and_then(mtui_hosts::Target::lastexit)
-                == Some(-1)
-        });
-        let wrap: fn(UpdateError) -> UpdateFailure = if never_ran {
-            UpdateFailure::NotRun
-        } else {
+        // A probe failure is the third non-rolling cause, and the one the
+        // rollback is *least* entitled to fire on: the host ran the update
+        // command and reported that it could not work out what to patch, so it
+        // never dispatched a patch at all. Its packages are what they were
+        // before the flow started. It is carried as a typed flag on the error
+        // rather than re-derived here — the alternative, matching the reason
+        // string, would be the first place in the tree where control flow
+        // depended on a reason's text.
+        //
+        // The rollback question is one bit — "can a group-wide downgrade
+        // repair any host that failed?" — so it is asked that way: `any`
+        // repairable host routes `Check`, exactly as before (a run that mixes
+        // a lost host with a genuine check failure still rolls back, on behalf
+        // of the host the rollback can actually repair). Only the *label* on
+        // the non-repairable runs is split further.
+        let repairable = |e: &UpdateError| {
+            !e.probe_failed
+                && e.host
+                    .as_deref()
+                    .and_then(|h| targets.get(h))
+                    .and_then(mtui_hosts::Target::lastexit)
+                    != Some(-1)
+        };
+        let wrap: fn(UpdateError) -> UpdateFailure = if failures.iter().any(repairable) {
             UpdateFailure::Check
+        } else if failures.iter().all(|e| e.probe_failed) {
+            UpdateFailure::ProbeFailed
+        } else {
+            UpdateFailure::NotRun
         };
         aggregate_failures("update", failures).map_err(wrap)
     } else {
@@ -2422,6 +2496,57 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_failures_carries_the_typed_flags_through_the_summary() {
+        // The single-failure path returns the error verbatim, flags and all;
+        // the summary path builds a fresh one, so without care the flags exist
+        // on one path and vanish on the other. They are the declared routing
+        // contract — `reports::update_flow` routes on `probe_failed`, and the
+        // command layer reports `cancelled` — so a summary that drops them is a
+        // summary that lies about the run.
+        //
+        // `all`, not `any`: a summary claiming "no patch was dispatched" while
+        // one host had dispatched one would be worse than no claim.
+        let err = aggregate_failures(
+            "update",
+            vec![
+                UpdateError::probe_failure("could not determine what to patch", "h1"),
+                UpdateError::probe_failure("could not determine what to patch", "h2"),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            err.probe_failed,
+            "a summary of probe failures is still a probe failure: {err:?}"
+        );
+
+        let mixed = aggregate_failures(
+            "update",
+            vec![
+                UpdateError::probe_failure("could not determine what to patch", "h1"),
+                UpdateError::new("Unknown Error", "h2"),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            !mixed.probe_failed,
+            "one host that did dispatch a patch clears the flag: {mixed:?}"
+        );
+
+        let cancelled = aggregate_failures(
+            "update",
+            vec![
+                UpdateError::cancelled("cancelled before pkg-a"),
+                UpdateError::cancelled("cancelled before pkg-b"),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            cancelled.is_cancelled(),
+            "a summary of cancellations is still a cancellation: {cancelled:?}"
+        );
+    }
+
+    #[test]
     fn aggregate_failures_summarises_multiple_hosts() {
         let failures = vec![
             UpdateError::new("boom", "h2"),
@@ -2965,19 +3090,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn update_timeout_does_not_roll_back_healthy_hosts() {
-        // `Target::run` records -1 for a timeout, a mid-command connection
-        // loss, and an unconnected target — i.e. "the flow could not talk to
-        // this host", not "the patch went wrong". Routing that into the
-        // group-wide rollback would revert every host that patched cleanly on
-        // behalf of one the downgrade cannot reach anyway, which is exactly
-        // what the reboot arm already refuses to do.
-        //
-        // h1's patch times out; h2 patches cleanly. The `-1` is scripted onto
-        // the patch command only — it is exactly what `Target::run` records
-        // when the command times out, and scripting it via `with_default`
-        // would put it on the probes too.
+    /// An SL Micro target whose *update command* records `Target::run`'s
+    /// never-ran sentinel (`-1`) — a timeout, a mid-command connection loss, or
+    /// an unconnected target.
+    ///
+    /// The `-1` is scripted onto the update command alone: scripting it via
+    /// `with_default` would put it on the probes too, a state no run produces.
+    fn slmicro_target_with_lost_update(hostname: &str) -> (Target, MockConnection) {
         let patch = WorkflowRegistry::default()
             .doer(Role::Update, "slmicro", true)
             .expect("slmicro has an updater")
@@ -2990,13 +3109,13 @@ mod tests {
                 .collect(),
             )
             .expect("safe substitution never fails");
-        let lost = MockConnection::new("h1")
+        let lost = MockConnection::new(hostname)
             .with_default(CommandLog::new("", "", "", 0, 0))
             .with_response(patch.clone(), CommandLog::new(&patch, "", "", -1, 0))
             .with_changing_boot_id();
-        let lost_handle = lost.clone();
-        let mut t1 = Target::with_connection("h1", TargetState::Enabled, Box::new(lost));
-        t1.set_system(
+        let handle = lost.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(lost));
+        t.set_system(
             System::new(
                 SystemProduct::new("SL-Micro", "6.0", "x86_64"),
                 BTreeSet::new(),
@@ -3004,6 +3123,20 @@ mod tests {
             ),
             true,
         );
+        (t, handle)
+    }
+
+    #[tokio::test]
+    async fn update_timeout_does_not_roll_back_healthy_hosts() {
+        // `Target::run` records -1 for a timeout, a mid-command connection
+        // loss, and an unconnected target — i.e. "the flow could not talk to
+        // this host", not "the patch went wrong". Routing that into the
+        // group-wide rollback would revert every host that patched cleanly on
+        // behalf of one the downgrade cannot reach anyway, which is exactly
+        // what the reboot arm already refuses to do.
+        //
+        // h1's patch times out; h2 patches cleanly.
+        let (t1, lost_handle) = slmicro_target_with_lost_update("h1");
         let (t2, healthy) = slmicro_target("h2", "pkg-a = 1.0-1\n", 0);
         let mut group = HostsGroup::new(vec![t1, t2], false);
         let mut report = crate::reports::SlReport::new(Config::default());
@@ -3042,6 +3175,32 @@ mod tests {
             "the lost host cannot be rolled back either: {:?}",
             lost_handle.commands()
         );
+
+        // And the variant itself, which the rollback wrapper above collapses
+        // to a bare `UpdateError`. Without this the routing is observed only
+        // through its consequence, and `NotRun` could be replaced by any other
+        // non-rolling variant with the whole suite still green.
+        let (t, _) = slmicro_target_with_lost_update("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+        let res = perform_update(
+            &mut group,
+            &report,
+            &packages,
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+        let Err(UpdateFailure::NotRun(e)) = res else {
+            panic!("a host whose command never ran returns Err(NotRun): {res:?}");
+        };
+        assert_eq!(e.reason, "update command timed out or failed to run");
+        assert!(!e.probe_failed, "a lost host is not a probe failure: {e:?}");
     }
 
     #[tokio::test]
@@ -3305,6 +3464,244 @@ mod tests {
             false,
         );
         (t, handle, patch)
+    }
+
+    /// A SLES 15 target whose update script reports a **probe** failure: the
+    /// marker line on stdout, and the failed probe's own status as the
+    /// script's.
+    ///
+    /// That pairing is what the rendered template actually produces when
+    /// `zypper -n patches` fails — pinned end-to-end against a real `/bin/sh`
+    /// in `actions::update`'s `rendered_script` module, which is where it can
+    /// be pinned: `MockConnection` scripts one outcome per command string and
+    /// cannot run a shell. Replaying it here is what lets the *routing* be
+    /// tested, and the marker comes from the same constant the check greps
+    /// for, so the two cannot drift apart silently.
+    ///
+    /// The default stdout is a resolvable version line, so a rollback that did
+    /// run would render an `--oldpackage` command — without that, "assert no
+    /// rollback happened" would pass however the failure was routed.
+    fn sles_target_with_probe_failure(
+        hostname: &str,
+        packages: &[String],
+    ) -> (Target, MockConnection, String) {
+        use crate::update_workflow::checks::update::PROBE_FAILURE_MARKER;
+
+        let update = zypper_patch_command(packages);
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", "pkg-a = 1.0-1\n", "", 0, 0))
+            .with_response(
+                update.clone(),
+                CommandLog::new(
+                    update.clone(),
+                    format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6"),
+                    "",
+                    6,
+                    0,
+                ),
+            );
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        (t, handle, update)
+    }
+
+    #[tokio::test]
+    async fn perform_update_routes_a_probe_failure_away_from_the_rollback() {
+        // Issue #447's routing decision. A host that could not work out what
+        // to patch never ran a patch, so its packages are exactly what they
+        // were: there is nothing half-applied for the group-wide rollback
+        // downgrade to repair, and firing it would revert every healthy peer.
+        //
+        // The variant *and* the reason: `ProbeFailed` is the only non-rolling
+        // route reachable from a check failure other than `NotRun`, and the
+        // reason is what tells an operator to look at the repo state rather
+        // than at the host's packages.
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+        let (t, handle, update) = sles_target_with_probe_failure("h1", &packages);
+        let mut group = HostsGroup::new(vec![t], false);
+        let repo = RecordingRepo::default();
+
+        let res = perform_update(
+            &mut group,
+            &repo,
+            &packages,
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+
+        // Not vacuous: the failing script really was dispatched.
+        assert!(
+            handle.commands().contains(&update),
+            "the update command must have been dispatched: {:?}",
+            handle.commands()
+        );
+        let Err(UpdateFailure::ProbeFailed(e)) = res else {
+            panic!("a failed probe returns Err(ProbeFailed): {res:?}");
+        };
+        assert_eq!(e.reason, "could not determine what to patch");
+        assert_eq!(e.host.as_deref(), Some("h1"));
+
+        // As on any failure, the test repos are kept — here so the operator
+        // can inspect the repo state the probe complained about.
+        let ops = repo.ops.lock().unwrap().clone();
+        assert!(ops.contains(&RepoOp::Add), "repo add must run: {ops:?}");
+        assert!(
+            !ops.contains(&RepoOp::Remove),
+            "on failure the repos are kept (no Remove): {ops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_probe_failure_does_not_roll_back_a_healthy_peer() {
+        // The same decision seen where its blast radius is: through the
+        // rollback wrapper, with a healthy peer in the group. `perform_update_
+        // with_rollback` hands the downgrade the *whole* group, so a probe
+        // failure routed to `Check` would revert h2 — a host that patched
+        // perfectly — on behalf of h1's broken repo configuration.
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+        let packages = report.get_package_list();
+        let (t1, h1, _) = sles_target_with_probe_failure("h1", &packages);
+        let (t2, h2, _) = sles_target_with_patch_exit("h2", &packages, 0);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("a host that could not list its patches must not report success");
+        assert_eq!(err.reason, "could not determine what to patch");
+
+        // h2 first: the peer is what this test exists for.
+        assert!(
+            !h2.commands().iter().any(|c| c.contains("--oldpackage")),
+            "the healthy peer h2 must not be rolled back on h1's behalf: {:?}",
+            h2.commands()
+        );
+        assert!(
+            !h1.commands().iter().any(|c| c.contains("--oldpackage")),
+            "h1 never ran a patch, so it has nothing to roll back: {:?}",
+            h1.commands()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_mixed_probe_failure_and_lost_host_routes_not_run_and_skips_the_rollback() {
+        // The case the routing rewrite silently changed, and the one nothing
+        // observed. At HEAD the rule was `all(lastexit == -1)`, so a run mixing
+        // a probe failure with a lost host answered "not every host is `-1`" →
+        // `Check` → the group-wide rollback fired. It should not: neither host
+        // is one a downgrade can repair — h1 never ran a patch, and h2 cannot
+        // be reached.
+        //
+        // The label is `NotRun` rather than `ProbeFailed`: it is the more
+        // conservative of the two, and its claim ("the host's state is
+        // unknown") is true of h2.
+        let report = report_with_rrid();
+        let packages = report.get_package_list();
+
+        let (t1, _, _) = sles_target_with_probe_failure("h1", &packages);
+        let (t2, _) = slmicro_target_with_lost_update("h2");
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+        let repo = RecordingRepo::default();
+        let res = perform_update(
+            &mut group,
+            &repo,
+            &packages,
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+        let Err(UpdateFailure::NotRun(e)) = res else {
+            panic!("a probe failure mixed with a lost host returns Err(NotRun): {res:?}");
+        };
+        // Both hosts are named — the label is the conservative one, but
+        // neither failure is swallowed.
+        assert!(
+            e.reason.contains("h1") && e.reason.contains("h2"),
+            "both failed hosts are named: {}",
+            e.reason
+        );
+        // The aggregate does not claim "no patch was dispatched" for a run in
+        // which one host's state is unknown.
+        assert!(
+            !e.probe_failed,
+            "a mixed run must not carry the probe-failure flag: {e:?}"
+        );
+
+        // And through the rollback wrapper: neither host is downgraded.
+        let (t1, h1, _) = sles_target_with_probe_failure("h1", &packages);
+        let (t2, h2) = slmicro_target_with_lost_update("h2");
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+        report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("two failed hosts must not report success");
+        for (name, handle) in [("h1", &h1), ("h2", &h2)] {
+            assert!(
+                !handle.commands().iter().any(|c| c.contains("--oldpackage")),
+                "{name} must not be rolled back: neither host ran a patch this could undo: {:?}",
+                handle.commands()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_still_rolls_back_when_a_probe_failure_rides_with_a_real_one() {
+        // The other side of the routing rule, and the reason it asks "is *any*
+        // failed host repairable?" rather than "did they all fail the same
+        // way?". h2's patch ran and returned 104, which is the half-applied
+        // state the rollback exists to undo; h1's probe failure must not
+        // downgrade the *verdict* and strand h2 with a failed transaction.
+        let mut report = crate::reports::SlReport::new(Config::default());
+        seed_rrid_and_package(&mut report);
+        let packages = report.get_package_list();
+        let (t1, _h1, _) = sles_target_with_probe_failure("h1", &packages);
+        let (t2, h2, patch) = sles_target_with_patch_exit("h2", &packages, 104);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let err = report
+            .perform_update(&mut group, true, false, &mut Vec::new())
+            .await
+            .expect_err("two failed hosts must not report success");
+        // Both hosts are named, neither reason is swallowed.
+        assert!(
+            err.reason.contains("could not determine what to patch")
+                && err.reason.contains("package not found"),
+            "both failures are reported: {}",
+            err.reason
+        );
+
+        // Not vacuous: h2's patch really did run and fail.
+        assert!(
+            h2.commands().contains(&patch),
+            "h2's patch must have been dispatched: {:?}",
+            h2.commands()
+        );
+        assert!(
+            h2.commands().iter().any(|c| c.contains("--oldpackage")),
+            "h2 ran a patch that failed and must still be rolled back: {:?}",
+            h2.commands()
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -47,8 +47,11 @@
 //! assignment-only command takes the status of its last command substitution —
 //! so each probe is captured on its own (`mtui_patch_rows=$(zypper -n
 //! patches)`) and its `$?` read on the next line. The rows then reach awk
-//! through the **builtin** `printf '%s\n'`, not `echo` or `xargs`, so no
-//! `ARG_MAX` limit sits between them.
+//! through the **builtin** `printf '%s\n'`, not `echo` or `xargs`, so on any
+//! shell where `printf` is a builtin — dash, bash and busybox, i.e. every
+//! shell these run under — no `ARG_MAX` limit sits between them. Were it ever
+//! to resolve to `/usr/bin/printf`, a large enough patch table would fail the
+//! probe rather than truncate it: the fail-safe direction.
 //!
 //! `mtui_probe_ok <label> <status>` is the guard. On `0` it returns; on
 //! anything else it prints the marker line
@@ -69,24 +72,42 @@
 //! healthy update. `the_rendered_update_templates_do_not_trip_the_gate` pins
 //! it.
 //!
-//! ## Why the accepted set is `0` and nothing else
+//! ## Why the accepted set is `0`, plus `106` only when the repo is there
 //!
 //! **Deliberately narrower than `classify_exit`'s success set, and the two
 //! must not be unified.** That set is argued from "the transaction committed",
 //! which is a statement about the *patch*. Read as a verdict on a metadata
-//! *probe* its members invert: `106`
-//! (`ZYPPER_EXIT_INF_REPO_SKIPPED`) says a repository was skipped, and if the
-//! skipped one is the issue repo then the list legitimately lacks the patch —
-//! precisely the silent no-op this guard exists to stop. `zypper -n patches`
-//! cannot say *which* repo was skipped, so the status cannot be made to mean
-//! "the issue repo is present" by widening the set.
+//! *probe* its members invert: `106` (`ZYPPER_EXIT_INF_REPO_SKIPPED`) says a
+//! repository was skipped, and if the skipped one is the issue repo then the
+//! list legitimately lacks the patch — precisely the silent no-op this guard
+//! exists to stop.
 //!
-//! The asymmetry is chosen with its cost understood: a host carrying an
-//! unrelated broken repository alongside working ones now fails the update
-//! with "could not determine what to patch" instead of patching. That failure
-//! is **cheap** — it does not roll back (see `UpdateFailure::ProbeFailed`),
-//! and it points the operator at the repo state, which is where the problem
-//! is. A false *pass* is the bug being fixed.
+//! But `106` cannot simply be *rejected* either, and the reason is the same
+//! one that leaves `refresh` unguarded below: `init_repos()` raises it for
+//! **any** skipped repository and cannot say which. A refhost routinely
+//! carries one stale or unreachable repo alongside working ones, and those
+//! hosts patch correctly today. Rejecting `106` would abort exactly the hosts
+//! that leaving `refresh` unguarded was meant to protect — the two rules would
+//! cancel out, and the fleet, not one code path, would pay for it.
+//!
+//! So the status is not asked to carry the verdict at all. On `106` the script
+//! asks the question the guard actually cares about — *is the update's own
+//! repo still there?* — with `mtui_issue_repo_present`, which greps `$repa` out
+//! of `zypper -n lr`, the same selector and the same listing the cleanup loop
+//! already matches on. Repo present: the skipped one was somebody else's, so
+//! note it in the transcript and carry on. Repo absent: the list cannot be
+//! trusted, and the probe fails.
+//!
+//! `mtui_issue_repo_present` is a pipeline, and here the last-stage rule is
+//! wanted rather than worked around: awk's `END { exit !found }` *is* the
+//! verdict. An `lr` that fails outright therefore reads as "absent" and fails
+//! the probe, which is the conservative direction.
+//!
+//! A host carrying none of the update's products is untouched by this: no repo
+//! was added for it, so `patches` answers `0`, no `106` arises, and the empty
+//! list stays the legitimate no-op it always was. The alias question is only
+//! ever asked on the `106` path, which is why it cannot turn that no-op into a
+//! failure.
 //!
 //! ## What is and is not guarded
 //!
@@ -106,10 +127,19 @@
 //! `init_repos()` during an operation command, not here. So a refhost with one
 //! stale, unreachable or unsigned-key repository alongside working ones is
 //! indistinguishable from a host whose issue repo failed, and guarding it would
-//! abort updates that are fine. The case it would have caught is not lost: a
-//! wholesale refresh failure resurfaces on `zypper -n patches`, which *does* go
-//! through `init_repos` and so answers `106` (or worse) when the issue repo is
-//! missing — and `106` is rejected.
+//! abort updates that are fine. The dominant case it would have caught is not
+//! lost: for a freshly added repo with no local cache, a refresh failure means
+//! `zypper -n patches` — which *does* go through `init_repos` — answers `106`,
+//! and the alias question above then finds the repo missing or disabled.
+//!
+//! **One residual remains, narrowed rather than closed.** Repos are added with
+//! `zypper ar` and no `-f` (`mtui-hosts` `target/repo_manager.rs`), so
+//! `patches` will not autorefresh them. A repo whose cache is *stale but
+//! present* — an `update` re-run after an earlier successful `prepare`, with
+//! the repo now unreachable — lets `patches` answer `0` from that cache with
+//! the new patch absent, and the script exits `0`: the original silent no-op,
+//! on that one path. Closing it needs a freshness assertion, not a status
+//! test.
 //!
 //! Also not guarded: the post-state `grep` (a successful patch makes it exit
 //! `1` — the reason `$mtui_status` exists), the repo-cleanup loop (a cosmetic
@@ -176,9 +206,18 @@ yum -y update $packages
 /// patch list are guarded, and why `zypper -n refresh` is not one of them.
 const ZYPPER_UPDATE: &str = r#"
 export LANG=
+mtui_issue_repo_present() {
+  zypper -n lr | awk -F "|" '/$repa\>/ { found = 1 } END { exit !found }'
+}
 mtui_probe_ok() {
   case "$$2" in
   0) return 0 ;;
+  106)
+    if mtui_issue_repo_present; then
+      printf 'mtui: note: %s exited 106, a repository was skipped; the update repo is present, continuing\n' "$$1"
+      return 0
+    fi
+    ;;
   esac
   printf 'mtui: could not %s\n' "determine what to patch: $$1 exited $$2"
   exit "$$2"
@@ -210,9 +249,18 @@ exit $$mtui_status
 /// legitimately empty list that no guard can see.
 const SLM_UPDATE: &str = r#"
 export LANG=
+mtui_issue_repo_present() {
+  zypper -n lr | awk -F "|" '/$repa\>/ { found = 1 } END { exit !found }'
+}
 mtui_probe_ok() {
   case "$$2" in
   0) return 0 ;;
+  106)
+    if mtui_issue_repo_present; then
+      printf 'mtui: note: %s exited 106, a repository was skipped; the update repo is present, continuing\n' "$$1"
+      return 0
+    fi
+    ;;
   esac
   printf 'mtui: could not %s\n' "determine what to patch: $$1 exited $$2"
   exit "$$2"
@@ -329,16 +377,50 @@ mod tests {
         // stderr — and the script would carry on to the empty-list skip and
         // exit 0, which is the bug it exists to close.
         //
-        // Its accepted set is `0` **alone**, deliberately narrower than
-        // `classify_exit`'s (see the module docs: `106` on a probe can mean
-        // the issue repo was the skipped one), and the marker is split across
-        // the format string and its argument so the script's own text does not
-        // contain it.
+        // Pinned by shape rather than as one literal blob, so that editing the
+        // guard's prose does not fail this while a semantic change slips
+        // through it. Each of these is a separate way the guard could stop
+        // guarding.
+        let guard_at = rendered
+            .find("mtui_probe_ok() {")
+            .unwrap_or_else(|| panic!("{name}: the probe guard is not defined at all: {rendered}"));
+        let first_call = rendered
+            .find("mtui_probe_ok \"")
+            .unwrap_or_else(|| panic!("{name}: nothing ever calls the probe guard: {rendered}"));
+        assert!(
+            guard_at < first_call,
+            "{name}: the guard must be defined before any probe runs, else it is \
+             'command not found' (127) and the script carries on to the empty-list \
+             skip and exits 0 — the bug it exists to close: {rendered}"
+        );
+        // `0` is the only status accepted outright.
+        assert!(
+            rendered.contains("  case \"$2\" in\n  0) return 0 ;;\n"),
+            "{name}: the guard must accept `0` and only `0` outright: {rendered}"
+        );
+        // `106` is accepted *conditionally*, on the issue repo still being
+        // listed — the whole of the answer to "a refhost carrying one
+        // unrelated broken repo must still patch". Dropping the condition and
+        // accepting `106` flat would reopen #447 for a skipped issue repo.
+        assert!(
+            rendered.contains("  106)\n    if mtui_issue_repo_present; then\n"),
+            "{name}: `106` must be accepted only when the issue repo is present: {rendered}"
+        );
+        assert!(
+            rendered.contains(&format!(
+                "mtui_issue_repo_present() {{\n  zypper -n lr | awk -F \"|\" '/{repa}\\>/ \
+                 {{ found = 1 }} END {{ exit !found }}'\n}}"
+            )),
+            "{name}: the presence probe must ask `lr` about this update's own repo: {rendered}"
+        );
+        // Every other status prints the marker and exits with the probe's own
+        // status. The marker is split across the format string and its
+        // argument so the script's own text does not contain it.
         assert!(
             rendered.contains(
-                "mtui_probe_ok() {\n  case \"$2\" in\n  0) return 0 ;;\n  esac\n  printf 'mtui: could not %s\\n' \"determine what to patch: $1 exited $2\"\n  exit \"$2\"\n}\n"
+                "  printf 'mtui: could not %s\\n' \"determine what to patch: $1 exited $2\"\n  exit \"$2\"\n}\n"
             ),
-            "{name}: the probe guard must be defined before any probe runs: {rendered}"
+            "{name}: an unrecognised probe status must mark and exit: {rendered}"
         );
         // The other half of the split: the check's marker must not appear in
         // the script text, or a transcript echoing the command would report a
@@ -995,6 +1077,12 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // the package-not-found set (`104`, `4`, `5`, `8`), the band's
             // boundaries (`99`, `108`), and plain errors. A code that becomes
             // acceptable on a probe has to be argued for here, individually.
+            //
+            // `106` is in the list and refused *because* `Knobs::default()`
+            // leaves `repo_row` empty — the update's repo is not listed, so
+            // its conditional acceptance does not apply. Both halves of that
+            // condition are pinned at the end of
+            // `only_a_zero_probe_status_is_accepted`.
             for code in [
                 1, 2, 3, 4, 5, 6, 7, 8, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 255,
             ] {
@@ -1028,6 +1116,72 @@ exit "$MTUI_STUB_PATCH_EXIT"
             }
             // And `0` is accepted, or the loop above proves only that the
             // script always fails.
+            // Both directions of the one conditional acceptance.
+            //
+            // `106` is `ZYPPER_EXIT_INF_REPO_SKIPPED`, which `init_repos()`
+            // raises for *any* skipped repository without saying which. A
+            // refhost carrying one stale or unreachable repo alongside working
+            // ones is routine and patches correctly today, so refusing `106`
+            // outright would abort exactly the hosts that leaving
+            // `zypper -n refresh` unguarded exists to protect — the two rules
+            // would cancel out. So the status is not asked to carry the
+            // verdict: the script asks `lr` whether the update's own repo is
+            // still listed.
+            //
+            // Deleting the `106` arm fails the first case; accepting `106`
+            // unconditionally fails the second, which is #447 for a skipped
+            // issue repo.
+            for (name, cmds) in templates() {
+                // Repo listed: somebody else's repo was skipped. Patch runs.
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patches_exit: 106,
+                        repo_row: REPO_ROW,
+                        ..Knobs::default()
+                    },
+                );
+                assert_eq!(
+                    stubs.patch_invocations().len(),
+                    1,
+                    "{name}: 106 with the update repo listed must still patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert!(
+                    !ran.stdout.contains(PROBE_FAILURE_MARKER),
+                    "{name}: 106 with the update repo listed must not mark a probe failure: {}",
+                    ran.stdout
+                );
+                assert_eq!(ran.code, 0, "{name}: and must not fail the update");
+
+                // Repo absent from `lr`: the skipped one may well have been
+                // ours, so the empty list cannot be trusted.
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patches_exit: 106,
+                        repo_row: "",
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    ran.stdout.contains(&format!(
+                        "{PROBE_FAILURE_MARKER}: zypper -n patches exited 106"
+                    )),
+                    "{name}: 106 without the update repo must be refused: {}",
+                    ran.stdout
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: and must skip the patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert_eq!(ran.code, 106, "{name}: reported verbatim");
+            }
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
                 let ran = run_script(&cmds, &stubs, Knobs::default());

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -30,6 +30,93 @@
 //! package manager complain about its own arguments — a status that is now
 //! real. That verdict is unchanged; only the way it is reached is.
 //!
+//! # The probe guard
+//!
+//! `$mtui_patches` decides whether the patch runs at all, so the commands that
+//! *produce* it are the script's premise. If one of them fails the list comes
+//! back empty, the guard skips the patch, and the script exits `0` — mtui
+//! reporting an update it never installed. That is issue #447, and it is not
+//! merely a discarded status: `mtui_patches=$(zypper -n patches | awk …)` took
+//! the **pipeline's** status, which POSIX defines as the *last* stage's, so it
+//! was awk's — and awk exits `0` on empty input. zypper's status was not
+//! discarded there, it was unobservable.
+//!
+//! `set -o pipefail` (not POSIX) and `${PIPESTATUS[0]}` (bash-only) are both
+//! out: the acceptance tests below run this text under `/bin/sh`, which is
+//! dash on Debian-family builders. The portable lever is POSIX XCU 2.9.1 — an
+//! assignment-only command takes the status of its last command substitution —
+//! so each probe is captured on its own (`mtui_patch_rows=$(zypper -n
+//! patches)`) and its `$?` read on the next line. The rows then reach awk
+//! through the **builtin** `printf '%s\n'`, not `echo` or `xargs`, so no
+//! `ARG_MAX` limit sits between them.
+//!
+//! `mtui_probe_ok <label> <status>` is the guard. On `0` it returns; on
+//! anything else it prints the marker line
+//! `mtui: could not determine what to patch: <label> exited <status>` and
+//! exits with **the probe's own status**. The marker is the signal — the check
+//! gates on it ahead of the exit-code rules
+//! ([`crate::update_workflow::checks::update`]) — because no exit code could
+//! carry it: a POSIX `exit N` truncates to `0..=255`, so any value a template
+//! chose would sit inside the package manager's own space. Nothing in this
+//! workspace exits with a status of its own choosing; every `exit` in shell
+//! text passes a tool's status through, and this one does too.
+//!
+//! The marker is assembled from the `printf` format string **and** its
+//! argument (`printf 'mtui: could not %s\n' "determine what to patch: …"`) so
+//! that the script's own text does not contain the string the check greps for.
+//! Otherwise a transcript that echoed the command — a `set -x` in the host's
+//! profile, a verbose transport — would report a probe failure on every
+//! healthy update. `the_rendered_update_templates_do_not_trip_the_gate` pins
+//! it.
+//!
+//! ## Why the accepted set is `0` and nothing else
+//!
+//! **Deliberately narrower than `classify_exit`'s success set, and the two
+//! must not be unified.** That set is argued from "the transaction committed",
+//! which is a statement about the *patch*. Read as a verdict on a metadata
+//! *probe* its members invert: `106`
+//! (`ZYPPER_EXIT_INF_REPO_SKIPPED`) says a repository was skipped, and if the
+//! skipped one is the issue repo then the list legitimately lacks the patch —
+//! precisely the silent no-op this guard exists to stop. `zypper -n patches`
+//! cannot say *which* repo was skipped, so the status cannot be made to mean
+//! "the issue repo is present" by widening the set.
+//!
+//! The asymmetry is chosen with its cost understood: a host carrying an
+//! unrelated broken repository alongside working ones now fails the update
+//! with "could not determine what to patch" instead of patching. That failure
+//! is **cheap** — it does not roll back (see `UpdateFailure::ProbeFailed`),
+//! and it points the operator at the repo state, which is where the problem
+//! is. A false *pass* is the bug being fixed.
+//!
+//! ## What is and is not guarded
+//!
+//! Guarded: `zypper -n patches` (both templates) and **the awk that filters
+//! its output**. awk is the last stage of the filter pipeline, so `$?` on the
+//! next line is already awk's and the capture is free — and without it #447 is
+//! still reachable: an awk that exits `2`, or is missing from `PATH`, yields an
+//! empty list, a skipped patch and `exit 0`, which is the original verdict
+//! verbatim.
+//!
+//! **`zypper -n refresh` is deliberately NOT guarded**, although it is the
+//! other command whose failure leaves the patch absent from the metadata. Its
+//! status cannot support the verdict: verified against `openSUSE/zypper`
+//! `src/commands/repos/refresh.cc:337-345`, the explicit `refresh` command
+//! returns `ZYPPER_EXIT_ERR_ZYPP` (`4`) both when *every* repository failed and
+//! when only *some* did — and it never returns `106`, which is set by
+//! `init_repos()` during an operation command, not here. So a refhost with one
+//! stale, unreachable or unsigned-key repository alongside working ones is
+//! indistinguishable from a host whose issue repo failed, and guarding it would
+//! abort updates that are fine. The case it would have caught is not lost: a
+//! wholesale refresh failure resurfaces on `zypper -n patches`, which *does* go
+//! through `init_repos` and so answers `106` (or worse) when the issue repo is
+//! missing — and `106` is rejected.
+//!
+//! Also not guarded: the post-state `grep` (a successful patch makes it exit
+//! `1` — the reason `$mtui_status` exists), the repo-cleanup loop (a cosmetic
+//! `zypper -n rr` hiccup must not revert the fleet), and the pre-state `grep`
+//! (exit `1` there is the legitimate "this host carries none of these
+//! products" case).
+//!
 //! The emptiness test is `set -- $mtui_patches` followed by `[ "$#" -gt 0 ]`,
 //! **not** `[ -n "$mtui_patches" ]`. The two differ on a list of whitespace:
 //! `-n` calls it non-empty, but the unquoted expansion that follows splits it
@@ -40,23 +127,11 @@
 //! receive, and lets the patch itself use a quoted `"$@"` instead of a bare
 //! unquoted expansion.
 //!
-//! # The residual: a refresh that fails silently
-//!
-//! `zypper -n refresh` is **not** guarded, and the empty-list no-op above is
-//! what makes that a real gap: if the issue repo is unreachable or its key is
-//! untrusted, the refresh fails, `zypper -n patches` matches no row, the guard
-//! skips the patch and the script exits `0`. An update that installed nothing
-//! passes its check. Deferred rather than fixed, because `refresh` returns `4`
-//! whether one repository failed or all of them did, so its status cannot tell
-//! "the issue repo went missing" from "an unrelated stale repo did" — and
-//! failing on the latter would abort updates on refhosts that would have
-//! patched correctly, which is routine on QAM refhosts. Closing it needs a
-//! check that the *issue* repo specifically is present, not a status test.
-//!
 //! Two constraints on the text:
 //!
 //! * every `$` meant for the remote shell is written `$$`
-//!   (`$$mtui_status`, `$$?`, `$$(`, `$$#`, `$$@`, `$$r`). A bare `$?` happens
+//!   (`$$mtui_status`, `$$?`, `$$(`, `$$#`, `$$@`, `$$r`, and the guard
+//!   function's own `$$1` / `$$2`). A bare `$?` happens
 //!   to survive [`SubstMode::Safe`] today, but `$$` is the documented escape
 //!   and the only form that stays correct if the mode is ever tightened. The
 //!   awk field refs (`print $2`) stay bare — that is the tested convention.
@@ -69,11 +144,21 @@
 //!   `patches` lines, but nothing depends on that —
 //!   `checks::update::transactional_update` deliberately has no such gate.
 //!
-//! One portability note, pre-existing and unchanged: `/$repa\>/` uses `\>`,
-//! which is a **GNU-awk** word-boundary operator. The SUSE hosts these run on
-//! ship gawk. Other awks degrade it to a literal `>`, which matters only to the
-//! tests below — they execute this text under the *build host's* awk, and pick
-//! a stub row that matches under either reading.
+//! One portability note, pre-existing and unchanged: **these templates require
+//! GNU awk on the refhost.** `/$repa\>/` uses `\>`, a GNU-awk word-boundary
+//! operator; mawk, busybox awk and `gawk --traditional` degrade an unknown
+//! escape to the literal character, and against a realistic
+//! `zypper -n patches` row that extracts nothing — an empty patch list, a
+//! skipped patch and a silent no-op. The SUSE hosts these run on ship gawk, so
+//! the dependency is met in production, and it is stated here rather than
+//! guarded because the guard cannot see it (awk succeeds; it simply matches
+//! nothing).
+//!
+//! Do not mistake the tests below for awk coverage. They execute this text
+//! under the *build host's* awk, and the stub row is deliberately chosen to
+//! match under **either** dialect — that keeps the macOS CI leg (BWK awk)
+//! working, and it is exactly why those tests cannot notice a dialect that
+//! extracts nothing.
 
 use crate::update_workflow::actions::{ActionCommands, SubstMode};
 
@@ -87,13 +172,24 @@ yum -y update $packages
 /// zypper update command.
 ///
 /// See the module docs for why the patch's status is captured rather than left
-/// to the shell's last-command-wins rule.
+/// to the shell's last-command-wins rule, why the two commands that produce the
+/// patch list are guarded, and why `zypper -n refresh` is not one of them.
 const ZYPPER_UPDATE: &str = r#"
 export LANG=
+mtui_probe_ok() {
+  case "$$2" in
+  0) return 0 ;;
+  esac
+  printf 'mtui: could not %s\n' "determine what to patch: $$1 exited $$2"
+  exit "$$2"
+}
 zypper -n lr -puU
 zypper -n refresh
 zypper -n patches | grep $repa
-mtui_patches=$$(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_patch_rows=$$(zypper -n patches)
+mtui_probe_ok "zypper -n patches" $$?
+mtui_patches=$$(printf '%s\n' "$$mtui_patch_rows" | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_probe_ok "awk" $$?
 mtui_status=0
 set -- $$mtui_patches
 if [ "$$#" -gt 0 ]; then
@@ -108,12 +204,25 @@ exit $$mtui_status
 /// slmicro update command.
 ///
 /// See the module docs for why the patch's status is captured rather than left
-/// to the shell's last-command-wins rule.
+/// to the shell's last-command-wins rule, and why the two commands that produce
+/// the patch list are guarded. Note this template carries no `zypper -n
+/// refresh` line at all — it never refreshes, so stale metadata here yields a
+/// legitimately empty list that no guard can see.
 const SLM_UPDATE: &str = r#"
 export LANG=
+mtui_probe_ok() {
+  case "$$2" in
+  0) return 0 ;;
+  esac
+  printf 'mtui: could not %s\n' "determine what to patch: $$1 exited $$2"
+  exit "$$2"
+}
 zypper -n lr -puU
 zypper -n patches | grep $repa
-mtui_patches=$$(zypper -n patches | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_patch_rows=$$(zypper -n patches)
+mtui_probe_ok "zypper -n patches" $$?
+mtui_patches=$$(printf '%s\n' "$$mtui_patch_rows" | awk -F "|" '/$repa\>/ { print $2; }')
+mtui_probe_ok "awk" $$?
 mtui_status=0
 set -- $$mtui_patches
 if [ "$$#" -gt 0 ]; then
@@ -154,6 +263,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::update_workflow::checks::update::PROBE_FAILURE_MARKER;
 
     fn vars<'a>(repa: &'a str, packages: &'a str) -> HashMap<&'a str, &'a str> {
         [("repa", repa), ("packages", packages)]
@@ -214,11 +324,60 @@ mod tests {
             !rendered.contains("$$"),
             "{name}: an unresolved `$$` reached the remote shell: {rendered}"
         );
-        // The patch list is captured before the patch so the empty case is
-        // distinguishable.
+        // The guard the probe status is fed to. Without the definition
+        // `mtui_probe_ok …` would be a "command not found" — status 127 on
+        // stderr — and the script would carry on to the empty-list skip and
+        // exit 0, which is the bug it exists to close.
+        //
+        // Its accepted set is `0` **alone**, deliberately narrower than
+        // `classify_exit`'s (see the module docs: `106` on a probe can mean
+        // the issue repo was the skipped one), and the marker is split across
+        // the format string and its argument so the script's own text does not
+        // contain it.
         assert!(
-            rendered.contains("mtui_patches=$(zypper -n patches | awk -F \"|\""),
-            "{name}: the patch list must be captured first: {rendered}"
+            rendered.contains(
+                "mtui_probe_ok() {\n  case \"$2\" in\n  0) return 0 ;;\n  esac\n  printf 'mtui: could not %s\\n' \"determine what to patch: $1 exited $2\"\n  exit \"$2\"\n}\n"
+            ),
+            "{name}: the probe guard must be defined before any probe runs: {rendered}"
+        );
+        // The other half of the split: the check's marker must not appear in
+        // the script text, or a transcript echoing the command would report a
+        // probe failure on a host that patched fine.
+        assert!(
+            !rendered.contains(PROBE_FAILURE_MARKER),
+            "{name}: the script text must not contain the marker it prints: {rendered}"
+        );
+        // The patch list is captured before the patch so the empty case is
+        // distinguishable — and captured in three steps, as one contiguous
+        // block, because each step is load-bearing:
+        //
+        // * the probe runs **alone** in a command substitution, so the
+        //   assignment takes zypper's own status (POSIX XCU 2.9.1). Piped
+        //   straight into awk, as it was, the status is the pipeline's — the
+        //   *last* stage's — and awk exits 0 on empty input, so zypper's was
+        //   not observable at all;
+        // * the guard reads that status on the very next line, before
+        //   anything else can clobber `$?`;
+        // * only then does awk filter the captured rows, through the builtin
+        //   `printf` rather than `echo`/`xargs`, so no `ARG_MAX` limit sits
+        //   between the probe and the filter;
+        // * and awk's own status is guarded in turn — it is the last stage of
+        //   that pipeline, so `$?` on the next line is already awk's. An awk
+        //   that exits 2 (or is missing from `PATH`) otherwise produces an
+        //   empty list, a skipped patch and `exit 0`: #447's verdict verbatim,
+        //   reached through the one stage the probe guard does not cover.
+        assert!(
+            rendered.contains(&format!(
+                "mtui_patch_rows=$(zypper -n patches)\nmtui_probe_ok \"zypper -n patches\" $?\nmtui_patches=$(printf '%s\\n' \"$mtui_patch_rows\" | awk -F \"|\" '/{repa}\\>/ {{ print $2; }}')\nmtui_probe_ok \"awk\" $?\n"
+            )),
+            "{name}: the patch list must be captured, guarded, filtered, guarded: {rendered}"
+        );
+        // Discriminating: the block above proves the guarded form is present,
+        // not that the unguarded one is gone. A template carrying both would
+        // satisfy it while the second, unguarded assignment silently won.
+        assert!(
+            !rendered.contains("mtui_patches=$(zypper"),
+            "{name}: no unguarded `zypper … | awk` capture may survive: {rendered}"
         );
         // Guarded on the *word count*, not on the string being non-empty: a
         // whitespace-only list is `-n`-true but splits to zero words, which
@@ -357,6 +516,16 @@ mod tests {
         /// guard counts split words instead.
         const BLANK_PATCH_ROW: &str = "issue-:p=42:7>repo |    | security";
 
+        /// A `zypper -n patches` row for a **different** update.
+        ///
+        /// The production shape of "this host carries none of the update's
+        /// products": the probe answers `0` and prints a full table, and none
+        /// of its rows match `$repa`. An empty *table* (`PATCH_ROW = ""`) is
+        /// the rarer case — a host with no patches at all — so pinning only
+        /// that one would leave the common no-op unpinned.
+        const OTHER_PATCH_ROW: &str =
+            "issue-:p=99:1>repo | patch-omega | security | important | --- | needed";
+
         /// A `zypper -n lr` row the repo-cleanup loop matches, so the loop body
         /// (`zypper -n rr`) actually runs and its status can be controlled.
         const REPO_ROW: &str = "1 | issue-:p=42:7>repo | Yes | Yes";
@@ -371,11 +540,23 @@ mod tests {
         /// as much as the patch: without them "the patch never ran" — the
         /// assertion the empty-list case rests on — is also what a broken
         /// `PATH` produces, and the test would pass with no stubs at all.
+        ///
+        /// `patches` carries its own exit knob because it is the script's
+        /// *probe*: what it returns decides whether the patch runs at all, and
+        /// the template must not read its failure as "this host has nothing to
+        /// patch". `refresh` carries one too, for the opposite reason — to
+        /// show that a failing refresh does **not** abort the update (its
+        /// status cannot distinguish a broken issue repo from an unrelated
+        /// broken repo; see the module docs).
         const ZYPPER_STUB: &str = r#"#!/bin/sh
 printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran"
 case "$2" in
 patches)
     if [ -n "$MTUI_STUB_PATCH_ROW" ]; then printf '%s\n' "$MTUI_STUB_PATCH_ROW"; fi
+    exit "$MTUI_STUB_PATCHES_EXIT"
+    ;;
+refresh)
+    exit "$MTUI_STUB_REFRESH_EXIT"
     ;;
 lr)
     if [ -n "$MTUI_STUB_REPO_ROW" ]; then printf '%s\n' "$MTUI_STUB_REPO_ROW"; fi
@@ -461,21 +642,76 @@ exit "$MTUI_STUB_PATCH_EXIT"
             vec![("zypper", zypper()), ("slmicro", slmicro())]
         }
 
-        /// Renders `cmds` and runs it under `/bin/sh -c`, returning the script's
-        /// own exit status.
+        /// The knobs one scripted run is driven with.
         ///
-        /// `patch_row` empty means the update matches no patch on this host;
-        /// `repo_row` empty means the cleanup loop finds nothing to remove (its
-        /// body never runs, so the loop's status is `0` — the masking the whole
-        /// issue is about).
-        fn run_script(
-            cmds: &ActionCommands,
-            stubs: &Stubs,
+        /// A struct rather than six more parameters: `run_script` would
+        /// otherwise trip `clippy::too_many_arguments`, and a call site reading
+        /// `Knobs { patches_exit: 7, ..Knobs::default() }` names the one thing
+        /// the case is about. [`Default`] is the wholly healthy run — every
+        /// command exits `0` and [`PATCH_ROW`] matches.
+        #[derive(Clone, Copy)]
+        struct Knobs {
+            /// `zypper -n refresh`'s status. Only `ZYPPER_UPDATE` runs a
+            /// refresh at all; on `SLM_UPDATE` this knob has nothing to act
+            /// on, which is itself asserted below.
+            refresh_exit: i32,
+            /// `zypper -n patches`'s status — the probe whose output becomes
+            /// the patch list, on both templates.
+            patches_exit: i32,
+            /// awk's status. Non-zero replaces `awk` on `PATH` with a stub
+            /// that consumes stdin and exits with it — the shape of a broken
+            /// or missing awk, which is the *other* way the patch list can
+            /// come back empty without anything having gone wrong visibly.
+            awk_exit: i32,
+            /// The patch command's own status.
             patch_exit: i32,
+            /// `zypper -n rr`'s status in the repo-cleanup loop.
             cleanup_exit: i32,
-            patch_row: &str,
-            repo_row: &str,
-        ) -> i32 {
+            /// The `zypper -n patches` row. Empty means the update matches no
+            /// patch on this host.
+            patch_row: &'static str,
+            /// The `zypper -n lr` row. Empty means the cleanup loop finds
+            /// nothing to remove — its body never runs, so the loop's status is
+            /// `0`, the masking #400 was about.
+            repo_row: &'static str,
+        }
+
+        impl Default for Knobs {
+            fn default() -> Self {
+                Self {
+                    refresh_exit: 0,
+                    patches_exit: 0,
+                    awk_exit: 0,
+                    patch_exit: 0,
+                    cleanup_exit: 0,
+                    patch_row: PATCH_ROW,
+                    repo_row: "",
+                }
+            }
+        }
+
+        /// What one scripted run produced.
+        struct Ran {
+            /// The script's own exit status.
+            code: i32,
+            /// The script's stdout — where the probe guard's marker line
+            /// lands, and so what the update check would classify.
+            stdout: String,
+        }
+
+        /// Renders `cmds` and runs it under `/bin/sh -c`.
+        ///
+        /// A non-zero `awk_exit` shadows the real `awk` with a stub for this
+        /// run; the stub dir is already first on `PATH`, and `Stubs` is
+        /// per-case, so nothing leaks into another run.
+        fn run_script(cmds: &ActionCommands, stubs: &Stubs, knobs: Knobs) -> Ran {
+            if knobs.awk_exit != 0 {
+                write_exe(
+                    stubs.dir.path(),
+                    "awk",
+                    &format!("#!/bin/sh\ncat > /dev/null\nexit {}\n", knobs.awk_exit),
+                );
+            }
             let rendered = cmds
                 .render_command(&vars(REPA, "pkg-a"))
                 .expect("safe substitute never fails");
@@ -484,15 +720,21 @@ exit "$MTUI_STUB_PATCH_EXIT"
                 .arg(&rendered)
                 .env("PATH", &stubs.path)
                 .env("MTUI_STUB_DIR", stubs.dir.path())
-                .env("MTUI_STUB_PATCH_EXIT", patch_exit.to_string())
-                .env("MTUI_STUB_CLEANUP_EXIT", cleanup_exit.to_string())
-                .env("MTUI_STUB_PATCH_ROW", patch_row)
-                .env("MTUI_STUB_REPO_ROW", repo_row)
+                .env("MTUI_STUB_REFRESH_EXIT", knobs.refresh_exit.to_string())
+                .env("MTUI_STUB_PATCHES_EXIT", knobs.patches_exit.to_string())
+                .env("MTUI_STUB_PATCH_EXIT", knobs.patch_exit.to_string())
+                .env("MTUI_STUB_CLEANUP_EXIT", knobs.cleanup_exit.to_string())
+                .env("MTUI_STUB_PATCH_ROW", knobs.patch_row)
+                .env("MTUI_STUB_REPO_ROW", knobs.repo_row)
                 .output()
                 .expect("run rendered script under /bin/sh");
-            out.status
-                .code()
-                .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status))
+            Ran {
+                code: out
+                    .status
+                    .code()
+                    .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status)),
+                stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            }
         }
 
         #[test]
@@ -538,7 +780,14 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // a genuinely failed patch reported success.
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
-                let code = run_script(&cmds, &stubs, 8, 0, PATCH_ROW, "");
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patch_exit: 8,
+                        ..Knobs::default()
+                    },
+                );
                 assert_eq!(
                     stubs.patch_invocations().len(),
                     1,
@@ -548,7 +797,10 @@ exit "$MTUI_STUB_PATCH_EXIT"
                     stubs.cleanup_invocations().is_empty(),
                     "{name}: no repo row, so the cleanup loop body must not run"
                 );
-                assert_eq!(code, 8, "{name}: the script must report the patch's status");
+                assert_eq!(
+                    ran.code, 8,
+                    "{name}: the script must report the patch's status"
+                );
             }
         }
 
@@ -560,7 +812,15 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // downgrade, reverting every healthy host in the group.
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
-                let code = run_script(&cmds, &stubs, 0, 3, PATCH_ROW, REPO_ROW);
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        cleanup_exit: 3,
+                        repo_row: REPO_ROW,
+                        ..Knobs::default()
+                    },
+                );
                 assert_eq!(
                     stubs.patch_invocations().len(),
                     1,
@@ -572,7 +832,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                     "{name}: the cleanup loop body must have run and failed"
                 );
                 assert_eq!(
-                    code, 0,
+                    ran.code, 0,
                     "{name}: a cosmetic cleanup hiccup must not fail the update"
                 );
             }
@@ -586,7 +846,15 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // status would now be real.
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
-                let code = run_script(&cmds, &stubs, 8, 0, "", "");
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patch_exit: 8,
+                        patch_row: "",
+                        ..Knobs::default()
+                    },
+                );
                 // Liveness first. The headline assertion here is a *negative*,
                 // and an empty `PATH` produces exactly the same observation —
                 // so show the script actually reached the stub.
@@ -600,7 +868,18 @@ exit "$MTUI_STUB_PATCH_EXIT"
                     "{name}: with no matching patch the patch command must not run: {:?}",
                     stubs.patch_invocations()
                 );
-                assert_eq!(code, 0, "{name}: a host with nothing to patch passes");
+                assert_eq!(ran.code, 0, "{name}: a host with nothing to patch passes");
+                // And it must not even *look* like a failure. The probe guard
+                // added for #447 sits directly upstream of this skip, and the
+                // one thing it must never do is turn "this host carries none
+                // of the update's products" into "could not determine what to
+                // patch" — the empty list here is the probe's honest answer,
+                // reached with a `0` status.
+                assert!(
+                    !ran.stdout.contains(PROBE_FAILURE_MARKER),
+                    "{name}: a legitimately empty patch list is not a probe failure: {}",
+                    ran.stdout
+                );
             }
         }
 
@@ -619,7 +898,15 @@ exit "$MTUI_STUB_PATCH_EXIT"
             // asserts on the exit status rather than on a reason string.
             for (name, cmds) in templates() {
                 let stubs = Stubs::new();
-                let code = run_script(&cmds, &stubs, 8, 0, BLANK_PATCH_ROW, "");
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patch_exit: 8,
+                        patch_row: BLANK_PATCH_ROW,
+                        ..Knobs::default()
+                    },
+                );
                 assert!(
                     stubs.probe_invocations().iter().any(|c| c == "patches"),
                     "{name}: the script never reached the stub zypper at all: {:?}",
@@ -630,7 +917,275 @@ exit "$MTUI_STUB_PATCH_EXIT"
                     "{name}: a whitespace-only list must not run the patch: {:?}",
                     stubs.patch_invocations()
                 );
-                assert_eq!(code, 0, "{name}: nothing to patch is not a failure");
+                assert_eq!(ran.code, 0, "{name}: nothing to patch is not a failure");
+            }
+        }
+
+        #[test]
+        fn a_failed_patch_list_probe_fails_the_script_and_skips_the_patch() {
+            // Issue #447. `zypper -n patches` is the script's premise: its
+            // output *is* the patch list. When it fails — `6` (the host has no
+            // repositories at all), `7` (a ZYpp lock), an unreadable rpmdb —
+            // the list comes back empty and the guard below skips the patch.
+            // Before this, that skip exited `0` and mtui reported an update it
+            // never installed.
+            //
+            // Note what is *not* in that list: an update repo that was simply
+            // never added. zypper answers that perfectly well, with a table
+            // that lacks this update's rows, so it is indistinguishable from a
+            // host carrying none of the update's products — see
+            // `a_patch_list_with_no_matching_rows_skips_the_patch_and_succeeds`.
+            //
+            // The old capture could not even see it: `mtui_patches=$(zypper -n
+            // patches | awk …)` takes the *pipeline's* status, which is awk's,
+            // and awk exits 0 on empty input.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patches_exit: 7,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "patches"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: a failed probe must not be followed by a patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                // The signal the check gates on, naming the probe that broke.
+                assert!(
+                    ran.stdout.contains(&format!(
+                        "{PROBE_FAILURE_MARKER}: zypper -n patches exited 7"
+                    )),
+                    "{name}: the marker must name the failed probe and its status: {}",
+                    ran.stdout
+                );
+                // Pass-through, not a sentinel: a POSIX `exit N` truncates to
+                // `0..=255`, so any value of the template's own choosing would
+                // sit inside the package manager's space. The marker carries
+                // the meaning; the status stays honest.
+                assert_eq!(
+                    ran.code, 7,
+                    "{name}: the script must exit with the probe's own status"
+                );
+            }
+        }
+
+        #[test]
+        fn only_a_zero_probe_status_is_accepted() {
+            // The probe's success set is `0` **alone**, and deliberately not
+            // `classify_exit`'s — which is the set the *patch*'s status is read
+            // against. Every member of that set means "the transaction
+            // committed", a statement about a command that installs something;
+            // as a verdict on a metadata probe they invert. `106`
+            // (`ZYPPER_EXIT_INF_REPO_SKIPPED`) is the one that matters: it says
+            // a repository was skipped, and if the skipped one is the issue
+            // repo then the list legitimately lacks the patch — the silent
+            // no-op this guard exists to stop.
+            //
+            // The whole vocabulary, not a sample: the informational band
+            // (`100`-`103`, `106`, `107`) which the patch's classifier passes,
+            // the package-not-found set (`104`, `4`, `5`, `8`), the band's
+            // boundaries (`99`, `108`), and plain errors. A code that becomes
+            // acceptable on a probe has to be argued for here, individually.
+            for code in [
+                1, 2, 3, 4, 5, 6, 7, 8, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 255,
+            ] {
+                for (name, cmds) in templates() {
+                    let stubs = Stubs::new();
+                    let ran = run_script(
+                        &cmds,
+                        &stubs,
+                        Knobs {
+                            patches_exit: code,
+                            ..Knobs::default()
+                        },
+                    );
+                    assert!(
+                        ran.stdout.contains(&format!(
+                            "{PROBE_FAILURE_MARKER}: zypper -n patches exited {code}"
+                        )),
+                        "{name}: probe exit {code} must be refused: {}",
+                        ran.stdout
+                    );
+                    assert!(
+                        stubs.patch_invocations().is_empty(),
+                        "{name}: probe exit {code} must skip the patch: {:?}",
+                        stubs.patch_invocations()
+                    );
+                    assert_eq!(
+                        ran.code, code,
+                        "{name}: probe exit {code} must be reported verbatim"
+                    );
+                }
+            }
+            // And `0` is accepted, or the loop above proves only that the
+            // script always fails.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let ran = run_script(&cmds, &stubs, Knobs::default());
+                assert_eq!(
+                    stubs.patch_invocations().len(),
+                    1,
+                    "{name}: a probe that answered must patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert!(
+                    !ran.stdout.contains(PROBE_FAILURE_MARKER),
+                    "{name}: a probe exit 0 is not a probe failure: {}",
+                    ran.stdout
+                );
+            }
+        }
+
+        #[test]
+        fn a_failed_refresh_does_not_abort_the_update() {
+            // `zypper -n refresh` is the other command whose failure can leave
+            // the patch out of the metadata, and it is deliberately **not**
+            // guarded. Verified against `openSUSE/zypper`
+            // `src/commands/repos/refresh.cc:337-345`: the explicit `refresh`
+            // command returns `ZYPPER_EXIT_ERR_ZYPP` (`4`) both when every
+            // repository failed and when only some did, and never returns
+            // `106`. So its status cannot distinguish "the issue repo failed"
+            // from "an unrelated stale repo failed" — and a QAM refhost
+            // routinely carries the latter. Guarding it would abort updates
+            // that are fine.
+            //
+            // Pinned as a positive: exit 4 from the refresh, and the patch
+            // still runs. The case it would have caught is not lost — a
+            // wholesale refresh failure resurfaces as a non-zero
+            // `zypper -n patches`, which `only_a_zero_probe_status_is_accepted`
+            // covers.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        refresh_exit: 4,
+                        ..Knobs::default()
+                    },
+                );
+                assert_eq!(
+                    stubs.patch_invocations().len(),
+                    1,
+                    "{name}: a failed refresh must not stop the patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert!(
+                    !ran.stdout.contains(PROBE_FAILURE_MARKER),
+                    "{name}: a failed refresh is not a probe failure: {}",
+                    ran.stdout
+                );
+                assert_eq!(ran.code, 0, "{name}: the patch's own status is reported");
+            }
+            // The zypper template really does run a refresh (or the knob above
+            // acted on nothing); the slmicro template really does not.
+            let stubs = Stubs::new();
+            run_script(&zypper(), &stubs, Knobs::default());
+            assert!(
+                stubs.probe_invocations().iter().any(|c| c == "refresh"),
+                "zypper: this template refreshes: {:?}",
+                stubs.probe_invocations()
+            );
+            let stubs = Stubs::new();
+            run_script(&slmicro(), &stubs, Knobs::default());
+            assert!(
+                !stubs.probe_invocations().iter().any(|c| c == "refresh"),
+                "slmicro: this template refreshes nothing: {:?}",
+                stubs.probe_invocations()
+            );
+        }
+
+        #[test]
+        fn a_broken_awk_fails_the_script_and_skips_the_patch() {
+            // The stage that actually *produces* the list, and the one the
+            // probe guard alone does not cover. awk is the last stage of the
+            // filter pipeline, so an awk that exits 2 — or is missing from
+            // `PATH`, which is exit 127 — yields an empty list, a skipped
+            // patch and `exit 0`: #447's verdict verbatim, reached through a
+            // different command. Its status is free to capture, because `$?`
+            // on the line after the pipeline is already awk's.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        awk_exit: 2,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "patches"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: a broken awk must not be followed by a patch: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert!(
+                    ran.stdout
+                        .contains(&format!("{PROBE_FAILURE_MARKER}: awk exited 2")),
+                    "{name}: the marker must name awk: {}",
+                    ran.stdout
+                );
+                assert_eq!(ran.code, 2, "{name}: awk's own status is reported");
+            }
+        }
+
+        #[test]
+        fn a_patch_list_with_no_matching_rows_skips_the_patch_and_succeeds() {
+            // The production shape of the legitimate no-op: the probe answers
+            // `0` and prints a perfectly good table, and none of its rows carry
+            // this update's `$repa`. The other empty case
+            // (`an_empty_patch_list_skips_the_patch_and_succeeds`) has the
+            // probe print nothing at all, which is the rarer one — a host with
+            // no patches whatsoever.
+            //
+            // This is the case a probe guard is most likely to get wrong, since
+            // "the filter matched nothing" and "the filter could not run" reach
+            // the same empty variable.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        patch_exit: 8,
+                        patch_row: OTHER_PATCH_ROW,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "patches"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert!(
+                    stubs.patch_invocations().is_empty(),
+                    "{name}: no row matches this update, so no patch may run: {:?}",
+                    stubs.patch_invocations()
+                );
+                assert!(
+                    !ran.stdout.contains(PROBE_FAILURE_MARKER),
+                    "{name}: a host carrying another update's patches is a no-op, \
+                     not a probe failure: {}",
+                    ran.stdout
+                );
+                assert_eq!(
+                    ran.code, 0,
+                    "{name}: a host with nothing of ours to patch passes"
+                );
             }
         }
     }

--- a/crates/mtui-testreport/src/update_workflow/checks/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/mod.rs
@@ -168,6 +168,11 @@ pub(crate) enum ExitClass {
 /// host mtui never contacted has been told the wrong thing. The gate that
 /// normally catches it first is `not_run` in [`update`].
 ///
+/// The reason string is **not** what vetoes the group-wide rollback for such a
+/// host — `reports::update_flow` routes on `Target::lastexit()` and on
+/// `UpdateError`'s typed `probe_failed` flag, never on a reason's text. Nothing
+/// in the tree makes control flow depend on that text, and nothing should.
+///
 /// [`NotRun`]: ExitClass::NotRun
 /// [`Unknown`]: ExitClass::Unknown
 pub(crate) fn classify_exit(exitcode: i32) -> ExitClass {

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -339,7 +339,12 @@ pub(crate) const PROBE_FAILURE_MARKER: &str = "mtui: could not determine what to
 /// nothing half-applied for a downgrade to repair, and the rollback would
 /// revert every healthy peer.
 fn probe_failure(args: CheckArgs<'_>) -> Result<(), UpdateError> {
-    if args.stdout.contains(PROBE_FAILURE_MARKER) || args.stderr.contains(PROBE_FAILURE_MARKER) {
+    let marked = |stream: &str| {
+        stream
+            .lines()
+            .any(|line| line.starts_with(PROBE_FAILURE_MARKER))
+    };
+    if marked(args.stdout) || marked(args.stderr) {
         log_failed(args);
         return Err(UpdateError::probe_failure(
             "could not determine what to patch",
@@ -933,6 +938,31 @@ mod tests {
                 zypper(args("zypper -n in -t patch", stdout, "", 0)).is_ok(),
                 "an unrelated mtui line must not read as a probe failure: {stdout}"
             );
+        }
+
+        // The other direction: the marker is matched at the *start of a line*,
+        // not anywhere in the stream. The split-`printf` trick keeps the
+        // script's own text from carrying the sentence, but it cannot stop a
+        // host echoing or quoting it mid-line — a `set -x` trace, a log line
+        // that embeds the previous run's output, a package's own message.
+        // Only a line that begins with it is mtui's own verdict.
+        for stdout in [
+            format!("+ echo '{PROBE_FAILURE_MARKER}: zypper -n patches exited 6'\n"),
+            format!("2026-08-13 log: saw \"{PROBE_FAILURE_MARKER}\" on the last run\n"),
+            format!("   {PROBE_FAILURE_MARKER}: indented, so not ours\n"),
+        ] {
+            assert!(
+                zypper(args("zypper -n in -t patch", &stdout, "", 0)).is_ok(),
+                "the marker mid-line must not read as a probe failure: {stdout}"
+            );
+        }
+
+        // And a line that really does begin with it still fires, on either
+        // stream — or the guard above would have disarmed the gate entirely.
+        let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6\n");
+        for (out, err) in [(marker.as_str(), ""), ("", marker.as_str())] {
+            let err = zypper(args("zypper -n in -t patch", out, err, 0)).unwrap_err();
+            assert_eq!(err.reason, "could not determine what to patch");
         }
     }
 

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -22,6 +22,11 @@ use crate::update_workflow::checks::{
 /// classified, by [`classify_exit`] — the same three sets the install check
 /// uses, in one place.
 ///
+/// The one status that is *not* the patch's is a probe failure, and it is
+/// gated ahead of the classification by [`probe_failure`]: the script exits
+/// with the failed probe's status, which sits in the same numeric space as the
+/// patch's, so only the marker line tells the two apart.
+///
 /// The informational carve-out is the load-bearing part, not the failure rule:
 /// zypper exits `102` ("reboot needed") after patching a kernel and `107` when
 /// a package's `%post` script failed but the package is installed and
@@ -44,16 +49,18 @@ use crate::update_workflow::checks::{
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run" (exit `-1`), "package not found" (exit `104` always; `4`,
-/// `5`, `8` on a clean transcript), "update stack locked", "Dependency Error",
-/// "RPM Error", or "Unknown Error" (any other non-zero exit with a clean
-/// transcript). The informational
+/// failed to run" (exit `-1`), "could not determine what to patch" (the
+/// [`PROBE_FAILURE_MARKER`] line), "package not found" (exit `104` always;
+/// `4`, `5`, `8` on a clean transcript), "update stack locked", "Dependency
+/// Error", "RPM Error", or "Unknown Error" (any other non-zero exit with a
+/// clean transcript). The informational
 /// exits (`100`-`103`, `106`, `107`) and the two recognised output sections
 /// ("Additional rpm output", "not supported by its vendor") do not fail the
 /// check; `106` additionally logs a warning, and the two sections are returned
 /// as [`Diagnostic`]s for the caller to render.
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
+    probe_failure(args)?;
     if !args.stdin.contains("zypper") {
         return markers(args);
     }
@@ -131,10 +138,11 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update command timed out or
-/// failed to run", "package not found", "update stack locked", "Dependency
-/// Error", "RPM Error", or "Unknown Error".
+/// failed to run", "could not determine what to patch", "package not found",
+/// "update stack locked", "Dependency Error", "RPM Error", or "Unknown Error".
 fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     not_run(args)?;
+    probe_failure(args)?;
     classified(args)
 }
 
@@ -276,6 +284,69 @@ fn not_run(args: CheckArgs<'_>) -> Result<(), UpdateError> {
 fn not_run_error(args: CheckArgs<'_>) -> UpdateError {
     log_failed(args);
     UpdateError::new("update command timed out or failed to run", args.hostname)
+}
+
+/// The line the update templates print when a probe failed, and the whole of
+/// the contract between them and [`probe_failure`].
+///
+/// The templates append `": <probe> exited <status>"`, so this is a prefix
+/// match on a line, not the whole line. The text is mtui's own — nothing in
+/// zypper's or `transactional-update`'s vocabulary resembles it — and it reads
+/// as a sentence, which matters because a `show_log` transcript is where an
+/// operator meets it.
+///
+/// The templates assemble it from a `printf` format string *and* its argument
+/// specifically so that **this string does not occur in the script's own
+/// text**. `show_log` echoes the whole script on every update, healthy or not,
+/// and `CheckArgs::stdin` carries it too; a transcript that put the command
+/// into stdout or stderr (a `set -x` in the host's profile, a verbose
+/// transport) would otherwise make every update on that host report a probe
+/// failure. `the_rendered_update_templates_do_not_trip_the_gate` pins it from
+/// this side, `assert_status_comes_from_the_patch` from the template's.
+pub(crate) const PROBE_FAILURE_MARKER: &str = "mtui: could not determine what to patch";
+
+/// Raises when the update script could not work out what to patch.
+///
+/// The update templates decide whether to patch at all from `zypper -n
+/// patches` (and, on the zypper key, from `zypper -n refresh` before it). A
+/// failure there yields an *empty* patch list, which is indistinguishable from
+/// the legitimate case — a host carrying none of the update's products — so
+/// the script names it explicitly with [`PROBE_FAILURE_MARKER`] and exits with
+/// the probe's own status. Without this gate the script exited `0` and mtui
+/// reported an update it never installed (issue #447).
+///
+/// Gated on the **marker**, not on the exit code, because no exit code could
+/// carry it: a POSIX `exit N` truncates to `0..=255`, so the script's status
+/// necessarily sits inside the package manager's own space — a probe that
+/// failed with `6` is indistinguishable from a patch that failed with `6`.
+/// The marker is a signal only mtui emits.
+///
+/// It runs **before** [`classified`] for that same reason, and before
+/// [`zypper`]'s `zypper`-token gate for [`not_run`]'s: like the `-1` sentinel
+/// this is mtui's own verdict about its own script, not a reading of a package
+/// manager's transcript, so the question "is this a zypper transcript?" does
+/// not arise.
+///
+/// Both streams are read. The templates print the marker to stdout, but a
+/// transport that merged the two would otherwise silently disarm the gate —
+/// the failure mode being closed here in the first place.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "could not determine what to
+/// patch", flagged as a probe failure so the flow can route it away from the
+/// group-wide rollback downgrade: the host never ran a patch, so there is
+/// nothing half-applied for a downgrade to repair, and the rollback would
+/// revert every healthy peer.
+fn probe_failure(args: CheckArgs<'_>) -> Result<(), UpdateError> {
+    if args.stdout.contains(PROBE_FAILURE_MARKER) || args.stderr.contains(PROBE_FAILURE_MARKER) {
+        log_failed(args);
+        return Err(UpdateError::probe_failure(
+            "could not determine what to patch",
+            args.hostname,
+        ));
+    }
+    Ok(())
 }
 
 /// The stdout/stderr classification shared by every update check.
@@ -714,6 +785,174 @@ mod tests {
         // `package_not_found_codes_on_both_zypper_keys`, which passes empty
         // stdout and stderr for all four codes. Repeating it here would
         // constrain nothing the marker cases above do not.
+    }
+
+    #[test]
+    fn the_probe_marker_outranks_the_exit_code_rules() {
+        // Issue #447. The script exits with the *probe's* status, which shares
+        // its numeric space with the patch's — `6` could be either — so only
+        // the marker tells them apart, and it has to be read before
+        // `classify_exit` gets the code. Each pairing below is a status the
+        // classifier has a confident answer for, and each answer would be
+        // wrong here: `0` would pass the host, `104` would say "package not
+        // found", `7` would say "Unknown Error".
+        //
+        // `0` is in the list for the case that matters most: a probe failure
+        // whose status the transport lost would otherwise be reported as a
+        // clean update.
+        let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6");
+        for code in [0, 7, 104, 106] {
+            for (name, check) in [
+                ("zypper", update_check("15", false).unwrap()),
+                ("transactional", update_check("slmicro", true).unwrap()),
+            ] {
+                let err = check(args("zypper -n in -t patch", &marker, "", code))
+                    .expect_err("a probe failure must fail the check");
+                assert_eq!(
+                    err.reason, "could not determine what to patch",
+                    "{name}: exit {code}"
+                );
+                assert_eq!(err.host.as_deref(), Some("h1"), "{name}: exit {code}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_probe_marker_is_read_from_either_stream() {
+        // The templates print it to stdout; a transport that merged the two
+        // streams would otherwise silently disarm the gate, which is the
+        // failure mode being closed here in the first place.
+        let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n refresh exited 4");
+        let err = zypper(args("zypper", "", &marker, 4)).unwrap_err();
+        assert_eq!(err.reason, "could not determine what to patch");
+    }
+
+    #[test]
+    fn the_probe_marker_does_not_fire_on_an_ordinary_transcript() {
+        // The trap this whole issue is built around: "nothing to do" is not a
+        // failure. A host carrying none of the update's products runs the same
+        // script, skips the patch, and exits `0` with no marker — and there is
+        // no other site in the workspace where an empty result reads as a
+        // failure, so this must not become the first.
+        assert!(
+            zypper(args("zypper -n in -t patch", "", "", 0))
+                .unwrap()
+                .is_empty()
+        );
+        // Nor on a transcript that merely talks about patching.
+        assert!(
+            zypper(args(
+                "zypper -n in -t patch",
+                "The following 1 patch is going to be installed:\n  patch-alpha\n",
+                "",
+                0,
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn the_probe_marker_is_flagged_for_the_flow_to_route_on() {
+        // The reason string is for the operator; the *flag* is what
+        // `reports::update_flow` routes on, and routing it wrong fires the
+        // group-wide rollback downgrade over a host that never ran a patch.
+        // Nothing else in the tree makes control flow depend on a reason's
+        // text, so the flag is the contract — asserted here rather than only
+        // in the flow, where a `false` would still produce a plausible-looking
+        // error.
+        let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6");
+        let err = zypper(args("zypper", &marker, "", 6)).unwrap_err();
+        assert!(err.probe_failed, "the probe-failure flag must be set");
+        // And it is set nowhere else: a patch that genuinely failed is a
+        // rollback's business.
+        let err = zypper(args("zypper", "", "", 7)).unwrap_err();
+        assert!(
+            !err.probe_failed,
+            "a failed patch is not a probe failure: {err:?}"
+        );
+        let err = zypper(args("zypper", "", "", -1)).unwrap_err();
+        assert!(
+            !err.probe_failed,
+            "a command that never ran is not a probe failure: {err:?}"
+        );
+    }
+
+    #[test]
+    fn the_rendered_update_templates_do_not_trip_the_gate() {
+        // The script *text* must not contain the marker, only the script's
+        // *output* on a real failure. `CheckArgs::stdin` is the whole rendered
+        // script on every update, and a host whose profile carries a `set -x`
+        // (or a transport that merged the command into the transcript) would
+        // put that text into stdout/stderr too — turning every healthy update
+        // on that host into "could not determine what to patch". The templates
+        // split the marker across `printf`'s format string and its argument
+        // exactly so this cannot happen.
+        //
+        // Fed on all three fields, because the gate reads two of them and the
+        // third is where the script legitimately lives.
+        let vars = [("repa", ":p=42:7"), ("packages", "pkg-a")];
+        for (key, transactional, check) in [
+            (
+                "15",
+                false,
+                Box::new(zypper) as Box<dyn Fn(CheckArgs<'_>) -> _>,
+            ),
+            ("slmicro", true, Box::new(transactional_update)),
+        ] {
+            let rendered = crate::update_workflow::actions::update::updater(key, transactional)
+                .expect("both keys have an updater")
+                .render_command(&vars.into_iter().collect())
+                .expect("safe substitution never fails");
+            assert!(
+                !rendered.contains(PROBE_FAILURE_MARKER),
+                "{key}: the script text must not contain the marker: {rendered}"
+            );
+            assert!(
+                check(args(&rendered, &rendered, &rendered, 0)).is_ok(),
+                "{key}: a transcript echoing the script must not read as a probe failure"
+            );
+        }
+        // The coupling the assertion above does not carry — that the template
+        // *prints* this exact string when a probe fails — is pinned where it
+        // can be: `actions::update`'s `rendered_script` cases run the real
+        // script under a real `/bin/sh` and match its stdout against this
+        // constant.
+    }
+
+    #[test]
+    fn the_probe_marker_is_matched_in_full() {
+        // `contains(PROBE_FAILURE_MARKER)` weakened to any prefix of it (say
+        // `"mtui:"`) still passes every other test here, and would then fire on
+        // any mtui-namespaced line the templates or a future action print.
+        for stdout in [
+            "mtui: could not remove the test update repo\n",
+            "mtui: nothing to do\n",
+            "mtui_probe_ok: not found\n",
+        ] {
+            assert!(
+                zypper(args("zypper -n in -t patch", stdout, "", 0)).is_ok(),
+                "an unrelated mtui line must not read as a probe failure: {stdout}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_probe_marker_outranks_the_zypper_token_gate() {
+        // `zypper`'s exit-code rules are gated on the command text containing
+        // the literal `zypper`, and `probe_failure` deliberately runs *before*
+        // that gate — like `not_run`, it is mtui's own verdict about its own
+        // script, not a reading of a package manager's transcript.
+        //
+        // Every other fixture here carries `zypper` in `stdin`, so moving the
+        // gate below the token check survives them all. The template losing
+        // that token is a live hazard the module docs call out; if it ever
+        // happens, this is what keeps a host that printed the marker from
+        // returning `Ok` through the marker-only path.
+        let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6");
+        let err = zypper(args("some update command", &marker, "", 6))
+            .expect_err("the marker must be read whatever the command text says");
+        assert_eq!(err.reason, "could not determine what to patch");
+        assert!(err.probe_failed);
     }
 
     #[test]

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -48,11 +48,12 @@ pub(crate) type WorkflowKey = (String, bool);
 /// `Display` renders `"{host}: {reason}"` when a host is
 /// present, otherwise just `"{reason}"`. The `reason` strings are diagnoses
 /// shown to an operator and asserted on by tests ("package not found", "update
-/// stack locked", "RPM Error", "Dependency Error", "Unknown Error",
-/// "Unspecified Error"); no code branches on them, so a check is free to pick
-/// the most accurate one for a given transcript. What *is* a contract is the
-/// `UpdateFailure` variant a failure routes to, which decides whether the
-/// group is rolled back.
+/// stack locked", "RPM Error", "Dependency Error", "could not determine what to
+/// patch", "Unknown Error", "Unspecified Error"); no code branches on them, so
+/// a check is free to pick the most accurate one for a given transcript. What
+/// *is* a contract is the `UpdateFailure` variant a failure routes to, which
+/// decides whether the group is rolled back — which is why the probe failure
+/// travels as the typed `probe_failed` flag and not as its string.
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub struct UpdateError {
     /// The failure reason: a short diagnosis for the operator, not a value
@@ -67,6 +68,16 @@ pub struct UpdateError {
     /// inferring it from the session token — inferring would misreport a
     /// genuine host failure that merely coincided with a cancel.
     pub(crate) cancelled: bool,
+    /// `true` when the update command ran but never dispatched a patch,
+    /// because it could not work out what to patch (`checks::update`'s
+    /// `probe_failure`).
+    ///
+    /// Carried as a flag for the same reason `cancelled` is: the flow has to
+    /// route this away from the group-wide rollback downgrade, and the only
+    /// alternative — matching on the `reason` string in
+    /// `reports::update_flow` — would be the first place in the tree where
+    /// control flow depended on the text of a reason.
+    pub(crate) probe_failed: bool,
 }
 
 impl UpdateError {
@@ -77,6 +88,7 @@ impl UpdateError {
             reason: reason.into(),
             host: Some(host.into()),
             cancelled: false,
+            probe_failed: false,
         }
     }
 
@@ -87,6 +99,7 @@ impl UpdateError {
             reason: reason.into(),
             host: None,
             cancelled: true,
+            probe_failed: false,
         }
     }
 
@@ -96,11 +109,25 @@ impl UpdateError {
         self.cancelled
     }
 
+    /// Builds an [`UpdateError`] for an update that could not determine what
+    /// to patch, so never dispatched one.
+    ///
+    /// The flag is what `reports::update_flow` routes on; see
+    /// [`probe_failed`](Self::probe_failed).
+    #[must_use]
+    pub(crate) fn probe_failure(reason: impl Into<String>, host: impl Into<String>) -> Self {
+        Self {
+            probe_failed: true,
+            ..Self::new(reason, host)
+        }
+    }
+
     /// Builds a host-less [`UpdateError`].
     #[must_use]
     pub(crate) fn reason_only(reason: impl Into<String>) -> Self {
         Self {
             cancelled: false,
+            probe_failed: false,
             reason: reason.into(),
             host: None,
         }


### PR DESCRIPTION
Closes #447.

Rebased onto `main` now that #446 has merged; this is standalone and its own two commits are the whole diff.

## The bug

The patch list was built by a pipeline, and a pipeline reports its **last stage's** status — awk's, which succeeds on empty input. zypper's status was not merely discarded, it was unobservable there. A ZYpp lock, a broken repo or an unreadable rpmdb gave an empty list, skipped the patch, and exited 0: an update reported as applied that installed nothing.

## The fix

Each probe runs on its own line so its status can be read, and the rows reach awk through the `printf` builtin. A failed probe prints a marker and exits with **its own** status — no invented sentinel, since a POSIX `exit` truncates to 0..255 and any chosen value would collide with the package manager's own space. There is no precedent in the tree for a template exiting with a status of its own choosing, and this does not add one.

**awk is guarded too.** It is the stage that actually produces the list, and it failed in exactly the same silent way — the first review round found #447 still reachable through it.

## Two judgement calls, both against the obvious choice

**The probe accepts `0`, and `106` only while the update's own repo is still listed.** Still deliberately narrower than the set the *patch's* status is read against — that one is argued from "the transaction committed", which is a claim about the patch, and on a metadata probe its members invert.

But rejecting `106` outright — which is what the first round of this PR did — was wrong for the same reason that leaves `refresh` unguarded below. `init_repos()` raises `106` for **any** skipped repository and cannot say which, and a refhost routinely carries one stale or unreachable repo alongside working ones. Rejecting it aborted exactly the hosts that leaving `refresh` unguarded was meant to protect: the two rules cancelled out and the same host failed one line later.

So the status is no longer asked to carry the verdict. On `106` the script asks the question the guard actually cares about — *is the update's own repo still there?* — via `mtui_issue_repo_present`, which greps `$repa` out of `zypper -n lr`, the same selector and the same listing the cleanup loop already matches on. Repo present: the skipped one was somebody else's, so note it in the transcript and carry on. Repo absent: the list cannot be trusted, and the probe fails.

Two properties keep that from becoming a false-positive machine, and both are pinned by tests:

- The alias question is asked **only** on the `106` path. A host carrying none of the update's products adds no repo, answers `0`, and is never asked — so the legitimate empty case stays the no-op it always was.
- `mtui_issue_repo_present` is a pipeline **on purpose**: awk's `END { exit !found }` *is* the verdict, so an `lr` that fails outright reads as "absent" and fails the probe. That is the conservative direction.

**`zypper -n refresh` is deliberately *not* guarded.** My first draft did guard it. Review caught that `refresh.cc:337-345` returns `4` whether one repository failed or all of them did, and that the explicit `refresh` command never returns `106` (that is set only by `init_repos` inside an operation command). So its status cannot separate "the issue repo went missing" from "an unrelated stale repo did", and guarding it would abort the update on a refhost that would have patched correctly — routine on QAM refhosts. The case is not lost: a refresh failure that really does hide the update resurfaces on the patches probe, which goes through `init_repos` and answers `106`, at which point the alias question above finds the repo missing or disabled.

## The failure does not roll back

A host that could not determine what to patch never ran a patch. Nothing is half-applied for a downgrade to undo, and the rollback is group-wide — it would revert every healthy host in the group. New `UpdateFailure::ProbeFailed`, selected from a typed flag on `UpdateError`, never from the reason text.

`ProbeFailed` rather than widening `NotRun` because the command *did* run to completion and *did* produce a verdict, so `NotRun`'s "absence of a verdict, state unknown" doc would have become false.

The predicate is now `any(repairable)` → `Check`, else `all(probe_failed)` → `ProbeFailed`, else `NotRun`. On any run with no probe failures this is provably identical to the old `all(lastexit == -1)` form, so the documented rule that a mixed run still rolls back on behalf of the host it can repair is unchanged. One case did change: a run mixing a probe failure with a lost host no longer rolls back, since neither host has anything to repair.

## Testing

Rendered templates are executed under a real `/bin/sh` with stubs — the suite's `MockConnection` scripts one exit code per command and cannot model a shell's last-command-wins rule. 40 mutations applied to the original design, observed red and reverse-restored; each red is credited by a panic message unique to its assertion. The `106` path was mutation-verified the same way after the redesign: collapsing the conditional acceptance back to a plain reject turns the new cases red on "106 with the update repo listed must still patch".

The legitimate empty case — a host carrying none of the update's products — is pinned as first-class at both script and check level. It stays a no-op, not a failure.

The probe-failure marker is matched **at the start of a line** rather than anywhere in the stream, so a `set -x` trace, a quoting log line or an indented copy of the text cannot forge a probe failure.

## Known limitations, stated rather than hidden

- The template's `\>` is a GNU awk extension. SUSE refhosts ship gawk, but a non-GNU awk would match nothing and skip silently; the module doc now says so, and says the fixture row is dialect-neutral so nobody mistakes the shell tests for awk coverage.
- Repos are added without `-f`, so `patches` does not autorefresh them: a stale-but-present cache still answers `0` with the patch absent. Closing that needs a freshness assertion, not a status test.
- zypper's exact `106` conditions are not documented anywhere I could verify; the design only assumes it means *some* repo was skipped, which is why it asks `lr` rather than trusting the code.
- No MCP client can distinguish "failed and rolled back" from "failed and left alone" — the variant collapses to a string at the boundary.
- `zypper -n patches` now runs twice per update, so the transcript's list is not literally the list that was patched.
- `SLM_UPDATE` has no refresh at all, so stale metadata on SL Micro is a silent no-op no guard can see.
- The same shape in the rollback path is filed separately as #451.
