### PR TITLE
docs(testreport): state what the dead-probe gate catches, not what it will catch

### DIFF
--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -1405,15 +1405,12 @@ async fn downgrade_body(
         // row before returning — the site below is unreachable from here, so
         // there is no double write.
         //
-        // Merge note (#451/PR #454): the `lastexit != 0` test above is
-        // unchanged there, but the probe template starts guarding its own
-        // stages and exiting with the failing tool's status. Today the
-        // pipeline's status is awk's, and awk exits `0` over empty input, so
-        // this gate can in practice only catch the `-1` SSH-death sentinel;
-        // afterwards a broken `zypper se` reaches it too. This row is therefore
-        // written in strictly more zero-commands-ran cases once #454 lands —
-        // which is the point: those are exactly the aborts that leave a host
-        // with its issue repo removed and nothing rolled back.
+        // The `lastexit != 0` gate above catches more than SSH-level death:
+        // the probe template guards its own producing stages and exits with
+        // the failing tool's own status (#451), so a refused `zypper se`
+        // reaches here as well as the `-1` sentinel. Every one of those is an
+        // abort that left the host with its issue repo removed and nothing
+        // rolled back, which is precisely the state this row exists to record.
         add_op_history(targets, "downgrade", id, packages).await;
         return Err(UpdateError::new(
             "package version probe failed",


### PR DESCRIPTION
Follow-up to the review of #457, which merged as `3ca2b895`.

## The problem

`downgrade_body`'s all-probes-dead abort carries a comment written while #451
was still in flight, phrased as a prediction:

> Merge note (#451/PR #454): [...] **Today** the pipeline's status is awk's, and
> awk exits `0` over empty input, so this gate **can in practice only catch the
> `-1` SSH-death sentinel**; afterwards a broken `zypper se` reaches it too.
> This row is therefore written in strictly more zero-commands-ran cases **once
> #454 lands**.

#451 landed in `bef9a952`, two merges before #457. So the comment now describes
the pre-fix world as the present, and the sentence a reader actually acts on —
"this gate can in practice only catch the `-1` sentinel" — is false: the probe
template has exited with the failing tool's own status since #451, so a refused
`zypper -n se` reaches the gate as well.

This is the shape AGENTS.md calls out: a retired rationale gets replaced, not
left standing next to the constraint it used to explain. The constraint is
load-bearing (it decides whether a `/var/log/mtui.log` row is owed on the
rollback path), so the fix is to keep it and drop the prediction.

## The change

Comment only. Six lines stating what the gate catches now, in place of nine
predicting what it would catch. No behaviour change, no test change, no
CHANGELOG entry (internal, nothing a user or MCP client observes —
`CONTRIBUTING.md` § Changelog).

Verified: `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc
--workspace --no-deps --all-features --document-private-items`, and
`cargo clippy -p mtui-testreport --all-targets -- -D warnings` all clean.