### PR TITLE
chore(deps): refresh lockfile and upgrade ruoqa to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - The openQA REST client is now built on the `ruoqa` crate instead of mtui's
   own hand-rolled signed-request implementation. User-visible effects:
-  `$OPENQA_CONFIG` and `$XDG_CONFIG_HOME/openqa/client.conf` are now honoured
-  as `client.conf` search paths, in addition to `/etc/openqa/client.conf` and
-  `~/.config/openqa/client.conf`; a credentialed `openqa_instance` URL
+  `client.conf` discovery is now **tiered and non-merging** —
+  `$OPENQA_CONFIG` (when set), else the user config directory
+  (`$XDG_CONFIG_HOME/openqa`, or `~/.config/openqa`), else `/etc/openqa` and
+  `/usr/etc/openqa`, with the **first tier that yields any file winning
+  outright**; a `~/.config/openqa/client.conf` override no longer combines
+  with host sections that exist only in `/etc/openqa/client.conf`, it
+  replaces them entirely. `$OPENQA_API_KEY`/`$OPENQA_API_SECRET` are now
+  honoured as a credential pair, taken ahead of `client.conf`. An openQA
+  instance served under a path prefix (`https://host/openqa`) is now
+  addressed and signed correctly — previously the prefix was silently
+  dropped, yielding 403/404. A bare-authority `--url-openqa localhost:9526`
+  now infers `http`, not `https`. A credentialed `openqa_instance` URL
   (`https://user:pass@host`) now has the userinfo dropped when resolving the
   request target, rather than merely redacted for display; and the
   unauthenticated `Accept` header sent with every request changed from `json`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "ruoqa"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e2366733a0e88dbab896d700e161ce43efe35acb96001235eb76d5acff4294"
+checksum = "a9e238a0cc7ebbe4039696aaa08550ee4c092048ea850d12bf8b872a4c82b648"
 dependencies = [
  "bytes",
  "hmac",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -397,6 +397,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -486,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -529,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1143,7 +1149,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,7 +1369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1421,9 +1427,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1458,9 +1464,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1473,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1483,15 +1489,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1500,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1519,32 +1525,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1785,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1863,7 +1869,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2141,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2191,7 +2197,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -2590,7 +2596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2611,9 +2617,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3196,7 +3202,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3271,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags",
 ]
@@ -3364,7 +3370,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3500,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
+checksum = "b41043523e0edcbd4e31d00903e26f12994f63b21bae9904f7405c1ed92752a5"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3663,7 +3669,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3720,7 +3726,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3731,9 +3737,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3768,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "sandogasa-rpmvercmp"
-version = "0.19.2"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2044602f338503c12a46d32553d924cb3d2f2b9e5a2b80425cea728f49d612"
+checksum = "3ae5611e2896aa0fae6b4c981045d925c4278e4c1c463ac50ea3c9f397772d40"
 
 [[package]]
 name = "schannel"
