### PR TITLE
docs(changelog): backfill the released 26.0.2 and 26.0.3 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,10 +127,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - An unreachable openQA instance now reports the actual transport failure
   (e.g. `"...: Connection refused (os error 61)"`) instead of restating the
   request URL (`"...: error sending request for url (http://.../api/v1/jobs)"`).
-- MCP calls passing a list to a repeatable single-value flag (e.g. `approve`
-  with two `group`s) no longer fail to parse: the reconstructed argv now
-  repeats the flag before every element instead of emitting it once for the
-  whole list.
 - `approve` no longer approves a Gitea update whose PR head differs from the
   checked-out testreport without saying so. Interactively it now logs the
   expected/actual hash pair and asks for confirmation (default no); a missing
@@ -496,6 +492,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   underlying certificate/IO cause instead of `reqwest`'s error kind plus URL,
   which is both more actionable and URL-free by construction.
 
+## [26.1.2] - 2026-08-04
+
+### Fixed
+
+- MCP tool calls passing an array with more than one element (e.g. `add_host`
+  `target`, `openqa_overview` `aggregated_groups`, `list_refhosts` `arch`) no
+  longer fail with `unexpected argument '<second element>' found`: the
+  reconstructed argv now repeats the flag before every element instead of
+  emitting it once for the whole list.
+
 ## [26.1.1] - 2026-07-27
 
 ### Added
@@ -507,14 +513,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   CI runs the targets under the address sanitizer on every PR and main push
   via ClusterFuzzLite; a crash fails the job.
 
-- New `[connection]` config keys `reboot_timeout` (default `10` seconds) and
-  `reboot_retries` (default `10`) control the reconnect budget `prepare`,
-  `reboot`, and `update` use after rebooting a host: `reboot_timeout` is the
-  backoff base and `reboot_retries` the number of attempts beyond the first,
-  giving a slow/high-latency host (e.g. aarch64, cross-site refhosts) up to
-  ~12.7 minutes by default to come back before it is marked failed. Both are
-  visible in `config show`, settable with `config set`, and overridable with
-  the new `--reboot-timeout`/`--reboot-retries` CLI flags.
 
 ### Changed
 
@@ -657,21 +655,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   differed, the marker disagreed with the account Gitea attributes the comment
   to. If the lookup fails, it falls back to the session user so the action still
   completes. Passing an explicit user still overrides both.
