### PR TITLE
fix(testreport): give prepare/install/uninstall and downgrade a verdict on slmicro and YUM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,34 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   templates` count now reports templates actually completed instead of counting
   never-attempted ones as done — as does the `succeeded` log line, which no
   longer names templates the stop never reached.
+- `prepare`, `install` and `uninstall` now judge SL Micro (`transactional-
+  update`) and RHEL (`yum`/`dnf`) hosts (#406). Both keys had commands for all
+  three roles but no post-run check: `prepare` skipped such a host silently, so
+  only the coarse "non-zero exit or any stderr" scan spoke for it, and
+  `install`/`uninstall` fell back to the exit code alone, reporting every
+  failure as "install command failed" with no further attribution. On SL Micro
+  the checks now read the same output markers the `update` check uses, so a
+  locked update stack, an unresolved dependency prompt or an RPM error is named
+  — and, the headline case, a `prepare` that reported a locked stack **and
+  still exited `0`** no longer reboots the host into the failed transaction. On
+  RHEL the verdict stays deliberately narrow: `install`/`uninstall` judge the
+  exit code (zypper's informational `100`-`107` are *not* transferred to
+  `yum`/`dnf`), while `prepare` judges only whether the command ran, because
+  `prepare --installed-only` renders `rpm -q <pkg> && yum … install <pkg>`,
+  which exits `1` on the routine "this host does not carry the package" skip.
+  A command that never ran to completion (a timeout, a dropped connection, an
+  unconnected host) now gets its own verdict on every one of these keys instead
+  of passing on an empty transcript. Neither check treats stderr as a failure:
+  both package managers write progress there on a successful run. The verdict
+  is taken after **every** fan-out, so `prepare --installed-only` — which runs
+  one command per package — is judged on each package rather than only the
+  last, whose clean no-op used to mask an earlier one.
+  **Reason strings an operator or MCP client sees change accordingly** — the
+  typed failure a check routes to, which is what decides whether a group is
+  rolled back, is unchanged. A multi-failure summary also names each host once
+  now: a single host can contribute two failures (a lock message is reported
+  both by the stderr scan and by the check that recognised it), which used to
+  read "prepare failed on h1, h1".
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,6 +408,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   now: a single host can contribute two failures (a lock message is reported
   both by the stderr scan and by the check that recognised it), which used to
   read "prepare failed on h1, h1".
+- A `downgrade` on a RHEL host is no longer reported as completed when its
+  `yum -y downgrade` never ran (#406) — the last `(release, transactional)`
+  key with a downgrade command and no check. As on SL Micro, the check judges
+  only that: a rollback that timed out, lost its connection, or never reached
+  the host leaves the packages at the update version while the flow ends
+  looking done.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,10 +404,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   last, whose clean no-op used to mask an earlier one.
   **Reason strings an operator or MCP client sees change accordingly** — the
   typed failure a check routes to, which is what decides whether a group is
-  rolled back, is unchanged. A multi-failure summary also names each host once
-  now: a single host can contribute two failures (a lock message is reported
-  both by the stderr scan and by the check that recognised it), which used to
-  read "prepare failed on h1, h1".
+  rolled back, is unchanged, and so is the failing host's name: where a check
+  and the coarse scan both speak for one host, `prepare` now reports the
+  check's sharper reason alone rather than summarising two, which would have
+  dropped the host field the summary form cannot carry. A summary over
+  genuinely distinct causes on one host also names it once now, instead of
+  reading "downgrade failed on h1, h1".
 - A `downgrade` on a RHEL host is no longer reported as completed when its
   `yum -y downgrade` never ran (#406) — the last `(release, transactional)`
   key with a downgrade command and no check. As on SL Micro, the check judges

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -397,14 +397,42 @@ fn build_reboot_map(
 ///
 /// The check reads each host's `last*` snapshot after the command ran. Only the
 /// `update` check currently emits diagnostics; the other roles append nothing.
+///
+/// Every host in the group is judged. A caller that fans out to a *subset* —
+/// the per-package `prepare` and `downgrade` loops — must use
+/// [`run_checks_where`] instead of filtering the returned list: a check logs
+/// its own ERROR breadcrumb before returning `Err`, so a verdict discarded
+/// afterwards has already been printed, for a host whose `last*` snapshot
+/// belongs to some earlier phase.
 fn run_checks(
     targets: &HostsGroup,
     registry: &WorkflowRegistry,
     role: Role,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Vec<UpdateError> {
+    run_checks_where(targets, registry, role, diagnostics, |_| true)
+}
+
+/// [`run_checks`] restricted to the hosts `allowed` accepts.
+///
+/// The predicate is applied *before* the check runs, not to its verdict. That
+/// is the whole point: a check calls
+/// [`log_failed`](crate::update_workflow::checks) on the way to its `Err`, so a
+/// post-filter still emits an operator-facing ERROR for a host whose verdict is
+/// then thrown away — once per package under `prepare --installed-only`, each
+/// time against a snapshot from a fan-out that host was not part of.
+fn run_checks_where(
+    targets: &HostsGroup,
+    registry: &WorkflowRegistry,
+    role: Role,
+    diagnostics: &mut Vec<Diagnostic>,
+    allowed: impl Fn(&str) -> bool,
+) -> Vec<UpdateError> {
     let mut failures = Vec::new();
     for target in targets.targets() {
+        if !allowed(target.hostname()) {
+            continue;
+        }
         let Some((release, transactional)) = host_key(target) else {
             continue;
         };
@@ -924,7 +952,26 @@ async fn prepare_body(
 
     // Surface any per-host command failure from the install fan-out; the
     // prepare check's own failures were collected per fan-out above.
-    let mut failures = host_command_failures(targets, "prepare command failed");
+    //
+    // A host the check already named is dropped here: the two rules overlap on
+    // one signal. `Target::run` records exit `-1` for a timeout, a dropped
+    // connection or an unconnected host, which trips this scan's
+    // `lastexit() != 0` *and* the `("slmicro", true)` / `("YUM", false)`
+    // checks' never-ran gate; a lock message on stderr trips the stderr half
+    // and the marker check. Both would name one host twice, which pushes
+    // `aggregate_failures` out of its single-failure verbatim branch into the
+    // summary — where `host` becomes `None` and the MCP client loses the one
+    // field that says *which* refhost to go and look at. The check's verdict
+    // is the one kept because it is the more specific of the two ("timed out
+    // or failed to run" and "update stack locked" both say more than "prepare
+    // command failed"); dropping the check's instead would trade attribution
+    // back for a coarser diagnosis. `downgrade_body` resolves the identical
+    // overlap the identical way — its `failed_downgrade.insert` gates the
+    // exit-code entry behind the check's verdict for the same host.
+    let mut failures: Vec<UpdateError> = host_command_failures(targets, "prepare command failed")
+        .into_iter()
+        .filter(|e| !e.host.as_ref().is_some_and(|h| check_failed.contains(h)))
+        .collect();
 
     // A host whose prepare failed must not reboot into the failed transaction,
     // mirroring the install/uninstall template's per-host gate: activating the
@@ -1071,6 +1118,20 @@ fn note_dispatch(
 /// a package it was skipped for), and judging that as a prepare would invent a
 /// verdict. First-failure-wins per host keeps `aggregate_failures` in its
 /// single-failure verbatim branch, where `host` survives.
+///
+/// The scope is imposed through [`run_checks_where`], so an out-of-fan-out host
+/// is never *judged*, rather than judged and then filtered: a check logs its
+/// own ERROR breadcrumb before it returns `Err`, and a discarded verdict has
+/// still been printed to the operator — once per package under
+/// `--installed-only`.
+///
+/// A consequence worth naming because it is intended, not incidental: a host
+/// [`build_prepare_map`] dropped (unresolved release key, or a template with no
+/// `--installed-only` variant) is in no `cmd` map, so it is never check-judged
+/// on its stale snapshot. It is not thereby excused — `prepare_body`'s dispatch
+/// accounting fails it by name with "no prepare command could be built for this
+/// host" (#396), which is a truthful verdict where a check's would have been an
+/// invented one.
 fn note_check(
     targets: &HostsGroup,
     registry: &WorkflowRegistry,
@@ -1078,11 +1139,11 @@ fn note_check(
     check_failed: &mut BTreeSet<String>,
     failures: &mut Vec<UpdateError>,
 ) {
-    for e in run_checks(targets, registry, Role::Prepare, &mut Vec::new()) {
+    let judged = run_checks_where(targets, registry, Role::Prepare, &mut Vec::new(), |host| {
+        cmd.contains_key(host)
+    });
+    for e in judged {
         let Some(host) = e.host.clone() else { continue };
-        if !cmd.contains_key(&host) {
-            continue;
-        }
         if check_failed.insert(host) {
             error!(error = %e, "prepare check failed");
             failures.push(e);
@@ -1319,14 +1380,20 @@ async fn downgrade_body(
             targets.run(Command::PerHost(cmd.clone())).await;
             // Check only the hosts that actually ran this command: a host
             // outside `cmd` (e.g. a dead-probe host) still carries its previous
-            // record, whose stale -1 would trip the new timeout gate and cancel
-            // the healthy hosts' rollback.
-            for e in run_checks(targets, registry, Role::Downgrade, &mut Vec::new()) {
-                let host = e.host.as_deref().unwrap_or("");
-                if cmd.contains_key(host) && !transactional_hosts.contains(host) {
-                    error!(error = %e, "downgrade check failed");
-                    failures.push(e);
-                }
+            // record, whose stale -1 would trip the timeout gate and cancel
+            // the healthy hosts' rollback. Scoped through `run_checks_where`,
+            // so such a host is not judged at all — a post-filter would still
+            // have emitted its ERROR breadcrumb, once per package.
+            let judged = run_checks_where(
+                targets,
+                registry,
+                Role::Downgrade,
+                &mut Vec::new(),
+                |host| cmd.contains_key(host) && !transactional_hosts.contains(host),
+            );
+            for e in judged {
+                error!(error = %e, "downgrade check failed");
+                failures.push(e);
             }
         }
     }
@@ -1363,15 +1430,21 @@ async fn downgrade_body(
     let mut failed_downgrade: BTreeSet<String> = BTreeSet::new();
     if !combined.is_empty() {
         targets.run(Command::PerHost(combined.clone())).await;
-        // Same scoping as the per-package loop: only check the transactional
-        // hosts that ran this combined command.
-        for e in run_checks(targets, registry, Role::Downgrade, &mut Vec::new()) {
-            let host = e.host.as_deref().unwrap_or("");
-            if combined.contains_key(host) && transactional_hosts.contains(host) {
-                error!(error = %e, "downgrade check failed");
-                failed_downgrade.insert(host.to_owned());
-                failures.push(e);
-            }
+        // Same scoping as the per-package loop, and imposed the same way: a
+        // host outside `combined` is not judged, rather than judged and then
+        // dropped after its breadcrumb has already been logged.
+        let judged = run_checks_where(
+            targets,
+            registry,
+            Role::Downgrade,
+            &mut Vec::new(),
+            |host| combined.contains_key(host) && transactional_hosts.contains(host),
+        );
+        for e in judged {
+            let Some(host) = e.host.clone() else { continue };
+            error!(error = %e, "downgrade check failed");
+            failed_downgrade.insert(host);
+            failures.push(e);
         }
         // The transactional check only gates "timed out or failed to run"; the
         // downgrade template is a single command, so a non-zero exit is
@@ -2633,6 +2706,50 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn perform_install_names_the_host_of_an_install_that_never_ran() {
+        // The install/uninstall twin of `perform_prepare_names_the_host_of_a_
+        // prepare_that_never_ran`, and the answer to "does this path double a
+        // `-1` too?": it does not, and this pins that it stays that way.
+        //
+        // The two flows collect failures differently. `prepare_body` runs its
+        // own `host_command_failures` scan alongside the check, so the two
+        // overlap on `-1` and the flow has to suppress one. This path collects
+        // *only* what the `Operation` template reports: exactly one
+        // `check_failures` entry per host plan
+        // (`mtui-hosts::target::operation`, one `push` per plan), plus
+        // `reboot_failures` — which cannot add a second entry for the same
+        // host, because a host whose check failed is removed from the reboot
+        // map before the reboot runs. No exit-code scan runs here at all, so
+        // there is nothing to double with.
+        for (product, version, transactional) in [("SL-Micro", "6.0", true), ("rhel", "9", false)] {
+            let conn = MockConnection::new("h1")
+                .with_default(CommandLog::new("", "", "", -1, 0))
+                .with_changing_boot_id();
+            let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+            t.set_system(
+                System::new(
+                    SystemProduct::new(product, version, "x86_64"),
+                    BTreeSet::new(),
+                    transactional,
+                ),
+                transactional,
+            );
+            let mut group = HostsGroup::new(vec![t], false);
+
+            let err = perform_install(&mut group, &["pkg-a".to_owned()])
+                .await
+                .expect_err("an install that never ran must not report success");
+
+            assert_eq!(err.host.as_deref(), Some("h1"), "{product}: {err}");
+            // Role-neutral wording, because this table also serves uninstall.
+            assert_eq!(
+                err.reason, "command timed out or failed to run",
+                "{product}"
+            );
+        }
+    }
+
     #[test]
     fn aggregate_failures_carries_the_typed_flags_through_the_summary() {
         // The single-failure path returns the error verbatim, flags and all;
@@ -2704,31 +2821,36 @@ mod tests {
 
     #[test]
     fn aggregate_failures_names_each_host_once() {
-        // One host legitimately contributes two failures: an exit-`0` prepare
-        // carrying a lock message is reported by `host_command_failures`'
-        // stderr rule *and* by the check that recognised the marker. Undeduped,
-        // the roll-call read "prepare failed on h1, h1", which names one host
-        // as two.
+        // One host can legitimately contribute two failures with two distinct
+        // causes: `downgrade_body` seeds its list from the issue-repo removal
+        // scan and then adds that same host's downgrade-check verdict.
+        // Undeduped, the roll-call read "downgrade failed on h1, h1", which
+        // names one host as two. (The prepare flow's own overlap — one signal,
+        // two rules — is resolved upstream of here instead, in `prepare_body`:
+        // deduping a roll-call would not have restored the `host` field the
+        // summary branch drops.)
         let err = aggregate_failures(
-            "prepare",
+            "downgrade",
             vec![
-                UpdateError::new("prepare command failed", "h1"),
-                UpdateError::new("update stack locked", "h1"),
+                UpdateError::new("failed to remove issue repo", "h1"),
+                UpdateError::new("downgrade command timed out or failed to run", "h1"),
             ],
         )
         .unwrap_err();
-        // `starts_with`, not `contains`: "prepare failed on h1, h1 (" contains
-        // "prepare failed on h1" too, so a `contains` here would pin nothing.
+        // `starts_with`, not `contains`: "downgrade failed on h1, h1 (" contains
+        // "downgrade failed on h1" too, so a `contains` here would pin nothing.
         assert!(
-            err.reason.starts_with("prepare failed on h1 ("),
+            err.reason.starts_with("downgrade failed on h1 ("),
             "one host, named once: {}",
             err.reason
         );
         // Both causes still reach the operator — this dedups the roll-call,
         // not the diagnosis.
         assert!(
-            err.reason.contains("h1: prepare command failed")
-                && err.reason.contains("h1: update stack locked"),
+            err.reason.contains("h1: failed to remove issue repo")
+                && err
+                    .reason
+                    .contains("h1: downgrade command timed out or failed to run"),
             "both causes survive: {}",
             err.reason
         );
@@ -5020,14 +5142,125 @@ mod tests {
             !fired.iter().any(|c| c.contains("systemctl reboot")),
             "a host whose prepare reported a locked stack must not be rebooted: {fired:?}"
         );
-        // `to_string`, not `err.reason`: the host is named twice here (the
-        // stderr rule in `host_command_failures` and the check's own verdict),
-        // which puts `aggregate_failures` in its summary branch where `host`
-        // is `None` and the detail is embedded in the reason.
+        // Exact reason *and* host: the stderr rule in `host_command_failures`
+        // fires on this transcript too, so the host is a candidate to be named
+        // twice — which would put `aggregate_failures` in its summary branch,
+        // where `host` is `None` and the diagnosis is buried in the reason
+        // string. `prepare_body` drops its own coarse entry for a host the
+        // check named, so the specific verdict is returned verbatim and keeps
+        // its host.
+        assert_eq!(err.reason, "update stack locked", "err: {err}");
+        assert_eq!(err.host.as_deref(), Some("h1"), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_checks_where_never_judges_a_host_outside_the_predicate() {
+        // The scoping has to happen *before* the check runs, not after it
+        // returns: a check calls `log_failed` on its way to `Err`, so a
+        // verdict filtered out afterwards has already printed an operator- and
+        // MCP-visible ERROR for a host whose `last*` snapshot belongs to some
+        // other fan-out — once per package on the `--installed-only` path.
+        //
+        // Both hosts here carry the same failing transcript, so the only thing
+        // that can separate them is the predicate.
+        let (t1, _h1) = slmicro_target_with_stderr("h1", "System management is locked");
+        let (t2, _h2) = slmicro_target_with_stderr("h2", "System management is locked");
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+        let cmd: BTreeMap<String, String> = ["h1", "h2"]
+            .into_iter()
+            .map(|h| {
+                (
+                    h.to_owned(),
+                    "transactional-update -n pkg in -l  pkg-a".to_owned(),
+                )
+            })
+            .collect();
+        group.run(Command::PerHost(cmd)).await;
+        let registry = WorkflowRegistry::default();
+
+        let (failures, logs) = capture_logs(async {
+            run_checks_where(&group, &registry, Role::Prepare, &mut Vec::new(), |host| {
+                host == "h1"
+            })
+        })
+        .await;
+
+        // h1 is in scope: it is judged, it fails, and it says so.
+        assert_eq!(failures.len(), 1, "only the in-scope host is judged");
+        assert_eq!(failures[0].host.as_deref(), Some("h1"));
         assert!(
-            err.to_string().contains("update stack locked"),
-            "the check's diagnosis must reach the operator: {err}"
+            logs.contains("h1"),
+            "the in-scope host's breadcrumb still fires: {logs}"
         );
+        // h2 is out of scope: not judged at all, so nothing about it is
+        // logged. This is the assertion a post-filter cannot satisfy — the
+        // verdict would be dropped from the returned list, but `log_failed`
+        // would already have named h2.
+        assert!(
+            !logs.contains("h2"),
+            "an out-of-scope host must not be judged, so it must not be logged: {logs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_names_the_host_of_a_prepare_that_never_ran() {
+        // `-1` is `Target::run`'s sentinel for a timeout, a dropped connection
+        // or a host that was never connected, and it is the one signal both
+        // new prepare checks raise on. `host_command_failures` raises on the
+        // *same* exit code (`bad_exit = lastexit() != 0`), so unless the flow
+        // suppresses its own coarse entry one host contributes TWO failures,
+        // `aggregate_failures` leaves its single-failure verbatim branch, and
+        // `host` — the field an MCP client reads to know which refhost to go
+        // look at — collapses to `None`.
+        //
+        // Before #406 these keys had no prepare check at all, so a timed-out
+        // prepare returned a single verbatim error carrying its host. Keeping
+        // that attribution while gaining the sharper reason is the point;
+        // losing it would be a regression on exactly the path #406 adds.
+        for (product, version, transactional) in [("SL-Micro", "6.0", true), ("rhel", "9", false)] {
+            let conn = MockConnection::new("h1")
+                .with_default(CommandLog::new("", "", "", -1, 0))
+                .with_changing_boot_id();
+            let handle = conn.clone();
+            let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+            t.set_system(
+                System::new(
+                    SystemProduct::new(product, version, "x86_64"),
+                    BTreeSet::new(),
+                    transactional,
+                ),
+                transactional,
+            );
+            let mut group = HostsGroup::new(vec![t], false);
+
+            let err = perform_prepare(
+                &mut group,
+                &NoopRepo,
+                &["pkg-a".to_owned()],
+                false,
+                false,
+                false,
+            )
+            .await
+            .expect_err("a prepare that never ran must not report success");
+
+            // The fixture is only meaningful if a prepare really dispatched:
+            // a host no command was built for fails by a different name.
+            let cmds = handle.commands();
+            assert!(
+                cmds.iter().any(|c| c.contains("pkg-a")),
+                "{product}: a prepare command must have been dispatched: {cmds:?}"
+            );
+            assert_eq!(err.host.as_deref(), Some("h1"), "{product}: {err}");
+            // Exact, not `contains`: "prepare command failed" is
+            // `host_command_failures`' coarse wording for this very exit code,
+            // and the whole point is that the check's sharper verdict is the
+            // one that survives — and survives *alone*.
+            assert_eq!(
+                err.reason, "prepare command timed out or failed to run",
+                "{product}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -445,6 +445,12 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
     } else {
         let mut hosts: Vec<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
         hosts.sort();
+        // One name per host: the same host legitimately contributes two
+        // failures (an exit-`0` lock message is reported by both the stderr
+        // rule and the check that recognised the marker), and "prepare failed
+        // on h1, h1" reads as two hosts. The `detail` list still carries both
+        // causes — this dedups the roll-call, not the diagnosis.
+        hosts.dedup();
         let detail: Vec<String> = failures.iter().map(ToString::to_string).collect();
         let mut aggregate = UpdateError::reason_only(format!(
             "{op} failed on {} ({})",
@@ -850,6 +856,17 @@ async fn prepare_body(
     // earlier failure and let the host reboot into it.
     let mut dispatched: BTreeSet<String> = BTreeSet::new();
     let mut inert: BTreeSet<String> = BTreeSet::new();
+    // The check verdicts, accumulated in the same place and for the same
+    // reason: `run_checks` reads the `last*` snapshot too, so a single
+    // post-loop call would judge only the last package's transcript. The
+    // exit-code half of that hole was closed by `note_dispatch`; the marker
+    // half needs this, or an exit-`0` lock message on package 1 of 2 is
+    // overwritten by package 2's clean run and the host reboots into it
+    // (#406). `check_failed` keeps it to one verdict per host — a second entry
+    // would push `aggregate_failures` out of its single-failure verbatim
+    // branch, where `host` is `Some`.
+    let mut check_failed: BTreeSet<String> = BTreeSet::new();
+    let mut check_failures: Vec<UpdateError> = Vec::new();
 
     // Parity with perform_downgrade: an empty list is not a host failure, but
     // it must never be a silent success either — only the issue repositories
@@ -881,6 +898,13 @@ async fn prepare_body(
             let cmd = build_prepare_map(targets, registry, Some(&quoted), true);
             targets.run(Command::PerHost(cmd.clone())).await;
             note_dispatch(targets, &cmd, &mut dispatched, &mut inert);
+            note_check(
+                targets,
+                registry,
+                &cmd,
+                &mut check_failed,
+                &mut check_failures,
+            );
         }
     } else if !pkgs.is_empty() {
         // Install every package in a SINGLE transaction (one snapshot for
@@ -889,13 +913,18 @@ async fn prepare_body(
         let cmd = build_prepare_map(targets, registry, Some(&joined), false);
         targets.run(Command::PerHost(cmd.clone())).await;
         note_dispatch(targets, &cmd, &mut dispatched, &mut inert);
+        note_check(
+            targets,
+            registry,
+            &cmd,
+            &mut check_failed,
+            &mut check_failures,
+        );
     }
 
-    // Surface any per-host command failure from the install fan-out plus the
-    // prepare check's own failures. The prepare check emits no diagnostics; the
-    // sink is discarded.
+    // Surface any per-host command failure from the install fan-out; the
+    // prepare check's own failures were collected per fan-out above.
     let mut failures = host_command_failures(targets, "prepare command failed");
-    let check_failures = run_checks(targets, registry, Role::Prepare, &mut Vec::new());
 
     // A host whose prepare failed must not reboot into the failed transaction,
     // mirroring the install/uninstall template's per-host gate: activating the
@@ -909,15 +938,16 @@ async fn prepare_body(
     // commands, so the recorded exit code is genuinely the prepare command's
     // own.
     //
-    // The check verdicts are seeded too, but they are inert for the hosts that
-    // matter today: `prepare_check` has no ("slmicro", true) entry, and only
-    // transactional hosts are ever in `reboot`. Kept so the gate is already
-    // right when that check is registered, not because it fires now.
-    inert.extend(check_failures.iter().filter_map(|e| e.host.clone()));
-    for e in check_failures {
-        error!(error = %e, "prepare check failed");
-        failures.push(e);
-    }
+    // The check verdicts are the other half of the gate, and on
+    // ("slmicro", true) they are what makes it complete: a prepare that
+    // reported a locked update stack, a dependency prompt or an RPM error and
+    // still exited `0` is invisible to the exit-code rule above, and its
+    // reboot would activate the failed transaction. A marker-failed prepare
+    // therefore skips its reboot, while a host whose only stderr is progress
+    // still gets one (#406) — for *any* package it failed on, not just the
+    // last, which is why `check_failed` is filled per fan-out.
+    inert.extend(check_failed.iter().cloned());
+    failures.extend(check_failures);
 
     // `host_command_failures` reads one post-loop snapshot, so on the
     // per-package path it only ever sees the last package. Name every host a
@@ -1022,6 +1052,40 @@ fn note_dispatch(
             .is_some_and(|c| c != 0)
         {
             inert.insert(hostname.clone());
+        }
+    }
+}
+
+/// Runs the prepare check over the hosts *this* fan-out reached and records the
+/// first failure per host.
+///
+/// The companion to [`note_dispatch`], and called from the same places for the
+/// same reason: [`run_checks`] reads the `last*` snapshot, which the next
+/// package's fan-out overwrites. A single post-loop call therefore judges only
+/// the last package — and under `--installed-only` that is very often a clean
+/// no-op, so an exit-`0` lock message on an earlier package would be masked and
+/// the host would reboot into it (#406).
+///
+/// Scoped to `cmd`'s keys, again like `note_dispatch`: a host outside this
+/// fan-out still carries an earlier phase's record (the `set_repo` fan-out, or
+/// a package it was skipped for), and judging that as a prepare would invent a
+/// verdict. First-failure-wins per host keeps `aggregate_failures` in its
+/// single-failure verbatim branch, where `host` survives.
+fn note_check(
+    targets: &HostsGroup,
+    registry: &WorkflowRegistry,
+    cmd: &BTreeMap<String, String>,
+    check_failed: &mut BTreeSet<String>,
+    failures: &mut Vec<UpdateError>,
+) {
+    for e in run_checks(targets, registry, Role::Prepare, &mut Vec::new()) {
+        let Some(host) = e.host.clone() else { continue };
+        if !cmd.contains_key(&host) {
+            continue;
+        }
+        if check_failed.insert(host) {
+            error!(error = %e, "prepare check failed");
+            failures.push(e);
         }
     }
 }
@@ -2521,33 +2585,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn perform_install_falls_back_to_raw_scan_without_a_check_table() {
-        // slmicro/YUM keys have no install check registered. They must still get
-        // a verdict rather than an unconditional pass.
-        let conn = MockConnection::new("h1").with_default(CommandLog::new("t-u", "", "", 1, 0));
-        let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
-        t.set_system(
-            System::new(
-                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
-                BTreeSet::new(),
-                true,
-            ),
-            true,
-        );
-        let key = host_key(&t).expect("resolvable key");
-        assert!(
-            WorkflowRegistry::default()
-                .check(Role::Install, &key.0, key.1)
-                .is_none(),
-            "this test is only meaningful while the key has no check table"
-        );
-        let mut group = HostsGroup::new(vec![t], false);
+    async fn perform_install_reports_the_check_verdict_on_formerly_uncovered_keys() {
+        // The slmicro and YUM keys used to have *no* install check, so they
+        // fell through to the `PlanProvider` adapter's exit-code-only fallback
+        // and every failure read "install command failed" — the same sentence
+        // for a locked update stack, a failed RPM transaction and a command
+        // that never ran (#406). Both keys now carry a check, so the verdict
+        // comes from it.
+        //
+        // Both host shapes are driven because they take different routes into
+        // the same table: SL Micro is transactional (its check shares the
+        // update check's classifier), RHEL is not (its check judges the exit
+        // code alone).
+        for (product, version, transactional) in [("SL-Micro", "6.0", true), ("rhel", "9", false)] {
+            let conn = MockConnection::new("h1")
+                .with_default(CommandLog::new("t-u", "", "", 1, 0))
+                .with_changing_boot_id();
+            let mut t = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+            t.set_system(
+                System::new(
+                    SystemProduct::new(product, version, "x86_64"),
+                    BTreeSet::new(),
+                    transactional,
+                ),
+                transactional,
+            );
+            let key = host_key(&t).expect("resolvable key");
+            // The guard this test used to carry asserted the *absence* of the
+            // check — it pinned the hole. Inverted: the verdict below is only
+            // the check's if there is one.
+            assert!(
+                WorkflowRegistry::default()
+                    .check(Role::Install, &key.0, key.1)
+                    .is_some(),
+                "{product}: the install check table must cover this key"
+            );
+            let mut group = HostsGroup::new(vec![t], false);
 
-        let err = perform_install(&mut group, &["pkg-a".to_owned()])
-            .await
-            .expect_err("a non-zero exit must still be reported");
-        assert_eq!(err.host.as_deref(), Some("h1"));
-        assert_eq!(err.reason, "install command failed");
+            let err = perform_install(&mut group, &["pkg-a".to_owned()])
+                .await
+                .expect_err("a non-zero exit must still be reported");
+            assert_eq!(err.host.as_deref(), Some("h1"), "{product}");
+            // Exact, not `contains`: "install command failed" is what the
+            // adapter's fallback says, and the whole point is that the check —
+            // not the fallback — now answers.
+            assert_eq!(err.reason, "Unknown Error", "{product}");
+        }
     }
 
     #[test]
@@ -2616,6 +2699,53 @@ mod tests {
         assert!(
             msg.contains("prepare failed on h1, h2"),
             "aggregated message names both hosts sorted: {msg}"
+        );
+    }
+
+    #[test]
+    fn aggregate_failures_names_each_host_once() {
+        // One host legitimately contributes two failures: an exit-`0` prepare
+        // carrying a lock message is reported by `host_command_failures`'
+        // stderr rule *and* by the check that recognised the marker. Undeduped,
+        // the roll-call read "prepare failed on h1, h1", which names one host
+        // as two.
+        let err = aggregate_failures(
+            "prepare",
+            vec![
+                UpdateError::new("prepare command failed", "h1"),
+                UpdateError::new("update stack locked", "h1"),
+            ],
+        )
+        .unwrap_err();
+        // `starts_with`, not `contains`: "prepare failed on h1, h1 (" contains
+        // "prepare failed on h1" too, so a `contains` here would pin nothing.
+        assert!(
+            err.reason.starts_with("prepare failed on h1 ("),
+            "one host, named once: {}",
+            err.reason
+        );
+        // Both causes still reach the operator — this dedups the roll-call,
+        // not the diagnosis.
+        assert!(
+            err.reason.contains("h1: prepare command failed")
+                && err.reason.contains("h1: update stack locked"),
+            "both causes survive: {}",
+            err.reason
+        );
+        // And distinct hosts are still listed separately: a dedup that
+        // collapsed them would hide a host.
+        let err = aggregate_failures(
+            "prepare",
+            vec![
+                UpdateError::new("boom", "h1"),
+                UpdateError::new("boom", "h2"),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            err.reason.starts_with("prepare failed on h1, h2 ("),
+            "two hosts stay two: {}",
+            err.reason
         );
     }
 
@@ -4650,6 +4780,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn perform_prepare_judges_the_markers_of_every_package_not_just_the_last() {
+        // The marker half of the test above, and the half the first cut of
+        // #406 left open: every command here exits `0`, so `note_dispatch`'s
+        // exit-code rule and `host_command_failures`' stderr rule (which reads
+        // only the post-loop snapshot — pkg-b's clean run) see nothing at all.
+        // The ONLY mechanism that can fail h1 or keep it out of the reboot map
+        // is the `("slmicro", true)` prepare check's verdict on pkg-a — and
+        // with the check run once after the loop it judged pkg-b's clean
+        // transcript instead, so the host rebooted into the locked
+        // transaction while the flow reported success.
+        let locked = "if $(rpm -q pkg-a &>/dev/null); \
+                      then transactional-update -n pkg in -l  pkg-a ; fi";
+        let conn = MockConnection::new("h1")
+            .with_default(CommandLog::new("", "", "", 0, 0))
+            .with_response(
+                locked.to_owned(),
+                CommandLog::new(locked, "", "System management is locked", 0, 0),
+            )
+            .with_changing_boot_id();
+        let h1 = conn.clone();
+        let mut t1 = Target::with_connection("h1", TargetState::Enabled, Box::new(conn));
+        t1.set_system(
+            System::new(
+                SystemProduct::new("SL-Micro", "6.0", "x86_64"),
+                BTreeSet::new(),
+                true,
+            ),
+            true,
+        );
+        // h2 is clean throughout: it keeps the reboot assertion honest in the
+        // positive direction, so an empty `fired` list cannot fake h1's red.
+        let (t2, h2) = slmicro_target("h2", "", 0);
+        let mut group = HostsGroup::new(vec![t1, t2], false);
+
+        let res = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned(), "pkg-b".to_owned()],
+            false,
+            false,
+            true,
+        )
+        .await;
+
+        // The fixture only means anything if BOTH fan-outs really happened:
+        // pkg-a's locked one, and a later clean one to overwrite its snapshot.
+        let cmds = h1.commands();
+        assert!(
+            cmds.iter().any(|c| c == locked),
+            "pkg-a's command must have been dispatched: {cmds:?}"
+        );
+        assert!(
+            cmds.iter().any(|c| c.contains("pkg-b")),
+            "pkg-b must have run after it, overwriting the snapshot: {cmds:?}"
+        );
+
+        // The reboot before the verdict, as in `perform_prepare_skips_the_
+        // reboot_of_an_exit_zero_lock_message_prepare`: it is the consequence
+        // the issue is about, so it must own the red when both regress.
+        let fired1 = h1.fired_commands();
+        assert!(
+            !fired1.iter().any(|c| c.contains("systemctl reboot")),
+            "h1's pkg-a hit a locked stack; it must not reboot into it: {fired1:?}"
+        );
+        let fired2 = h2.fired_commands();
+        assert!(
+            fired2.iter().any(|c| c.contains("systemctl reboot")),
+            "healthy h2 must still reboot so its snapshot activates: {fired2:?}"
+        );
+
+        // Exact, not `contains`: only h1 failed, so the single failure is
+        // returned verbatim and keeps its host. A second entry would collapse
+        // `host` to `None` via the aggregate summary.
+        let err = res.expect_err("a locked stack on any package must fail the prepare");
+        assert_eq!(err.host.as_deref(), Some("h1"), "err: {err}");
+        assert_eq!(err.reason, "update stack locked", "err: {err}");
+    }
+
+    #[tokio::test]
     async fn perform_prepare_does_not_reboot_a_host_with_nothing_staged() {
         // An empty package list dispatches no prepare command at all, but the
         // reboot map is built from the host's transactional flag and does not
@@ -4775,6 +4984,49 @@ mod tests {
         assert!(
             fired.iter().any(|c| c.contains("systemctl reboot")),
             "a stderr-only host keeps its reboot: {fired:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_prepare_skips_the_reboot_of_an_exit_zero_lock_message_prepare() {
+        // The failure #406 names: `transactional-update` reported a locked
+        // update stack and still exited `0`. The exit-code half of the reboot
+        // gate cannot see that, and the stderr half deliberately must not
+        // (progress on stderr is routine — see the test above), so before the
+        // `("slmicro", true)` prepare check existed the host rebooted straight
+        // into the failed transaction.
+        //
+        // The inverse of `perform_prepare_still_reboots_a_host_that_only_wrote_
+        // _to_stderr`, and the pair is the whole rule: stderr gates nothing,
+        // a *recognised marker* on stderr gates the reboot.
+        let (t, handle) = slmicro_target_with_stderr("h1", "System management is locked");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_prepare(
+            &mut group,
+            &NoopRepo,
+            &["pkg-a".to_owned()],
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a locked update stack must not report success");
+        // The reboot first: it is the consequence the issue is about, and
+        // asserting it before the message keeps the message assert from
+        // masking it when both regress together.
+        let fired = handle.fired_commands();
+        assert!(
+            !fired.iter().any(|c| c.contains("systemctl reboot")),
+            "a host whose prepare reported a locked stack must not be rebooted: {fired:?}"
+        );
+        // `to_string`, not `err.reason`: the host is named twice here (the
+        // stderr rule in `host_command_failures` and the check's own verdict),
+        // which puts `aggregate_failures` in its summary branch where `host`
+        // is `None` and the detail is embedded in the reason.
+        assert!(
+            err.to_string().contains("update stack locked"),
+            "the check's diagnosis must reach the operator: {err}"
         );
     }
 

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -474,10 +474,18 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         let mut hosts: Vec<String> = failures.iter().filter_map(|e| e.host.clone()).collect();
         hosts.sort();
         // One name per host: the same host legitimately contributes two
-        // failures (an exit-`0` lock message is reported by both the stderr
-        // rule and the check that recognised the marker), and "prepare failed
-        // on h1, h1" reads as two hosts. The `detail` list still carries both
-        // causes — this dedups the roll-call, not the diagnosis.
+        // failures with two distinct causes (`downgrade_body` seeds its list
+        // from the issue-repo removal scan and then adds that same host's
+        // downgrade-check verdict), and "downgrade failed on h1, h1" reads as
+        // two hosts. The `detail` list still carries both causes — this dedups
+        // the roll-call, not the diagnosis.
+        //
+        // Not the place to fix *one* signal reported by two rules: that
+        // duplication has to be resolved before it reaches here, because
+        // arriving at all means the verbatim branch above was skipped and the
+        // `host` field is already lost. `prepare_body` and `downgrade_body`
+        // each drop their coarse exit-code entry for a host whose check has
+        // already named it, for exactly that reason.
         hosts.dedup();
         let detail: Vec<String> = failures.iter().map(ToString::to_string).collect();
         let mut aggregate = UpdateError::reason_only(format!(

--- a/crates/mtui-testreport/src/update_workflow/checks/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/downgrade.rs
@@ -85,12 +85,39 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
     Ok(Vec::new())
 }
 
+/// The yum downgrade check.
+///
+/// The same shape as [`transactional_update`] above and for the same kind of
+/// reason: only the timed-out/unrunnable gate, because nothing else about a
+/// `yum -y downgrade` transcript can be judged without guessing. The zypper
+/// branches (`104`, the lock strings) are that transcript's vocabulary, not
+/// this one's, and a non-zero status is a routine outcome on a refhost that
+/// carries only part of the update's package list. What is *not* routine is a
+/// rollback command that never ran to completion: the host stays on the update
+/// version while the flow ends looking done.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "downgrade command timed out or
+/// failed to run" when the command recorded exit `-1`.
+fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "downgrade command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    Ok(Vec::new())
+}
+
 /// The downgrade check for `(release, transactional)`, or `None` for an
 /// unknown key.
 #[must_use]
 pub(crate) fn downgrade_check(release: &str, transactional: bool) -> Option<CheckFn> {
     match (release, transactional) {
         ("11", false) | ("12", false) | ("15", false) | ("16", false) => Some(Box::new(zypper)),
+        ("YUM", false) => Some(Box::new(yum)),
         ("slmicro", true) => Some(Box::new(transactional_update)),
         _ => None,
     }
@@ -176,8 +203,41 @@ mod tests {
     }
 
     #[test]
+    fn yum_downgrade_judges_only_whether_the_command_ran() {
+        // The last key with a downgrader and no check (#406). The verdict is
+        // as narrow as the transactional one directly above, and for the same
+        // reason: `yum -y downgrade` on a host that carries only part of the
+        // update's package list is a routine outcome, and the zypper markers
+        // are not this transcript's vocabulary — but a rollback command that
+        // never ran leaves the host on the update version while the flow ends
+        // looking done.
+        let err = yum(args("", "", -1)).unwrap_err();
+        assert_eq!(err.reason, "downgrade command timed out or failed to run");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+
+        // Everything the check cannot justify judging still passes.
+        assert!(yum(args("", "", 1)).is_ok());
+        assert!(yum(args("", "Error: nothing to downgrade", 0)).is_ok());
+        assert!(yum(args("", "", 104)).is_ok());
+    }
+
+    #[test]
     fn table_lookup() {
         assert!(downgrade_check("11", false).is_some());
+        // The YUM key has had a downgrader since the port; it now has a check
+        // too, so a `yum` rollback that never ran is not read as a completed
+        // one.
+        let check = downgrade_check("YUM", false).expect("YUM check registered");
+        let err = check(CheckArgs {
+            hostname: "h1",
+            stdout: "",
+            stdin: "yum -y downgrade pkg-a",
+            stderr: "",
+            exitcode: -1,
+        })
+        .unwrap_err();
+        assert_eq!(err.reason, "downgrade command timed out or failed to run");
+        assert!(downgrade_check("YUM", true).is_none());
         assert!(downgrade_check("12", false).is_some());
         assert!(downgrade_check("15", false).is_some());
         assert!(downgrade_check("16", false).is_some());

--- a/crates/mtui-testreport/src/update_workflow/checks/install.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/install.rs
@@ -61,12 +61,99 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     Err(UpdateError::new("Unknown Error", args.hostname))
 }
 
+/// The transactional-update (`slmicro`) install/uninstall check.
+///
+/// Reuses the `update` check's [`classified`](super::update::classified)
+/// verdict — `classify_exit` interleaved with the shared stdout/stderr markers
+/// — rather than restating it, so the two `transactional-update` keys cannot
+/// drift apart. The reasoning for what that classifier means on this key is
+/// recorded once, on `checks::update`'s `transactional_update`: the command
+/// returns **only** `0` or `1` (verified against upstream
+/// `openSUSE/transactional-update` v6.1.3, unchanged from v2.28.3), because it
+/// absorbs zypper's status instead of propagating it. So the informational band
+/// and the package-not-found set are inert here by construction, and the
+/// classifier reduces to "`0` passes, anything else is an Unknown Error" —
+/// while the markers still catch the shape an exit code cannot: a run that
+/// reported a locked update stack, a dependency prompt or an RPM error and
+/// still exited `0`.
+///
+/// The `-1` sentinel is gated here rather than deferred to the classifier's own
+/// [`NotRun`](super::ExitClass::NotRun) arm because that arm speaks the
+/// `update` vocabulary ("update command timed out…"), and this table serves
+/// `install` *and* `uninstall` — hence the role-neutral wording.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "command timed out or failed to
+/// run" (exit `-1`), "update stack locked", "Dependency Error", "RPM Error",
+/// "package not found" or "Unknown Error".
+fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    super::update::classified(args)
+}
+
+/// The yum install/uninstall check.
+///
+/// Deliberately narrow: the exit code is the whole verdict, with no marker
+/// reading and no zypper exit-code semantics.
+///
+/// * **The accepted statuses.** `yum(8)` and `dnf(8)` document `0` as success
+///   and any other status as an error for `install`/`remove`; unlike zypper
+///   there is no informational band to carve out. zypper's `100`-`107` must
+///   **not** transfer — `dnf`'s only documented `100` belongs to
+///   `check-update`, which no install or uninstall doer runs, so accepting it
+///   here would pass a genuinely failed transaction. `-1` is mtui's own "never
+///   produced a status" sentinel and gets its own reason, so a host mtui never
+///   reached is not reported as a package failure.
+/// * **No markers.** Three of [`markers`](super::update::markers)' four
+///   strings are zypper-only vocabulary, and the fourth (`Error:` on stderr)
+///   was written against zypper transcripts; the yum *update* check's doc
+///   records the same reasoning at length. Adding it here would be a new rule
+///   judging a transcript it was never written for.
+///
+/// "Unknown Error" is therefore an admission rather than a diagnosis: naming
+/// the failure would take observed `yum`/`dnf` output from a real RHEL refhost
+/// rather than inference. Unlike the *update* check — where a false failure
+/// fires the group-wide rollback downgrade — a failed install/uninstall verdict
+/// only fails the operation that was asked for, which is why judging the exit
+/// code at all is safe here.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "command timed out or failed to
+/// run" (exit `-1`) or "Unknown Error" (any other non-zero exit).
+fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    if args.exitcode != 0 {
+        log_failed(args);
+        return Err(UpdateError::new("Unknown Error", args.hostname));
+    }
+    Ok(Vec::new())
+}
+
 /// The install check for `(release, transactional)`, or `None` for an unknown
 /// key.
+///
+/// Shared with `uninstall` (see [`CheckProvider`](crate::update_workflow::CheckProvider)),
+/// so every reason here is worded role-neutrally.
 #[must_use]
 pub(crate) fn install_check(release: &str, transactional: bool) -> Option<CheckFn> {
     match (release, transactional) {
         ("11", false) | ("12", false) | ("15", false) | ("16", false) => Some(Box::new(zypper)),
+        ("YUM", false) => Some(Box::new(yum)),
+        ("slmicro", true) => Some(Box::new(transactional_update)),
         _ => None,
     }
 }
@@ -161,9 +248,185 @@ mod tests {
         assert_eq!(err.reason, "Unknown Error");
     }
 
+    /// Like [`args`] but with the command text spelled out, for the keys whose
+    /// transcript is not zypper's.
+    fn args_for<'a>(
+        stdin: &'a str,
+        stdout: &'a str,
+        stderr: &'a str,
+        exitcode: i32,
+    ) -> CheckArgs<'a> {
+        CheckArgs {
+            hostname: "h1",
+            stdout,
+            stdin,
+            stderr,
+            exitcode,
+        }
+    }
+
+    #[test]
+    fn slmicro_failed_exit_is_unknown_error() {
+        // Before this key had a check the adapter's fallback answered
+        // "install command failed" for every failure. The verdict must survive
+        // the move — a check that could not fail would be worse than the
+        // fallback it replaced.
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg install pkg-a",
+            "",
+            "",
+            1,
+        ))
+        .expect_err("a failed transactional install must fail the check");
+        assert_eq!(err.reason, "Unknown Error");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn slmicro_clean_exit_with_chatty_stderr_passes() {
+        // The unit-level twin of `perform_install_ignores_stderr_on_a_clean_
+        // exit`, which now routes through this check: `transactional-update`
+        // and `yum` write progress and warnings to stderr on a successful run,
+        // so no `!stderr.is_empty()` rule may exist here. This exact string is
+        // the one that flow test feeds.
+        assert!(
+            transactional_update(args_for(
+                "transactional-update -n pkg install pkg-a",
+                "",
+                "warning: chatty",
+                0,
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn slmicro_lock_message_on_a_clean_exit_is_stack_locked() {
+        // The markers must run on the *success* class too: a
+        // `transactional-update` that reported a locked stack and still exited
+        // `0` is the failure an exit-code rule cannot see. A short-circuit
+        // `if exitcode == 0 { return Ok(...) }` ahead of the classifier would
+        // silently pass it.
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg install pkg-a",
+            "",
+            "System management is locked",
+            0,
+        ))
+        .expect_err("a locked stack fails the install whatever the exit code");
+        assert_eq!(err.reason, "update stack locked");
+    }
+
+    #[test]
+    fn slmicro_timed_out_reason_is_its_own_not_updates() {
+        // Exact string, because this is what the local `-1` gate buys: without
+        // it the shared classifier's `NotRun` arm answers, in the *update*
+        // check's vocabulary ("update command timed out or failed to run"),
+        // on a table that also serves `uninstall`.
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg install pkg-a",
+            "",
+            "",
+            -1,
+        ))
+        .expect_err("a command that never ran must fail the check");
+        assert_eq!(err.reason, "command timed out or failed to run");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn yum_exit_code_is_the_whole_verdict() {
+        // (a) No markers: `Error:` is zypper vocabulary, and this key's
+        // transcript is not zypper's.
+        assert!(
+            yum(args_for(
+                "yum -y install pkg-a",
+                "",
+                "Error: Cannot retrieve repository metadata for repo 'x'",
+                0,
+            ))
+            .is_ok()
+        );
+        // (b) A failed transaction is still a failure.
+        let err = yum(args_for("yum -y install pkg-a", "", "", 1)).unwrap_err();
+        assert_eq!(err.reason, "Unknown Error");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        // (c) zypper's informational band does NOT transfer. `100` is
+        // "updates available" to zypper and an error to yum/dnf (whose only
+        // documented `100` belongs to `check-update`, which no install or
+        // uninstall doer runs), so routing this key through the shared
+        // classifier would pass a failed transaction.
+        for code in [100, 101, 102, 103, 106, 107] {
+            assert!(
+                yum(args_for("yum -y install pkg-a", "", "", code)).is_err(),
+                "zypper's informational exit {code} is not yum's"
+            );
+        }
+        // (d) And the never-ran sentinel keeps its own reason.
+        let err = yum(args_for("yum -y install pkg-a", "", "", -1)).unwrap_err();
+        assert_eq!(err.reason, "command timed out or failed to run");
+    }
+
     #[test]
     fn table_lookup() {
         assert!(install_check("15", false).is_some());
-        assert!(install_check("slmicro", true).is_none());
+        // Both keys that have an *installer* and an *uninstaller* but used to
+        // have no check: they fell back to the `PlanProvider` adapter's
+        // exit-code-only verdict, with no lock/dependency/RPM attribution and
+        // no distinct verdict for a command that never ran.
+        assert!(install_check("slmicro", true).is_some());
+        assert!(install_check("YUM", false).is_some());
+        // The key shape still matters — `slmicro` is only ever transactional,
+        // and no zypper release is.
+        assert!(install_check("slmicro", false).is_none());
+        assert!(install_check("15", true).is_none());
+        assert!(install_check("nonesuch", false).is_none());
+    }
+
+    #[test]
+    fn the_new_arms_resolve_to_their_own_check_not_a_sibling() {
+        // `is_some()` above pins that the arm exists, not *what* it binds to.
+        // Every behaviour test in this module calls the functions directly, and
+        // on exit `1` all three answer "Unknown Error" — so merging the arms
+        // onto one function would leave the suite green. Two transcripts
+        // separate all three here.
+        let yum_fn = install_check("YUM", false).expect("the YUM key has an install check");
+        // (a) A clean exit carrying a zypper lock marker: `yum` reads no
+        // markers and passes it; `transactional_update` fails it. This is the
+        // shape a successful `yum install` on a RHEL host can really produce.
+        assert!(
+            yum_fn(args_for(
+                "yum -y install pkg-a",
+                "",
+                "System management is locked",
+                0
+            ))
+            .is_ok(),
+            "the YUM arm must bind the marker-blind yum check"
+        );
+        // (b) Exit `100`: zypper's informational band is success to `zypper`
+        // and a failed transaction to yum/dnf, so this separates the YUM arm
+        // from the zypper one, which (a) cannot.
+        assert_eq!(
+            yum_fn(args_for("yum -y install pkg-a", "", "", 100))
+                .expect_err("zypper's informational band is not yum's")
+                .reason,
+            "Unknown Error"
+        );
+
+        // The same transcript on the slmicro arm must FAIL: `transactional_
+        // update` runs the markers on the success class too, while both `yum`
+        // (no markers) and `zypper` (exit `0` short-circuits ahead of them)
+        // pass it. One assertion separates that arm from both siblings.
+        let slmicro_fn =
+            install_check("slmicro", true).expect("the slmicro key has an install check");
+        let err = slmicro_fn(args_for(
+            "transactional-update -n pkg install pkg-a",
+            "",
+            "System management is locked",
+            0,
+        ))
+        .expect_err("the slmicro arm must bind the marker-reading check");
+        assert_eq!(err.reason, "update stack locked");
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/mod.rs
@@ -10,12 +10,18 @@
 //! contract callers match on.
 //!
 //! A diagnostic breadcrumb is logged via `tracing` before each raised error.
-//! `update`'s check additionally *prints* two recognised-but-non-fatal
-//! diagnostic sections to stdout (one with the word `warning` highlighted
-//! yellow). To reproduce that stdout parity without a crate cycle, a check
-//! returns those sections as [`Diagnostic`]s on the `Ok` path; the command
-//! layer (`mtui-core::commands::perform`) drains and renders them through
-//! `session.display`, where the color mode lives.
+//! `update`'s check is the only one whose *diagnostic sections* are surfaced
+//! to the operator's terminal: it recognises two non-fatal stdout sections and
+//! returns them as [`Diagnostic`]s on the `Ok` path (one with the word
+//! `warning` highlighted yellow), which the command layer
+//! (`mtui-core::commands::perform`) drains and renders through
+//! `session.display`, where the color mode lives — stdout parity without a
+//! crate cycle.
+//!
+//! The prepare and install `("slmicro", true)` checks reuse `update`'s shared
+//! marker classification, so they can return those sections too; neither
+//! caller renders them (`prepare_body` discards its sink, and the
+//! `PlanProvider` adapter info-logs them), which is why only `update` prints.
 
 pub(crate) mod downgrade;
 pub(crate) mod install;

--- a/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
@@ -43,7 +43,14 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 ///
 /// * **`-1`**, mtui's own "timed out / connection lost / not connected"
 ///   sentinel: a prepare that never ran to completion is not a successful
-///   prepare, and its transcript is empty, so no marker would catch it.
+///   prepare, and its transcript is empty, so no marker would catch it. It is
+///   worth a verdict even though `host_command_failures` also reports the
+///   host — for a *different* fact. "prepare command failed" says the command
+///   ran and returned a failure; on `-1` it did neither, and the operator's
+///   next step (go and see whether the host is alive) differs accordingly.
+///   Both rules firing on the one signal would name the host twice, which
+///   `prepare_body` resolves by dropping its own coarser entry for a host this
+///   check has named — so the sharper reason survives *and* stays attributed.
 /// * **The shared stdout/stderr [`markers`](super::update::markers)**, which
 ///   close the hole this check exists for: `transactional-update` can report a
 ///   locked update stack, a dependency prompt or an RPM error and still exit
@@ -53,12 +60,14 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 ///
 /// **No bare non-zero-exit arm, on purpose.** `prepare_body` already owns exit
 /// codes: `note_dispatch` feeds them to the reboot gate and
-/// `host_command_failures` reports them. A second verdict on the same signal
-/// would name the host twice, pushing `aggregate_failures` out of its
-/// single-failure verbatim branch into the summary — where `host` becomes
-/// `None`, which `perform_prepare_skips_the_reboot_of_a_host_whose_prepare_
-/// failed` pins. Adding the arm is not "completing" the check; it duplicates a
-/// verdict the flow already renders.
+/// `host_command_failures` reports them, accurately — the prepare templates are
+/// a single command, so a non-zero status *is* the prepare's own, and "prepare
+/// command failed" is exactly what happened. An arm here could only reword that
+/// (this key's `transactional-update` returns just `0` or `1`, so there is no
+/// status to classify), while changing the reason string
+/// `perform_prepare_skips_the_reboot_of_a_host_whose_prepare_failed` pins.
+/// Adding it is not "completing" the check; it restates a verdict the flow
+/// already renders.
 ///
 /// The `Error:`-from-a-sibling-command caveat the markers carry on the update
 /// template does not arise here: a prepare command is a single
@@ -259,13 +268,15 @@ mod tests {
 
     #[test]
     fn slmicro_prepare_does_not_judge_a_bare_non_zero_exit() {
-        // Exit codes are `prepare_body`'s to report (`note_dispatch` gates the
-        // reboot on them, `host_command_failures` names the host). A verdict
-        // here would name the same host a second time, pushing
-        // `aggregate_failures` into its summary branch — where `host` is
-        // `None`, which `perform_prepare_skips_the_reboot_of_a_host_whose_
-        // prepare_failed` asserts against. So a clean transcript with a failing
-        // status passes *this* check while the flow still fails the host.
+        // Exit codes are `prepare_body`'s to report, and it reports them
+        // accurately: `note_dispatch` gates the reboot on them and
+        // `host_command_failures` names the host "prepare command failed",
+        // which is precisely what a non-zero status from this single-command
+        // template means. A verdict here could only reword that — and would
+        // change the reason string
+        // `perform_prepare_skips_the_reboot_of_a_host_whose_prepare_failed`
+        // pins. So a clean transcript with a failing status passes *this*
+        // check while the flow still fails the host.
         assert!(
             transactional_update(args_for(
                 "transactional-update -n pkg in -l  pkg-a",

--- a/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
@@ -37,12 +37,93 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     Ok(Vec::new())
 }
 
+/// The transactional-update (`slmicro`) prepare check.
+///
+/// Two rules, and the *absence* of a third is the load-bearing part.
+///
+/// * **`-1`**, mtui's own "timed out / connection lost / not connected"
+///   sentinel: a prepare that never ran to completion is not a successful
+///   prepare, and its transcript is empty, so no marker would catch it.
+/// * **The shared stdout/stderr [`markers`](super::update::markers)**, which
+///   close the hole this check exists for: `transactional-update` can report a
+///   locked update stack, a dependency prompt or an RPM error and still exit
+///   `0`. Nothing else in `prepare_body` can see that — the reboot gate reads
+///   exit codes and check verdicts, and deliberately not stderr — so before
+///   this check the host rebooted straight into the failed transaction.
+///
+/// **No bare non-zero-exit arm, on purpose.** `prepare_body` already owns exit
+/// codes: `note_dispatch` feeds them to the reboot gate and
+/// `host_command_failures` reports them. A second verdict on the same signal
+/// would name the host twice, pushing `aggregate_failures` out of its
+/// single-failure verbatim branch into the summary — where `host` becomes
+/// `None`, which `perform_prepare_skips_the_reboot_of_a_host_whose_prepare_
+/// failed` pins. Adding the arm is not "completing" the check; it duplicates a
+/// verdict the flow already renders.
+///
+/// The `Error:`-from-a-sibling-command caveat the markers carry on the update
+/// template does not arise here: a prepare command is a single
+/// `transactional-update` invocation, so the whole transcript is the command
+/// being judged.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "prepare command timed out or
+/// failed to run" (exit `-1`), "update stack locked", "Dependency Error", or
+/// "RPM Error".
+fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "prepare command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    super::update::markers(args)
+}
+
+/// The yum prepare check.
+///
+/// Gates **only** on the `-1` sentinel — a command that never ran to
+/// completion is not a successful prepare — and claims nothing else.
+///
+/// Both richer signals are ruled out here, and by different arguments than on
+/// the sibling install check:
+///
+/// * **The exit code**, which the install check *does* read, cannot be read on
+///   this role. `prepare --installed-only` renders
+///   `rpm -q $package &>/dev/null && yum … install $package`
+///   ([`crate::update_workflow::actions::prepare`]), and that template exits
+///   `1` on the routine "the host does not carry this package" skip — the case
+///   `--installed-only` exists to serve — indistinguishably from a `yum` that
+///   failed. (The zypper and slmicro forms use `if …; then …; fi`, which exits
+///   `0` on the same skip, which is why they are not exposed to this.)
+/// * **The markers**, for the reason the yum *update* check records: three of
+///   the four strings are zypper-only vocabulary and the fourth was written
+///   against zypper transcripts.
+///
+/// # Errors
+///
+/// Returns [`UpdateError`] with a reason of "prepare command timed out or
+/// failed to run" when the command recorded exit `-1`.
+fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+    if args.exitcode == -1 {
+        log_failed(args);
+        return Err(UpdateError::new(
+            "prepare command timed out or failed to run",
+            args.hostname,
+        ));
+    }
+    Ok(Vec::new())
+}
+
 /// The prepare check for `(release, transactional)`, or `None` for an unknown
 /// key.
 #[must_use]
 pub(crate) fn prepare_check(release: &str, transactional: bool) -> Option<CheckFn> {
     match (release, transactional) {
         ("11", false) | ("12", false) | ("15", false) | ("16", false) => Some(Box::new(zypper)),
+        ("YUM", false) => Some(Box::new(yum)),
+        ("slmicro", true) => Some(Box::new(transactional_update)),
         _ => None,
     }
 }
@@ -59,6 +140,38 @@ mod tests {
             stderr,
             exitcode: 0,
         }
+    }
+
+    /// Like [`args`] but with the command text and the exit code spelled out,
+    /// for the keys whose verdict depends on either.
+    fn args_for<'a>(
+        stdin: &'a str,
+        stdout: &'a str,
+        stderr: &'a str,
+        exitcode: i32,
+    ) -> CheckArgs<'a> {
+        CheckArgs {
+            hostname: "h1",
+            stdout,
+            stdin,
+            stderr,
+            exitcode,
+        }
+    }
+
+    /// The rendered `("YUM", false)` prepare templates, so the tests judge the
+    /// command the flow really sends rather than a hand-written approximation.
+    fn yum_templates() -> (String, String) {
+        use std::collections::HashMap;
+        let cmds = crate::update_workflow::actions::prepare::preparer("YUM", false, false, false)
+            .expect("the YUM key has a preparer");
+        let vars: HashMap<&str, &str> = [("package", "pkg-a")].into_iter().collect();
+        (
+            cmds.render_command(&vars).expect("renders"),
+            cmds.render_installed_only(&vars)
+                .expect("renders")
+                .expect("the YUM key has an installed-only variant"),
+        )
     }
 
     #[test]
@@ -91,8 +204,190 @@ mod tests {
     }
 
     #[test]
+    fn slmicro_lock_message_on_a_clean_exit_is_stack_locked() {
+        // The exact hole #406 names. `transactional-update` exited `0` and
+        // still reported a locked update stack, so neither the exit-code rule
+        // in `note_dispatch` nor `host_command_failures`' stderr rule (which
+        // the reboot gate deliberately ignores) can see it — only the markers.
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg in -l  pkg-a",
+            "",
+            "System management is locked",
+            0,
+        ))
+        .expect_err("a locked stack must fail the check whatever the exit code");
+        assert_eq!(err.reason, "update stack locked");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+
+        // The other two markers reach it on a clean exit too.
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg in -l  pkg-a",
+            "choose (c): c",
+            "",
+            0,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "Dependency Error");
+        let err = transactional_update(args_for(
+            "transactional-update -n pkg in -l  pkg-a",
+            "",
+            "Error: boom",
+            0,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "RPM Error");
+    }
+
+    #[test]
+    fn slmicro_clean_exit_with_progress_on_stderr_passes() {
+        // The hard constraint on this whole fix: no `!stderr.is_empty()` rule.
+        // `transactional-update` writes progress and warnings to stderr on a
+        // successful run, and this is the exact string
+        // `perform_prepare_still_reboots_a_host_that_only_wrote_to_stderr`
+        // feeds the flow — a check that failed here would strand the healthy
+        // staged snapshot by skipping its reboot.
+        assert!(
+            transactional_update(args_for(
+                "transactional-update -n pkg in -l  pkg-a",
+                "",
+                "1 issue found. see the log",
+                0,
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn slmicro_prepare_does_not_judge_a_bare_non_zero_exit() {
+        // Exit codes are `prepare_body`'s to report (`note_dispatch` gates the
+        // reboot on them, `host_command_failures` names the host). A verdict
+        // here would name the same host a second time, pushing
+        // `aggregate_failures` into its summary branch — where `host` is
+        // `None`, which `perform_prepare_skips_the_reboot_of_a_host_whose_
+        // prepare_failed` asserts against. So a clean transcript with a failing
+        // status passes *this* check while the flow still fails the host.
+        assert!(
+            transactional_update(args_for(
+                "transactional-update -n pkg in -l  pkg-a",
+                "",
+                "",
+                1,
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn timed_out_prepare_raises_on_both_new_keys() {
+        // `-1` is `Target::run`'s catch-all for "timed out", "connection failed
+        // mid-command" and "not connected". The transcript is empty, so with
+        // the gate removed the slmicro key's markers match nothing and the YUM
+        // key has no other rule at all — both would report a prepare that never
+        // ran as a success.
+        for (name, check) in [
+            ("slmicro", prepare_check("slmicro", true).unwrap()),
+            ("yum", prepare_check("YUM", false).unwrap()),
+        ] {
+            let Err(err) = check(args_for("some prepare command", "", "", -1)) else {
+                panic!("{name} must fail on exit -1");
+            };
+            assert_eq!(
+                err.reason, "prepare command timed out or failed to run",
+                "{name}"
+            );
+            assert_eq!(err.host.as_deref(), Some("h1"), "{name}");
+        }
+    }
+
+    #[test]
+    fn yum_prepare_judges_only_whether_the_command_ran() {
+        let (plain, installed_only) = yum_templates();
+        // The rendered installed-only template is `rpm -q pkg &>/dev/null &&
+        // yum … install pkg`, which exits `1` on the routine "not installed
+        // here" skip — the case the flag exists for. A bare non-zero rule would
+        // fail every host that legitimately skipped a package.
+        assert!(
+            installed_only.starts_with("rpm -q pkg-a &>/dev/null &&"),
+            "the reason the exit code is unreadable here: {installed_only}"
+        );
+        assert!(yum(args_for(&installed_only, "", "", 1)).is_ok());
+        // And no marker copying: `Error:` is zypper vocabulary, while `yum`
+        // prints its own errors in a transcript these strings were never
+        // written against.
+        assert!(
+            yum(args_for(
+                &plain,
+                "",
+                "Error: Cannot retrieve repository metadata for repo 'x'",
+                1,
+            ))
+            .is_ok()
+        );
+        // Nor are zypper's exit-code classes transferable: `104` is
+        // `ZYPPER_EXIT_INF_CAP_NOT_FOUND`, which means nothing to yum. Reusing
+        // the shared classifier here would fail this host.
+        assert!(yum(args_for(&plain, "", "", 104)).is_ok());
+
+        // What it does catch: the command never ran to completion.
+        let err = yum(args_for(&plain, "", "", -1)).unwrap_err();
+        assert_eq!(err.reason, "prepare command timed out or failed to run");
+    }
+
+    #[test]
     fn table_lookup() {
         assert!(prepare_check("11", false).is_some());
-        assert!(prepare_check("YUM", false).is_none());
+        // Both keys that have a *preparer* but used to have no check at all.
+        // `run_checks` skipped them via its `else { continue }`, so a prepare
+        // on an SL Micro or RHEL host contributed no verdict — and on the
+        // transactional key the reboot gate is fed by check verdicts, so a
+        // prepare that failed with exit `0` rebooted into the failed
+        // transaction.
+        assert!(prepare_check("YUM", false).is_some());
+        assert!(prepare_check("slmicro", true).is_some());
+        // The key shape still matters — `slmicro` is only ever transactional,
+        // and no zypper release is.
+        assert!(prepare_check("slmicro", false).is_none());
+        assert!(prepare_check("15", true).is_none());
+        assert!(prepare_check("nonesuch", false).is_none());
+    }
+
+    #[test]
+    fn the_new_arms_resolve_to_their_own_check_not_a_sibling() {
+        // `is_some()` above pins that the arm exists, not *what* it binds to —
+        // so merging the two new arms onto one function would keep the whole
+        // suite green (every behaviour test below calls the functions
+        // directly, and both answer identically on `-1`). A clean exit
+        // carrying a zypper lock marker is the discriminator that separates
+        // all three functions on this table.
+
+        // YUM reads no markers: this transcript passes. `zypper` and
+        // `transactional_update` both fail it with "update stack locked", so
+        // binding either here would fail a RHEL host whose successful `yum`
+        // run merely printed the string.
+        let yum_fn = prepare_check("YUM", false).expect("the YUM key has a prepare check");
+        assert!(
+            yum_fn(args_for(
+                "yum -y install pkg-a",
+                "",
+                "System management is locked",
+                0
+            ))
+            .is_ok(),
+            "the YUM arm must bind the marker-blind yum check"
+        );
+
+        // slmicro reads them: the same transcript fails. That rules out `yum`;
+        // `timed_out_prepare_raises_on_both_new_keys` rules out `zypper`,
+        // which has no `-1` gate.
+        let slmicro_fn =
+            prepare_check("slmicro", true).expect("the slmicro key has a prepare check");
+        let err = slmicro_fn(args_for(
+            "transactional-update -n pkg in -l  pkg-a",
+            "",
+            "System management is locked",
+            0,
+        ))
+        .expect_err("the slmicro arm must bind the marker-reading check");
+        assert_eq!(err.reason, "update stack locked");
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -149,6 +149,13 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// Applies [`classify_exit`] to a patch status, interleaved with the
 /// stdout/stderr [`markers`].
 ///
+/// Also the install/uninstall check's `("slmicro", true)` verdict
+/// ([`super::install`]), which reuses it rather than restating "`0` passes,
+/// anything else fails" so the two `transactional-update` keys cannot drift
+/// apart. That caller gates `-1` itself — with its own role-neutral reason —
+/// before reaching here, so the [`ExitClass::NotRun`] arm's `update` wording
+/// never surfaces on it.
+///
 /// The interleaving is the whole content of this function: `104` is a named
 /// verdict and returns straight away, while every other failing status lets the
 /// markers speak first, because "update stack locked" is a diagnosis and
@@ -189,7 +196,7 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// locked", "Dependency Error", "RPM Error", "Unknown Error", or — only if a
 /// caller reaches here without its [`not_run`] gate — "update command timed out
 /// or failed to run".
-fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+pub(super) fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     match classify_exit(args.exitcode) {
         ExitClass::Success => markers(args),
         ExitClass::PackageNotFound if args.exitcode == 104 => {
@@ -360,11 +367,18 @@ fn probe_failure(args: CheckArgs<'_>) -> Result<(), UpdateError> {
 /// (see [`transactional_update`]); everything here reads only the command's
 /// output and so is valid on all of them.
 ///
+/// Also the `("slmicro", true)` *prepare* check's whole verdict beyond its `-1`
+/// gate ([`super::prepare`]), where it closes the exit-`0`-with-a-lock-message
+/// hole the prepare reboot gate could not see. The `Error:`-from-a-sibling-
+/// command exposure documented on [`transactional_update`] does not arise
+/// there: the prepare and install templates are a *single* command, so the
+/// whole transcript belongs to the command being judged.
+///
 /// # Errors
 ///
 /// Returns [`UpdateError`] with a reason of "update stack locked",
 /// "Dependency Error", or "RPM Error".
-fn markers(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
+pub(super) fn markers(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     let mut diagnostics = Vec::new();
     if let Some(section) = extract_between(args.stdout, "Additional rpm output:", "Retrieving") {
         // Logs a breadcrumb, then prints the section with "warning"

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -49,7 +49,10 @@ pub(crate) type WorkflowKey = (String, bool);
 /// present, otherwise just `"{reason}"`. The `reason` strings are diagnoses
 /// shown to an operator and asserted on by tests ("package not found", "update
 /// stack locked", "RPM Error", "Dependency Error", "could not determine what to
-/// patch", "Unknown Error", "Unspecified Error"); no code branches on them, so
+/// patch", "Unknown Error", "Unspecified Error", and the per-role never-ran
+/// verdicts "update/downgrade/prepare command timed out or failed to run" plus
+/// install/uninstall's role-neutral "command timed out or failed to run"); no
+/// code branches on them, so
 /// a check is free to pick the most accurate one for a given transcript. What
 /// *is* a contract is the `UpdateFailure` variant a failure routes to, which
 /// decides whether the group is rolled back — which is why the probe failure
@@ -373,15 +376,18 @@ impl mtui_hosts::PlanProvider for WorkflowRegistry {
                     Err(e) => Err(e.reason),
                 }
             }
-            // No *install/uninstall* check table for this key (`slmicro`,
-            // `YUM`): fall back to the exit code alone, exactly as
-            // `install_verdict` used to. Not "any stderr is a failure" —
-            // `transactional-update` and `yum` both write progress and
-            // warnings to stderr on a successful run.
+            // Defensive only: every key with an installer or uninstaller now
+            // has an install-table check (#406 registered the last two,
+            // `slmicro` and `YUM`), so no real key reaches here. It stays for
+            // the window in which a doer is added before its check — falling
+            // back to the exit code alone, which is what this arm has always
+            // done. Never "any stderr is a failure": `transactional-update`
+            // and `yum` both write progress and warnings to stderr on a
+            // successful run.
             //
-            // Only this adapter is meant: `update` does now have checks for
-            // both keys, but it resolves them through `CheckProvider`, not
-            // here.
+            // Unreachable in production means untested by the flows, so
+            // `plan_provider_check_falls_back_to_the_exit_code_for_an_unknown_key`
+            // drives it directly.
             None if a.exitcode != 0 => Err(format!("{op} command failed")),
             None => Ok(()),
         })
@@ -534,6 +540,29 @@ mod tests {
         assert!(reg.check(Role::Update, "YUM", false).is_some());
     }
 
+    #[test]
+    fn registry_resolves_the_prepare_and_install_checks_that_used_to_be_missing() {
+        // The sibling holes to the `update` ones above (#406). Both keys have
+        // had a preparer, an installer and an uninstaller since the port but no
+        // check for any of the three: `prepare` skipped the host in
+        // `run_checks`, while `install`/`uninstall` fell through to the
+        // `PlanProvider` adapter's exit-code-only fallback.
+        //
+        // Resolved through the registry, not the tables, because that is the
+        // path `run_checks` and the adapter actually take — and `Uninstall`
+        // is listed explicitly because it reaches the *install* table through
+        // this match, which a role-blind rewrite would silently break.
+        let reg = WorkflowRegistry::default();
+        for (release, transactional) in [("slmicro", true), ("YUM", false)] {
+            for role in [Role::Prepare, Role::Install, Role::Uninstall] {
+                assert!(
+                    reg.check(role, release, transactional).is_some(),
+                    "{role:?} @ ({release}, {transactional}) must resolve a check"
+                );
+            }
+        }
+    }
+
     // --- the mtui-hosts PlanProvider adapter --------------------------------
 
     #[test]
@@ -567,6 +596,42 @@ mod tests {
             format!("{uninstall:?}"),
             "installer and uninstaller must not resolve to the same doer"
         );
+    }
+
+    #[test]
+    fn plan_provider_check_falls_back_to_the_exit_code_for_an_unknown_key() {
+        use mtui_hosts::PlanProvider;
+
+        // Since #406 every key with an install/uninstall doer also has a
+        // check, so no production key reaches the adapter's `None` arms. They
+        // stay as the safety net for a doer added before its check — and a
+        // safety net nothing exercises is one nobody notices breaking, hence
+        // this direct drive.
+        let reg = WorkflowRegistry::default();
+        let mut check = PlanProvider::check(&reg, "installer", "nonesuch", false);
+        let args = |exitcode| mtui_hosts::CheckArgs {
+            hostname: "h1",
+            stdout: "",
+            stdin: "some install command",
+            stderr: "",
+            exitcode,
+        };
+        assert_eq!(
+            check(args(1)).unwrap_err(),
+            "install command failed",
+            "a non-zero exit with no check table must still fail"
+        );
+        assert!(check(args(0)).is_ok(), "a clean exit passes");
+        // Not "any stderr is a failure": that rule would fail every SL Micro
+        // install, which is why it is spelled out here as well as in the flow.
+        let chatty = mtui_hosts::CheckArgs {
+            hostname: "h1",
+            stdout: "",
+            stdin: "some install command",
+            stderr: "warning: chatty",
+            exitcode: 0,
+        };
+        assert!(check(chatty).is_ok(), "stderr alone is not a failure");
     }
 
     #[test]


### PR DESCRIPTION
Closes #406.

## The bug

`("slmicro", true)` and `("YUM", false)` have had a preparer, an installer and an uninstaller since the port — and `("YUM", false)` a downgrader too — but no post-run check for any of those roles. Both check modules' own `table_lookup` tests asserted that hole rather than flagging it.

The consequences differ by path:

- **`prepare`** resolves its check through `run_checks`, which silently `continue`s when the table answers `None`, so such a host contributed no attributed verdict at all. Worse, the per-host reboot gate's skip set is seeded from check verdicts — so a `transactional-update` that reported `System management is locked` **and still exited `0`** was invisible to every rule the flow had. The exit-code rule sees `0`; the stderr rule is deliberately excluded from the gate, because `transactional-update` writes progress to stderr on a *successful* run and skipping such a host's reboot would strand a healthy staged snapshot. The host rebooted straight into the locked transaction while the flow reported success.
- **`install`/`uninstall`** fell through to the `PlanProvider` adapter's exit-code-only fallback, which answered `"install command failed"` for a locked update stack, a failed RPM transaction and a command that never ran alike.
- **`downgrade`** on the YUM key was the last role with a rollback command and no check: a `yum -y downgrade` that never ran to completion left the host on the update version while the flow ended looking done.

## The fix

Two commits; the second is independent and droppable.

**1. `fix(testreport): give prepare/install/uninstall a verdict on slmicro and YUM`**

New check functions for both keys in `checks/prepare.rs` and `checks/install.rs` (the install table also serves `uninstall`), registered in the two tables.

On the transactional key both new checks reuse `checks::update`'s shared classification — `markers` for prepare, `classified` for install/uninstall — rather than restating it, so the two `transactional-update` keys cannot drift apart; those two helpers become `pub(super)` for it. The `Error:`-from-a-sibling-command caveat the markers carry on the update *template* does not arise here: a prepare or install command is a single invocation, so the whole transcript belongs to the command being judged.

The prepare verdict is now taken after **every** fan-out rather than once at the end, which is what makes the reboot gate complete on the `--installed-only` path. `run_checks` reads the same `last*` snapshot `note_dispatch` does, so a single post-loop call judged only the last package — very often a clean no-op `rpm -q` skip — and an exit-`0` lock message on an earlier package was overwritten by it. `note_check` is `note_dispatch`'s companion: same call sites, scoped to that fan-out's own hosts, first-failure-wins per host. Same shape the downgrade loop already uses.

`aggregate_failures` also names each host once. A single host legitimately contributes two failures here (the stderr scan and the check that recognised the marker), which rendered as `prepare failed on h1, h1`; the detail list still carries both causes.

**2. `fix(testreport): give downgrade a verdict on the YUM key`**

The same narrow `-1`-only gate the transactional downgrade check carries, for the same reason: a non-zero status is a routine outcome on a refhost carrying only part of the update's package list, but a command mtui never got a status from is not a completed rollback.

## Judgement calls, argued

- **The YUM verdict is deliberately narrower than zypper's, and asymmetric between roles.** `install`/`uninstall` read the exit code; `prepare` reads only the `-1` sentinel. That is not an oversight: `prepare --installed-only` renders `rpm -q $package &>/dev/null && yum … install $package`, which exits `1` on the routine "this host does not carry the package" skip — the case the flag exists to serve — indistinguishably from a `yum` that failed. The zypper and slmicro preparers use `if …; then …; fi`, which exits `0` on the same skip, which is why they are not exposed to this.
- **zypper's informational band is not transferred to `yum`/`dnf`.** `100`–`107` are zypper's vocabulary; `dnf`'s only documented `100` belongs to `check-update`, which no doer runs, so accepting it would pass a genuinely failed transaction. Pinned in both directions.
- **No markers on the YUM key.** Three of the four marker strings are zypper-only vocabulary and the fourth (`Error:` on stderr) was written against zypper transcripts. A successful `yum install` that printed `Error:` must not fail. `"Unknown Error"` on the YUM install key is therefore an admission, not a diagnosis — naming the failure needs observed `yum`/`dnf` output from a real RHEL refhost, not inference.
- **No `!stderr.is_empty()` rule anywhere.** Both package managers write progress to stderr on a successful run. This is the issue's own hard constraint and it is pinned in both directions (a marker-carrying stderr fails; a progress-carrying stderr passes and still reboots).
- **No bare non-zero-exit arm in the slmicro *prepare* check.** `prepare_body` already owns exit codes: `note_dispatch` feeds them to the reboot gate and `host_command_failures` reports them. A second verdict on the same signal would name the host twice and push `aggregate_failures` out of its single-failure verbatim branch, where `host` survives. Adding the arm is not "completing" the check; it duplicates a verdict the flow already renders.
- **Scoping `note_check` to the fan-out's hosts changes one adjacent behaviour, on purpose.** A host outside the fan-out is no longer judged at all, where the post-loop call would have judged whatever its `last*` still held — for an empty package list, the `set_repo` transcript. Inventing a prepare verdict from another phase's record is worse than abstaining, and hosts no command was built for are already failed by name (#396).
- **The adapter's `None` fallback is now unreachable through any real key, and stays.** It is the safety net for a doer added before its check, and it gained direct unit coverage so it cannot silently rot.
- **Reason strings an operator or MCP client sees change.** The typed failure a check routes to — which is what decides whether a group is rolled back — is unchanged, and nothing in `mtui-mcp` matches on the old strings. Called out in the CHANGELOG.

## Testing

`mtui-testreport` lib goes 313 → 317; full workspace 2504 passed / 0 failed across 37 suites, `-F mcp` 286 / 0 across 4. fmt, clippy `-D warnings`, rustdoc `-D warnings`, both feature-matrix builds and `typos` all clean.

Every new assertion was hand-broken and observed RED, not assumed:

- **`perform_prepare_judges_the_markers_of_every_package_not_just_the_last`** — deleted the in-loop `note_check` call (exactly the pre-fix shape). RED with `h1's pkg-a hit a locked stack; it must not reboot into it: ["systemctl reboot"]`, i.e. the host really did reboot into the locked transaction. The reboot assert is placed *before* the reason assert so the reboot claim owns the red. Attribution holds because every command in that fixture exits `0` with empty stderr except pkg-a's, so the check verdict is the only mechanism that can seed the reboot gate — the `with_default` trap from previous sessions is defused by giving one command its own response. Clean h2 in the same group must still reboot, so an empty `fired` list cannot fake the pass.
- **`the_new_arms_resolve_to_their_own_check_not_a_sibling`** (prepare + install) — applied the substitution the review named, `("YUM", false) | ("slmicro", true) => Some(Box::new(transactional_update))`, in both files. 70 passed / 2 failed: only the two new tests caught it, confirming that `is_some()` plus direct-call behaviour tests could not.
- **`aggregate_failures_names_each_host_once`** — removed `hosts.dedup()`. RED with the literal `prepare failed on h1, h1 (h1: prepare command failed; h1: update stack locked)`.
- The pre-existing `--installed-only` exit-code test and both stderr-direction flow tests still pass unchanged, so the new in-loop placement did not quietly re-open the half that was already closed.

## Known limitations

- **The slmicro *downgrade* check is still marker-blind.** An exit-`0` `transactional-update … --oldpackage` that reported a locked stack still reboots on the rollback path. The exit gating there is deliberate (a non-zero downgrade status is routine on a refhost carrying part of the package list), but the marker half is the same hole this PR closed for `prepare` and deserves its own issue — possibly folded into the #451 rollback-path work. Deliberately out of scope here.
- **The YUM `--installed-only` template still exits `1` on the routine skip.** The check correctly abstains, but `host_command_failures`' exit-code scan at flow level still reports that host, so a RHEL host legitimately skipping a package can fail the prepare. The fix is in the template (use the `if …; then …; fi` shape the other two families use), not in the check; separate issue.
- `"Unknown Error"` on the YUM install/uninstall key names nothing useful. Improving it needs a real transcript from an RHEL refhost.
- Coverage of the new code is by unit + flow tests only; no live SL Micro or RHEL host was involved, so the transcripts are the templates the flow really renders plus documented marker strings — not captured output.