@@ -3919,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2c6921c8ce48fb1b052b457619d008834039d80325992ed3bc55bbe6c155ad"
 dependencies = [
  "annotate-snippets",
- "base64",
+ "base64 0.23.1",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",
@@ -4446,7 +4452,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4936,9 +4942,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4949,9 +4955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4959,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4969,9 +4975,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4982,18 +4988,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5011,9 +5017,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -5063,7 +5069,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5398,7 +5404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -5469,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5504,14 +5510,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -5529,19 +5535,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.55"
+name = "zcheapstr"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5630,40 +5645,41 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.3",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ reqwest = { version = "0.13", features = ["json", "rustls"], default-features = 
 # `client.conf`/$OPENQA_CONFIG credential discovery, retries, and redirect
 # restriction, replacing mtui's own hand-rolled implementation. reqwest 0.13.4
 # on both sides so `ClientBuilder::http_client` shares mtui's connection pool.
-# "0.1.4" is a floor, not a preference: mtui depends on its userinfo
-# redaction in `Error::Request`/`Error::Connection`/`Error::CrossOriginRedirect`
-# Display and in `config::resolve`'s bare-authority stripping
+# "0.2" is a floor, not a preference: mtui depends on its userinfo redaction
+# in `Error::Request`/`Error::Connection`/`Error::CrossOriginRedirect` Display
+# and in `config::resolve`'s bare-authority stripping
 # (crates/mtui-datasources/src/openqa/client.rs), and a resolver allowed to
-# pick 0.1.3 would silently reintroduce the leak.
-ruoqa = "0.1.4"
+# pick an older release would silently reintroduce the leak.
+ruoqa = "0.2"
 # HMAC-SHA1, for the OpenSSH hashed known_hosts test helper (mtui-hosts dev-dep);
 # not used for openQA auth any more (ruoqa owns that).
 hmac = "0.13"

--- a/crates/mtui-core/src/commands/openqa_jobs.rs
+++ b/crates/mtui-core/src/commands/openqa_jobs.rs
@@ -454,6 +454,53 @@ mod tests {
         assert!(out.contains("1 still pending"), "{out}");
     }
 
+    /// Clears `$OPENQA_API_KEY`/`$OPENQA_API_SECRET` for the guard's
+    /// lifetime, restoring their prior value on drop. `ruoqa` 0.2 resolves
+    /// this pair *ahead of* `client.conf`, so a test asserting a specific
+    /// `client.conf` credential must not see an ambient pair from the
+    /// developer's or CI's shell. Must only be used inside
+    /// `#[serial(openqa_config_env)]` tests: `std::env` mutation is
+    /// process-global.
+    struct ApiEnvGuard {
+        prev_key: Option<std::ffi::OsString>,
+        prev_secret: Option<std::ffi::OsString>,
+    }
+
+    impl ApiEnvGuard {
+        #[allow(unsafe_code)]
+        fn new() -> Self {
+            let prev_key = std::env::var_os("OPENQA_API_KEY");
+            let prev_secret = std::env::var_os("OPENQA_API_SECRET");
+            // SAFETY: guarded by `#[serial(openqa_config_env)]`, so no other
+            // test reads/writes these vars concurrently.
+            unsafe {
+                std::env::remove_var("OPENQA_API_KEY");
+                std::env::remove_var("OPENQA_API_SECRET");
+            }
+            Self {
+                prev_key,
+                prev_secret,
+            }
+        }
+    }
+
+    impl Drop for ApiEnvGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: guarded by `#[serial(openqa_config_env)]`.
+            unsafe {
+                match self.prev_key.take() {
+                    Some(v) => std::env::set_var("OPENQA_API_KEY", v),
+                    None => std::env::remove_var("OPENQA_API_KEY"),
+                }
+                match self.prev_secret.take() {
+                    Some(v) => std::env::set_var("OPENQA_API_SECRET", v),
+                    None => std::env::remove_var("OPENQA_API_SECRET"),
+                }
+            }
+        }
+    }
+
     /// Proves Phase 2 of the ruoqa migration: `openqa_jobs` authenticates when
     /// `client.conf` has credentials for the instance, not just when openQA
     /// happens to accept an unauthenticated GET.
