### PR TITLE
fix(testreport): fail a rollback whose host could not work out what to downgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,20 @@ The `tests/` fixtures are the authority for these formats; treat them as golden.
   lands with that prefix automatically; don't hand-name it otherwise.
 - **Gate real hosts/containers** behind `#[ignore]` + a CI env flag (sshd
   integration fixture); unit tests must run offline and fast.
+- **Capturing `tracing` output: install the subscriber globally, scope the
+  sink.** `tracing::subscriber::set_default`'s guard is thread-local, but
+  callsite *interest* is cached **process-wide**: a callsite first reached from a
+  thread with no subscriber installed is cached `Interest::never()` and stays
+  silent for every later capture, so with libtest running in parallel whichever
+  test got there first decides whether a log assertion can even fail. Install
+  once with `set_global_default` and move the scoping to a thread-local sink.
+  The pattern is settled and already written up three times — canonical copy:
+  `crates/mtui-datasources/tests/log_capture.rs`; also
+  `mtui-datasources::teregen` and `mtui-testreport::reports::update_flow`'s test
+  modules. Copy it, do not re-derive it. Known cost: an unfiltered `Registry`
+  reports no `max_level_hint`, so `LevelFilter::current()` goes to `TRACE` for
+  that whole test binary and every `debug!`/`trace!` in it starts evaluating its
+  arguments; bound the layer with a `LevelFilter` if that ever matters.
 - **A test that cannot fail is not evidence.** Twice a real regression has sailed
   through a green workspace run: once because the fixture disarmed the assertion
   (a `MockConnection` answering empty stdout builds no downgrade command, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   previously did — neither host is one a downgrade could repair.
   The remote command text changes again, so `show_log` transcripts change with
   it.
+- `downgrade` — and the automatic rollback `update` runs after a failed check —
+  could report success while running zero downgrade commands (#451). The
+  package version probe was a shell pipeline, and a pipeline reports its last
+  stage's status: `awk`'s, which succeeds on empty input. So a failed
+  `zypper -n se` (a ZYpp lock, broken repo metadata, an unreadable rpmdb,
+  zypper missing) recorded exit `0` with an empty package list, the host was
+  taken for healthy, every package was skipped for want of a version to roll
+  back to, and the run finished with `done`. The probe now guards the commands
+  that produce the list, the same way the update templates do (#447): a failed
+  probe prints
+  `mtui: could not determine what to downgrade: <command> exited <status>` to
+  the transcript and exits with that command's own status, the host's downgrade
+  is abandoned, and the command fails (REPL and MCP) naming it. The healthy
+  hosts still roll back and still reboot — this run is usually the repair for
+  an update that already failed on the group — and the flow no longer logs
+  `done` while any host's state is unverified.
+  A host carrying none of the packages is still a no-op: `zypper search`
+  answers `104` for an empty result table, which stays an accepted, noted
+  answer. A skipped **unrelated** repository (`106`) is noted in the transcript
+  rather than failing the recovery — zypper raises it for any skipped
+  repository without saying which, and a refhost routinely carries one stale
+  one. The residual that leaves is named rather than papered over: if the
+  skipped repository was the one carrying the released versions, the list is
+  short and those packages stay at the update version — which the verdict
+  catches whenever the loaded update names required versions.
+  The remote command text changes, so `show_log` transcripts change with it.
 - `install` no longer fails when a package's `%post` script did. zypper exits
   `107` (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) in that case — an *informational*
   code meaning the packages "were successfully unpacked to disk and are

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -4222,6 +4222,27 @@ mod tests {
     /// the fan-out is `buffer_unordered` on the test's own task and
     /// `#[tokio::test]` is single-threaded, so no event under test is emitted
     /// off this thread.
+    ///
+    /// **Blast radius, accepted knowingly.** The `Registry` is unfiltered, so
+    /// it reports no `max_level_hint`; `set_global_default` reads that as "no
+    /// maximum" and `LevelFilter::current()` becomes `TRACE` for the *whole*
+    /// `mtui-testreport` lib test binary from the first capture onward. Every
+    /// `debug!`/`trace!` in the crate — previously dead, and none of them under
+    /// test here — then evaluates its formatting arguments and dispatches into
+    /// `CaptureLayer`, which drops it for want of a sink. The cost is argument
+    /// evaluation in tests only, and it buys the interest cache the race above
+    /// needs. Bounding the layer with a `LevelFilter` would keep the pinned
+    /// interest without the blast radius, and is the change to make if the lib
+    /// suite ever slows down noticeably.
+    ///
+    /// **This is the workspace's third copy of the pattern** — the others are
+    /// `mtui-datasources`' `tests/log_capture.rs` (the fullest write-up) and
+    /// `mtui-datasources::teregen`'s test module, and `mtui-core` gains a
+    /// fourth in #404/PR #459. They are copies rather than one helper because
+    /// each is a `#[cfg(test)]` module in a different crate and target
+    /// (unit-test modules cannot share an integration test's file); the
+    /// standing note in `AGENTS.md` § "Testing conventions" is what keeps the
+    /// next one from re-deriving the race from scratch.
     async fn capture_logs<T>(fut: impl std::future::Future<Output = T>) -> (T, String) {
         install_capture_subscriber();
         CAPTURE_SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -202,9 +202,13 @@ where
 /// Every other failure installed nothing — no updater for a host's key, a
 /// prepare that could not run, a cancel before dispatch, a host the flow lost,
 /// or a host that could not determine what to patch — so each re-surfaces
-/// without a rollback attempt. The rollback is best-effort
-/// ([`perform_downgrade`] returns `()`), so it can never bury the original
-/// update error.
+/// without a rollback attempt. The rollback is best-effort, but not because it
+/// cannot fail: [`perform_downgrade`] returns a `Result`, and a host whose
+/// version probe never answered raises it (#451). The precedence is enforced at
+/// the call site, which logs that error at WARN and re-surfaces the original
+/// update error, so a failed rollback can never bury the failure it was trying
+/// to repair — do not simplify the call away, or a broken rollback goes silent
+/// again.
 pub async fn perform_update_with_rollback<R>(
     report: &R,
     targets: &mut HostsGroup,
@@ -1141,13 +1145,26 @@ async fn downgrade_body(
     }
 
     // A dead probe must abort that host's downgrade, not degrade it. When the
-    // probe dies (an SSH no-output timeout records exit -1) its stdout is
-    // empty, the version map below stays empty, and the flow would
-    // "complete" having run zero downgrade commands — leaving every package at
-    // the update version behind a success-looking run. The pipeline's exit
-    // status is awk's, so a recorded non-zero exit here always means the probe
-    // itself broke, never "package not found". Handled per host: the healthy
-    // hosts still roll back (and transactional ones still reboot); the error for
+    // probe dies its stdout carries no versions, the version map below stays
+    // empty, and the flow would "complete" having run zero downgrade commands —
+    // leaving every package at the update version behind a success-looking run.
+    //
+    // Non-zero is the whole signal, and the template is what makes it
+    // trustworthy in both directions (#451). It guards the commands that
+    // *produce* the list and exits with the failed tool's own status, so a
+    // non-zero status here is either SSH-level death (the `-1` sentinel) or the
+    // guard passing zypper's or awk's status through — never "package not
+    // found", which the guard accepts as `104` and reports as `0`. And zero now
+    // genuinely means the probe answered: an empty list at `0` is a host
+    // carrying none of these packages, not a probe that failed unnoticed. Left
+    // as one pipeline the status was the *last* stage's — awk's, and awk
+    // succeeds on empty input — so a failed `zypper se` recorded `0` and this
+    // gate could only ever catch the `-1`.
+    //
+    // Handled per host: the healthy hosts still roll back (and transactional
+    // ones still reboot), because this downgrade is often the repair for an
+    // update that already failed on the group, and aborting it over one host's
+    // broken zypper would strand the healthy peers half-applied. The error for
     // the dead ones is raised at the end. All probes dead aborts immediately.
     let dead_probes: std::collections::BTreeSet<String> = list_map
         .keys()
@@ -1164,7 +1181,7 @@ async fn downgrade_body(
         error!(
             host = %hn,
             exit = ?exit,
-            "package version probe failed; skipping downgrade on this host"
+            "package version probe failed; this host was not downgraded"
         );
     }
     if !dead_probes.is_empty() && dead_probes.len() == list_map.len() {
@@ -1351,7 +1368,7 @@ async fn downgrade_body(
             .map(reboot_error),
     );
 
-    let not_downgraded = downgrade_verdict(targets).await;
+    let not_downgraded = downgrade_verdict(targets, &dead_probes).await;
 
     // A per-host check failure aborts first (matches the pre-#336 aggregation).
     aggregate_failures("downgrade", failures)?;
@@ -1416,7 +1433,20 @@ async fn downgrade_body(
 /// map of packages still at or above the update version — empty on a fully
 /// completed rollback. Iterated in sorted hostname order (the group's own
 /// ordering) so the log is deterministic.
-async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<String>> {
+///
+/// `probe_dead` names the hosts whose version probe never answered, and the
+/// all-clear is withheld while it is non-empty. Nothing was downgraded on those
+/// hosts, and this verdict cannot speak for them either: it flags a package only
+/// when the loaded report carries a `required` version to compare against, so on
+/// a standalone `downgrade` — or for a package outside the report's list — an
+/// unmeasured host produces the same empty map a completed rollback does.
+/// Logging `done` over it is the silent success of issue #451 restated one layer
+/// up. The hosts are named at WARN instead; the command's own failure is raised
+/// by the caller.
+async fn downgrade_verdict(
+    targets: &mut HostsGroup,
+    probe_dead: &BTreeSet<String>,
+) -> BTreeMap<String, Vec<String>> {
     // Query every host's versions concurrently via the shared fan-out, then
     // run the pure verdict scan below.
     targets.query_versions().await;
@@ -1448,8 +1478,20 @@ async fn downgrade_verdict(targets: &mut HostsGroup) -> BTreeMap<String, Vec<Str
         }
     }
 
+    if !probe_dead.is_empty() {
+        warn!(
+            hosts = %probe_dead.iter().cloned().collect::<Vec<_>>().join(", "),
+            "no package version probe answered on these hosts, so nothing was \
+             downgraded there and their package state is unverified"
+        );
+    }
+
     if not_downgraded.is_empty() {
-        tracing::info!("done");
+        // Only when every host was actually measured. A dead probe leaves this
+        // map empty for the same reason a completed rollback does.
+        if probe_dead.is_empty() {
+            tracing::info!("done");
+        }
     } else {
         for (hostname, names) in &not_downgraded {
             error!(
@@ -2758,6 +2800,164 @@ mod tests {
         );
     }
 
+    /// The exact `list_command` the downgrade flow renders for `packages` on a
+    /// SLES 15 host — the string [`MockConnection::with_response`] must match to
+    /// script the **version probe specifically**.
+    ///
+    /// Built through the same registry and the same `quote_args` the flow uses,
+    /// so the two cannot drift apart into a fixture that scripts nothing.
+    fn downgrade_list_command(packages: &[String]) -> String {
+        WorkflowRegistry::default()
+            .doer(Role::Downgrade, "15", false)
+            .expect("zypper has a downgrader")
+            .render_list_command(
+                &[("packages", quote_args(packages).as_str())]
+                    .into_iter()
+                    .collect(),
+            )
+            .expect("safe substitution never fails")
+            .expect("the zypper downgrader carries a list command")
+    }
+
+    /// A SLES 15 target whose **version probe** answers `exit`, with the
+    /// marker line the guarded template prints on stdout.
+    ///
+    /// That pairing is what the rendered probe actually produces when
+    /// `zypper -n se` fails — pinned end-to-end against a real `/bin/sh` in
+    /// `actions::downgrade`'s `rendered_script` module, which is where it *can*
+    /// be pinned: `MockConnection` scripts one outcome per command string and
+    /// cannot run a shell. Replaying it here is what lets the flow's *routing*
+    /// be tested.
+    ///
+    /// Scripted per command rather than through `with_default`, so the failure
+    /// is attributable to the probe: a mock answering every command alike would
+    /// leave nothing to attribute, and every other command on this host answers
+    /// cleanly.
+    fn sles_target_with_probe_exit(
+        hostname: &str,
+        packages: &[String],
+        exit: i16,
+    ) -> (Target, MockConnection, String) {
+        let list = downgrade_list_command(packages);
+        let conn = MockConnection::new(hostname)
+            .with_default(CommandLog::new("", "pkg-a = 1.0-1\n", "", 0, 0))
+            .with_response(
+                list.clone(),
+                CommandLog::new(
+                    list.clone(),
+                    format!(
+                        "mtui: could not determine what to downgrade: zypper -n se exited {exit}"
+                    ),
+                    "",
+                    exit,
+                    0,
+                ),
+            );
+        let handle = conn.clone();
+        let mut t = Target::with_connection(hostname, TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        (t, handle, list)
+    }
+
+    #[tokio::test]
+    async fn perform_downgrade_probe_nonzero_exit_is_a_dead_probe() {
+        // Issue #451. Before the guard, a refused `zypper -n se` status could
+        // not reach this gate at all: the probe was a pipeline, so the recorded
+        // status was awk's, and awk exits 0 on empty input. Now the template
+        // exits with the failed tool's own status, and *any* non-zero status is
+        // a dead probe — the `-1` SSH sentinel the two tests above use is only
+        // one of its values, so a predicate narrowed to `c == -1` would still
+        // pass them.
+        //
+        // Per host, deliberately: h1 is what the rollback exists for. Aborting
+        // the whole group over h2's broken zypper would strand every healthy
+        // peer half-applied — the opposite of the update's own probe failure,
+        // where nothing had been applied yet.
+        let packages = vec!["pkg-a".to_owned()];
+        let (t1, h1) = sles_target("h1", "pkg-a = 1.0-1\n");
+        let (t2, h2, list) = sles_target_with_probe_exit("h2", &packages, 7);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let res = perform_downgrade(&mut group, &NoopRepo, &packages, None).await;
+
+        // Not vacuous: the scripted probe really is the command that ran.
+        assert!(
+            h2.commands().contains(&list),
+            "the rendered version probe must have been dispatched: {:?}",
+            h2.commands()
+        );
+        let err = res.expect_err("a probe that refused its status must fail the command");
+        assert_eq!(err.reason, "package version probe failed");
+        assert_eq!(err.host.as_deref(), Some("h2"));
+        // The healthy host still rolled back — that is what the recovery is for.
+        assert!(
+            h1.commands()
+                .iter()
+                .any(|c| c.contains("--oldpackage") && c.contains("pkg-a") && c.contains("1.0-1")),
+            "the healthy host must still roll back: {:?}",
+            h1.commands()
+        );
+        assert!(
+            !h2.commands().iter().any(|c| c.contains("--oldpackage")),
+            "the dead-probe host must build no downgrade command: {:?}",
+            h2.commands()
+        );
+    }
+
+    #[tokio::test]
+    async fn downgrade_verdict_withholds_done_when_a_probe_died() {
+        // The all-clear must be unreachable on a host where no downgrade
+        // command ran. `downgrade_verdict` names a package only when the report
+        // carries a `required` version to compare against; on a standalone
+        // downgrade there is none, so with a dead probe the map came back empty
+        // and `done` was logged over a host nobody had measured — while the
+        // command failed. An operator reading the transcript saw both.
+        let packages = vec!["pkg-a".to_owned()];
+        let (t1, _h1) = sles_target("h1", "pkg-a = 1.0-1\n");
+        let (t2, _h2, _list) = sles_target_with_probe_exit("h2", &packages, 7);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let (res, logs) =
+            capture_logs(perform_downgrade(&mut group, &NoopRepo, &packages, None)).await;
+
+        let err = res.expect_err("a dead probe still fails the command");
+        assert_eq!(err.reason, "package version probe failed");
+        // The capture layer renders a message unquoted, so this is `== "done"`
+        // and not `contains("\"done\"")` — which would have matched nothing at
+        // all and passed however the code behaved.
+        assert!(
+            !logs.lines().any(|l| l == "done"),
+            "the all-clear must be withheld while a host's state is unverified: {logs}"
+        );
+        let unverified = logs
+            .lines()
+            .find(|l| l.contains("unverified"))
+            .unwrap_or_else(|| panic!("no warning about the unverified host: {logs}"));
+        assert!(
+            unverified.contains("h2"),
+            "the warning must name the host whose state is unknown: {unverified}"
+        );
+        // And the per-host ERROR says what happened to the host, not what the
+        // flow did next: "skipping downgrade on this host" reads as a step that
+        // was omitted, where the operator needs to know this host still carries
+        // the update.
+        let named = logs
+            .lines()
+            .find(|l| l.contains("was not downgraded"))
+            .unwrap_or_else(|| panic!("the per-host error must say so plainly: {logs}"));
+        assert!(
+            named.contains("h2"),
+            "the per-host error must name the host: {named}"
+        );
+    }
+
     #[tokio::test]
     async fn downgrade_verdict_names_packages_still_at_update_version() {
         // Re-query returns pkg-a still at 1.5-1, which is the update's `required`
@@ -2770,7 +2970,7 @@ mod tests {
         t.set_packages(vec![pkg]);
         let mut group = HostsGroup::new(vec![t], false);
 
-        let not_downgraded = downgrade_verdict(&mut group).await;
+        let not_downgraded = downgrade_verdict(&mut group, &BTreeSet::new()).await;
 
         assert_eq!(
             not_downgraded.get("h1").map(Vec::as_slice),
@@ -2799,7 +2999,7 @@ mod tests {
         t.set_packages(vec![pkg]);
         let mut group = HostsGroup::new(vec![t], false);
 
-        let _ = downgrade_verdict(&mut group).await;
+        let _ = downgrade_verdict(&mut group, &BTreeSet::new()).await;
 
         let p = &group.get("h1").unwrap().packages()[0];
         assert_eq!(
@@ -2822,7 +3022,7 @@ mod tests {
         t.set_packages(vec![pkg]);
         let mut group = HostsGroup::new(vec![t], false);
 
-        let _ = downgrade_verdict(&mut group).await;
+        let _ = downgrade_verdict(&mut group, &BTreeSet::new()).await;
 
         let p = &group.get("h1").unwrap().packages()[0];
         assert_eq!(
@@ -2846,7 +3046,7 @@ mod tests {
         t2.set_packages(vec![p2]);
         let mut group = HostsGroup::new(vec![t1, t2], false);
 
-        let not_downgraded = downgrade_verdict(&mut group).await;
+        let not_downgraded = downgrade_verdict(&mut group, &BTreeSet::new()).await;
 
         assert!(not_downgraded.contains_key("h1"), "{not_downgraded:?}");
         assert!(not_downgraded.contains_key("h2"), "{not_downgraded:?}");
@@ -2863,7 +3063,7 @@ mod tests {
         t.set_packages(vec![pkg]);
         let mut group = HostsGroup::new(vec![t], false);
 
-        let not_downgraded = downgrade_verdict(&mut group).await;
+        let not_downgraded = downgrade_verdict(&mut group, &BTreeSet::new()).await;
 
         assert!(not_downgraded.is_empty(), "{not_downgraded:?}");
         // Bookkeeping still advanced.

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1512,7 +1512,14 @@ async fn downgrade_verdict(
 
 /// Parses the downgrader `list_command` output into a `name -> highest version`
 /// map, selecting the highest version per package by RPM version ordering.
-fn parse_downgrade_versions(output: &str) -> HashMap<String, String> {
+///
+/// The split on `" = "` is a contract with the downgrade template, whose
+/// accepted-status notes print to this same stream — see
+/// [`crate::update_workflow::actions::downgrade`] § "The notes share a stream
+/// with the parser". `pub(crate)` so the test pinning that coupling can put the
+/// real script's real output through the real parser, instead of
+/// re-implementing the rule and then pinning its copy.
+pub(crate) fn parse_downgrade_versions(output: &str) -> HashMap<String, String> {
     use mtui_types::rpmver::RPMVersion;
 
     let mut release: HashMap<String, Vec<String>> = HashMap::new();

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -4192,21 +4192,56 @@ mod tests {
         );
     }
 
-    /// Runs `fut` under a scoped tracing subscriber that captures each
-    /// event's message synchronously into an in-memory buffer, returning
-    /// `fut`'s output paired with the joined records. Mirrors
-    /// `mtui-datasources/tests/obs_oscrc.rs`'s `capture_logs`, adapted for an
-    /// async body: `set_default`'s guard stays live across the awaited future
-    /// on the single-threaded `#[tokio::test]` runtime these tests run under.
+    /// Runs `fut` with this thread's log capture armed, recording each
+    /// event's message and fields synchronously into an in-memory buffer,
+    /// returning `fut`'s output paired with the joined records.
+    ///
+    /// The subscriber is **global and installed once**, and only the sink is
+    /// scoped to the calling thread. That is not a style choice: `tracing`
+    /// caches callsite *interest* process-wide, so a callsite first reached
+    /// from a thread with no subscriber installed is cached as
+    /// `Interest::never()` and stays silent for every later capture. With the
+    /// suite running in parallel that is a race, and it is not hypothetical —
+    /// under `tracing::subscriber::set_default`'s thread-local guard,
+    /// `downgrade_verdict_withholds_done_when_a_probe_died` failed about one
+    /// run in three with a capture holding a single line, because its sibling
+    /// `perform_downgrade_probe_nonzero_exit_is_a_dead_probe` drives the same
+    /// `warn!`/`error!` callsites with no subscriber and whichever test reached
+    /// them first decided the cache. `mtui-datasources`' `teregen` capture hit
+    /// the same race and is fixed the same way. An always-installed subscriber
+    /// keeps interest pinned to `always`.
+    ///
+    /// Scoping via the thread-local sink captures exactly what the guard did:
+    /// the fan-out is `buffer_unordered` on the test's own task and
+    /// `#[tokio::test]` is single-threaded, so no event under test is emitted
+    /// off this thread.
     async fn capture_logs<T>(fut: impl std::future::Future<Output = T>) -> (T, String) {
+        install_capture_subscriber();
+        CAPTURE_SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+        let out = fut.await;
+        let records = CAPTURE_SINK
+            .with(|s| s.borrow_mut().take())
+            .unwrap_or_default();
+        (out, records.join("\n"))
+    }
+
+    thread_local! {
+        /// Buffer for the capture in progress on this thread, or `None` when no
+        /// capture is active — events from a thread without one are dropped.
+        static CAPTURE_SINK: std::cell::RefCell<Option<Vec<String>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// Install the permissive global subscriber backing [`capture_logs`], once
+    /// per test binary. See [`capture_logs`] for why it must be global.
+    fn install_capture_subscriber() {
         use std::fmt::Write as _;
-        use std::sync::{Arc, Mutex};
+        use std::sync::OnceLock;
         use tracing::field::{Field, Visit};
         use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
         use tracing_subscriber::registry::Registry;
 
-        #[derive(Clone)]
-        struct CaptureLayer(Arc<Mutex<Vec<String>>>);
+        struct CaptureLayer;
 
         struct MessageVisitor(String);
         impl Visit for MessageVisitor {
@@ -4221,17 +4256,20 @@ mod tests {
 
         impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-                let mut visitor = MessageVisitor(String::new());
-                event.record(&mut visitor);
-                self.0.lock().unwrap().push(visitor.0);
+                CAPTURE_SINK.with(|s| {
+                    if let Some(buf) = s.borrow_mut().as_mut() {
+                        let mut visitor = MessageVisitor(String::new());
+                        event.record(&mut visitor);
+                        buf.push(visitor.0);
+                    }
+                });
             }
         }
 
-        let records = Arc::new(Mutex::new(Vec::new()));
-        let sub = Registry::default().with(CaptureLayer(records.clone()));
-        let _guard = tracing::subscriber::set_default(sub);
-        let out = fut.await;
-        (out, records.lock().unwrap().join("\n"))
+        static ONCE: OnceLock<()> = OnceLock::new();
+        ONCE.get_or_init(|| {
+            let _ = tracing::subscriber::set_global_default(Registry::default().with(CaptureLayer));
+        });
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -74,6 +74,31 @@
 //! cannot carry that verdict; only a comparison against what should be
 //! installed can, which is what the transcript note exists to prompt.
 //!
+//! ## The notes share a stream with the parser
+//!
+//! Both accepted-status notes print to **stdout** — the same stream
+//! [`crate::reports::update_flow::parse_downgrade_versions`] reads back as the
+//! version list. That parser takes *any* line containing a space-equals-space
+//! as one `name`/`version` row, so the notes are safe only because neither
+//! contains that separator. It is a real coupling between a shell string here
+//! and a Rust parser two modules away: rewording a note into, say, "no package
+//! = no rollback" would inject a bogus package into the version map and make
+//! the flow try to downgrade it. A short comment at the `printf` sites names
+//! the constraint, and
+//! `rendered_script::the_probe_notes_never_parse_as_versions` pins it against
+//! the real script's real output.
+//!
+//! Routing the notes to stderr instead is not the free escape it looks. The
+//! flow's general rule for judging a fan-out is
+//! [`crate::reports::update_flow`]'s `host_command_failures`, which counts
+//! *any* stderr as a failure — it is what judges the repo removal that runs
+//! immediately before this probe. The probe step itself is the exception,
+//! gated on the exit status alone (`dead_probes`), so a note on stderr would
+//! survive *today*; but that is one call site's choice, not a property of the
+//! flow, and the arm exists precisely to keep `104` from failing the command.
+//! Putting the note one snapshot field away from the rule that would refuse it
+//! buys nothing a comment and a test do not.
+//!
 //! ## What is not guarded
 //!
 //! The middle of the filter chain. `grep`, `sed` or a missing binary among them
@@ -106,6 +131,8 @@ const LIST_COMMAND: &str = r#"
 mtui_probe_ok() {
   case "$$2" in
   0) return 0 ;;
+  # Both notes print to stdout, which parse_downgrade_versions also reads. It
+  # splits on space-equals-space, so no note may ever contain that separator.
   104)
     printf 'mtui: note: %s exited 104, no package matched; nothing to downgrade here\n' "$$1"
     return 0
@@ -299,6 +326,15 @@ mod tests {
             listed.contains("  106)\n    printf 'mtui: note: %s exited 106,"),
             "{name}: `106` must be noted, not refused: {listed}"
         );
+        // Both notes ride the stream `parse_downgrade_versions` reads, and are
+        // safe only because neither carries the separator it splits on. That
+        // constraint lives two modules away, so the script names it where the
+        // notes are written; `the_probe_notes_never_parse_as_versions` pins the
+        // property itself.
+        assert!(
+            listed.contains("parse_downgrade_versions"),
+            "{name}: the notes must name the parser whose stream they share: {listed}"
+        );
         // Every other status marks and exits with the probe's own status. The
         // marker is split across the format string and its argument so the
         // script's own text does not contain it.
@@ -406,6 +442,7 @@ mod tests {
         use std::process::Command;
 
         use super::*;
+        use crate::reports::update_flow::parse_downgrade_versions;
 
         /// The start of the line a failed probe prints.
         ///
@@ -819,6 +856,85 @@ exit 0
                     ran.versions()
                 );
                 assert_eq!(ran.code, 0, "{name}: and the no-op must not fail");
+            }
+        }
+
+        #[test]
+        fn the_probe_notes_never_parse_as_versions() {
+            // Everything this template prints goes to **stdout**, and stdout is
+            // what `parse_downgrade_versions` reads back as the version list —
+            // it takes any line carrying the separator as one `name`/`version`
+            // row. So the three notes are safe only for as long as none of them
+            // contains it, and a reword ("... exited 104, no package = no
+            // rollback") would quietly add a package the flow then tries to
+            // downgrade. That coupling is between a shell string here and a
+            // parser two modules away, which is why it is pinned with the real
+            // parser rather than a local re-implementation of its rule.
+            //
+            // Each case is the real script's real stdout, so the note text is
+            // never copied into this test — a reword is caught because it is
+            // *parsed*, not because it stopped matching a literal.
+            for (name, cmds) in downgraders() {
+                for (case, knobs, expected) in [
+                    // A refused status: only the failure marker on stdout.
+                    (
+                        "a failed probe",
+                        Knobs {
+                            se_exit: 7,
+                            rows: "",
+                            ..Knobs::default()
+                        },
+                        Vec::new(),
+                    ),
+                    // `104`: the note, and nothing else.
+                    (
+                        "the 104 note",
+                        Knobs {
+                            se_exit: 104,
+                            rows: NO_MATCH_STDOUT,
+                            ..Knobs::default()
+                        },
+                        Vec::new(),
+                    ),
+                    // `106`: the note *alongside* a real version line, which is
+                    // the realistic shape (a repo was skipped, the survivors
+                    // still answered). Discriminating in a way the note-only
+                    // cases are not: a note that parsed would show up as a
+                    // second entry rather than as the difference between empty
+                    // and non-empty.
+                    (
+                        "the 106 note beside a real row",
+                        Knobs {
+                            se_exit: 106,
+                            ..Knobs::default()
+                        },
+                        vec![("pkg-a".to_owned(), "1.0-1".to_owned())],
+                    ),
+                ] {
+                    let stubs = Stubs::new();
+                    let ran = run_script(&cmds, &stubs, knobs);
+                    // Anti-vacuity: without a note on stdout every assertion
+                    // below holds for the wrong reason. Matched on the prefix
+                    // the script prints, not on the wording it is free to
+                    // change.
+                    assert!(
+                        ran.stdout
+                            .lines()
+                            .any(|l| l.starts_with("mtui: note: ") || l.starts_with(PROBE_MARKER)),
+                        "{name}/{case}: the script printed no note at all, so nothing is \
+                         being tested: {}",
+                        ran.stdout
+                    );
+                    let parsed = parse_downgrade_versions(&ran.stdout);
+                    let mut got: Vec<(String, String)> = parsed.into_iter().collect();
+                    got.sort();
+                    assert_eq!(
+                        got, expected,
+                        "{name}/{case}: the notes must contribute no package to the version \
+                         map: {}",
+                        ran.stdout
+                    );
+                }
             }
         }
 

--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -10,6 +10,78 @@
 //!
 //! `LIST_COMMAND`'s leading newline keeps the first command off the prompt line
 //! in the transcript `show_log` prints.
+//!
+//! # The probe guard
+//!
+//! `LIST_COMMAND`'s output *is* the downgrade: every package the flow rolls
+//! back is one this probe resolved a released version for, so a probe that
+//! fails silently is a rollback that runs zero commands and reports success
+//! ([`crate::reports::update_flow::perform_downgrade`] would find an empty
+//! version map and skip every package). That is issue #451 — the same defect
+//! [`crate::update_workflow::actions::update`] carries as #447, in the path
+//! that matters most, since the rollback runs *after* an update has already
+//! failed on the group.
+//!
+//! It was not merely a discarded status. The probe was one pipeline, and POSIX
+//! defines a pipeline's status as its **last** stage's: awk's, and awk exits
+//! `0` after a successful run over empty input. A failed `zypper se` — a ZYpp
+//! lock, broken repo metadata, an unreadable rpmdb, zypper missing — was
+//! therefore not observable at all, and `dead_probes`' `lastexit != 0` gate
+//! could only ever catch SSH-level death.
+//!
+//! The technique is the update templates', and the argument for each step is
+//! made in full in that module's docs (§ "The probe guard"); only what differs
+//! is restated here. In outline: each producing stage is captured on its own
+//! line so an assignment's status is the substitution's (POSIX XCU 2.9.1), the
+//! rows reach the filter through the **builtin** `printf '%s\n'` so no
+//! `ARG_MAX` limit sits between probe and filter, `mtui_probe_ok` prints a
+//! start-of-line marker and exits with **the tool's own status** (never an
+//! invented sentinel — a POSIX `exit` truncates to `0..=255`, so any chosen
+//! value would collide with zypper's own space), and the marker is assembled
+//! from `printf`'s format string *and* its argument so the script's own text
+//! never carries the sentence it prints.
+//!
+//! awk is guarded too, for the same reason it is in the update templates: it is
+//! the stage that actually produces the list, and `$?` after the filter
+//! pipeline is already awk's, so the capture is free.
+//!
+//! ## Why the accepted set is `0`, `104` and `106`
+//!
+//! `104` is `ZYPPER_EXIT_INF_CAP_NOT_FOUND`, which `zypper search` sets when
+//! its result table comes back empty. That is the legitimate "this host carries
+//! none of these packages", routine in a mixed group and a no-op the flow has
+//! always treated as one. Refusing it would fail the rollback on every host the
+//! update never touched.
+//!
+//! `106` is `ZYPPER_EXIT_INF_REPO_SKIPPED`, accepted on the fleet argument
+//! `a249a00d` made for the update path: `init_repos()` raises it for **any**
+//! skipped repository and cannot say which, a refhost routinely carries one
+//! stale or unreachable repo alongside working ones, and here the run *is* the
+//! recovery from a failed update — aborting it on hosts that would have rolled
+//! back correctly is the more expensive mistake. The update templates answer
+//! `106` by asking whether the update's own repo survived; that question cannot
+//! be asked here, and not for want of trying: `downgrade_body` removes the issue
+//! repository from every host on purpose before the probe runs, so its absence
+//! is the expected state. The released versions the rollback wants come from the
+//! host's ordinary repositories.
+//!
+//! **The residual that leaves, named rather than hidden:** if the skipped
+//! repository is the one carrying the released versions, the list is silently
+//! short and those packages stay at the update version. On the rollback path
+//! that is caught downstream — `downgrade_verdict` compares each package
+//! against the update's `required` version and fails the command — but on a
+//! standalone `downgrade` with no required versions loaded, it is not. A status
+//! cannot carry that verdict; only a comparison against what should be
+//! installed can, which is what the transcript note exists to prompt.
+//!
+//! ## What is not guarded
+//!
+//! The middle of the filter chain. `grep`, `sed` or a missing binary among them
+//! yields an empty list at awk's `0`, exactly as before — awk is the last stage
+//! and succeeds on no input. That is the same accepted residual the update
+//! templates carry, and closing it needs `pipefail` (not POSIX) or
+//! `${PIPESTATUS[@]}` (bash-only), while these scripts must run under the
+//! `/bin/sh` a refhost provides.
 
 use crate::update_workflow::actions::{ActionCommands, SubstMode};
 
@@ -20,12 +92,37 @@ use crate::update_workflow::actions::{ActionCommands, SubstMode};
 /// awk with no PTY, emits nothing until the last iteration — on a slow host a
 /// long package list blows the SSH no-output timeout (`connection_timeout`,
 /// default 300s) and the probe dies with no versions resolved.
+///
+/// See the module docs for why the two commands that produce the list are
+/// guarded, why the guard exits with the tool's own status, and why `104` and
+/// `106` are accepted while everything else is refused.
+///
+/// Every `$` meant for the remote shell is written `$$` (`$$?`, `$$(`, `$$1`,
+/// `$$2`, `$$mtui_rows`); the awk field refs (`$2`, `$4`) stay bare, which is
+/// the tested convention for [`SubstMode::Safe`]. Shell variables are
+/// `mtui_`-prefixed *and* `$$`-escaped, so no future `$name` template variable
+/// can silently expand one away.
 const LIST_COMMAND: &str = r#"
-zypper -n se -s --match-exact -t package $packages \
-| grep -v "(System" \
-| grep ^[iv] \
-| sed "s, ,,g" \
-| awk -F "|" '{ print $2,"=",$4 }'
+mtui_probe_ok() {
+  case "$$2" in
+  0) return 0 ;;
+  104)
+    printf 'mtui: note: %s exited 104, no package matched; nothing to downgrade here\n' "$$1"
+    return 0
+    ;;
+  106)
+    printf 'mtui: note: %s exited 106, a repository was skipped; the version list may be short\n' "$$1"
+    return 0
+    ;;
+  esac
+  printf 'mtui: could not %s\n' "determine what to downgrade: $$1 exited $$2"
+  exit "$$2"
+}
+mtui_rows=$$(zypper -n se -s --match-exact -t package $packages)
+mtui_probe_ok "zypper -n se" $$?
+mtui_versions=$$(printf '%s\n' "$$mtui_rows" | grep -v "(System" | grep ^[iv] | sed "s, ,,g" | awk -F "|" '{ print $2,"=",$4 }')
+mtui_probe_ok "awk" $$?
+printf '%s\n' "$$mtui_versions"
 "#;
 
 /// zypper downgrade command, verbatim.
@@ -111,8 +208,16 @@ mod tests {
         let listed = cmds.render_list_command(&vars).unwrap().unwrap();
         // No per-package loop.
         assert!(!listed.contains("for p in"), "{listed}");
-        // Exactly one zypper invocation, over the whole list.
-        assert_eq!(listed.matches("zypper").count(), 1, "{listed}");
+        // Exactly one zypper invocation, over the whole list. Counted on the
+        // whole invocation rather than the bare token `zypper`, which the probe
+        // guard's own label ("zypper -n se") also carries.
+        assert_eq!(
+            listed
+                .matches("zypper -n se -s --match-exact -t package")
+                .count(),
+            1,
+            "{listed}"
+        );
         assert!(
             listed.contains("zypper -n se -s --match-exact -t package a b c"),
             "{listed}"
@@ -121,6 +226,7 @@ mod tests {
         assert!(listed.contains("{ print $2,\"=\",$4 }"));
         // Discriminating: the doubled form contains the single-brace substring.
         assert!(!listed.contains("{{"), "{listed}");
+        assert_the_probe_is_guarded("zypper", &listed, "a b c");
     }
 
     #[test]
@@ -130,10 +236,123 @@ mod tests {
         let vars: HashMap<&str, &str> = [("packages", "a b")].into_iter().collect();
         let listed = cmds.render_list_command(&vars).unwrap().unwrap();
         assert!(!listed.contains("for p in"), "{listed}");
-        assert_eq!(listed.matches("zypper").count(), 1, "{listed}");
+        assert_eq!(
+            listed
+                .matches("zypper -n se -s --match-exact -t package")
+                .count(),
+            1,
+            "{listed}"
+        );
         assert!(
             listed.contains("zypper -n se -s --match-exact -t package a b"),
             "{listed}"
+        );
+        assert_the_probe_is_guarded("slmicro", &listed, "a b");
+    }
+
+    /// The `$$`-escaping and probe-guard contract, asserted on the **rendered**
+    /// text rather than the source constant — a `$` that was meant for the
+    /// remote shell but written bare still *looks* right in the source, and a
+    /// mangled escape would render a broken script that no
+    /// `MockConnection`-level test could notice.
+    ///
+    /// Pinned by shape rather than as one literal blob, so that editing the
+    /// guard's prose does not fail this while a semantic change slips through
+    /// it. Each assertion is a separate way the guard could stop guarding.
+    fn assert_the_probe_is_guarded(name: &str, listed: &str, packages: &str) {
+        // The single discriminating check on the escaping: after substitution
+        // no `$$` may survive. Every `$$` here is an escape for the remote
+        // shell, so one left doubled is one the shell would read as its own PID.
+        assert!(
+            !listed.contains("$$"),
+            "{name}: an unresolved `$$` reached the remote shell: {listed}"
+        );
+        // Without the definition, `mtui_probe_ok …` is "command not found"
+        // (127 on stderr) and the script carries on to emit an empty list at
+        // exit 0 — the bug it exists to close.
+        let guard_at = listed
+            .find("mtui_probe_ok() {")
+            .unwrap_or_else(|| panic!("{name}: the probe guard is not defined at all: {listed}"));
+        let first_call = listed
+            .find("mtui_probe_ok \"")
+            .unwrap_or_else(|| panic!("{name}: nothing ever calls the probe guard: {listed}"));
+        assert!(
+            guard_at < first_call,
+            "{name}: the guard must be defined before any probe runs: {listed}"
+        );
+        // `0` is the only status accepted without a word in the transcript.
+        assert!(
+            listed.contains("  case \"$2\" in\n  0) return 0 ;;\n"),
+            "{name}: the guard must accept `0` outright: {listed}"
+        );
+        // `104` — `zypper search`'s empty result table. Dropping this arm turns
+        // every host in a mixed group that carries none of the packages into a
+        // failed rollback.
+        assert!(
+            listed.contains("  104)\n    printf 'mtui: note: %s exited 104,"),
+            "{name}: `104` must stay the legitimate no-op: {listed}"
+        );
+        // `106` — any skipped repository, which `init_repos()` cannot name.
+        // Dropping this arm aborts the recovery on refhosts carrying one stale
+        // repo alongside working ones.
+        assert!(
+            listed.contains("  106)\n    printf 'mtui: note: %s exited 106,"),
+            "{name}: `106` must be noted, not refused: {listed}"
+        );
+        // Every other status marks and exits with the probe's own status. The
+        // marker is split across the format string and its argument so the
+        // script's own text does not contain it.
+        assert!(
+            listed.contains(
+                "  printf 'mtui: could not %s\\n' \"determine what to downgrade: $1 exited $2\"\n  exit \"$2\"\n}\n"
+            ),
+            "{name}: an unrecognised probe status must mark and exit: {listed}"
+        );
+        assert!(
+            !listed.contains("mtui: could not determine what to downgrade"),
+            "{name}: the script text must not contain the marker it prints, or a \
+             transcript echoing the command would read as a probe failure: {listed}"
+        );
+        // The list is produced in four steps, as one contiguous block, because
+        // each step is load-bearing:
+        //
+        // * the probe runs **alone** in a command substitution, so the
+        //   assignment takes zypper's own status (POSIX XCU 2.9.1). Piped
+        //   straight into the filter, as it was, the status is the pipeline's —
+        //   the *last* stage's — and awk exits 0 on empty input, so zypper's
+        //   was not observable at all;
+        // * the guard reads that status on the very next line, before anything
+        //   else can clobber `$?`;
+        // * only then do the filters run, fed by the builtin `printf` rather
+        //   than `echo`/`xargs`, so no `ARG_MAX` limit sits between the probe
+        //   and the filter;
+        // * and awk's own status is guarded in turn — it is the last stage of
+        //   that pipeline, so `$?` on the next line is already awk's.
+        assert!(
+            listed.contains(&format!(
+                "mtui_rows=$(zypper -n se -s --match-exact -t package {packages})\n\
+                 mtui_probe_ok \"zypper -n se\" $?\n\
+                 mtui_versions=$(printf '%s\\n' \"$mtui_rows\" | grep -v \"(System\" | \
+                 grep ^[iv] | sed \"s, ,,g\" | awk -F \"|\" '{{ print $2,\"=\",$4 }}')\n\
+                 mtui_probe_ok \"awk\" $?\n"
+            )),
+            "{name}: the version list must be captured, guarded, filtered, guarded: {listed}"
+        );
+        // Discriminating: the block above proves the guarded form is present,
+        // not that an unguarded one is gone. A template carrying both would
+        // satisfy it while the second, unguarded capture silently won.
+        assert_eq!(
+            listed.matches("awk -F \"|\"").count(),
+            1,
+            "{name}: exactly one awk may filter the rows: {listed}"
+        );
+        // And the captured list must actually be emitted, as the last thing the
+        // script does: capturing the rows and forgetting to re-emit them would
+        // hand the flow empty stdout at exit 0 — this fix reintroducing its own
+        // bug.
+        assert!(
+            listed.ends_with("printf '%s\\n' \"$mtui_versions\"\n"),
+            "{name}: the script must end by emitting the version list: {listed}"
         );
     }
 
@@ -162,5 +381,486 @@ mod tests {
     #[test]
     fn unknown_key_is_none() {
         assert!(downgrader("99", false).is_none());
+    }
+
+    /// Executes the *rendered* `LIST_COMMAND` under a real `/bin/sh`, with a
+    /// stub `zypper` first on `PATH`.
+    ///
+    /// The subject here is shell semantics — *which command's status the script
+    /// reports* — and no mock can express it: `MockConnection` keys on the whole
+    /// command string and scripts one exit code per command, so "the probe
+    /// failed but the last stage of the pipeline succeeded" is a state it cannot
+    /// produce. That state is issue #451 in one sentence, which is why these
+    /// run a shell.
+    ///
+    /// The stub appends to a sentinel file on every invocation, so a case whose
+    /// headline assertion is a *negative* ("no version line was emitted") can
+    /// also show the script reached the stub at all — otherwise a `PATH` mistake
+    /// would make every assertion here vacuous.
+    #[cfg(unix)]
+    mod rendered_script {
+        use std::ffi::OsString;
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::path::Path;
+        use std::process::Command;
+
+        use super::*;
+
+        /// The start of the line a failed probe prints.
+        ///
+        /// Matched at the **start of a line**, never anywhere in the stream: the
+        /// script's own text does not carry this sentence (it is split across
+        /// `printf`'s format string and its argument), but nothing stops a host
+        /// echoing it mid-line — a `set -x` trace, a log line quoting an earlier
+        /// run. Only a line that begins with it is mtui's own verdict.
+        const PROBE_MARKER: &str = "mtui: could not determine what to downgrade";
+
+        /// A `zypper -n se -s` row for an **installed** package, in the real
+        /// table's shape: status, name, type, version, arch, repository.
+        ///
+        /// The filter chain turns it into the `pkg-a = 1.0-1` line
+        /// `parse_downgrade_versions` splits on `" = "`.
+        const INSTALLED_ROW: &str = "i | pkg-a | package | 1.0-1 | x86_64 | test-repo";
+
+        /// A table every row of which the filter chain drops: one whose
+        /// repository is `(System Packages)` — an installed package no
+        /// repository offers, so there is no released version to go back to,
+        /// dropped by `grep -v "(System"` — and one for a package that is not
+        /// installed (blank status column), dropped by `grep ^[iv]`.
+        const FILTERED_ROWS: &str = "i | pkg-a | package | 1.0-1 | x86_64 | (System Packages)\n  \
+                                     | pkg-a | package | 2.0-1 | x86_64 | test-repo";
+
+        /// What `zypper se` prints on the run that exits `104`.
+        const NO_MATCH_STDOUT: &str = "No matching items found.";
+
+        /// The stub `zypper`. Every call the probe makes is
+        /// `zypper -n se …`, so `$2` discriminates — and the `esac` fallthrough
+        /// keeps any future subcommand from silently exiting non-zero.
+        ///
+        /// Every arm records its invocation, which is the liveness signal the
+        /// negative assertions rest on.
+        const ZYPPER_STUB: &str = r#"#!/bin/sh
+printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran"
+case "$2" in
+se)
+    if [ -n "$MTUI_STUB_SE_ROWS" ]; then printf '%s\n' "$MTUI_STUB_SE_ROWS"; fi
+    exit "$MTUI_STUB_SE_EXIT"
+    ;;
+esac
+exit 0
+"#;
+
+        /// A temp dir holding the stub executables plus the sentinel files they
+        /// append to.
+        struct Stubs {
+            dir: tempfile::TempDir,
+            path: OsString,
+        }
+
+        impl Stubs {
+            fn new() -> Self {
+                let dir = tempfile::tempdir().expect("tempdir");
+                write_exe(dir.path(), "zypper", ZYPPER_STUB);
+                // Keep the inherited PATH behind the stubs: the template also
+                // calls the real `grep`, `sed` and `awk`.
+                let mut path = dir.path().as_os_str().to_owned();
+                if let Some(inherited) = std::env::var_os("PATH") {
+                    path.push(":");
+                    path.push(inherited);
+                }
+                Self { dir, path }
+            }
+
+            /// Every `zypper` subcommand the stub saw, in order.
+            fn probe_invocations(&self) -> Vec<String> {
+                fs::read_to_string(self.dir.path().join("probe.ran"))
+                    .unwrap_or_default()
+                    .lines()
+                    .map(ToOwned::to_owned)
+                    .collect()
+            }
+        }
+
+        fn write_exe(dir: &Path, name: &str, body: &str) {
+            let p = dir.join(name);
+            fs::write(&p, body).expect("write stub");
+            fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).expect("chmod stub");
+        }
+
+        /// The two downgraders that share `LIST_COMMAND`.
+        ///
+        /// Both are run through every case: the constant is shared today, and
+        /// pinning both is what notices a future divergence that guards only one.
+        fn downgraders() -> Vec<(&'static str, ActionCommands)> {
+            vec![
+                (
+                    "zypper",
+                    downgrader("15", false).expect("zypper downgrader"),
+                ),
+                (
+                    "slmicro",
+                    downgrader("slmicro", true).expect("slmicro downgrader"),
+                ),
+            ]
+        }
+
+        /// The knobs one scripted run is driven with. [`Default`] is the wholly
+        /// healthy probe: one installed row, everything exits `0`.
+        #[derive(Clone, Copy)]
+        struct Knobs {
+            /// `zypper -n se`'s status — the probe whose output *is* the version
+            /// list.
+            se_exit: i32,
+            /// awk's status. Non-zero shadows `awk` on `PATH` with a stub that
+            /// consumes stdin and exits with it — a broken or missing awk, the
+            /// other way the list comes back empty with nothing visibly wrong.
+            awk_exit: i32,
+            /// The `zypper -n se -s` table, one row per line.
+            rows: &'static str,
+        }
+
+        impl Default for Knobs {
+            fn default() -> Self {
+                Self {
+                    se_exit: 0,
+                    awk_exit: 0,
+                    rows: INSTALLED_ROW,
+                }
+            }
+        }
+
+        /// What one scripted run produced.
+        struct Ran {
+            /// The script's own exit status — what the flow records as
+            /// `Target::lastexit` and `dead_probes` filters on.
+            code: i32,
+            /// The script's stdout — what the flow parses into the version map,
+            /// and what `show_log` shows the operator.
+            stdout: String,
+        }
+
+        impl Ran {
+            /// The probe-failure marker line, if the script printed one at the
+            /// start of a line.
+            fn marker(&self) -> Option<&str> {
+                self.stdout
+                    .lines()
+                    .find(|l| l.starts_with(PROBE_MARKER))
+                    .map(str::trim_end)
+            }
+
+            /// The `name = version` lines the flow would parse
+            /// (`parse_downgrade_versions` splits on `" = "`).
+            fn versions(&self) -> Vec<&str> {
+                self.stdout.lines().filter(|l| l.contains(" = ")).collect()
+            }
+        }
+
+        /// Renders `cmds`'s list command and runs it under `/bin/sh -c`.
+        ///
+        /// A non-zero `awk_exit` shadows the real `awk` for this run only; the
+        /// stub dir is already first on `PATH`, and `Stubs` is per-case, so
+        /// nothing leaks between runs and no serialisation is needed.
+        fn run_script(cmds: &ActionCommands, stubs: &Stubs, knobs: Knobs) -> Ran {
+            if knobs.awk_exit != 0 {
+                write_exe(
+                    stubs.dir.path(),
+                    "awk",
+                    &format!("#!/bin/sh\ncat > /dev/null\nexit {}\n", knobs.awk_exit),
+                );
+            }
+            let vars: HashMap<&str, &str> = [("packages", "pkg-a")].into_iter().collect();
+            let rendered = cmds
+                .render_list_command(&vars)
+                .expect("safe substitute never fails")
+                .expect("both downgraders carry a list command");
+            let out = Command::new("/bin/sh")
+                .arg("-c")
+                .arg(&rendered)
+                .env("PATH", &stubs.path)
+                .env("MTUI_STUB_DIR", stubs.dir.path())
+                .env("MTUI_STUB_SE_EXIT", knobs.se_exit.to_string())
+                .env("MTUI_STUB_SE_ROWS", knobs.rows)
+                .output()
+                .expect("run the rendered list command under /bin/sh");
+            Ran {
+                code: out
+                    .status
+                    .code()
+                    .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status)),
+                stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            }
+        }
+
+        #[test]
+        fn a_failed_se_probe_fails_the_script_and_emits_no_versions() {
+            // Issue #451. `zypper -n se -s` is the probe whose output *is* the
+            // downgrade version list. When it fails — `7` on a locked ZYpp
+            // stack, `6` with no repositories, an unreadable rpmdb, zypper
+            // missing entirely — the list comes back empty. As a pipeline the
+            // probe's status was not merely discarded but unobservable: the
+            // pipeline reports its last stage's status, that stage is awk, and
+            // awk exits `0` on empty input. So the flow recorded exit `0`, the
+            // host never entered `dead_probes`, no downgrade command was built
+            // for it, and the rollback reported success having reverted nothing.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        se_exit: 7,
+                        ..Knobs::default()
+                    },
+                );
+                // Liveness first: the negative below is also what an empty
+                // `PATH` produces.
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "se"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert_eq!(
+                    ran.marker(),
+                    Some(format!("{PROBE_MARKER}: zypper -n se exited 7").as_str()),
+                    "{name}: the marker must start a line and name the probe and its \
+                     status: {}",
+                    ran.stdout
+                );
+                assert!(
+                    ran.versions().is_empty(),
+                    "{name}: a failed probe must emit no version line: {:?}",
+                    ran.versions()
+                );
+                // Pass-through, not a sentinel: a POSIX `exit N` truncates to
+                // `0..=255`, so any value of the template's own choosing would
+                // sit inside zypper's space. The marker carries the meaning; the
+                // status stays honest — and non-zero is what `dead_probes`
+                // filters on.
+                assert_eq!(
+                    ran.code, 7,
+                    "{name}: the script must exit with the probe's own status"
+                );
+            }
+        }
+
+        #[test]
+        fn only_zero_104_and_106_are_accepted_by_the_downgrade_probe() {
+            // The whole vocabulary, not a sample: zypper's informational band
+            // (`100`-`103`, `105`-`107`), the band's boundaries (`99`, `108`),
+            // the package-not-found neighbours (`4`, `5`, `8`) and plain errors.
+            // A code that becomes acceptable on this probe has to be argued for
+            // here, individually.
+            //
+            // `107` (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) is refused despite
+            // being a success for a *transaction*: that argument is "the
+            // transaction committed", a claim about a command that installs
+            // something. `se` installs nothing, so a `107` from it is not a
+            // partial success but a status this probe cannot account for.
+            for code in [
+                1, 2, 3, 4, 5, 6, 7, 8, 99, 100, 101, 102, 103, 105, 107, 108, 255,
+            ] {
+                for (name, cmds) in downgraders() {
+                    let stubs = Stubs::new();
+                    let ran = run_script(
+                        &cmds,
+                        &stubs,
+                        Knobs {
+                            se_exit: code,
+                            ..Knobs::default()
+                        },
+                    );
+                    assert_eq!(
+                        ran.marker(),
+                        Some(format!("{PROBE_MARKER}: zypper -n se exited {code}").as_str()),
+                        "{name}: probe exit {code} must be refused: {}",
+                        ran.stdout
+                    );
+                    assert!(
+                        ran.versions().is_empty(),
+                        "{name}: probe exit {code} must emit no version line: {:?}",
+                        ran.versions()
+                    );
+                    assert_eq!(
+                        ran.code, code,
+                        "{name}: probe exit {code} must be reported verbatim"
+                    );
+                }
+            }
+            // And the three accepted codes, or the loop above proves only that
+            // the script always fails.
+            //
+            // `104` is `ZYPPER_EXIT_INF_CAP_NOT_FOUND`: `zypper se` sets it when
+            // the result table is empty, which is the legitimate "this host
+            // carries none of these packages" — routine in a mixed group, and it
+            // must stay the no-op it has always been.
+            //
+            // `106` is `ZYPPER_EXIT_INF_REPO_SKIPPED`, raised by `init_repos()`
+            // for *any* skipped repository without saying which. A refhost
+            // routinely carries one stale or unreachable repo alongside working
+            // ones; refusing `106` would abort the recovery on hosts that would
+            // have rolled back correctly — and here the rollback is the repair
+            // for an update that already failed, so the fleet would pay for it.
+            for (name, cmds) in downgraders() {
+                for code in [0, 104, 106] {
+                    let stubs = Stubs::new();
+                    let ran = run_script(
+                        &cmds,
+                        &stubs,
+                        Knobs {
+                            se_exit: code,
+                            ..Knobs::default()
+                        },
+                    );
+                    assert_eq!(
+                        ran.marker(),
+                        None,
+                        "{name}: probe exit {code} must be accepted: {}",
+                        ran.stdout
+                    );
+                    assert_eq!(
+                        ran.code, 0,
+                        "{name}: probe exit {code} must not fail the probe: {}",
+                        ran.stdout
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn a_broken_awk_fails_the_downgrade_probe() {
+            // awk is the stage that actually *produces* the version list, and
+            // the one guarding `zypper se` alone does not cover: an awk that
+            // exits `2`, or is missing from `PATH` (`127`), yields an empty list
+            // at status `0` — #451's verdict verbatim, reached through a
+            // different command. Its status is free to read, because `$?` after
+            // the filter pipeline is already awk's.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        awk_exit: 2,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "se"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert_eq!(
+                    ran.marker(),
+                    Some(format!("{PROBE_MARKER}: awk exited 2").as_str()),
+                    "{name}: the marker must name awk: {}",
+                    ran.stdout
+                );
+                assert_eq!(ran.code, 2, "{name}: awk's own status is reported");
+            }
+        }
+
+        #[test]
+        fn a_healthy_probe_emits_the_parsable_version_list() {
+            // The positive contract the whole flow rests on: one `name = version`
+            // line per installed package, in the shape
+            // `parse_downgrade_versions` splits on. Capturing the rows into a
+            // variable and forgetting to re-emit them would give the flow empty
+            // stdout at exit `0` — the restructure's own way of reintroducing
+            // exactly the bug it fixes.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                let ran = run_script(&cmds, &stubs, Knobs::default());
+                assert_eq!(
+                    ran.versions(),
+                    vec!["pkg-a = 1.0-1"],
+                    "{name}: the probe must emit the parsable version list: {}",
+                    ran.stdout
+                );
+                assert_eq!(ran.marker(), None, "{name}: {}", ran.stdout);
+                assert_eq!(ran.code, 0, "{name}: a healthy probe succeeds");
+            }
+        }
+
+        #[test]
+        fn a_host_with_none_of_the_packages_stays_a_noop() {
+            // `zypper search` sets `ZYPPER_EXIT_INF_CAP_NOT_FOUND` (`104`) when
+            // its result table is empty. In a mixed group that is simply a host
+            // carrying none of the update's packages — there is nothing to roll
+            // back on it, and refusing `104` would turn every such host into a
+            // failed rollback.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        se_exit: 104,
+                        rows: NO_MATCH_STDOUT,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "se"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert_eq!(
+                    ran.marker(),
+                    None,
+                    "{name}: a host carrying none of the packages is not a probe \
+                     failure: {}",
+                    ran.stdout
+                );
+                assert!(
+                    ran.versions().is_empty(),
+                    "{name}: no package matched, so no version line: {:?}",
+                    ran.versions()
+                );
+                assert_eq!(ran.code, 0, "{name}: and the no-op must not fail");
+            }
+        }
+
+        #[test]
+        fn rows_filtered_to_nothing_is_a_noop() {
+            // The probe answers `0` with a perfectly good table whose every row
+            // the filter chain drops: `(System Packages)` (installed, but no
+            // repository offers it — nothing to go back to) and a not-installed
+            // row (blank status column). This pins the chain surviving the move
+            // into a `printf`-fed command substitution — a quoting mistake there
+            // would either break the filtering or make awk fail, and this is the
+            // case a probe guard is most likely to get wrong, since "the filter
+            // matched nothing" and "the filter could not run" reach the same
+            // empty variable.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                let ran = run_script(
+                    &cmds,
+                    &stubs,
+                    Knobs {
+                        rows: FILTERED_ROWS,
+                        ..Knobs::default()
+                    },
+                );
+                assert!(
+                    stubs.probe_invocations().iter().any(|c| c == "se"),
+                    "{name}: the script never reached the stub zypper at all: {:?}",
+                    stubs.probe_invocations()
+                );
+                assert_eq!(
+                    ran.marker(),
+                    None,
+                    "{name}: rows filtered to nothing is not a probe failure: {}",
+                    ran.stdout
+                );
+                assert!(
+                    ran.versions().is_empty(),
+                    "{name}: every row is filtered, so no version line: {:?}",
+                    ran.versions()
+                );
+                assert_eq!(ran.code, 0, "{name}: and it must not fail");
+            }
+        }
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -147,7 +147,7 @@ mtui_probe_ok() {
 }
 mtui_rows=$$(zypper -n se -s --match-exact -t package $packages)
 mtui_probe_ok "zypper -n se" $$?
-mtui_versions=$$(printf '%s\n' "$$mtui_rows" | grep -v "(System" | grep ^[iv] | sed "s, ,,g" | awk -F "|" '{ print $2,"=",$4 }')
+mtui_versions=$$(printf '%s\n' "$$mtui_rows" | grep -v "(System" | grep '^[iv]' | sed "s, ,,g" | awk -F "|" '{ print $2,"=",$4 }')
 mtui_probe_ok "awk" $$?
 printf '%s\n' "$$mtui_versions"
 "#;
@@ -369,7 +369,7 @@ mod tests {
                 "mtui_rows=$(zypper -n se -s --match-exact -t package {packages})\n\
                  mtui_probe_ok \"zypper -n se\" $?\n\
                  mtui_versions=$(printf '%s\\n' \"$mtui_rows\" | grep -v \"(System\" | \
-                 grep ^[iv] | sed \"s, ,,g\" | awk -F \"|\" '{{ print $2,\"=\",$4 }}')\n\
+                 grep '^[iv]' | sed \"s, ,,g\" | awk -F \"|\" '{{ print $2,\"=\",$4 }}')\n\
                  mtui_probe_ok \"awk\" $?\n"
             )),
             "{name}: the version list must be captured, guarded, filtered, guarded: {listed}"
@@ -464,7 +464,7 @@ mod tests {
         /// repository is `(System Packages)` — an installed package no
         /// repository offers, so there is no released version to go back to,
         /// dropped by `grep -v "(System"` — and one for a package that is not
-        /// installed (blank status column), dropped by `grep ^[iv]`.
+        /// installed (blank status column), dropped by `grep '^[iv]'`.
         const FILTERED_ROWS: &str = "i | pkg-a | package | 1.0-1 | x86_64 | (System Packages)\n  \
                                      | pkg-a | package | 2.0-1 | x86_64 | test-repo";
 


### PR DESCRIPTION
Closes #451.

## The bug

`downgrade` — and the automatic rollback `update` runs after a failed check — could report success having run zero downgrade commands.

The version list was produced by a single shell pipeline, and POSIX defines a pipeline's exit status as its **last** stage's. That stage is `awk`, and `awk` exits `0` after a successful run over empty input. So a failed `zypper -n se` — a ZYpp lock, broken repo metadata, an unreadable rpmdb, zypper missing — was not merely a discarded status, it was *unobservable*: the probe recorded exit `0` with an empty version map, every package was skipped for want of a version to roll back to, and the run finished by logging `done`.

`dead_probes` was written against that shape. Its comment was truthful — a recorded non-zero really did always mean the probe itself had broken — but the gate depends on the **converse**, that zero means it worked, and that did not hold. It could catch SSH-level death (the `-1` sentinel) and nothing else.

This is #447's defect in the path where it costs most. The rollback runs *after* an update has already failed on the group, so it is the last thing standing between a half-applied update and an operator who has just been told everything is fine.

## The fix

At the three layers the issue names.

**The template** (`update_workflow/actions/downgrade.rs`). #447's technique, deliberately the same one rather than a second dialect. Each producing command runs on its own line so its status can be read (an assignment's status is the substitution's — POSIX XCU 2.9.1); the rows reach the filter chain through the `printf` **builtin**, so no `ARG_MAX` limit sits between probe and filter; and `mtui_probe_ok` prints a start-of-line marker and exits with **the failed tool's own status**. No invented sentinel: a POSIX `exit` truncates to `0..=255`, so any value we picked would sit inside zypper's own space. The marker is assembled from `printf`'s format string *and* its argument, so the script's own text never contains the sentence it prints. `awk` is guarded too — it is the stage that actually produces the list, and `$?` after the filter pipeline is already awk's, so that capture is free.

**The gate** (`reports/update_flow.rs`). The `c != 0` predicate is unchanged; what changed is that it can now be believed in both directions. A non-zero is now either SSH-level death or the guard passing the tool's own status through — never "package not found", which the guard accepts as `104` and reports as `0`. And a zero genuinely means the probe answered, so an empty list at `0` is a host carrying none of these packages rather than a probe that failed unnoticed. A dead probe abandons that host's downgrade, and the command fails naming it (`h2: package version probe failed`).

**The verdict.** `downgrade_verdict` no longer logs `done` while any probe is dead; the unverified hosts are named at WARN instead. The per-host ERROR now says the host **was not downgraded** rather than that a step was *skipped* — the operator needs to know this host still carries the update, not that the flow omitted a step.

Accepted statuses are `0`, `104` and `106`; everything else refuses.

## Judgement calls

**A dead probe aborts that host, not the group.** This is the opposite of the update path's own probe failure, and deliberately so. There, nothing had been applied yet, so failing the whole group costs nothing. Here the run *is* the recovery from an update that already failed, so aborting it over one host's broken zypper would strand every healthy peer half-applied. The healthy hosts still roll back and still reboot; the error for the dead ones is raised at the end. All probes dead aborts immediately.

**No new failure variant.** `perform_downgrade` returns one `UpdateError`, nothing downstream routes on probe-ness, and on the rollback route the existing best-effort contract already keeps the original update error outranking it (the call site logs the downgrade error at WARN and re-surfaces the update's). Adding a variant would have bought a distinction no caller can act on. The stale doc on `perform_update_with_rollback` that claimed this worked because `perform_downgrade` "returns `()`" is corrected in the same commit — it has returned a `Result` for some time, and that Err path is now the carrier of this verdict, so the doc named the wrong mechanism at exactly the wrong moment.

**`106` is accepted, without the disambiguation the update path has.** `ZYPPER_EXIT_INF_REPO_SKIPPED` is raised by `init_repos()` for *any* skipped repository without saying which, and a refhost routinely carries one stale one. The update templates answer `106` by asking whether the update's own repo survived; that question is not merely hard here, it is unanswerable — `downgrade_body` calls `fanout_set_repo(RepoOp::Remove)` and removes the issue repository from every host *on purpose* before the probe runs, so its absence is the expected state. The released versions a rollback wants come from the host's ordinary repositories. `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`, an empty search result) is accepted for the plainer reason that it is the legitimate "this host carries none of these packages", routine in a mixed group.

**Withholding `done` is a second layer, not belt-and-braces.** `downgrade_verdict` flags a package only when the loaded report carries a `required` version to compare against. On a standalone `downgrade` there is none, so a dead probe produces exactly the same empty map a completed rollback does — the silent success of this issue restated one layer up, and the command failing does not stop `done` being printed above it in the same transcript.

**`commands/listversions.rs` is left alone.** It has the same pipeline shape, but it is advisory and read-only, and the issue asks for it separately.

**The second commit is a test-harness fix, not product code.** It is separate precisely so it can be reviewed as such.

## Testing

The template is pinned by executing the **rendered** script under a real `/bin/sh`, with a stub `zypper` on `PATH` and an awk-shadowing knob. That layer exists because `MockConnection` scripts one outcome per command string and cannot run a shell — it cannot express the last-command-wins rule that *is* the bug, so a mock-only test could not have caught this and cannot pin the fix. Asserting on the rendered text rather than the source also means a broken `$$`-escape is caught where a source-level look-alike would hide it.

Coverage across the two layers: a failed `zypper -n se` (marker present, versions empty, exits the tool's status); every one of the 17 refused codes rejected *and* `0`/`104`/`106` accepted, each half guarding the other against a trivially always-fail or always-pass guard; a broken `awk` (the discriminating assert is that the marker *names awk* — the old pipeline coincidentally also exits 2, so a status-only assert would have been vacuous); the healthy path; the `104`/`106` no-op paths; and at the flow layer, a probe exit of `7` routed as a dead probe (the `-1` sentinel is only one value of the predicate, so a predicate narrowed to `c == -1` would still pass the two pre-existing tests — this one pins the widened form), plus the `done`-withholding.

**How RED was observed.** Every assertion was driven red against unfixed or hand-broken code before being trusted, and the fixture was checked for its ability to express failure first:

- Reverting `LIST_COMMAND` to the old pipeline reds both render tests and the failed-`zypper`, exhaustive-code and broken-`awk` tests. Reverting the `downgrade_verdict` change reds the `done`-withholding test. Removing the `probe_dead` parameter breaks compilation at 7 call sites. No test in this diff passes with the feature deleted.
- The dead-probe flow test asserts `h2.commands().contains(&list)` — that the rendered probe really was dispatched — because an empty or mistyped `PATH` also yields "no versions", and without that liveness check the test would pass for the wrong reason.
- The probe is scripted per exact command string rather than through `with_default`. A mock answering every command identically leaves nothing attributable, which is how a headline test in #393 passed with the feature deleted.
- The `done` assert is `l == "done"`, not `contains("\"done\"")`. The capture layer renders a message unquoted, so the quoted form would have matched nothing at all and passed however the code behaved.
- In the final pass, three anchors of the `done`-withholding test were re-broken by hand and each watched go red: dropping the `probe_dead` guard around `done`, reverting the per-host wording, and deleting the unverified WARN.

That last exercise is what surfaced the second commit. The `done`-withholding test was **flaky** — failing about one run in three of `cargo test -p mtui-testreport --lib` while the code under test was correct. The test-only `capture_logs` helper scoped its subscriber with `tracing::subscriber::set_default`, whose guard is thread-local, but `tracing` caches callsite *interest* process-wide: a callsite first reached from a thread with no subscriber installed is cached as `Interest::never()` and stays silent for every later capture. Its sibling test drives the same `warn!`/`error!` callsites with no subscriber, so whichever reached them first decided whether the capture could see anything. `mtui-datasources`' `teregen` capture hit this same race and is already fixed the same way, so the second commit is this crate catching up with a pattern the workspace had settled: install the subscriber once, globally and permissively, and move the scoping to a thread-local sink. The captured set is unchanged — `set_default`'s guard was thread-local too, and the fan-out is `buffer_unordered` on the test's own single-threaded task. 20 consecutive lib runs green afterwards, and the three hand-breaks above were all re-verified *under the new helper*, one of them confirming the capture now holds the full transcript rather than the single line the race produced.

Full gate green: `fmt`, `clippy -D warnings`, `rustdoc -D warnings`, `cargo test --workspace` (37 suites, 2494 tests), `cargo test -p mtui-mcp -F mcp` (286 tests), the compile-only feature matrix both ways, and `typos`.

## Known limitations

- **The middle of the filter chain is still unguarded.** A failing `grep` or `sed`, or a missing binary among them, yields an empty list at awk's `0`, exactly as before — awk is the last stage and succeeds on no input. This is the same accepted residual the update templates carry; closing it needs `pipefail` (not POSIX) or `${PIPESTATUS[@]}` (bash-only), while these scripts must run under whatever `/bin/sh` a refhost provides.
- **The `106` residual is real and named rather than papered over.** If the skipped repository happens to be the one carrying the released versions, the list is silently short and those packages stay at the update version. On the rollback path `downgrade_verdict` catches it whenever the loaded update names `required` versions; on a standalone `downgrade` with none loaded, it is not caught. A status cannot carry that verdict — only a comparison against what should be installed can — which is what the transcript note exists to prompt.
- **The flow test does not pin the template, and the sh tests do not pin the flow.** The flow test passes with the template reverted, because `MockConnection` cannot express last-command-wins. That is the declared division of labour, not an oversight: the sh tests pin the template, the flow test pins the widened predicate, and reverting either reds its own side.
- **`show_log` transcripts change.** The remote command text is different, as it was for #447.
- **`commands/listversions.rs` still carries the same pipeline shape**, deliberately, for its own issue.