### PR TITLE
Four minor cleanups: two docs contradicting the code, a lossy seam, two weak tests

### DIFF
--- a/crates/mtui-hosts/src/lib.rs
+++ b/crates/mtui-hosts/src/lib.rs
@@ -34,8 +34,8 @@ pub use prompter::{Prompter, Reader};
 #[cfg(test)]
 pub(crate) use target::POOL_LOCK_PATH;
 pub use target::{
-    Check, CheckArgs, Clock, Command, Doer, HostArbiter, HostOutput, HostPlan, HostsGroup,
-    InstallOperation, LockOutcome, Operation, OperationGroup, OperationReport, Owner,
+    Check, CheckArgs, CheckFailure, Clock, Command, Doer, HostArbiter, HostOutput, HostPlan,
+    HostsGroup, InstallOperation, LockOutcome, Operation, OperationGroup, OperationReport, Owner,
     PackageQuerier, PlanProvider, PoolLock, RebootFailure, RebootFailureCause, RemoteLock,
     RepoManager, RepoOp, SetRepo, Sink, SpinnerGuard, Suspend, SystemClock, TARGET_LOCK_PATH,
     Target, TargetLock, TtySpinner, UninstallOperation, get_arbiter, parse_system, set_test_sink,

--- a/crates/mtui-hosts/src/target/mod.rs
+++ b/crates/mtui-hosts/src/target/mod.rs
@@ -53,8 +53,9 @@ pub use hostgroup::{HostsGroup, LockOutcome};
 pub(crate) use locks::POOL_LOCK_PATH;
 pub use locks::{Clock, LockRow, PoolLock, RemoteLock, SystemClock, TARGET_LOCK_PATH, TargetLock};
 pub use operation::{
-    Check, CheckArgs, Doer, HostOutput, HostPlan, InstallOperation, Operation, OperationGroup,
-    OperationReport, PlanProvider, RebootFailure, RebootFailureCause, UninstallOperation,
+    Check, CheckArgs, CheckFailure, Doer, HostOutput, HostPlan, InstallOperation, Operation,
+    OperationGroup, OperationReport, PlanProvider, RebootFailure, RebootFailureCause,
+    UninstallOperation,
 };
 pub use package_querier::PackageQuerier;
 pub use parsers::parse_system;

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -202,9 +202,12 @@ pub trait OperationGroup: Send {
 
     /// Reads back `hostname`'s post-run output, for the [`Check`] call.
     ///
-    /// Returns `None` for a host outside the group (should not happen for a
-    /// host with a [`HostPlan`]); the template treats that as an empty
-    /// snapshot rather than panicking.
+    /// A `None` here is a bug by construction: every caller only ever asks for
+    /// a hostname it just built a [`HostPlan`] for, so the host cannot be
+    /// outside the group. The template does not panic on it — it falls back to
+    /// [`HostOutput::default`], which is **exit 0**. Every [`Check`] reads exit
+    /// 0 as success, so a `None` here makes the host silently pass its check
+    /// and stay in the reboot map instead of failing loudly.
     fn last_output(&self, hostname: &str) -> Option<HostOutput>;
 
     /// Reboots the transactional hosts named in `reboot`.
@@ -405,7 +408,16 @@ pub trait Operation: Send + Sync {
 
         let mut check_failures: Vec<(String, String)> = Vec::new();
         for plan in &mut plans {
-            let output = group.last_output(&plan.hostname).unwrap_or_default();
+            let output = group.last_output(&plan.hostname).unwrap_or_else(|| {
+                // See `OperationGroup::last_output`: this host has a `HostPlan`,
+                // so it cannot really be missing from the group. Warn so the
+                // silent-pass is at least visible, rather than swallowing it.
+                tracing::warn!(
+                    host = %plan.hostname,
+                    "no post-run output for a planned host; treating as exit 0"
+                );
+                HostOutput::default()
+            });
             let args = CheckArgs {
                 hostname: &plan.hostname,
                 stdout: &output.stdout,
@@ -652,6 +664,9 @@ mod tests {
         reboot_failures: Vec<RebootFailure>,
         /// What `unlock` should report per host.
         unlock_outcomes: BTreeMap<String, LockOutcome>,
+        /// When `true`, `last_output` returns `None` for every host, modelling
+        /// a host outside the group despite having a [`HostPlan`].
+        missing_output: bool,
     }
 
     impl MockGroup {
@@ -673,6 +688,7 @@ mod tests {
                 fail_update_lock: false,
                 reboot_failures: Vec::new(),
                 unlock_outcomes: BTreeMap::new(),
+                missing_output: false,
             }
         }
 
@@ -693,6 +709,14 @@ mod tests {
         /// release failed or was contended.
         fn with_unlock_outcomes(mut self, outcomes: BTreeMap<String, LockOutcome>) -> Self {
             self.unlock_outcomes = outcomes;
+            self
+        }
+
+        /// Scripts `last_output` to return `None` for every host, modelling
+        /// the unreachable-by-construction case documented on
+        /// [`OperationGroup::last_output`].
+        fn with_missing_output(mut self) -> Self {
+            self.missing_output = true;
             self
         }
 
@@ -734,6 +758,9 @@ mod tests {
         }
 
         fn last_output(&self, _hostname: &str) -> Option<HostOutput> {
+            if self.missing_output {
+                return None;
+            }
             // The tests below assert on the Check event log, not the output
             // snapshot, so an empty snapshot is enough here.
             Some(HostOutput::default())
@@ -1146,6 +1173,53 @@ mod tests {
                 &vec![("h2".to_owned(), "systemctl reboot".to_owned())],
                 "only the passing host's reboot may run: {map:?}"
             );
+        }
+    }
+
+    // --- run(): a missing last_output silently passes the check ------------
+
+    #[tokio::test]
+    async fn missing_last_output_silently_passes_the_check_and_keeps_the_reboot() {
+        // Pins the hazard documented on `OperationGroup::last_output`: a
+        // `None` snapshot falls back to `HostOutput::default()` (exit 0),
+        // which the check below reads as a failure only on a non-zero exit
+        // code — so it passes, and the host stays in the reboot map. If the
+        // fallback ever changes to fail the check instead, this goes red.
+        let check: Check = Box::new(|a: CheckArgs<'_>| {
+            if a.exitcode == 0 {
+                Ok(())
+            } else {
+                Err("nonzero exit".to_owned())
+            }
+        });
+        let plans = vec![HostPlan {
+            hostname: "h1".to_owned(),
+            transactional: true,
+            doer: Doer::new("in $packages", "systemctl reboot"),
+            check,
+        }];
+        let mut group = MockGroup::new(Ok(plans)).with_missing_output();
+
+        let op = InstallOperation::new(strs(&["pkg-a"]));
+        let report = op.run(&mut group).await.expect("the run started");
+
+        assert!(
+            report.check_failures.is_empty(),
+            "a missing snapshot must not fail the check: {:?}",
+            report.check_failures
+        );
+        if let Some(Event::Reboot(map)) = group
+            .events()
+            .into_iter()
+            .find(|e| matches!(e, Event::Reboot(_)))
+        {
+            assert_eq!(
+                map,
+                vec![("h1".to_owned(), "systemctl reboot".to_owned())],
+                "the host with no output still stays in the reboot map: {map:?}"
+            );
+        } else {
+            panic!("expected a Reboot event");
         }
     }
 

--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -100,9 +100,55 @@ impl Doer {
 /// The post-run *check* callable for one target.
 ///
 /// Invoked once per target with that host's post-run output, and returns
-/// `Err(reason)` when it recognises a failure. Boxed so it is object-safe and
+/// `Err(failure)` when it recognises a failure. Boxed so it is object-safe and
 /// can be produced per target by the doer/check registry seam.
-pub type Check = Box<dyn FnMut(CheckArgs<'_>) -> Result<(), String> + Send>;
+pub type Check = Box<dyn FnMut(CheckArgs<'_>) -> Result<(), CheckFailure> + Send>;
+
+/// Why a post-run [`Check`] failed.
+///
+/// Mirrors [`RebootFailure`]'s `reason` + cause shape: a bare `String` made a
+/// cancellation unrepresentable across this seam, so `reports::update_flow`
+/// could not route a check that stopped at a cancellation checkpoint away from
+/// the group-wide rollback the way it does for every other cancel point. The
+/// producer side lives in `mtui-testreport`'s `WorkflowRegistry::check` adapter
+/// (`update_workflow/mod.rs`), which forwards `UpdateError::cancelled` here;
+/// nothing on this path sets it today (checks are pure verdicts over a
+/// captured transcript), so the flag exists for representability, not because
+/// a live check currently cancels.
+///
+/// Deliberately **not** produced by `checks::update`'s `probe_failed` case:
+/// only `checks::update` ever sets that flag, and the update role does not go
+/// through this seam (it drives its own template, not
+/// [`Operation`]/[`OperationGroup`]) — so `probe_failed` has nothing to cross
+/// here, and its omission is a decision, not an oversight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckFailure {
+    /// The failure reason, shown to the operator.
+    pub reason: String,
+    /// `true` when the check stopped at a cancellation checkpoint rather than
+    /// failing.
+    pub cancelled: bool,
+}
+
+impl CheckFailure {
+    /// Builds a plain (non-cancelled) check failure.
+    #[must_use]
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            cancelled: false,
+        }
+    }
+
+    /// Builds a check failure recording a cooperative cancellation.
+    #[must_use]
+    pub fn cancelled(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            cancelled: true,
+        }
+    }
+}
 
 /// The argument tuple passed to a [`Check`], keeping the call site readable.
 #[derive(Debug, Clone, Copy)]
@@ -238,8 +284,8 @@ pub trait OperationGroup: Send {
               reports a failed operation as a clean one"]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OperationReport {
-    /// `(hostname, reason)` for every host whose post-run [`Check`] failed.
-    pub check_failures: Vec<(String, String)>,
+    /// `(hostname, failure)` for every host whose post-run [`Check`] failed.
+    pub check_failures: Vec<(String, CheckFailure)>,
     /// Every transactional host whose reboot did not demonstrably take effect.
     /// A host whose check already failed is excluded — its reboot was skipped,
     /// not attempted and lost.
@@ -406,7 +452,7 @@ pub trait Operation: Send + Sync {
             .add_history(&[self.history_label().to_owned(), self.packages().join(" ")])
             .await;
 
-        let mut check_failures: Vec<(String, String)> = Vec::new();
+        let mut check_failures: Vec<(String, CheckFailure)> = Vec::new();
         for plan in &mut plans {
             let output = group.last_output(&plan.hostname).unwrap_or_else(|| {
                 // See `OperationGroup::last_output`: this host has a `HostPlan`,
@@ -425,8 +471,8 @@ pub trait Operation: Send + Sync {
                 stderr: &output.stderr,
                 exitcode: output.exitcode,
             };
-            if let Err(reason) = (plan.check)(args) {
-                check_failures.push((plan.hostname.clone(), reason));
+            if let Err(failure) = (plan.check)(args) {
+                check_failures.push((plan.hostname.clone(), failure));
             }
         }
 
@@ -795,7 +841,7 @@ mod tests {
         transactional: bool,
         doer: Doer,
         sink: Arc<Mutex<Vec<Event>>>,
-        result: Result<(), String>,
+        result: Result<(), CheckFailure>,
     ) -> HostPlan {
         let check: Check = Box::new(move |a: CheckArgs<'_>| {
             sink.lock()
@@ -1133,7 +1179,7 @@ mod tests {
                 true,
                 Doer::new("in $packages", "systemctl reboot"),
                 log.clone(),
-                Err("boom".to_owned()),
+                Err(CheckFailure::new("boom")),
             ),
             plan_with_check(
                 "h2",
@@ -1150,7 +1196,7 @@ mod tests {
 
         assert_eq!(
             report.check_failures,
-            vec![("h1".to_owned(), "boom".to_owned())]
+            vec![("h1".to_owned(), CheckFailure::new("boom"))]
         );
 
         let events = group.events();
@@ -1189,7 +1235,7 @@ mod tests {
             if a.exitcode == 0 {
                 Ok(())
             } else {
-                Err("nonzero exit".to_owned())
+                Err(CheckFailure::new("nonzero exit"))
             }
         });
         let plans = vec![HostPlan {

--- a/crates/mtui-hosts/tests/operation_group.rs
+++ b/crates/mtui-hosts/tests/operation_group.rs
@@ -12,8 +12,8 @@ use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
 use mtui_hosts::{
-    Check, CheckArgs, Doer, HostError, HostsGroup, InstallOperation, Operation, OperationGroup,
-    PlanProvider, RebootFailure, RebootFailureCause, Target, UninstallOperation,
+    Check, CheckArgs, CheckFailure, Doer, HostError, HostsGroup, InstallOperation, Operation,
+    OperationGroup, PlanProvider, RebootFailure, RebootFailureCause, Target, UninstallOperation,
 };
 use mtui_types::enums::TargetState;
 use mtui_types::hostlog::CommandLog;
@@ -276,6 +276,43 @@ async fn install_reports_a_transactional_host_that_never_reconnects() {
         }]
     );
     assert_eq!(handle.reconnect_count(), 1);
+}
+
+/// A [`PlanProvider`] whose check always fails with a cancelled
+/// [`CheckFailure`], so the report round-trip can be asserted end to end.
+struct CancellingProvider;
+
+impl PlanProvider for CancellingProvider {
+    fn doer(&self, _role: &str, _release: &str, _transactional: bool) -> Result<Doer, HostError> {
+        Ok(Doer::new(
+            "zypper -n in -y -l $packages",
+            "systemctl reboot",
+        ))
+    }
+
+    fn check(&self, _role: &str, _release: &str, _transactional: bool) -> Check {
+        Box::new(|_a: CheckArgs<'_>| Err(CheckFailure::cancelled("stopped at a checkpoint")))
+    }
+}
+
+#[tokio::test]
+async fn a_cancelled_check_failure_arrives_in_the_report_with_the_flag_intact() {
+    let (h1, _m1) = target("h1", "SLES", "15.5", false);
+    let mut group =
+        HostsGroup::new(vec![h1], false).with_plan_provider(Arc::new(CancellingProvider));
+
+    let report = InstallOperation::new(vec!["pkg-a".to_owned()])
+        .run(&mut group)
+        .await
+        .expect("the run started even though the check failed");
+
+    assert_eq!(
+        report.check_failures,
+        vec![(
+            "h1".to_owned(),
+            CheckFailure::cancelled("stopped at a checkpoint")
+        )]
+    );
 }
 
 #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -688,7 +688,12 @@ async fn perform_operation(
     let mut failures: Vec<UpdateError> = report
         .check_failures
         .into_iter()
-        .map(|(host, reason)| UpdateError::new(reason, host))
+        .map(|(host, failure)| UpdateError {
+            reason: failure.reason,
+            host: Some(host),
+            cancelled: failure.cancelled,
+            probe_failed: false,
+        })
         .collect();
     failures.extend(report.reboot_failures.into_iter().map(reboot_error));
     aggregate_failures(op, failures)

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -4037,6 +4037,18 @@ mod tests {
             .await
             .expect_err("a lost transactional host must not report success");
         assert_eq!(err.host.as_deref(), Some("h1"));
+        assert!(
+            err.reason.contains("did not come back after the reboot"),
+            "reason: {}",
+            err.reason
+        );
+        // Discriminating: the two reachable causes must not be claimed for a
+        // host that genuinely went away — they route the rollback differently.
+        assert!(
+            !err.reason.contains("never rebooted") && !err.reason.contains("never received"),
+            "reason: {}",
+            err.reason
+        );
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -373,7 +373,10 @@ impl mtui_hosts::PlanProvider for WorkflowRegistry {
                         }
                         Ok(())
                     }
-                    Err(e) => Err(e.reason),
+                    Err(e) => Err(mtui_hosts::CheckFailure {
+                        reason: e.reason,
+                        cancelled: e.cancelled,
+                    }),
                 }
             }
             // Defensive only: every key with an installer or uninstaller now
@@ -388,7 +391,9 @@ impl mtui_hosts::PlanProvider for WorkflowRegistry {
             // Unreachable in production means untested by the flows, so
             // `plan_provider_check_falls_back_to_the_exit_code_for_an_unknown_key`
             // drives it directly.
-            None if a.exitcode != 0 => Err(format!("{op} command failed")),
+            None if a.exitcode != 0 => Err(mtui_hosts::CheckFailure::new(format!(
+                "{op} command failed"
+            ))),
             None => Ok(()),
         })
     }
@@ -618,7 +623,7 @@ mod tests {
         };
         assert_eq!(
             check(args(1)).unwrap_err(),
-            "install command failed",
+            mtui_hosts::CheckFailure::new("install command failed"),
             "a non-zero exit with no check table must still fail"
         );
         assert!(check(args(0)).is_ok(), "a clean exit passes");

--- a/crates/mtui-testreport/src/update_workflow/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/mod.rs
@@ -589,18 +589,33 @@ mod tests {
 
     #[test]
     fn plan_provider_resolves_the_role_specific_table() {
-        use mtui_hosts::PlanProvider;
+        use mtui_hosts::{Doer, PlanProvider};
 
         let reg = WorkflowRegistry::default();
-        // The role string must actually select the table: an adapter that
-        // ignored it would make `uninstall` run the *install* command.
+        // The role string must actually select the *matching* table: an
+        // adapter comparing the two doers for mere inequality would also pass
+        // on a role swap (installer <-> uninstaller). Compare each resolved
+        // doer against one built straight from that role's own table entry, so
+        // only the correct mapping passes. `Doer::command` / `Doer::reboot`
+        // are crate-private, so `Debug` is the only way to compare from here.
         let install = PlanProvider::doer(&reg, "installer", "15", false).expect("installer");
         let uninstall = PlanProvider::doer(&reg, "uninstaller", "15", false).expect("uninstaller");
-        assert_ne!(
-            format!("{install:?}"),
-            format!("{uninstall:?}"),
-            "installer and uninstaller must not resolve to the same doer"
+
+        let install_commands =
+            DoerProvider::doer(&reg, Role::Install, "15", false).expect("install table entry");
+        let expected_install = Doer::new(
+            install_commands.command_template(),
+            install_commands.reboot_template().unwrap_or_default(),
         );
+        let uninstall_commands =
+            DoerProvider::doer(&reg, Role::Uninstall, "15", false).expect("uninstall table entry");
+        let expected_uninstall = Doer::new(
+            uninstall_commands.command_template(),
+            uninstall_commands.reboot_template().unwrap_or_default(),
+        );
+
+        assert_eq!(format!("{install:?}"), format!("{expected_install:?}"));
+        assert_eq!(format!("{uninstall:?}"), format!("{expected_uninstall:?}"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `crates/mtui-hosts/src/target/operation.rs`: `OperationGroup::last_output`'s doc called the `None` fallback benign, but `HostOutput::default()` is exit 0, which every check reads as success — the host silently passes and stays in the reboot map. Doc now names the hazard, the use site logs a WARN naming the host, and a `MockGroup` test pins the current fallback behaviour.
- Widened the check seam from a bare `String` to a typed `CheckFailure { reason, cancelled }` (mirroring `RebootFailure`'s shape), so a check that stops at a cancellation checkpoint can carry that fact across `mtui-hosts` into `UpdateError.cancelled` instead of being hardcoded to `false`.
- `perform_uninstall_reports_a_transactional_host_that_never_reconnects` only asserted the host name, so it passed for any reboot-failure cause. Brought it up to its install sibling's two discriminating assertions.
- `plan_provider_resolves_the_role_specific_table` asserted the two doers merely differ, which a role swap also satisfies. Now compares each resolved doer against one built from that role's own table entry.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` and `--all-features`

Each new/strengthened test was observed failing against the unfixed/unswapped code, then restored, before landing.

No CHANGELOG entry — no user-visible change.

closes #408 