### PR TITLE
test(mcp): drive the heartbeat send-failure test on virtual time

### DIFF
--- a/crates/mtui-mcp/Cargo.toml
+++ b/crates/mtui-mcp/Cargo.toml
@@ -79,7 +79,7 @@ tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "test-util"] }
 insta.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -196,6 +196,11 @@ pub(crate) async fn run_with_heartbeat<F>(
 where
     F: Future,
 {
+    // `progress` is measured on the std clock, which tokio's `start_paused`
+    // does not advance — a test on virtual time sees 0.0 on every frame, and an
+    // assertion about progress values would hold vacuously there. Tick *counts*
+    // stay exact under a paused clock (the ticker is a tokio timer), so pin the
+    // schedule with counts on virtual time and the values on the wall clock.
     let started = Instant::now();
     tokio::pin!(fut);
     loop {
@@ -3461,7 +3466,13 @@ mod tests {
 
     /// A sink whose send would fail must not mask the command result: the slow
     /// future still returns its value and the sink's attempts are recorded.
-    #[tokio::test]
+    ///
+    /// Driven on a paused clock so the schedule is exact rather than a race
+    /// against wall time: tokio auto-advances to each next timer, so the ticks
+    /// land at virtual 40/80/120ms and the body completes at 150ms — three
+    /// attempted sends, every run. The wall-clock version could observe zero
+    /// ticks on a starved CPU.
+    #[tokio::test(start_paused = true)]
     async fn run_with_heartbeat_send_failure_does_not_mask_result() {
         let sink = FailingSink::default();
         let body = async {
@@ -3472,9 +3483,10 @@ mod tests {
         let out =
             run_with_heartbeat(body, &sink, "_sleepy_command", Duration::from_millis(40)).await;
         assert_eq!(out, "ok", "result survives a failing sink");
-        assert!(
-            *sink.calls.lock().unwrap() >= 1,
-            "at least one heartbeat was attempted"
+        assert_eq!(
+            *sink.calls.lock().unwrap(),
+            3,
+            "every tick before completion attempted a send (40/80/120ms)"
         );
     }
 }


### PR DESCRIPTION
Closes #442.

Test-only, one commit. `run_with_heartbeat` itself is byte-identical to `main` apart from a comment.

## The bug

`session::tests::run_with_heartbeat_send_failure_does_not_mask_result` asserted on wall time. It ran a 150ms body against a 40ms heartbeat interval and required that at least one tick had landed by the time the body finished. That is a race, not a guarantee: under CPU starvation the runtime can be descheduled long enough that both timers are ready when it next runs, the `biased` select in `run_with_heartbeat` returns the body arm first, and the test finishes having observed zero ticks. The issue reproduced it at 1 failure in 8 concurrent lib runs pinned to a single core; CI runs the suite with no retries.

The 40ms/150ms ratio is this suite's outlier — the convention elsewhere is real time with generous margins.

## The fix

Run the test on a paused clock (`#[tokio::test(start_paused = true)]`). Tokio then auto-advances virtual time to the earliest pending deadline whenever the runtime idles, so the schedule stops being a race and becomes arithmetic: the loop arms a fresh `sleep(40ms)` each iteration, so ticks land at virtual 40/80/120ms and the body completes at 150ms before the fourth tick's 160ms deadline. Three attempted sends, every run.

That makes the count assertable, so `>= 1` becomes `== 3`.

`start_paused` needs `tokio/test-util`, which is added to this crate's dev-dependencies. The workspace's `full` feature set does not include it (tokio deliberately keeps it out of `full`), and `mtui-hosts` already enabling it in *its* dev-dependencies does not carry over to a `cargo test -p mtui-mcp` build.

## Judgement calls

**Tightening the assertion rather than just pausing the clock.** Pausing alone would have fixed the flake and left `>= 1` in place. But once the schedule is exact, a loose bound is strictly worse than a tight one, and the loose form has a real blind spot: a loop that gives up after its first failed send satisfies `>= 1`. That is the exact failure mode this test exists to rule out, since its whole subject is *"a failing sink must not change what the loop does."* I confirmed the blind spot rather than assuming it — see Testing.

**The sibling wall-clock test stays on the wall clock.** `run_with_heartbeat_fires_for_slow_future` (250ms body, 50ms interval) is left alone, and not merely for scope discipline. `run_with_heartbeat` measures `progress` with `std::time::Instant`, which tokio's paused clock does not advance. Migrating that test to virtual time would make every frame report `0.0`, and its two value assertions — `progress >= 0.0` and "progress is monotonic" — would then hold vacuously. Trading a real assertion for a green one is the wrong direction, so this PR pins the *schedule* on virtual time and leaves the *values* on the wall clock, where they mean something. Its 5:1 margin is also nowhere near the outlier that #442 is about; it survived the issue's own repro profile here.

**A comment in production code, in a test-only commit.** The `std::time::Instant` interaction above was undocumented, which is precisely how the next person "fixes" the sibling test into vacuity. The comment at `run_with_heartbeat`'s `Instant::now()` records the constraint. It is the only production edit and it changes no bytes that run.

**No CHANGELOG entry.** No user or MCP client can observe this; `CONTRIBUTING.md` § Changelog scopes entries to user-visible changes.

## Testing

Full gate green in the worktree: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --workspace` (37 suites, 2486 passed / 0 failed), `cargo test -p mtui-mcp -F mcp` (4 suites, 286 passed / 0 failed — 233 lib + 53 integration), both feature-matrix builds, and `typos`. The changed test is `mcp`-gated, so it is the `-F mcp` run that exercises it; it is named in that run's output rather than inferred from the total.

**RED was observed, three times, by hand-breaking the loop.** Each mutation was applied to `run_with_heartbeat`, the single test run by its exact name, and the file restored from a byte-identical backup (verified by checksum), never by `git checkout`:

- **Heartbeat send deleted** (tick arm keeps the timer, drops `sink.report`): FAILED, `left: 0, right: 3`.
- **Loop gives up after its first send** (returns the body's output after one `report`): FAILED, `left: 1, right: 3`.
- **Feature deleted** (`run_with_heartbeat` reduced to `fut.await`): FAILED, `left: 0, right: 3`. It also turned the sibling test red, which is the check that the mutation was real.

**And the control that justifies the tightening:** with the give-up-after-first-send mutation still in place, reverting *only* the assertion to the old `>= 1` form made the test **pass**. The old assertion was blind to that bug; the new one is not.

Each red is credited by the assertion's own message and by `1 failed` in the run — not by a non-zero exit that could have come from a compile error. The filter was checked to actually select the test: an earlier `--exact` invocation with a prefix matched nothing and reported `running 0 tests`, which is a green-looking result that proves nothing, so every run quoted above is one where the test is confirmed to have run.

**Determinism, measured rather than argued:** 40 sequential runs pinned to one core (`taskset -c 0`), 0 failures; then the issue's own repro profile — 8 concurrent single-core runs of all three heartbeat tests — 3 passed in every one, 0 failures. The virtual-clock test's runtime drops from ~150ms to 0.01s.

## Known limitations, stated rather than hidden

- **`== 3` encodes tokio's re-arm semantics.** The loop arms a fresh `sleep(interval)` per iteration, which is what makes the ticks 40/80/120. If it ever moves to `tokio::time::interval` with a non-default `MissedTickBehavior`, the expected count must be re-derived rather than trusted. Under the current code it is exact.
- **The "failing" sink does not actually fail.** `FailingSink` records the attempt and returns; it cannot do otherwise, because `ProgressSink::report` returns `()` and the trait's contract is that implementors swallow transport errors. So the test pins "the loop keeps calling the sink and returns the body's value", with send failure modelled by that contract rather than exercised. This is unchanged by this PR — it was equally true of the wall-clock version — and closing it properly would mean giving `report` a fallible signature, which is a production design question, not a test fix.
- **Progress *values* are still untested under virtual time**, by the deliberate choice above; the wall-clock sibling remains their only coverage.
- **`tokio/test-util` is now on for this crate's test builds.** It is not new to `cargo test --workspace`, where `mtui-hosts`' dev-dependency already unified it in, and it changes no behaviour unless a test pauses the clock. Nothing ships with it: dev-dependencies are absent from the binary builds, and `Cargo.lock` is unchanged.