@@ -463,6 +510,7 @@ mod tests {
     // `#[serial(openqa_config_env)]` guard makes the mutation exclusive.
     #[allow(unsafe_code)]
     async fn authenticates_against_an_instance_requiring_x_api_hash() {
+        let _env = ApiEnvGuard::new();
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/incident_settings/1"))

--- a/crates/mtui-datasources/src/openqa/client.rs
+++ b/crates/mtui-datasources/src/openqa/client.rs
@@ -99,12 +99,39 @@ mod tests {
     /// catches a future edit re-adding either call here. Observed red: adding
     /// `.tls(TlsMode::danger_accept_invalid_certs())` to
     /// `build_openqa_client_with_transport` fails this assertion.
+    ///
+    /// `#[serial(openqa_config_env)]`-guarded: `ruoqa` 0.2 also resolves
+    /// `$OPENQA_API_KEY`/`$OPENQA_API_SECRET`, and exactly one set in the
+    /// ambient environment (rather than a matched pair, or neither) would
+    /// turn this build into an `Err`.
     #[test]
+    #[serial_test::serial(openqa_config_env)]
+    // `std::env::set_var`/`remove_var` are `unsafe` in edition 2024; the
+    // `#[serial(openqa_config_env)]` guard makes the mutation exclusive.
+    #[allow(unsafe_code)]
     fn build_openqa_client_succeeds_with_default_verify() {
         // No `client.conf` in this process's search path is assumed; a bad
         // config would surface as `ClientBuild`, exercised via the
         // integration suite instead (needs a real filesystem fixture).
+        let prev_key = std::env::var_os("OPENQA_API_KEY");
+        let prev_secret = std::env::var_os("OPENQA_API_SECRET");
+        // SAFETY: guarded by `#[serial(openqa_config_env)]`.
+        unsafe {
+            std::env::remove_var("OPENQA_API_KEY");
+            std::env::remove_var("OPENQA_API_SECRET");
+        }
         let client = build_openqa_client(VerifyPolicy::Default(true), "openqa.example.com");
+        // SAFETY: guarded by `#[serial(openqa_config_env)]`.
+        unsafe {
+            match prev_key {
+                Some(v) => std::env::set_var("OPENQA_API_KEY", v),
+                None => std::env::remove_var("OPENQA_API_KEY"),
+            }
+            match prev_secret {
+                Some(v) => std::env::set_var("OPENQA_API_SECRET", v),
+                None => std::env::remove_var("OPENQA_API_SECRET"),
+            }
+        }
         assert!(client.is_ok());
     }
 

--- a/crates/mtui-datasources/tests/openqa.rs
+++ b/crates/mtui-datasources/tests/openqa.rs
@@ -49,6 +49,59 @@ fn base_for_no_creds(server_uri: &str) -> OpenQABase {
     base_for(server_uri, dir.path())
 }
 
+/// Clears `$OPENQA_API_KEY`/`$OPENQA_API_SECRET` for the guard's lifetime,
+/// restoring their prior value on drop. `ruoqa` 0.2 resolves this pair
+/// *ahead of* `client.conf`, so a test asserting a specific `client.conf`
+/// credential (or none at all) via [`base_for`]/[`base_for_no_creds`] must
+/// not see an ambient pair from the developer's or CI's shell. Must only be
+/// used inside `#[serial(openqa_config_env)]` tests: `std::env` mutation is
+/// process-global.
+struct ApiEnvGuard {
+    prev_key: Option<std::ffi::OsString>,
+    prev_secret: Option<std::ffi::OsString>,
+}
+
+impl ApiEnvGuard {
+    #[allow(unsafe_code)]
+    fn new() -> Self {
+        let prev_key = std::env::var_os("OPENQA_API_KEY");
+        let prev_secret = std::env::var_os("OPENQA_API_SECRET");
+        // SAFETY: guarded by `#[serial(openqa_config_env)]`, so no other
+        // test reads/writes these vars concurrently.
+        unsafe {
+            std::env::remove_var("OPENQA_API_KEY");
+            std::env::remove_var("OPENQA_API_SECRET");
+        }
+        Self {
+            prev_key,
+            prev_secret,
+        }
+    }
+}
+
+impl Drop for ApiEnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: guarded by `#[serial(openqa_config_env)]`.
+        unsafe {
+            restore_env("OPENQA_API_KEY", self.prev_key.take());
+            restore_env("OPENQA_API_SECRET", self.prev_secret.take());
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe fn restore_env(key: &str, prev: Option<std::ffi::OsString>) {
+    // SAFETY: only ever called from `ApiEnvGuard::drop`, itself gated behind
+    // `#[serial(openqa_config_env)]`.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
 #[tokio::test]
 async fn get_jobs_returns_parsed_jobs_on_success() {
     let server = MockServer::start().await;
@@ -239,7 +292,9 @@ async fn request_carries_accept_and_query_params() {
 }
 
 #[tokio::test]
+#[serial_test::serial(openqa_config_env)]
 async fn request_carries_auth_headers_when_credentials_present() {
+    let _env = ApiEnvGuard::new();
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/v1/jobs"))
@@ -266,7 +321,9 @@ async fn request_carries_auth_headers_when_credentials_present() {
 }
 
 #[tokio::test]
+#[serial_test::serial(openqa_config_env)]
 async fn request_omits_auth_headers_without_credentials() {
+    let _env = ApiEnvGuard::new();
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/v1/jobs"))
@@ -286,6 +343,7 @@ async fn request_omits_auth_headers_without_credentials() {
 // `#[serial(openqa_config_env)]` guard makes the mutation exclusive.
 #[allow(unsafe_code)]
 async fn request_carries_auth_headers_from_openqa_config_env() {
+    let _env = ApiEnvGuard::new();
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/v1/jobs"))

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -123,14 +123,27 @@ Defaults below are the built-in values.
 | `distri` | string | `sle` | openQA install `distri` parameter. |
 
 openQA API credentials (`key`/`secret`, used to sign requests with
-`X-API-Hash`) are **not** part of `mtui.toml`. They are read from the openQA
-project's own `client.conf` — an INI file with one `[host[:port]]` section per
-instance — searched at `/etc/openqa/client.conf` then
-`$XDG_CONFIG_HOME/openqa/client.conf` (or `~/.config/openqa/client.conf` when
-`$XDG_CONFIG_HOME` is unset), later files overriding earlier ones. Setting
-`$OPENQA_CONFIG` to a directory makes it the **only** path searched. An
-instance with no matching section (or no `client.conf` at all) is queried
-unauthenticated, which openQA permits for GET requests.
+`X-API-Hash`) are **not** part of `mtui.toml`. mtui delegates their discovery
+to the `ruoqa` client, which resolves them in this order:
+
+1. **`$OPENQA_API_KEY`/`$OPENQA_API_SECRET`**, honoured as a pair — setting
+   only one is a configuration error. When both are set they are used for
+   every instance, ahead of `client.conf`.
+2. The openQA project's own `client.conf` — an INI file with one
+   `[host[:port]]` section per instance — found via a **tiered**, non-merging
+   search: `$OPENQA_CONFIG` (when set), else the user config directory
+   (`$XDG_CONFIG_HOME/openqa`, or `~/.config/openqa` when `$XDG_CONFIG_HOME`
+   is unset), else `/etc/openqa` and `/usr/etc/openqa`. **The first tier that
+   yields any file wins outright; later tiers are not read at all** — a
+   `~/.config/openqa/client.conf` does not merge with sections that exist
+   only in `/etc/openqa/client.conf`; it replaces it. Within the winning
+   tier, each directory contributes its `client.conf` (if present) followed
+   by its sorted `client.conf.d/*.conf` drop-ins, later files overriding
+   earlier keys.
+
+An instance with no matching section (or no `client.conf` at all, and no
+`$OPENQA_API_KEY`/`$OPENQA_API_SECRET` pair) is queried unauthenticated, which
+openQA permits for GET requests.
 
 ### `[gitea]`
 


### PR DESCRIPTION
## Summary

- Refresh `Cargo.lock`: a plain `cargo update` moving 37 transitive crates, all within existing semver ranges and MSRV-1.96-compatible. `Cargo.toml` is untouched by this commit.
- Upgrade `ruoqa` 0.1.4 → 0.2. No mtui call sites change; the API surface mtui uses is unchanged upstream.

## User-visible changes from the ruoqa upgrade

- `client.conf` discovery is now **tiered and non-merging**: `$OPENQA_CONFIG` (when set), else the user config directory (`$XDG_CONFIG_HOME/openqa`, or `~/.config/openqa`), else `/etc/openqa` and `/usr/etc/openqa` — the first tier that yields any file wins outright, later tiers are not read. A `~/.config/openqa/client.conf` override no longer merges with host sections that exist only in `/etc/openqa/client.conf`.
- `$OPENQA_API_KEY`/`$OPENQA_API_SECRET` are now honoured as a credential pair, taken ahead of `client.conf`.
- An openQA instance served under a path prefix (`https://host/openqa`) is now addressed and signed correctly — previously the prefix was silently dropped, yielding 403/404.
- A bare-authority `--url-openqa localhost:9526` now infers `http`, not `https`.
- A credentialed `openqa_instance` URL has the userinfo dropped when resolving the request target, rather than merely redacted for display.

`docs/src/configuration.md` and the `CHANGELOG.md` `[Unreleased]` entry are updated to match.

## Test hermeticity fix

ruoqa 0.2's new env-credential lookup meant a developer or CI shell exporting `OPENQA_API_KEY`/`OPENQA_API_SECRET` could silently override the credentials three existing tests assert on via `client.conf` fixtures. Added a save/clear/restore guard for both vars, under the existing `#[serial(openqa_config_env)]` convention, in:

- `crates/mtui-datasources/tests/openqa.rs`
- `crates/mtui-core/src/commands/openqa_jobs.rs`
- `crates/mtui-datasources/src/openqa/client.rs`

Each guarded test was observed failing with the vars exported and no guard, then passing with the guard added, with and without the vars set.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` / `--all-features`
- `cargo audit`
- `mdbook build docs`
- `cargo run -p mtui-cli -- --help` / `cargo run -p mtui-mcp --features mcp -- --help`