### PR TITLE
fix(testreport,hosts): record the history rows the aborts owe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   only that: a rollback that timed out, lost its connection, or never reached
   the host leaves the packages at the update version while the flow ends
   looking done.
+- Aborts that had already changed a host no longer leave `/var/log/mtui.log`
+  silent (#407). `prepare` now records its own history row once it has
+  dispatched an install command — standalone, and for both prepares that run
+  inside `update` (the initial one and `--newpackage`'s after the update) — so
+  an `update` cancelled at its pre-dispatch gate, or aborted for a missing
+  updater, no longer leaves the packages its prepare installed unrecorded on
+  every host. A prepare that dispatched nothing (cancelled before its first
+  package, an empty package list, no command built for any host) still writes
+  no row. A full `update` run therefore now leaves one row per operation that
+  dispatched: `prepare` and `update`. `list_history` gained `prepare` as an
+  `-e/--event` filter value (**MCP schema note:** the `list_history` tool's
+  `event` enum gained `"prepare"`). A `downgrade` aborted because every version
+  probe died now writes its row before aborting: its issue-repo removal had
+  already run on every host, and that abort fires precisely on the rollback
+  path, where reconstructing what was done to a refhost matters most. The
+  cancel message on the update's pre-dispatch gate now says that a completed
+  prepare's packages are left in place, instead of only that the update
+  command never dispatched.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,11 +422,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   inside `update` (the initial one and `--newpackage`'s after the update) — so
   an `update` cancelled at its pre-dispatch gate, or aborted for a missing
   updater, no longer leaves the packages its prepare installed unrecorded on
-  every host. A prepare that dispatched nothing (cancelled before its first
-  package, an empty package list, no command built for any host) still writes
-  no row. A full `update` run therefore now leaves one row per operation that
-  dispatched: `prepare` and `update`. `list_history` gained `prepare` as an
-  `-e/--event` filter value (**MCP schema note:** the `list_history` tool's
+  every host. The row goes only to the hosts a prepare command actually
+  reached, and names only the packages that were actually dispatched: a host
+  the flow could build no command for keeps its "nothing was installed"
+  failure with no row to contradict it, and a prepare cancelled at package 3
+  of 10 records those three, not all ten. A prepare that dispatched nothing
+  (cancelled before its first package, an empty package list, no command built
+  for any host) still writes no row. On a transactional host the row records
+  what was *staged*: it is written before the reboot that activates the
+  snapshot, deliberately, because a host that never comes back would otherwise
+  leave those packages unrecorded entirely. A full `update` run therefore now
+  leaves one row per operation that dispatched: `prepare` and `update`.
+  `list_history` gained `prepare` as an `-e/--event` filter value
+  (**MCP schema note:** the `list_history` tool's
   `event` enum gained `"prepare"`). A `downgrade` aborted because every version
   probe died now writes its row before aborting: its issue-repo removal had
   already run on every host, and that abort fires precisely on the rollback

--- a/crates/mtui-core/src/commands/listhistory.rs
+++ b/crates/mtui-core/src/commands/listhistory.rs
@@ -10,7 +10,14 @@ use crate::error::{CommandError, CommandResult};
 use crate::session::Session;
 
 /// The event types `-e/--event` accepts.
-const EVENTS: [&str; 5] = ["connect", "disconnect", "install", "update", "downgrade"];
+const EVENTS: [&str; 6] = [
+    "connect",
+    "disconnect",
+    "install",
+    "update",
+    "downgrade",
+    "prepare",
+];
 
 /// Lists the history of mtui events recorded on the reference hosts.
 ///
@@ -123,6 +130,31 @@ mod tests {
         assert_eq!(
             history_command(10, &["install".to_owned()]),
             "tac /var/log/mtui.log | grep -m 10 -e \":install\" | tac"
+        );
+    }
+
+    #[test]
+    fn prepare_is_a_selectable_event() {
+        // `prepare` writes its own `/var/log/mtui.log` rows (#407), so it must
+        // be selectable like every other op: the value parser rejects any
+        // event not in `EVENTS`, and `matches` panics on a rejected argv.
+        let args = matches(&ListHistory, &["-e", "prepare"]);
+        let events: Vec<String> = args
+            .get_many::<String>("event")
+            .expect("the event arg parsed")
+            .cloned()
+            .collect();
+        assert_eq!(events, vec!["prepare".to_owned()]);
+        assert_eq!(
+            history_command(10, &["prepare".to_owned()]),
+            "tac /var/log/mtui.log | grep -m 10 -e \":prepare\" | tac"
+        );
+        // And it is offered by tab-completion, where the prefix is ambiguous
+        // with nothing else in the list.
+        let (session, _buf) = empty_session();
+        assert_eq!(
+            ListHistory.complete(&session, "prep", "list_history -e prep"),
+            vec!["prepare".to_owned()]
         );
     }
 

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -2099,6 +2099,44 @@ mod tests {
         );
     }
 
+    /// The history fan-out is never gated on cancellation.
+    ///
+    /// The flows write their `/var/log/mtui.log` row *after* the work landed on
+    /// the host, which for a cancelled operation means after the token was
+    /// cancelled — an `update` stopped at its pre-dispatch gate still owes a row
+    /// for the packages its prepare installed (#407). A cancel check here (or in
+    /// `run_fanout`, whose own contract forbids one) would suppress the record
+    /// exactly when an operator needs it: after a `job_cancel`.
+    #[tokio::test]
+    async fn add_history_still_writes_after_the_token_is_cancelled() {
+        let conn = echo("h1");
+        let handle = conn.clone();
+        let mut g = HostsGroup::new(
+            vec![Target::with_connection(
+                "h1",
+                TargetState::Enabled,
+                Box::new(conn),
+            )],
+            false,
+        );
+        g.cancel_token().cancel();
+        assert!(g.cancel_requested(), "the group observes the cancel");
+
+        g.add_history(&["prepare".to_owned(), "pkg-a".to_owned()])
+            .await;
+
+        let written = String::from_utf8(
+            handle
+                .file_contents("/var/log/mtui.log")
+                .expect("a cancelled group still records its history row"),
+        )
+        .unwrap();
+        assert!(
+            written.ends_with(":prepare:pkg-a\n"),
+            "history line: {written:?}"
+        );
+    }
+
     // --- sftp_read / sftp_put_bytes map fan-outs (#434) --------------------
 
     /// Per-host DISTINCT content: identical fixtures could pass with the

--- a/crates/mtui-hosts/src/target/hostgroup.rs
+++ b/crates/mtui-hosts/src/target/hostgroup.rs
@@ -35,7 +35,7 @@
 //! deterministically ordered by hostname — order-sensitive operations always
 //! iterate in sorted order, without an insertion-order dependency.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -963,6 +963,37 @@ impl HostsGroup {
             max_parallel,
             Some("add_history"),
             |_t| true,
+            |t| {
+                let fields = fields.to_vec();
+                Box::pin(async move { t.add_history(&fields).await }) as actions::BoxTargetFut<'_>
+            },
+        )
+        .await;
+    }
+
+    /// Appends a history entry to *only* the named hosts' remote history files.
+    ///
+    /// The host-scoped counterpart to [`add_history`](Self::add_history), for a
+    /// flow whose work reached some of the group but not all of it. The
+    /// group-wide fan-out is the right default for an op whose command map
+    /// covers every enabled host, but `prepare` builds a per-host map and
+    /// deliberately drops a host whose release key does not resolve or whose
+    /// template does not render — and that same host is then failed with
+    /// "nothing was installed". Writing it a `:prepare:` row anyway would put a
+    /// false entry in `/var/log/mtui.log`, which is an interop contract other
+    /// tools read (#407).
+    ///
+    /// `hosts` is matched against [`Target::hostname`]; a name that is not in
+    /// the group is ignored, and the per-target
+    /// [`enabled`](mtui_types::enums::TargetState) check still applies on top.
+    pub async fn add_history_for(&mut self, hosts: &BTreeSet<String>, fields: &[String]) {
+        let (is_repl, max_parallel) = (self.is_repl, self.max_parallel);
+        actions::run_fanout(
+            &mut self.data,
+            is_repl,
+            max_parallel,
+            Some("add_history"),
+            |t| hosts.contains(t.hostname()),
             |t| {
                 let fields = fields.to_vec();
                 Box::pin(async move { t.add_history(&fields).await }) as actions::BoxTargetFut<'_>
@@ -2134,6 +2165,46 @@ mod tests {
         assert!(
             written.ends_with(":prepare:pkg-a\n"),
             "history line: {written:?}"
+        );
+    }
+
+    /// `add_history_for` writes to the named hosts and to no others.
+    ///
+    /// The distinction the group-wide [`HostsGroup::add_history`] cannot make:
+    /// `prepare` builds a per-host command map, so a host it never dispatched
+    /// to must not be handed a row claiming an install (#407). Both directions
+    /// are asserted — a predicate stuck at `true` fails on h2, one stuck at
+    /// `false` fails on h1.
+    #[tokio::test]
+    async fn add_history_for_writes_only_to_the_named_hosts() {
+        let (c1, c2) = (echo("h1"), echo("h2"));
+        let (h1, h2) = (c1.clone(), c2.clone());
+        let mut g = HostsGroup::new(
+            vec![
+                Target::with_connection("h1", TargetState::Enabled, Box::new(c1)),
+                Target::with_connection("h2", TargetState::Enabled, Box::new(c2)),
+            ],
+            false,
+        );
+
+        let only_h1: BTreeSet<String> = ["h1".to_owned()].into_iter().collect();
+        g.add_history_for(&only_h1, &["prepare".to_owned(), "pkg-a".to_owned()])
+            .await;
+
+        let written = String::from_utf8(
+            h1.file_contents("/var/log/mtui.log")
+                .expect("the named host gets its row"),
+        )
+        .unwrap();
+        assert!(
+            written.ends_with(":prepare:pkg-a\n"),
+            "history line: {written:?}"
+        );
+        assert!(
+            h2.file_contents("/var/log/mtui.log").is_none(),
+            "an unnamed host must not be written to: {:?}",
+            h2.file_contents("/var/log/mtui.log")
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
         );
     }
 

--- a/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
+++ b/crates/mtui-mcp/tests/snapshots/it__slim_profile__slimmed_command_tool_schemas_snapshot.snap
@@ -397,7 +397,8 @@ expression: pretty
               "disconnect",
               "install",
               "update",
-              "downgrade"
+              "downgrade",
+              "prepare"
             ],
             "type": "string"
           },

--- a/crates/mtui-testreport/Cargo.toml
+++ b/crates/mtui-testreport/Cargo.toml
@@ -41,6 +41,11 @@ thiserror.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile = "3"
+# `test-util` for `#[tokio::test(start_paused = true)]`: the prepare loop's
+# cancellation checkpoint is a boundary between two awaited fan-outs, and
+# virtual time is the only way to land a cancel *between* two of them without a
+# wall-clock race.
+tokio = { workspace = true, features = ["test-util"] }
 wiremock.workspace = true
 # Perf baseline bench: metadata JSON parse hot path.
 criterion.workspace = true

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -49,11 +49,19 @@ type UpdateMaps = (BTreeMap<String, String>, BTreeMap<String, String>);
 /// and re-surfaces the error untouched.
 ///
 /// "No" is not one situation, and the variants keep the differences because an
-/// operator needs them: nothing was ever installed (`MissingUpdater`,
-/// `Prepare`, `Cancelled`, `ProbeFailed`), or something may well have been
-/// installed but the flow cannot reach the host to undo it (`Reboot`), or it is
-/// unknown whether anything was (`NotRun`). All of them collapse to a single
-/// [`UpdateError`] at the command boundary.
+/// operator needs them: no update patch was ever dispatched, so there is
+/// nothing for a downgrade to undo (`MissingUpdater`, `Prepare`, `Cancelled`,
+/// `ProbeFailed`), or the patch may well have applied but the flow cannot
+/// reach the host to undo it (`Reboot`), or it is unknown whether it did
+/// (`NotRun`). All of them collapse to a single [`UpdateError`] at the command
+/// boundary.
+///
+/// "No patch was dispatched" is not the same as "the host is untouched": an
+/// abort that follows a *completed* `prepare` — the pre-dispatch cancel gate
+/// and `MissingUpdater` — leaves that prepare's packages installed. That is
+/// still a "no" for the rollback, which exists to undo a patch that never ran
+/// here, but the host did change, so the prepare writes its own
+/// `/var/log/mtui.log` row rather than leaving the abort silent (#407).
 #[derive(Debug, PartialEq, Eq)]
 pub enum UpdateFailure {
     /// One or more hosts failed the `updater` check after the command ran.
@@ -292,9 +300,13 @@ where
 /// never started — but *before* any transactional reboot, since a host that
 /// does not come back can no longer be written to.
 ///
-/// `id_field` carries the RRID for ops that log it (`update`/`downgrade`) and
-/// is `None` for `install`/`uninstall`. The op label and package list
-/// complete the colon-joined line written by [`HostsGroup::add_history`].
+/// `id_field` carries the RRID for the ops that log one (`update`,
+/// `downgrade`) and is `None` for `prepare`, whose row is just the label and
+/// the package set. The op label and package list complete the colon-joined
+/// line written by [`HostsGroup::add_history`]. `install`/`uninstall` write a
+/// row of the same shape, but from `OperationGroup::run` rather than through
+/// here — so this function's callers are not the full list of ops that appear
+/// in `/var/log/mtui.log`.
 pub async fn add_op_history(
     targets: &mut HostsGroup,
     op: &str,
@@ -958,6 +970,29 @@ async fn prepare_body(
         );
     }
 
+    // A prepare *installs packages*, so it owes its own history row — the
+    // record every other dispatching op already writes. Placed here for the
+    // same two reasons as `update`'s and `downgrade`'s rows: after the
+    // dispatch, so no row ever claims work that never started, and before
+    // `reboot_transactional`, because a host that does not come back can no
+    // longer be written to.
+    //
+    // It is also what closes #407 for `update`: both of that flow's
+    // post-prepare aborts (the pre-dispatch cancel gate and the missing-updater
+    // abort) return without an `update` row — correctly, since no updater
+    // command dispatched — but the packages this prepare installed stay on
+    // every host. Writing the row where the side effect is produced records
+    // them for the standalone `prepare`, the initial prepare inside `update`,
+    // and the `--newpackage` prepare alike.
+    //
+    // Gated on a real dispatch: an empty list, a cancel before the first
+    // package, or a prepare for which no command could be built leaves no row.
+    // The row names the whole prepare set, as `update`/`downgrade` do; a
+    // per-package cancel names its own progress in the error.
+    if !dispatched.is_empty() {
+        add_op_history(targets, "prepare", None, pkgs).await;
+    }
+
     // Surface any per-host command failure from the install fan-out; the
     // prepare check's own failures were collected per fan-out above.
     //
@@ -1318,6 +1353,13 @@ async fn downgrade_body(
         );
     }
     if !dead_probes.is_empty() && dead_probes.len() == list_map.len() {
+        // The abort still leaves side effects behind: `fanout_set_repo(Remove)`
+        // above has already stripped the issue repo from every host, and this
+        // path fires most often *during the update rollback*, when
+        // reconstructing what was done to a refhost matters most. Record the
+        // row before returning — the site below is unreachable from here, so
+        // there is no double write.
+        add_op_history(targets, "downgrade", id, packages).await;
         return Err(UpdateError::new(
             "package version probe failed",
             dead_probes.iter().cloned().collect::<Vec<_>>().join(", "),
@@ -1782,8 +1824,19 @@ pub async fn perform_update(
         // on every host (the same undo the MissingUpdater abort performs).
         targets.fanout_set_repo(RepoOp::Remove, report).await;
         warn_on_unlock_failures("update", &targets.unlock().await);
+        // True of the *update command* — but with a prepare behind us the host
+        // is not untouched, and saying only "nothing was dispatched" reads as
+        // if it were. The repo add is undone above; a completed prepare's
+        // packages are not, and its own history row is the record of them.
         return Err(UpdateFailure::Cancelled(UpdateError::cancelled(
-            "cancelled before the update command was dispatched",
+            if noprepare {
+                "cancelled before the update command was dispatched".to_owned()
+            } else {
+                "cancelled before the update command was dispatched; any packages \
+                 installed by the prepare that ran first are left in place \
+                 (see `list_history`)"
+                    .to_owned()
+            },
         )));
     }
 
@@ -2647,6 +2700,300 @@ mod tests {
         );
     }
 
+    // --- #407: an abort that already produced side effects records them ----
+
+    #[tokio::test]
+    async fn prepare_records_history_once_dispatched() {
+        // `prepare` installs packages, so it owes its own row — the residue an
+        // `update` aborted after its prepare would otherwise leave unrecorded.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned(), "pkg-b".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await;
+        assert!(res.is_ok(), "a clean prepare returns Ok: {res:?}");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a prepare that dispatched an install records history"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        // Anchored on the tail: it pins the label *and* the package list. A
+        // bare `contains("prepare")` would also match a package named
+        // `prepare-something` or the `:update:` row's payload.
+        assert!(
+            contents.ends_with(":prepare:pkg-a pkg-b\n"),
+            "history line: {contents:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_writes_no_history_when_cancelled_before_any_dispatch() {
+        // The inverse failure direction: a row claiming an install that never
+        // started is worse than no row. `installed_only` takes the per-package
+        // loop, whose checkpoint breaks at package 0, so nothing dispatches.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        group.cancel_token().cancel();
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned(), "pkg-b".to_owned()],
+            false,
+            false,
+            true,
+        )
+        .await
+        .expect_err("a cancelled prepare reports an error");
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+
+        assert!(
+            handle.commands().is_empty(),
+            "cancelled at package 0, so nothing dispatched: {:?}",
+            handle.commands()
+        );
+        assert!(
+            handle.file_contents(HISTORY_LOG).is_none(),
+            "a prepare that dispatched nothing must leave no row: {:?}",
+            handle.file_contents(HISTORY_LOG)
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_writes_no_history_for_an_empty_package_list() {
+        // Reaches the same site through the empty-list warn path and returns
+        // Ok: still nothing dispatched, so still no row.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_prepare(&mut group, &NoopRepo, &[], false, false, false).await;
+        assert!(res.is_ok(), "an empty prepare is a no-op Ok: {res:?}");
+        assert!(
+            handle.file_contents(HISTORY_LOG).is_none(),
+            "an empty prepare must leave no row"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_records_history_for_a_host_lost_to_its_reboot() {
+        // Pins the row's placement *before* `reboot_transactional`: the mock's
+        // `sftp_append` reconnects at entry like the real `SshConnection`, so a
+        // write attempted after the reboot would fail on the dead host.
+        let (t, handle) = slmicro_target_failing_reconnect("h1");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a lost transactional host must not report success");
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("a host lost to its reboot must still have its prepare row"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        assert!(
+            contents.ends_with(":prepare:pkg-a\n"),
+            "history line: {contents:?}"
+        );
+    }
+
+    /// A [`SetRepo`] that cancels the group's token the first time it is asked
+    /// to *add* a repo, recording every op it saw.
+    ///
+    /// The only `RepoOp::Add` in `perform_update` happens after the initial
+    /// prepare has dispatched and before the pre-dispatch cancel gate, so this
+    /// reproduces "`job_cancel` during a multi-minute prepare" deterministically,
+    /// with no timing.
+    struct CancellingRepo {
+        /// Cancels the group's token. A boxed closure rather than the token
+        /// itself so the test double needs no `tokio-util` dependency here.
+        cancel: Box<dyn Fn() + Send + Sync>,
+        ops: std::sync::Mutex<Vec<RepoOp>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SetRepo for CancellingRepo {
+        async fn set_repo(&self, _target: &mut Target, operation: RepoOp) {
+            self.ops.lock().unwrap().push(operation);
+            if operation == RepoOp::Add {
+                (self.cancel)();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn update_cancelled_at_the_pre_dispatch_gate_records_the_prepare_row() {
+        // #407's headline path: the update is cancelled after its prepare has
+        // installed packages on every host. The repo add is undone, but the
+        // installed packages are not — so the prepare must be on record.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        let token = group.cancel_token();
+        let repo = CancellingRepo {
+            cancel: Box::new(move || token.cancel()),
+            ops: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let res = perform_update(
+            &mut group,
+            &repo,
+            &["pkg-a".to_owned()],
+            "42",
+            "7",
+            None,
+            false,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+
+        let Err(UpdateFailure::Cancelled(err)) = res else {
+            panic!("a cancel at the pre-dispatch gate is Err(Cancelled): {res:?}");
+        };
+        // Discriminating: the entry gate says "before the update started", so
+        // this pins the *pre-dispatch* gate, the one that runs after prepare.
+        assert!(
+            err.reason
+                .contains("before the update command was dispatched"),
+            "reason: {}",
+            err.reason
+        );
+        // …and it must not read as "nothing happened here": a prepare ran.
+        assert!(
+            err.reason.contains("left in place"),
+            "the message must own the prepare residue: {}",
+            err.reason
+        );
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("the completed prepare must be on record"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        assert!(
+            contents.ends_with(":prepare:pkg-a\n"),
+            "history line: {contents:?}"
+        );
+        // A row claiming the *update* ran would be worse than none: the update
+        // command never dispatched.
+        assert!(
+            !contents.contains(":update:"),
+            "no update row may be written when no updater command ran: {contents:?}"
+        );
+        assert!(
+            !handle.commands().iter().any(|c| c.contains(":p=42:7")),
+            "the updater command must not have dispatched: {:?}",
+            handle.commands()
+        );
+        // The undo still runs: the repo the gate added is removed again.
+        let ops = repo.ops.lock().unwrap().clone();
+        assert!(
+            ops.contains(&RepoOp::Add) && ops.last() == Some(&RepoOp::Remove),
+            "the cancel gate undoes its repo add: {ops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_cancelled_at_the_gate_under_noprepare_records_nothing() {
+        // Same gate, `--noprepare`: nothing was installed and no updater
+        // command dispatched, so this abort owes no row — and its message must
+        // not invent a prepare residue that cannot exist here.
+        let (t, handle) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+        let token = group.cancel_token();
+        let repo = CancellingRepo {
+            cancel: Box::new(move || token.cancel()),
+            ops: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let res = perform_update(
+            &mut group,
+            &repo,
+            &["pkg-a".to_owned()],
+            "42",
+            "7",
+            None,
+            true,
+            false,
+            &mut Vec::new(),
+        )
+        .await;
+
+        let Err(UpdateFailure::Cancelled(err)) = res else {
+            panic!("a cancel at the pre-dispatch gate is Err(Cancelled): {res:?}");
+        };
+        assert!(
+            err.reason
+                .contains("before the update command was dispatched"),
+            "reason: {}",
+            err.reason
+        );
+        assert!(
+            !err.reason.contains("left in place"),
+            "no prepare ran, so nothing was left in place: {}",
+            err.reason
+        );
+        assert!(
+            handle.file_contents(HISTORY_LOG).is_none(),
+            "an abort that dispatched nothing must leave no row: {:?}",
+            handle.file_contents(HISTORY_LOG)
+        );
+    }
+
+    #[tokio::test]
+    async fn downgrade_all_probes_dead_still_records_history() {
+        // The issue repo was removed from every host before the probe ran, and
+        // this abort fires on the rollback path — the row is what an operator
+        // reconstructs the refhost's state from.
+        let (t, handle) = sles_target_with_exit("h1", "", -1);
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let res = perform_downgrade(&mut group, &NoopRepo, &["pkg-a".to_owned()], None).await;
+        let err = res.expect_err("a dead probe must still abort");
+        // The verdict must not change: writing the row is bookkeeping.
+        assert_eq!(err.reason, "package version probe failed");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        assert!(
+            !handle.commands().iter().any(|c| c.contains("--oldpackage")),
+            "no downgrade command may run after a dead probe: {:?}",
+            handle.commands()
+        );
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("the repo removal already landed; the row must be written"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        // `id` is None here, so the row carries no RRID field.
+        assert!(
+            contents.ends_with(":downgrade:pkg-a\n"),
+            "history line: {contents:?}"
+        );
+    }
+
     #[tokio::test]
     async fn perform_install_accepts_zyppers_informational_exit_codes() {
         // zypper exits 100-103/106 to mean "update needed", "reboot needed",
@@ -2982,6 +3329,14 @@ mod tests {
             ops.contains(&RepoOp::Remove),
             "abort removes the repo: {ops:?}"
         );
+        // #407's other half: this abort is *correct* to stay silent. With
+        // `noprepare` nothing was installed and no updater command dispatched,
+        // so the fix must not make this path write a row either.
+        assert!(
+            handle.file_contents(HISTORY_LOG).is_none(),
+            "an abort that dispatched nothing must leave no row: {:?}",
+            handle.file_contents(HISTORY_LOG)
+        );
     }
 
     // --- perform_downgrade -------------------------------------------------
@@ -3064,6 +3419,23 @@ mod tests {
             !h2.commands().iter().any(|c| c.contains("--oldpackage")),
             "dead host must build no downgrade command: {:?}",
             h2.commands()
+        );
+        // Not every probe died, so the all-dead abort must not fire: the flow
+        // reaches the single post-dispatch history site and writes exactly one
+        // downgrade row. An abort-site write that escaped its `if` would show
+        // up here as two.
+        let contents = String::from_utf8(
+            h1.file_contents(HISTORY_LOG)
+                .expect("the healthy host's row"),
+        )
+        .unwrap();
+        assert_eq!(
+            contents
+                .lines()
+                .filter(|l| l.contains(":downgrade:"))
+                .count(),
+            1,
+            "exactly one downgrade row on the healthy host: {contents:?}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -313,12 +313,36 @@ pub async fn add_op_history(
     id_field: Option<&str>,
     packages: &[String],
 ) {
+    let fields = op_history_fields(op, id_field, packages);
+    targets.add_history(&fields).await;
+}
+
+/// [`add_op_history`], written to `hosts` only.
+///
+/// For an op whose fan-out did not reach the whole group. `prepare` builds a
+/// per-host command map and drops a host whose release key does not resolve or
+/// whose template does not render; that host is failed with "nothing was
+/// installed", so a group-wide row would contradict its own verdict in a file
+/// other tools parse (#407).
+pub async fn add_op_history_for(
+    targets: &mut HostsGroup,
+    hosts: &BTreeSet<String>,
+    op: &str,
+    id_field: Option<&str>,
+    packages: &[String],
+) {
+    let fields = op_history_fields(op, id_field, packages);
+    targets.add_history_for(hosts, &fields).await;
+}
+
+/// The colon-joined field list of a history row: `op[:id]:pkg-a pkg-b`.
+fn op_history_fields(op: &str, id_field: Option<&str>, packages: &[String]) -> Vec<String> {
     let mut fields = vec![op.to_owned()];
     if let Some(id) = id_field {
         fields.push(id.to_owned());
     }
     fields.push(packages.join(" "));
-    targets.add_history(&fields).await;
+    fields
 }
 
 /// The `$repa` maintenance-selector for an update.
@@ -975,7 +999,10 @@ async fn prepare_body(
     // same two reasons as `update`'s and `downgrade`'s rows: after the
     // dispatch, so no row ever claims work that never started, and before
     // `reboot_transactional`, because a host that does not come back can no
-    // longer be written to.
+    // longer be written to. On a transactional host that placement means the
+    // row records what was *staged*, not what is active — deliberate, because
+    // a host that never returns from its reboot would otherwise leave the
+    // packages it holds in a snapshot entirely unrecorded.
     //
     // It is also what closes #407 for `update`: both of that flow's
     // post-prepare aborts (the pre-dispatch cancel gate and the missing-updater
@@ -985,12 +1012,30 @@ async fn prepare_body(
     // them for the standalone `prepare`, the initial prepare inside `update`,
     // and the `--newpackage` prepare alike.
     //
-    // Gated on a real dispatch: an empty list, a cancel before the first
-    // package, or a prepare for which no command could be built leaves no row.
-    // The row names the whole prepare set, as `update`/`downgrade` do; a
-    // per-package cancel names its own progress in the error.
+    // Two things keep the row from over-claiming, both instances of "a row
+    // claiming an install that never started is worse than no row":
+    //
+    // * **Per host, not group-wide.** `dispatched` is a per-host set and
+    //   `build_prepare_map` drops a host whose release key does not resolve or
+    //   whose template does not render — the very hosts the block below fails
+    //   with "nothing was installed". A group-wide fan-out would hand exactly
+    //   those hosts a `:prepare:` row contradicting their own verdict, in a
+    //   file the project treats as an interop contract, so the write is scoped
+    //   to the hosts a command actually reached.
+    // * **The dispatched subset, not the whole set.** A cancel at package `i`
+    //   of the `--installed-only` loop dispatched `pkgs[..i]` and nothing
+    //   after, so that is what the row names. The error message names the
+    //   progress too, but it is transient; the log line is what an operator
+    //   coming back to the host later reconstructs from.
+    //
+    // An empty list, a cancel before the first package, or a prepare for which
+    // no command could be built for any host therefore leaves no row at all.
+    let recorded: &[String] = match cancelled_at {
+        Some(i) => &pkgs[..i],
+        None => pkgs,
+    };
     if !dispatched.is_empty() {
-        add_op_history(targets, "prepare", None, pkgs).await;
+        add_op_history_for(targets, &dispatched, "prepare", None, recorded).await;
     }
 
     // Surface any per-host command failure from the install fan-out; the
@@ -2766,6 +2811,140 @@ mod tests {
             handle.file_contents(HISTORY_LOG).is_none(),
             "a prepare that dispatched nothing must leave no row: {:?}",
             handle.file_contents(HISTORY_LOG)
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_records_history_only_on_the_hosts_it_dispatched_to() {
+        // Per host, not group-wide. `build_prepare_map` drops a host whose
+        // release key does not resolve, and `prepare_body` then fails exactly
+        // that host with "nothing was installed". A group-wide history fan-out
+        // would hand the same host a `:prepare:` row — a false entry in a
+        // format the project treats as an interop contract, and one that
+        // contradicts the host's own verdict in the same run.
+        let (good, good_handle) = sles_target("h1", "");
+        // h2: enabled, answers commands, but has no parsed system — so
+        // `host_key` resolves nothing and no command is ever built for it.
+        let bad_conn = MockConnection::new("h2").with_default(CommandLog::new("", "", "", 0, 0));
+        let bad_handle = bad_conn.clone();
+        let bad = Target::with_connection("h2", TargetState::Enabled, Box::new(bad_conn));
+        let mut group = HostsGroup::new(vec![good, bad], false);
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("the dropped host must fail the flow");
+        // The contradiction this test exists to prevent, stated from the other
+        // side: h2 is told nothing was installed on it.
+        assert_eq!(err.host.as_deref(), Some("h2"), "{err}");
+        assert!(
+            err.to_string().contains("nothing was installed"),
+            "cause stated: {err}"
+        );
+
+        // The host that was actually dispatched to is on record.
+        let contents = String::from_utf8(
+            good_handle
+                .file_contents(HISTORY_LOG)
+                .expect("the dispatched host keeps its prepare row"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        assert!(
+            contents.ends_with(":prepare:pkg-a\n"),
+            "history line: {contents:?}"
+        );
+
+        // The dropped one is not. Mock-level proof it was never dispatched to,
+        // so the row would be a claim about work that never started.
+        assert!(
+            bad_handle.commands().is_empty(),
+            "no command reached h2: {:?}",
+            bad_handle.commands()
+        );
+        assert!(
+            bad_handle.file_contents(HISTORY_LOG).is_none(),
+            "a host nothing was dispatched to must have no prepare row: {:?}",
+            bad_handle
+                .file_contents(HISTORY_LOG)
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+        );
+    }
+
+    /// A cancel mid-way through the `--installed-only` loop must record the
+    /// packages that were dispatched, not the whole prepare set.
+    ///
+    /// Deterministic without a wall clock: under `start_paused` the runtime
+    /// only advances the timer when every task is idle, so the interleaving is
+    /// fixed. Each package's fan-out takes 10ms of virtual time and the
+    /// canceller fires at 15ms: package 0 completes at 10ms, package 1's
+    /// checkpoint passes (the cancel is still 5ms away), the cancel lands at
+    /// 15ms, package 1 completes at 20ms, and package 2's checkpoint breaks the
+    /// loop. Two of four packages dispatched.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_cancelled_mid_loop_records_only_the_dispatched_packages() {
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .with_run_delay(std::time::Duration::from_millis(10));
+        let handle = conn.clone();
+        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t.set_system(
+            System::new(
+                SystemProduct::new("SLES", "15.5", "x86_64"),
+                BTreeSet::new(),
+                false,
+            ),
+            false,
+        );
+        let mut group = HostsGroup::new(vec![t], false);
+        let token = group.cancel_token();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+            token.cancel();
+        });
+
+        let pkgs: Vec<String> = ["pkg-a", "pkg-b", "pkg-c", "pkg-d"]
+            .iter()
+            .map(|p| (*p).to_owned())
+            .collect();
+        let err = perform_prepare(&mut group, &NoopRepo, &pkgs, false, false, true)
+            .await
+            .expect_err("a cancelled prepare reports an error");
+        assert!(err.is_cancelled(), "must be flagged as a cancel: {err:?}");
+        // Pins the interleaving itself, so a change that moved the cancel to a
+        // different package would fail here rather than silently re-aiming the
+        // assertion below.
+        assert_eq!(
+            err.reason,
+            "prepare cancelled after 2/4 packages; applied: [pkg-a, pkg-b]; \
+             not attempted: [pkg-c, pkg-d]",
+            "the loop must have broken at package 2"
+        );
+        assert_eq!(
+            handle.commands().len(),
+            2,
+            "exactly two packages dispatched: {:?}",
+            handle.commands()
+        );
+
+        let contents = String::from_utf8(
+            handle
+                .file_contents(HISTORY_LOG)
+                .expect("two packages were installed, so there is a row"),
+        )
+        .unwrap();
+        assert_eq!(contents.lines().count(), 1, "history: {contents:?}");
+        // The whole point: `pkg-c`/`pkg-d` were never attempted, so naming them
+        // would be the same over-claim as a row for a prepare that never ran.
+        assert!(
+            contents.ends_with(":prepare:pkg-a pkg-b\n"),
+            "the row must name only the dispatched packages: {contents:?}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1404,6 +1404,16 @@ async fn downgrade_body(
         // reconstructing what was done to a refhost matters most. Record the
         // row before returning — the site below is unreachable from here, so
         // there is no double write.
+        //
+        // Merge note (#451/PR #454): the `lastexit != 0` test above is
+        // unchanged there, but the probe template starts guarding its own
+        // stages and exiting with the failing tool's status. Today the
+        // pipeline's status is awk's, and awk exits `0` over empty input, so
+        // this gate can in practice only catch the `-1` SSH-death sentinel;
+        // afterwards a broken `zypper se` reaches it too. This row is therefore
+        // written in strictly more zero-commands-ran cases once #454 lands —
+        // which is the point: those are exactly the aborts that leave a host
+        // with its issue repo removed and nothing rolled back.
         add_op_history(targets, "downgrade", id, packages).await;
         return Err(UpdateError::new(
             "package version probe failed",

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -558,7 +558,7 @@ Options:
   -e, --event <event>
           event type to list (repeatable)
           
-          [possible values: connect, disconnect, install, update, downgrade]
+          [possible values: connect, disconnect, install, update, downgrade, prepare]
 
   -h, --help
           Print help


### PR DESCRIPTION
Closes #407.

## The bug

`/var/log/mtui.log` is what the next tester reconstructs a refhost's state
from — one `timestamp:user:field…` line per operation per host, read back by
`list_history`. Three abort paths returned *after* real side effects had
landed on the hosts, and none of them left a row:

1. **`update` cancelled at its pre-dispatch gate.** By the time the gate runs,
   the initial `prepare` has installed packages on every host. The gate undoes
   the repo add, releases the locks, and returns `Cancelled` — with no row
   anywhere, and a message (`cancelled before the update command was
   dispatched`) that reads as if the hosts were untouched.
2. **`update` aborted for a missing updater** (`MissingUpdater`), after the
   same prepare. Same residue, same silence.
3. **`downgrade` where every version probe died.** `fanout_set_repo(Remove)`
   has already stripped the issue repo from every host by then, and this abort
   fires precisely on the `update` rollback path — the moment where knowing
   what was done to a refhost matters most.

The root cause of 1 and 2 is the same: `prepare` had **no history site at
all**, although installing packages is exactly what it does. 3 is a return
that jumps over `downgrade`'s single post-dispatch site.

## The fix

- **`prepare` writes its own row** (`update_flow.rs::prepare_body`), once at
  least one host actually got an install command dispatched. Placement follows
  the rule `update` and `downgrade` already use: *after* the dispatch, so a row
  never claims work that never started, and *before* `reboot_transactional`,
  because a host that does not come back can no longer be written to. One site
  covers the standalone command, the prepare `update` runs before patching, and
  the `--newpackage` prepare after it — so both `update` aborts above are
  covered where the side effect is produced, not at each abort.
- **Gated on a real dispatch:** an empty package list, a cancel before the
  first package, or a prepare for which no command could be built for any host
  leaves no row. A row claiming an install that never started would be worse
  than none.
- **Scoped to the hosts a command actually reached**, via a new host-scoped
  fan-out `HostsGroup::add_history_for` (and its `add_op_history_for` wrapper).
  `prepare` builds a *per-host* command map, and `build_prepare_map` drops a
  host whose release key does not resolve or whose template does not render —
  the very hosts `prepare_body` then fails with "nothing was installed". A
  group-wide write would hand exactly those hosts a `:prepare:` row
  contradicting their own verdict, in a file the project treats as an interop
  contract.
- **The row names the dispatched subset, not the whole set.** A cancel at
  package `i` of the `--installed-only` loop dispatched `pkgs[..i]` and nothing
  after, so that is what the row records. The error message names the progress
  too, but it is transient; the log line is what an operator coming back to the
  host later reconstructs from.
- **`downgrade`'s all-probes-dead abort writes its row before returning.** The
  post-dispatch site below it is unreachable from that branch, so there is no
  double write.
- **The pre-dispatch cancel message owns the residue:** with a prepare behind
  it, it now says the installed packages are left in place and points at
  `list_history`. Under `--noprepare` it is unchanged.
- **`list_history -e prepare`** now selects the new rows (the value parser
  rejects anything outside `EVENTS`). Additive MCP schema change: the
  `list_history` tool's `event` enum gains `"prepare"`; the slim-profile
  snapshot and the generated CLI reference move with it, since both derive from
  the same array.
- A test in `mtui-hosts` pins that the history fan-out is **never** gated on
  cancellation — these rows are written after `job_cancel` has already
  cancelled the token, so a gate there would suppress the record exactly when
  an operator needs it.

Net effect: a full `update` run now leaves one row per operation that
dispatched — `prepare` then `update`, plus a second `prepare` row when
`--newpackage` is used.

## Judgement calls

- **The `prepare` row names the dispatched prefix; the other ops' rows still
  name the whole set.** This was the issue's "Decision needed". `prepare` can
  answer it because its loop already tracks what it dispatched, so a cancel at
  package `i` records `pkgs[..i]` rather than claiming the rest. `update` and
  `downgrade` are unchanged — narrowing them means threading progress through
  flows that do not track it, and the history format has no field for "how far
  it got" in any case. The accurate applied/not-attempted split is in the error
  the operator sees.
- **The `downgrade` row is written for an abort whose downgrade command never
  dispatched.** Arguably it over-claims. The argument for writing it: the row
  records an *operation that changed the host* — the issue repo was removed
  from every host before the probe ran — and this is the rollback path, where a
  silent record is most damaging. The alternative (a new event label for "repo
  removed") widens the wire contract every mtui on the fleet parses, for a
  strictly rarer case.
- **The message is gated on the flow's own `noprepare` flag, not on sniffing
  the session token** — the same rule the cancellation verdicts follow, so a
  message can never claim a prepare residue that could not exist.
- **`uninstall` is still missing from the `-e/--event` values** although
  uninstall rows exist. Pre-existing gap, unrelated to this abort; left for its
  own change rather than widened into this one.
- **Two doc comments were corrected in passing**, both in the family this issue
  is about: `add_op_history`'s list of ops that reach it (`prepare` was
  missing, and `install`/`uninstall` reach `add_history` through
  `OperationGroup` instead), and `UpdateFailure`'s "nothing was ever installed"
  — which is precisely the claim #407 disproves. The rollback verdicts are
  unchanged; only the prose is.

## Testing

Full DoD gate on the final tree, all green:

| gate | result |
| --- | --- |
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc …` | exit 0 |
| `cargo test --workspace` | 37 suites, 2495 passed, 0 failed, 0 ignored |
| `cargo test -p mtui-mcp -F mcp` | 4 suites, 286 passed, 0 failed, 0 ignored |
| `cargo build --workspace --no-default-features` | exit 0 |
| `cargo build --workspace --all-features` (compile-only) | exit 0 |
| `typos .` | exit 0 |

**How RED was observed.** Every new assertion was checked against a concrete
mutation of the production code, and each run reports its denominator so a
filter that matched nothing cannot pass for a green run (the nine
`update_flow` tests run as `9 tests`, `297 filtered out`):

| mutation | tests that went RED |
| --- | --- |
| delete the `prepare` history write | `prepare_records_history_once_dispatched`, `prepare_records_history_for_a_host_lost_to_its_reboot`, `update_cancelled_at_the_pre_dispatch_gate_records_the_prepare_row` (3/9 failed) |
| move that write *below* `reboot_transactional` | `prepare_records_history_for_a_host_lost_to_its_reboot` (1/9) — existence and placement are pinned separately |
| drop the `!dispatched.is_empty()` gate | `prepare_writes_no_history_when_cancelled_before_any_dispatch`, `prepare_writes_no_history_for_an_empty_package_list` (2/9) |
| delete the `downgrade` abort-site row | `downgrade_all_probes_dead_still_records_history` (1/9) |
| let that row escape its `if` (write on every downgrade) | `perform_downgrade_partial_dead_probe_rolls_back_healthy_host` (1/9) — it counts exactly one row |
| cancel message never mentions the residue | `update_cancelled_at_the_pre_dispatch_gate_records_the_prepare_row` (1/9) |
| cancel message *always* claims a residue | `update_cancelled_at_the_gate_under_noprepare_records_nothing` (1/9) |
| revert `EVENTS` to its five previous values | `prepare_is_a_selectable_event` (1/1) |
| gate `HostsGroup::add_history` on cancellation | `add_history_still_writes_after_the_token_is_cancelled` (1/1) |

Assertions are anchored so they cannot pass on the wrong token: the row asserts
are tail-anchored on `":prepare:pkg-a pkg-b\n"` rather than
`contains("prepare")` (which a package named `prepare-*`, or an `:update:`
row's payload, would satisfy), the negative command assert uses the literal
`:p=42:7` selector `repa_for` builds, and the cancelled-before-dispatch test
also asserts `commands().is_empty()`, so "no row was written" is attributable
to the cancel landing at package 0 rather than to a fixture that never ran
anything. The MCP schema snapshot is compared against
the synthesised schema, so its `"prepare"` entry is evidence about the schema,
not a hand-edit.

## Known limitations

- **`update` and `downgrade` rows are still group-level.** Only the new
  `prepare` row is host-scoped; the pre-existing two are written to every
  enabled host once the op dispatched, so a host the fan-out could not build a
  command for still receives one. Such a host is already named as a failure to
  the operator (#396), but the log line alone does not distinguish it. Bringing
  those two onto `add_history_for` is a behaviour change to existing rows and
  belongs in its own commit.
- **A `prepare` row cannot say a package failed**, only that it was
  dispatched. The wire format has no field for an outcome, so a host whose
  install was dispatched and then failed carries the same row as one where it
  succeeded; the verdict lives in the error the operator sees, not in the log.
- **The write stays best-effort.** `Target::add_history` swallows an append
  failure, so a host with a read-only or full `/var/log` still yields no row
  and no error. That is #409's territory and is deliberately not changed here.
- **The `downgrade` row does not distinguish the abort from a real downgrade.**
  Reading the log alone, an all-probes-dead abort looks like a downgrade that
  ran; the wire format has no place to say otherwise without extending it.
- **Expect a merge conflict with the #451 branch**, which rewrites the same
  `dead_probes` abort in `downgrade_body`. The resolution is mechanical — keep
  this branch's `add_op_history` call at the top of the abort branch — but it
  will not auto-merge.

---

_Description updated by a maintainer at merge time: the host-scoped `add_history_for` and the dispatched-prefix row landed after the original write-up, which still described the group-wide version._
