### PR TITLE
fix(core): let a body-level cancel be the fan-out's verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,10 +346,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   it had applied — instead of `fan-out failed on ...` with the cancel listed as
   a template failure (#404). A real template failure collected before the
   cancel still outranks it and is still reported as the fan-out aggregate, now
-  without the cancel entry padding the failure list; and the `stopped after N
-  of M templates` count now reports templates actually completed instead of
-  counting never-attempted ones as done — as does the `succeeded` log line,
-  which no longer names templates the stop never reached.
+  without the cancel entry padding the failure list — but the stop is no longer
+  dropped from that aggregate either: it is appended to the message
+  (`fan-out failed on A (A: boom); stopped after 0 of 3 templates; B: <what the
+  interrupted flow had done>`), so a caller is no longer left believing the
+  templates the stop never reached ran clean. The `stopped after N of M
+  templates` count now reports templates actually completed instead of counting
+  never-attempted ones as done — as does the `succeeded` log line, which no
+  longer names templates the stop never reached.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   non-determinism: `request_review --watch` used to arm the process-wide SIGINT
   handler as a side effect, after which Ctrl-C was silently swallowed for the
   rest of the session.
+- A cancel (MCP `job_cancel`, REPL Ctrl-C) that lands inside a command body
+  during a multi-template fan-out is again reported as `cancelled: stopped
+  after N of M templates` — carrying the interrupted flow's own detail of what
+  it had applied — instead of `fan-out failed on ...` with the cancel listed as
+  a template failure (#404). A real template failure collected before the
+  cancel still outranks it and is still reported as the fan-out aggregate, now
+  without the cancel entry padding the failure list; and the `stopped after N
+  of M templates` count now reports templates actually completed instead of
+  counting never-attempted ones as done — as does the `succeeded` log line,
+  which no longer names templates the stop never reached.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "wiremock",
 ]

--- a/crates/mtui-core/Cargo.toml
+++ b/crates/mtui-core/Cargo.toml
@@ -51,3 +51,7 @@ serial_test.workspace = true
 tempfile = "3"
 wiremock.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+# Captures the fan-out driver's `succeeded` summary field, so the list of
+# templates it names is asserted rather than assumed
+# (`commands::cancellation_seam::succeeded_log`).
+tracing-subscriber.workspace = true

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -155,7 +155,10 @@ pub trait Command: Send + Sync {
     /// boundary and keeping the flow's detail — rather than collecting it as a
     /// template failure. A real failure banked before the cancel still
     /// outranks it and is still reported as the [`CommandError::FanOut`]
-    /// aggregate.
+    /// aggregate; the stop then rides along as that aggregate's `stop` note
+    /// (`stopped after N of M templates`, plus the interrupted flow's detail),
+    /// so it neither pads the failure list nor leaves the templates the break
+    /// never reached looking as though they ran clean.
     async fn run(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
         session.check_cancelled()?;
         let resolved = resolve_templates(self.scope(), session, args)?;
@@ -247,23 +250,33 @@ pub trait Command: Send + Sync {
         }
 
         restore_active(session, restore);
+        // How far the fan-out got, in one shape for both verdicts: it is the
+        // `Cancelled` payload when the stop *is* the verdict, and the `FanOut`
+        // aggregate's `stop` note when a real failure outranks it. The cancel
+        // never becomes a failure entry — it is not a broken template — but a
+        // caller told only "template X failed" would otherwise read the
+        // templates the break never reached as having run clean.
+        let stop_summary = || {
+            let mut msg = format!(
+                "stopped after {} of {} templates",
+                completed.len(),
+                resolved.len()
+            );
+            if let Some((rrid, detail)) = &body_stop
+                && !detail.is_empty()
+            {
+                msg.push_str(&format!("; {rrid}: {detail}"));
+            }
+            msg
+        };
+
         if cancelled && failures.is_empty() {
             // Report the stop — but only when nothing actually failed. A real
             // per-template failure outranks it and falls through to the
             // `FanOut` aggregate below: burying a broken template behind a
             // bare "cancelled" is the one thing the caller must not be told.
             tracing::info!(command = self.name(), "fan-out cancelled");
-            let mut msg = format!(
-                "stopped after {} of {} templates",
-                completed.len(),
-                resolved.len()
-            );
-            if let Some((rrid, detail)) = body_stop
-                && !detail.is_empty()
-            {
-                msg.push_str(&format!("; {rrid}: {detail}"));
-            }
-            return Err(CommandError::Cancelled(msg));
+            return Err(CommandError::Cancelled(stop_summary()));
         }
 
         if !completed.is_empty() {
@@ -273,7 +286,10 @@ pub trait Command: Send + Sync {
             tracing::info!(command = self.name(), skipped = %skipped.join(", "), "no connected host");
         }
         if !failures.is_empty() {
-            return Err(CommandError::FanOut(failures));
+            return Err(CommandError::FanOut {
+                failures,
+                stop: cancelled.then(stop_summary),
+            });
         }
         if !skipped.is_empty() && completed.is_empty() {
             // Every resolved template was skipped: the command executed on

--- a/crates/mtui-core/src/command.rs
+++ b/crates/mtui-core/src/command.rs
@@ -149,7 +149,13 @@ pub trait Command: Send + Sync {
     /// multi-template job stops at the next template boundary instead of
     /// grinding through the rest. A cancel arriving *mid*-`call` is only
     /// observed if the body opts in ([`Session::cancel_requested`]); otherwise
-    /// the MCP job layer hard-aborts after its grace period.
+    /// the MCP job layer hard-aborts after its grace period. A body that does
+    /// opt in reports its stop as [`CommandError::Cancelled`], and the driver
+    /// treats that variant as the cancel itself — breaking at the template
+    /// boundary and keeping the flow's detail — rather than collecting it as a
+    /// template failure. A real failure banked before the cancel still
+    /// outranks it and is still reported as the [`CommandError::FanOut`]
+    /// aggregate.
     async fn run(&self, session: &mut Session, args: &ArgMatches) -> CommandResult {
         session.check_cancelled()?;
         let resolved = resolve_templates(self.scope(), session, args)?;
@@ -193,6 +199,17 @@ pub trait Command: Send + Sync {
         let mut skipped: Vec<String> = Vec::new();
 
         let mut cancelled = false;
+        // Templates whose body actually returned `Ok`, in fan-out order —
+        // counted, never derived. Deriving it (`resolved` minus `skipped` minus
+        // `failures`) claimed every template a `break` never reached, and the
+        // body-cancelled one that no longer lands in `failures`, as done: it
+        // reported "stopped after M of M templates" for a fan-out that stopped
+        // at the first one, and named never-attempted templates as `succeeded`.
+        let mut completed: Vec<&str> = Vec::new();
+        // Set when the break came from a body-level cancel: the flow's own
+        // verdict detail, preserved rather than flattened (`CommandError::
+        // Cancelled` promises the payload names what the flow managed to do).
+        let mut body_stop: Option<(String, String)> = None;
         for rrid in &resolved {
             // Template boundary = cancellation checkpoint: a job_cancel that
             // lands while template N runs stops the fan-out before N+1.
@@ -208,9 +225,24 @@ pub trait Command: Send + Sync {
             }
             session.activate(rrid);
             session.display.template_banner(rrid);
-            if let Err(exc) = self.call(session, args).await {
-                tracing::error!(command = self.name(), rrid = %rrid, error = %exc, "command failed");
-                failures.push((rrid.clone(), exc));
+            match self.call(session, args).await {
+                Ok(()) => completed.push(rrid.as_str()),
+                // A body that stopped at one of its own cancellation
+                // checkpoints (`commands::perform::map_flow_error`) *is* the
+                // cancel verdict, not a template failure: stop at the boundary
+                // exactly like the loop-top check does. Pushing it into
+                // `failures` would let a cancel impersonate a broken template
+                // and be reported as a `FanOut` aggregate.
+                Err(CommandError::Cancelled(detail)) => {
+                    tracing::info!(command = self.name(), rrid = %rrid, "template body cancelled");
+                    body_stop = Some((rrid.clone(), detail));
+                    cancelled = true;
+                    break;
+                }
+                Err(exc) => {
+                    tracing::error!(command = self.name(), rrid = %rrid, error = %exc, "command failed");
+                    failures.push((rrid.clone(), exc));
+                }
             }
         }
 
@@ -221,25 +253,21 @@ pub trait Command: Send + Sync {
             // `FanOut` aggregate below: burying a broken template behind a
             // bare "cancelled" is the one thing the caller must not be told.
             tracing::info!(command = self.name(), "fan-out cancelled");
-            let done = resolved.len() - skipped.len() - failures.len();
-            return Err(CommandError::Cancelled(format!(
-                "stopped after {done} of {} templates",
+            let mut msg = format!(
+                "stopped after {} of {} templates",
+                completed.len(),
                 resolved.len()
-            )));
+            );
+            if let Some((rrid, detail)) = body_stop
+                && !detail.is_empty()
+            {
+                msg.push_str(&format!("; {rrid}: {detail}"));
+            }
+            return Err(CommandError::Cancelled(msg));
         }
 
-        let done: std::collections::HashSet<&str> = failures
-            .iter()
-            .map(|(r, _)| r.as_str())
-            .chain(skipped.iter().map(String::as_str))
-            .collect();
-        let ok: Vec<&str> = resolved
-            .iter()
-            .map(String::as_str)
-            .filter(|r| !done.contains(r))
-            .collect();
-        if !ok.is_empty() {
-            tracing::info!(command = self.name(), succeeded = %ok.join(", "));
+        if !completed.is_empty() {
+            tracing::info!(command = self.name(), succeeded = %completed.join(", "));
         }
         if !skipped.is_empty() {
             tracing::info!(command = self.name(), skipped = %skipped.join(", "), "no connected host");
@@ -247,7 +275,7 @@ pub trait Command: Send + Sync {
         if !failures.is_empty() {
             return Err(CommandError::FanOut(failures));
         }
-        if !skipped.is_empty() && ok.is_empty() {
+        if !skipped.is_empty() && completed.is_empty() {
             // Every resolved template was skipped: the command executed on
             // nothing, which must stay an error, not a silent success.
             return Err(CommandError::NoRefhostsDefined);

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -1110,6 +1110,28 @@ mod cancellation_seam {
     /// rebuilds that cache and then keeps interest pinned. Scoping moves to a
     /// thread-local sink instead, so the tests running in parallel on other
     /// threads cannot see (or pollute) this capture.
+    ///
+    /// Two consequences of that choice, both deliberate:
+    ///
+    /// - **The level ceiling goes to `TRACE` binary-wide.** An unfiltered
+    ///   `Registry` reports no `max_level_hint`, so from the first [`start`]
+    ///   call `LevelFilter::current()` is `TRACE` for the whole `mtui-core` lib
+    ///   test binary: every `debug!`/`trace!` callsite that was dead before now
+    ///   evaluates its formatting arguments (in every parallel test, not just
+    ///   this one). That costs a little time, and a `Display`/`Debug` impl that
+    ///   takes a lock the emitting thread already holds would deadlock rather
+    ///   than stay unevaluated. Nothing in this binary does that today; if a
+    ///   callsite ever pays for it, bound the layer with a `LevelFilter` — that
+    ///   keeps the interest rebuild without the blast radius — rather than
+    ///   going back to a thread-local default.
+    /// - **The capture assumes the fan-out runs on the arming thread.**
+    ///   `#[tokio::test]` defaults to the current-thread flavour, so the driver
+    ///   and its `info!` run on the thread that called [`start`] and reach its
+    ///   sink. Adding `flavor = "multi_thread"` to a test using this capture
+    ///   would move the event to a worker thread with no sink, silently
+    ///   emptying the buffer — and the caller's exact-equality assertion would
+    ///   then read as a product bug ("the driver named no templates") rather
+    ///   than as the harness change it is.
     mod succeeded_log {
         use std::cell::RefCell;
         use std::sync::Once;

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -1207,10 +1207,12 @@ mod cancellation_seam {
         /// Template whose body stops at one of its own cancellation
         /// checkpoints (what `perform.rs::map_flow_error` produces).
         cancel_on: &'static str,
-        /// Also fire the session token from the cancelling body (the
-        /// `job_cancel` coincidence); `false` pins that the verdict needs no
-        /// token at all.
-        cancel_token_too: bool,
+        /// Template whose body also fires the session token, before returning
+        /// its scripted verdict (the `job_cancel` coincidence). `None` on a
+        /// `cancel_on` run pins that the verdict needs no token at all; set on
+        /// a `fail_on` run it produces the *other* stop shape — the loop-top
+        /// checkpoint breaking the fan-out with a failure already banked.
+        fire_token_on: Option<&'static str>,
     }
 
     #[async_trait]
@@ -1227,13 +1229,15 @@ mod cancellation_seam {
                 .lock()
                 .expect("probe log poisoned")
                 .push(rrid.clone());
+            // Fired first, so it also composes with the failing body: a token
+            // cancel banked alongside a real failure is the loop-top stop.
+            if self.fire_token_on == Some(rrid.as_str()) {
+                session.cancel_token().cancel();
+            }
             if self.fail_on == Some(rrid.as_str()) {
                 return Err(CommandError::Other("boom".into()));
             }
             if rrid == self.cancel_on {
-                if self.cancel_token_too {
-                    session.cancel_token().cancel();
-                }
                 return Err(CommandError::Cancelled("flow stopped mid-body".into()));
             }
             Ok(())
@@ -1258,7 +1262,7 @@ mod cancellation_seam {
             cancel_on: RRID_B,
             // Deliberately never cancelled: the verdict may only come from the
             // body's own error variant, never from sniffing the token.
-            cancel_token_too: false,
+            fire_token_on: None,
         };
         let args = matches(&cmd, &[]);
 
@@ -1286,6 +1290,10 @@ mod cancellation_seam {
     /// not pad the failure list, and the fan-out still stops at the boundary.
     /// The token *is* fired here, so a verdict derived from the token instead
     /// of the error variant would bury the broken template.
+    ///
+    /// The outranked cancel is still *reported*, as the aggregate's `stop`
+    /// note: without it the caller is told only that A broke, and reads the
+    /// interrupted B and the never-attempted C as clean.
     #[tokio::test]
     async fn real_failure_before_body_cancel_still_outranks_it() {
         let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
@@ -1297,7 +1305,7 @@ mod cancellation_seam {
             ran: Arc::clone(&ran),
             fail_on: Some(RRID_A),
             cancel_on: RRID_B,
-            cancel_token_too: true,
+            fire_token_on: Some(RRID_B),
         };
         let args = matches(&cmd, &[]);
 
@@ -1305,14 +1313,35 @@ mod cancellation_seam {
             .run(&mut session, &args)
             .await
             .expect_err("a failed template must not report success");
+        // Rendered first: this is the string the REPL prints and the MCP error
+        // envelope carries, and the whole point of the note is that it reaches
+        // a caller who never sees the `tracing` breadcrumb.
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "fan-out failed on {RRID_A} ({RRID_A}: boom); \
+                 stopped after 0 of 3 templates; {RRID_B}: flow stopped mid-body"
+            ),
+            "the aggregate must name the interrupted template and how far the \
+             fan-out got"
+        );
         match err {
-            CommandError::FanOut(failures) => {
+            CommandError::FanOut { failures, stop } => {
                 assert_eq!(failures.len(), 1, "the cancel must not pad the aggregate");
                 assert_eq!(failures[0].0, RRID_A);
                 assert!(
                     matches!(failures[0].1, CommandError::Other(_)),
                     "got: {}",
                     failures[0].1
+                );
+                assert_eq!(
+                    stop.as_deref(),
+                    Some(
+                        format!("stopped after 0 of 3 templates; {RRID_B}: flow stopped mid-body")
+                            .as_str()
+                    ),
+                    "the interrupted flow's own detail must survive the outranking \
+                     failure, not just the count"
                 );
             }
             other => panic!("expected FanOut, got {other:?}"),
@@ -1321,6 +1350,47 @@ mod cancellation_seam {
             *ran.lock().expect("probe log poisoned"),
             vec![RRID_A.to_owned(), RRID_B.to_owned()],
             "the outranked cancel must still stop the fan-out at the boundary"
+        );
+    }
+
+    /// The sibling stop shape: a *token* cancel fired while the first template
+    /// was failing, so the loop-top checkpoint — not a body verdict — breaks
+    /// the fan-out with a failure already banked.
+    ///
+    /// The aggregate is still the verdict, and still carries the stop note, so
+    /// the caller does not read the two templates that never ran as clean.
+    /// There is no interrupted body here, so the note is the bare count: a
+    /// `; rrid: detail` suffix appearing would mean the driver invented a
+    /// detail no flow reported.
+    #[tokio::test]
+    async fn real_failure_before_token_cancel_keeps_the_stop_note() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.templates.add(fake_report(RRID_B, &["h2"], "ok"));
+        session.templates.add(fake_report(RRID_C, &["h3"], "ok"));
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = ScriptedBody {
+            ran: Arc::clone(&ran),
+            fail_on: Some(RRID_A),
+            // No body ever returns `Cancelled` here: RRID_D is not loaded.
+            cancel_on: RRID_D,
+            fire_token_on: Some(RRID_A),
+        };
+        let args = matches(&cmd, &[]);
+
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("a failed template must not report success");
+        assert_eq!(
+            err.to_string(),
+            format!("fan-out failed on {RRID_A} ({RRID_A}: boom); stopped after 0 of 3 templates"),
+            "the aggregate must say how far the fan-out got"
+        );
+        assert_eq!(
+            *ran.lock().expect("probe log poisoned"),
+            vec![RRID_A.to_owned()],
+            "the token cancel must stop the fan-out at the next boundary"
         );
     }
 
@@ -1343,7 +1413,7 @@ mod cancellation_seam {
             ran: Arc::clone(&ran),
             fail_on: Some(RRID_B),
             cancel_on: RRID_C,
-            cancel_token_too: false,
+            fire_token_on: None,
         };
         let args = matches(&cmd, &[]);
 
@@ -1363,7 +1433,19 @@ mod cancellation_seam {
             "the fan-out summary must name only the template that completed"
         );
         assert!(
-            matches!(&err, CommandError::FanOut(f) if f.len() == 1 && f[0].0 == RRID_B),
+            matches!(
+                &err,
+                CommandError::FanOut { failures, stop }
+                    if failures.len() == 1
+                        && failures[0].0 == RRID_B
+                        && stop.as_deref()
+                            == Some(
+                                format!(
+                                    "stopped after 1 of 4 templates; {RRID_C}: flow stopped mid-body"
+                                )
+                                .as_str()
+                            )
+            ),
             "got: {err}"
         );
         assert_eq!(

--- a/crates/mtui-core/src/commands/mod.rs
+++ b/crates/mtui-core/src/commands/mod.rs
@@ -1095,6 +1095,81 @@ mod cancellation_seam {
 
     const RRID_A: &str = "SUSE:Maintenance:1:1";
     const RRID_B: &str = "SUSE:Maintenance:2:2";
+    const RRID_C: &str = "SUSE:Maintenance:3:3";
+    const RRID_D: &str = "SUSE:Maintenance:4:4";
+
+    /// Captures the `succeeded` field of the fan-out driver's summary log, so
+    /// the templates it *names* can be asserted and not just assumed from the
+    /// verdict.
+    ///
+    /// The subscriber is installed **globally and permanently**, not as a
+    /// thread-local default: `tracing` caches callsite interest process-wide,
+    /// so the `succeeded` callsite — reached by many other tests in this
+    /// binary, none of which has a subscriber — would otherwise be cached as
+    /// `Interest::never` and stay silent here for good. `set_global_default`
+    /// rebuilds that cache and then keeps interest pinned. Scoping moves to a
+    /// thread-local sink instead, so the tests running in parallel on other
+    /// threads cannot see (or pollute) this capture.
+    mod succeeded_log {
+        use std::cell::RefCell;
+        use std::sync::Once;
+
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+        use tracing_subscriber::registry::Registry;
+
+        thread_local! {
+            /// The active capture buffer for this thread, if any.
+            static SINK: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+        }
+
+        struct CaptureLayer;
+
+        /// Records the rendered `succeeded` field, if the event carries one.
+        struct SucceededVisitor(Option<String>);
+
+        impl Visit for SucceededVisitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                // `succeeded = %…` arrives as a `Display` value, which tracing
+                // hands to `record_debug` already rendered.
+                if field.name() == "succeeded" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                SINK.with(|s| {
+                    if let Some(buf) = s.borrow_mut().as_mut() {
+                        let mut v = SucceededVisitor(None);
+                        event.record(&mut v);
+                        if let Some(found) = v.0 {
+                            buf.push(found);
+                        }
+                    }
+                });
+            }
+        }
+
+        /// Arms the capture for this thread (installing the subscriber once).
+        pub fn start() {
+            static INSTALL: Once = Once::new();
+            INSTALL.call_once(|| {
+                // A pre-existing global default would leave the capture empty,
+                // which the caller's exact-equality assertion reports loudly
+                // rather than passing over.
+                let _ =
+                    tracing::subscriber::set_global_default(Registry::default().with(CaptureLayer));
+            });
+            SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+        }
+
+        /// Every `succeeded` value logged on this thread since [`start`].
+        pub fn take() -> Vec<String> {
+            SINK.with(|s| s.borrow_mut().take()).unwrap_or_default()
+        }
+    }
 
     /// A fan-out probe that records each template it runs on and cancels the
     /// session's token from inside its first `call`.
@@ -1120,6 +1195,182 @@ mod cancellation_seam {
             session.cancel_token().cancel();
             Ok(())
         }
+    }
+
+    /// A fan-out probe whose body returns a scripted per-template verdict, so
+    /// the driver's classification of a body-level cancel can be pinned
+    /// independently of the session token.
+    struct ScriptedBody {
+        ran: Arc<Mutex<Vec<String>>>,
+        /// Template whose body fails with a *real* error.
+        fail_on: Option<&'static str>,
+        /// Template whose body stops at one of its own cancellation
+        /// checkpoints (what `perform.rs::map_flow_error` produces).
+        cancel_on: &'static str,
+        /// Also fire the session token from the cancelling body (the
+        /// `job_cancel` coincidence); `false` pins that the verdict needs no
+        /// token at all.
+        cancel_token_too: bool,
+    }
+
+    #[async_trait]
+    impl Command for ScriptedBody {
+        fn name(&self) -> &'static str {
+            "scripted_probe"
+        }
+        fn scope(&self) -> Scope {
+            Scope::Fanout
+        }
+        async fn call(&self, session: &mut Session, _args: &ArgMatches) -> CommandResult {
+            let rrid = session.templates.active_rrid().unwrap_or("").to_owned();
+            self.ran
+                .lock()
+                .expect("probe log poisoned")
+                .push(rrid.clone());
+            if self.fail_on == Some(rrid.as_str()) {
+                return Err(CommandError::Other("boom".into()));
+            }
+            if rrid == self.cancel_on {
+                if self.cancel_token_too {
+                    session.cancel_token().cancel();
+                }
+                return Err(CommandError::Cancelled("flow stopped mid-body".into()));
+            }
+            Ok(())
+        }
+    }
+
+    /// Three loaded templates, the second one's *body* stopping at its own
+    /// cancellation checkpoint while the session token is never fired: the
+    /// verdict is [`CommandError::Cancelled`] carrying the flow's own detail
+    /// and an honest completion count — not a `FanOut` aggregate with the
+    /// cancel impersonating a broken template (#404).
+    #[tokio::test]
+    async fn fanout_body_cancel_reports_cancelled_not_fanout() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.templates.add(fake_report(RRID_B, &["h2"], "ok"));
+        session.templates.add(fake_report(RRID_C, &["h3"], "ok"));
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = ScriptedBody {
+            ran: Arc::clone(&ran),
+            fail_on: None,
+            cancel_on: RRID_B,
+            // Deliberately never cancelled: the verdict may only come from the
+            // body's own error variant, never from sniffing the token.
+            cancel_token_too: false,
+        };
+        let args = matches(&cmd, &[]);
+
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("a body-level cancel must not report success");
+        assert!(
+            matches!(
+                &err,
+                CommandError::Cancelled(m)
+                    if *m == format!("stopped after 1 of 3 templates; {RRID_B}: flow stopped mid-body")
+            ),
+            "got: {err}"
+        );
+        assert_eq!(
+            *ran.lock().expect("probe log poisoned"),
+            vec![RRID_A.to_owned(), RRID_B.to_owned()],
+            "the third template must never run after the body-level cancel"
+        );
+    }
+
+    /// A real per-template failure collected *before* a body-level cancel still
+    /// outranks it: the verdict stays the `FanOut` aggregate, the cancel does
+    /// not pad the failure list, and the fan-out still stops at the boundary.
+    /// The token *is* fired here, so a verdict derived from the token instead
+    /// of the error variant would bury the broken template.
+    #[tokio::test]
+    async fn real_failure_before_body_cancel_still_outranks_it() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.templates.add(fake_report(RRID_B, &["h2"], "ok"));
+        session.templates.add(fake_report(RRID_C, &["h3"], "ok"));
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = ScriptedBody {
+            ran: Arc::clone(&ran),
+            fail_on: Some(RRID_A),
+            cancel_on: RRID_B,
+            cancel_token_too: true,
+        };
+        let args = matches(&cmd, &[]);
+
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("a failed template must not report success");
+        match err {
+            CommandError::FanOut(failures) => {
+                assert_eq!(failures.len(), 1, "the cancel must not pad the aggregate");
+                assert_eq!(failures[0].0, RRID_A);
+                assert!(
+                    matches!(failures[0].1, CommandError::Other(_)),
+                    "got: {}",
+                    failures[0].1
+                );
+            }
+            other => panic!("expected FanOut, got {other:?}"),
+        }
+        assert_eq!(
+            *ran.lock().expect("probe log poisoned"),
+            vec![RRID_A.to_owned(), RRID_B.to_owned()],
+            "the outranked cancel must still stop the fan-out at the boundary"
+        );
+    }
+
+    /// The `succeeded` summary log names templates that actually completed.
+    ///
+    /// This is the outranked-cancel fall-through — a real failure *and* a
+    /// body-level cancel — which is the only shape where the old derived list
+    /// (`resolved` minus `failures` minus `skipped`) could lie: the
+    /// body-cancelled template no longer lands in `failures`, and the template
+    /// after the break never ran at all, so both were reported as succeeded.
+    #[tokio::test]
+    async fn succeeded_log_names_only_completed_templates() {
+        let (mut session, _buf) = session_with_hosts(RRID_A, &["h1"], "ok");
+        session.templates.add(fake_report(RRID_B, &["h2"], "ok"));
+        session.templates.add(fake_report(RRID_C, &["h3"], "ok"));
+        session.templates.add(fake_report(RRID_D, &["h4"], "ok"));
+
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let cmd = ScriptedBody {
+            ran: Arc::clone(&ran),
+            fail_on: Some(RRID_B),
+            cancel_on: RRID_C,
+            cancel_token_too: false,
+        };
+        let args = matches(&cmd, &[]);
+
+        succeeded_log::start();
+        let err = cmd
+            .run(&mut session, &args)
+            .await
+            .expect_err("a failed template must not report success");
+        let logged = succeeded_log::take();
+
+        // Only A ran to completion: B failed, C stopped mid-body, D was never
+        // reached. Exact equality, not `contains` — the whole defect is *extra*
+        // names in this list, which a substring check would sail past.
+        assert_eq!(
+            logged,
+            vec![RRID_A.to_owned()],
+            "the fan-out summary must name only the template that completed"
+        );
+        assert!(
+            matches!(&err, CommandError::FanOut(f) if f.len() == 1 && f[0].0 == RRID_B),
+            "got: {err}"
+        );
+        assert_eq!(
+            *ran.lock().expect("probe log poisoned"),
+            vec![RRID_A.to_owned(), RRID_B.to_owned(), RRID_C.to_owned()],
+            "the fourth template must never run after the body-level cancel"
+        );
     }
 
     /// Two loaded templates, cancel fired during the first `call`: the driver

--- a/crates/mtui-core/src/error.rs
+++ b/crates/mtui-core/src/error.rs
@@ -36,10 +36,27 @@ pub enum CommandError {
     MissingPackages,
 
     /// Aggregate raised after a fan-out command failed on one or more templates.
-    /// Every template still got its turn; the
-    /// per-template failures are collected here keyed by RRID.
-    #[error("fan-out failed on {} ({})", .0.iter().map(|(r, _)| r.as_str()).collect::<Vec<_>>().join(", "), .0.iter().map(|(r, e)| format!("{r}: {e}")).collect::<Vec<_>>().join("; "))]
-    FanOut(Vec<(String, CommandError)>),
+    /// The per-template failures are collected in `failures`, keyed by RRID.
+    ///
+    /// Every template got its turn unless `stop` is set: that is the fan-out's
+    /// own stop summary (`stopped after N of M templates`, plus the interrupted
+    /// flow's detail when it has one), carried when a cancel landed but a real
+    /// failure outranked it. The cancel is deliberately *not* a `failures`
+    /// entry — it is not a broken template — but it may not vanish either, or
+    /// the caller reads the templates the stop never reached as having run
+    /// clean. It is rendered as a suffix on the aggregate message.
+    #[error(
+        "fan-out failed on {} ({}){}",
+        .failures.iter().map(|(r, _)| r.as_str()).collect::<Vec<_>>().join(", "),
+        .failures.iter().map(|(r, e)| format!("{r}: {e}")).collect::<Vec<_>>().join("; "),
+        .stop.as_ref().map(|s| format!("; {s}")).unwrap_or_default()
+    )]
+    FanOut {
+        /// The per-template failures, keyed by RRID, in fan-out order.
+        failures: Vec<(String, CommandError)>,
+        /// How far the fan-out got when a cancel stopped it early, if one did.
+        stop: Option<String>,
+    },
 
     /// The dispatch was cancelled mid-flight (MCP `job_cancel`).
     ///
@@ -53,6 +70,18 @@ pub enum CommandError {
     /// for the pre-dispatch checkpoint, where nothing had run yet. A genuine
     /// failure always outranks a cancellation — a broken host is never buried
     /// behind "cancelled".
+    ///
+    /// **Fan-out contract:** this variant coming *out of a command body*
+    /// terminates the fan-out, independent of the session token — the
+    /// [`Command::run`](crate::Command::run) driver breaks at that template
+    /// boundary and never dispatches the remaining templates, keeping the
+    /// payload as its own verdict (or, when a real failure outranks it, as the
+    /// [`FanOut`](Self::FanOut) aggregate's `stop` note). Every producer today
+    /// derives from a genuine session-level cancel, so that is what the break
+    /// means. Raising it for a per-template condition that is *not* a
+    /// session-level stop would therefore silently abandon the templates after
+    /// it; such a condition wants [`Other`](Self::Other) (collected, fan-out
+    /// continues), not this variant.
     #[error("cancelled{}", if .0.is_empty() { String::new() } else { format!(": {}", .0) })]
     Cancelled(String),
 
@@ -115,10 +144,13 @@ mod tests {
     fn fanout_display_has_stable_format() {
         // Upstream: "fan-out failed on {rrids} ({detail})" where
         // rrids = ", ".join(rrid) and detail = "; ".join(f"{rrid}: {exc}").
-        let e = CommandError::FanOut(vec![
-            ("a".into(), CommandError::Other("boom".into())),
-            ("b".into(), CommandError::NoRefhostsDefined),
-        ]);
+        let e = CommandError::FanOut {
+            failures: vec![
+                ("a".into(), CommandError::Other("boom".into())),
+                ("b".into(), CommandError::NoRefhostsDefined),
+            ],
+            stop: None,
+        };
         assert_eq!(
             e.to_string(),
             "fan-out failed on a, b (a: boom; b: No refhosts defined)"
@@ -127,7 +159,25 @@ mod tests {
 
     #[test]
     fn fanout_with_single_failure() {
-        let e = CommandError::FanOut(vec![("x".into(), CommandError::Other("nope".into()))]);
+        let e = CommandError::FanOut {
+            failures: vec![("x".into(), CommandError::Other("nope".into()))],
+            stop: None,
+        };
         assert_eq!(e.to_string(), "fan-out failed on x (x: nope)");
+    }
+
+    #[test]
+    fn fanout_stop_note_is_appended_to_the_aggregate() {
+        // An outranked cancel: the failure list stays at one entry (the cancel
+        // is not a broken template), and the stop summary rides on the end so
+        // the caller cannot read the templates after the break as clean.
+        let e = CommandError::FanOut {
+            failures: vec![("h1".into(), CommandError::Other("boom".into()))],
+            stop: Some("stopped after 1 of 4 templates".to_owned()),
+        };
+        assert_eq!(
+            e.to_string(),
+            "fan-out failed on h1 (h1: boom); stopped after 1 of 4 templates"
+        );
     }
 }

--- a/crates/mtui-core/tests/fanout.rs
+++ b/crates/mtui-core/tests/fanout.rs
@@ -182,9 +182,12 @@ async fn partial_failure_raises_fanout_aggregate() {
     let cmd = MockCommand::failing(Scope::Fanout, &["b"]);
     let err = cmd.run(&mut s, &matches(&[])).await.unwrap_err();
     match err {
-        CommandError::FanOut(failures) => {
+        CommandError::FanOut { failures, stop } => {
             assert_eq!(failures.len(), 1);
             assert_eq!(failures[0].0, "b");
+            // Nothing stopped this fan-out: every template ran, so the
+            // aggregate carries no stop note to mislead the caller with.
+            assert_eq!(stop, None, "an uninterrupted fan-out has no stop note");
         }
         other => panic!("expected FanOut, got {other:?}"),
     }


### PR DESCRIPTION
Closes #404.

## The bug

The multi-template fan-out driver pushed **every** per-template `Err` into `failures` without looking at the variant, and set its `cancelled` flag **only** from the loop-top token check — never from the returned error.

A command body that stops at one of its own cancellation checkpoints returns `CommandError::Cancelled` (`commands/perform.rs::map_flow_error`, reachable from `install`, `uninstall`, `prepare`, `downgrade`, `update`). That cancel therefore landed in the failure aggregate, logged at `error!` "command failed" on the way in.

The `cancelled && failures.is_empty()` guard then saw a non-empty list and fell through to `FanOut`. That guard exists so a cancel cannot bury a real failure. The bug let a cancel *impersonate* one: the operator got `fan-out failed on <rrid> (<rrid>: cancelled: …)` for a job they had just cancelled themselves.

## The fix

Discriminate the variant in the loop. `Err(CommandError::Cancelled(detail))` breaks at the template boundary — exactly what the loop-top check already does — records the flow's own detail, and never enters `failures`. Everything else is collected as before.

Both halves of the AGENTS.md rule survive:

- The verdict comes from the **returned error variant**, never from sniffing the session token. Sniffing would mask a real host failure that merely coincided with a cancel.
- A real failure banked **before** the cancel still outranks it and is still reported as the `FanOut` aggregate — now without the cancel entry padding the failure list.

The `Cancelled` payload carries the interrupted flow's own detail (`stopped after 1 of 3 templates; SUSE:Maintenance:2:2: flow stopped mid-body`), which is what that variant promises: report what completed before stopping.

## Judgement calls

**Counted, not derived — and this is not optional scope.** The completion figure was `resolved.len() - skipped.len() - failures.len()`. That was already wrong on any `break` path (a fan-out that stopped at the first of two reported "stopped after 2 of 2 templates"), and the fix above makes it *worse*: the body-cancelled template no longer lands in `failures`, so the derivation would newly count it as done. The same derivation also fed the `succeeded` summary log — so on the outranked-cancel path the log named the template that was interrupted mid-flight, plus every template the break never reached, as templates the update had been applied to. `completed` is now a `Vec<&str>` pushed only where the body returned `Ok`, and the count, the log, and the all-skipped `NoRefhostsDefined` guard all read that one list. The old `HashSet` + filter derivation is deleted rather than left alongside.

**The issue's one-template shape does not exist, and I did not "fix" it.** #404 lists a single-template case producing `FanOut([(rrid, Cancelled(..))])`. `Command::run` early-returns for `resolved.len() <= 1` and propagates the body's error verbatim, so that path already surfaced `Cancelled` correctly. Only the multi-template shape was broken. Saying so is cheaper than adding a redundant guard that would need its own justification later.

**No new checkpoint, no new signal handler.** The change is entirely in how an *already returned* error is classified. The loop-top `session.cancel_requested()` check is the sanctioned template-boundary checkpoint and is untouched; nothing was added to a parallel fan-out, and nothing polls the token past a point of no return.

**A dev-dependency for one log assertion.** Pinning the `succeeded` line needed `tracing-subscriber` in `mtui-core`'s dev-dependencies and a small capture helper. The helper installs the subscriber **globally and permanently**, with a thread-local sink for scoping, rather than using a thread-local default: `tracing` caches callsite interest process-wide, and the `succeeded` callsite is reached by many other tests in this binary that have no subscriber, so a thread-local default would have been cached as `Interest::never` and made the assertion pass or fail by test order. `set_global_default` rebuilds that cache. Verified by running the test alone, under the full parallel suite five times, and under `--test-threads=1` (which forces the callsite to be reached by other tests first).

## Testing

Three new driver tests in `commands::cancellation_seam`, all mutation-verified.

`fanout_body_cancel_reports_cancelled_not_fanout` — three templates, the second body stopping at its own checkpoint while the session token is **deliberately never fired**. It asserts the full composed message by exact equality, not `contains("cancelled")`: the broken rendering nests `…: cancelled: …` *inside* `fan-out failed on …`, so a substring assertion would have passed on the unfixed code. It also asserts the full `ran` vector from a genuinely shared `Arc<Mutex<…>>` the probe writes from inside `call`. Because the token is never fired, a token-sniffing implementation degrades to `FanOut` and fails here.

`real_failure_before_body_cancel_still_outranks_it` — a real failure on template A, a body cancel on B, and the token **is** fired, so a token-sniffing implementation would bury A's error. Asserts `FanOut`, exactly one entry, that the entry is A's `Other`, and that the fan-out still stopped at the boundary.

`succeeded_log_names_only_completed_templates` — four templates: A completes, B fails for real, C stops mid-body, D is never reached. Captures the `succeeded` field and asserts exact vector equality against `[A]`. Exact equality because the defect is *extra* names in that list, which `contains` cannot see.

**How RED was observed.** Nine mutants across two passes, each applied by unique-anchor replacement that aborts unless the anchor matches exactly once, and each run checked to have actually *run* a non-zero test count rather than trusting an exit code:

| mutation | result |
| --- | --- |
| `Err(Cancelled)` arm reverted to the old catch-all push | RED ×2 — `fan-out failed on SUSE:Maintenance:2:2 (…: cancelled: flow stopped mid-body)`, and `left: 2, right: 1` on "the cancel must not pad the aggregate" |
| `break` removed from that arm | RED ×2 — `stopped after 2 of 3 templates`, and the log gains `SUSE:Maintenance:4:4` |
| completed templates no longer recorded | RED — `stopped after 0 of 3 templates` |
| count derived from the lists again | RED — `stopped after 3 of 3 templates` |
| detail suffix dropped | RED — suffix missing from the message |
| outrank guard weakened to plain `if cancelled` | RED — `expected FanOut, got Cancelled(…)` |
| `succeeded` log derived from the lists again | RED — `left: ["…1:1, …3:3, …4:4"]` vs `right: ["…1:1"]` |
| capture layer records nothing (anti-vacuity) | RED — `left: []`; an empty capture cannot read as "nothing extra was named" |

Worth recording: on the first pass the `succeeded`-log mutant came back **green**. That is how the log defect was established as genuinely unpinned rather than argued about — the test was written afterwards, and the same mutant is red now.

## Known limitations, stated rather than hidden

- The `!detail.is_empty()` branch is defensive only. `map_flow_error` always produces a non-empty detail, so the bare `stopped after N of M templates` form is unreachable from today's flows and is not covered by a test.
- On the **pre-existing** loop-top-break path (token fired between templates, no body involvement) only the verdict variant is pinned, by the untouched `fanout_driver_stops_at_template_boundary_on_cancel`. The completion count on that path is pinned only indirectly, through the shared counter.
- No MCP client can distinguish a cooperative body stop from a driver-boundary stop: both arrive as one `cancelled: …` string. `mtui-mcp` records the richer payload through its existing cancel-claimed-record path, but the wire shape is unchanged and this PR does not touch any tool schema.
- The capture subscriber is now the one global subscriber in `mtui-core`'s lib test binary and stays installed for the process. It is inert (thread-local sink, empty by default), but a future test wanting tracing output must reuse this helper rather than install its own.
- A cancel arriving mid-`call` in a body that does **not** opt into the seam is still handled only by the MCP job layer's hard abort. Unchanged, and out of scope here.