-- `prepare`/`reboot`/`update` no longer falsely mark a slow-to-reboot host as
-  "reconnect after reboot failed" when it is still mid-boot: reconnect after a
-  reboot now retries with a growing backoff (`reboot_timeout`/`reboot_retries`,
-  ~12.7 minutes by default) instead of a fixed ~1.2s burst of 6 attempts.
-  Because fan-out aggregates per-host failures, one slow host previously failed
-  the whole batch. Non-reboot paths (a dead SSH link mid-`run`/`shell`, or the
-  `sftp` pre-op check) are unaffected: they still fail fast on the first probe.
-- The `https` refhosts resolver no longer aborts when it cannot write its
-  on-disk mirror to a read-only `refhosts.path` (e.g. a package-managed
-  `/usr/share/qam-metadata/refhosts.yml`): the freshly downloaded database is
-  now used in-memory and a warning is logged instead. A separate warning fires
-  when the configured `refhosts.path` directory is missing or not writable.
-  The `refhosts.yml` I/O error message no longer misreports a write failure as
-  a read. `docs/src/configuration.md` now documents the real default
-  (`~/.local/share/refdb/refhosts.yml`) instead of a stale path.
 - `docs/src/configuration.md` documented the default `[mcp]
   session_idle_timeout` as `1800` (upstream Python mtui's value); the actual
   default is `14400`, chosen so an idle HTTP MCP session outlasts rmcp's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,6 +708,42 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   has no release, so the message read `Missing Installer for ` — while aborting
   the operation for every host in the group.
 
+## [26.0.3] - 2026-07-23
+
+### Added
+
+- New `[connection]` config keys `reboot_timeout` (default `10` seconds) and
+  `reboot_retries` (default `10`) control the reconnect budget `prepare`,
+  `reboot`, and `update` use after rebooting a host: `reboot_timeout` is the
+  backoff base and `reboot_retries` the number of attempts beyond the first,
+  giving a slow/high-latency host (e.g. aarch64, cross-site refhosts) up to
+  ~12.7 minutes by default to come back before it is marked failed. Both are
+  visible in `config show`, settable with `config set`, and overridable with
+  the new `--reboot-timeout`/`--reboot-retries` CLI flags.
+
+### Fixed
+
+- `prepare`/`reboot`/`update` no longer falsely mark a slow-to-reboot host as
+  "reconnect after reboot failed" when it is still mid-boot: reconnect after a
+  reboot now retries with a growing backoff (`reboot_timeout`/`reboot_retries`,
+  ~12.7 minutes by default) instead of a fixed ~1.2s burst of 6 attempts.
+  Because fan-out aggregates per-host failures, one slow host previously failed
+  the whole batch. Non-reboot paths (a dead SSH link mid-`run`/`shell`, or the
+  `sftp` pre-op check) are unaffected: they still fail fast on the first probe.
+
+## [26.0.2] - 2026-07-22
+
+### Fixed
+
+- The `https` refhosts resolver no longer aborts when it cannot write its
+  on-disk mirror to a read-only `refhosts.path` (e.g. a package-managed
+  `/usr/share/qam-metadata/refhosts.yml`): the freshly downloaded database is
+  now used in-memory and a warning is logged instead. A separate warning fires
+  when the configured `refhosts.path` directory is missing or not writable.
+  The `refhosts.yml` I/O error message no longer misreports a write failure as
+  a read. `docs/src/configuration.md` now documents the real default
+  (`~/.local/share/refdb/refhosts.yml`) instead of a stale path.
+
 ## [26.0.1] - 2026-07-22
 
 ### Changed


### PR DESCRIPTION
Part 1 of #401.

Deliberately not "Closes": part 2 (release notes from the CHANGELOG instead of `--generate-notes`) is posted as a proposal comment on the issue and needs a maintainer decision, so #401 stays open after this merges.

## What this does

Adds the missing sections for every released tag that had none — `## [26.0.2] - 2026-07-22`, `## [26.0.3] - 2026-07-23`, and (per review) `## [26.1.2] - 2026-08-04` — and removes each entry from every section other than the release that first shipped it.

## How each section's content was established

Every inserted line is copied **byte-for-byte from the CHANGELOG the release branch itself carries at that tag** (`git show <tag>:CHANGELOG.md`), cross-checked against the commit ranges between tags (`git log 26.0.1..26.0.2`, `26.0.2..26.0.3`, `26.1.1..26.1.2`) with each release-branch commit matched to its main-branch counterpart. Section dates are the tag dates (`git log -1 --format=%cs <tag>`). A scripted verifier pins provenance: every added body line exists byte-identical in the corresponding tag's file; sub-ranges are compared explicitly.

## De-duplication (second commit, per review)

The 26.1.1 cut had swept the 26.0.2/26.0.3 entries into `[26.1.1]`, so the first commit's purely-additive backfill initially duplicated three bullets. On review direction the duplication is gone: `[26.1.1]` loses its copies of the `reboot_timeout` keys, the slow-reboot false-failure, and the refhosts-cache abort entries, and the 26.1.2 fix's differently-worded record leaves `[Unreleased]` (it described released behaviour). A whole-file scan shows zero duplicated entry blocks; `[Unreleased]` now holds only unshipped work. This deliberately edits a released section — maintainer-directed, superseding the issue's purely-additive constraint: one entry, one section, first shipment wins.

## Verification

- `typos` clean (the load-bearing check for this file, proven with a positive control: an injected known misspelling in the new region is caught at its exact line).
- Diff touches `CHANGELOG.md` only.
- `## [26.1.2]` byte-identical to tag `26.1.2`'s own section; 26.0.x sections byte-identical to their tag sub-ranges (26.0.3: tag lines 11–32; 26.0.2: tag lines 11–22 — the tags' whole sections include entries that first shipped in earlier releases, excluded here by the first-shipment rule).
- Zero duplicated entry blocks file-wide after the second commit.
