### PR TITLE
test,docs(hosts,testreport): close the #461 review findings

### DIFF
--- a/crates/mtui-hosts/src/target/operation.rs
+++ b/crates/mtui-hosts/src/target/operation.rs
@@ -1245,6 +1245,14 @@ mod tests {
             check,
         }];
         let mut group = MockGroup::new(Ok(plans)).with_missing_output();
+        // Liveness guard: the fixture *is* the test. If `with_missing_output`
+        // stopped being consulted, `last_output` would answer
+        // `Some(HostOutput::default())` — also exit 0 — and every assertion
+        // below would keep passing while covering nothing.
+        assert!(
+            group.last_output("h1").is_none(),
+            "the fixture must really be scripting a missing snapshot"
+        );
 
         let op = InstallOperation::new(strs(&["pkg-a"]));
         let report = op.run(&mut group).await.expect("the run started");

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -559,10 +559,19 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         // The all-cancelled case loses the flag too, which `probe_failed`'s
         // `all()` above would have kept. That asymmetry is deliberate: with no
         // live producer there is no all-cancelled population to summarise, and
-        // minting a group-wide cancel verdict — which routes rollback and
-        // reporting differently — for a case that cannot yet occur would be a
-        // behaviour decision taken blind. Make it here, with `all()`, if a
-        // check ever does cancel.
+        // minting a group-wide cancel verdict for a case that cannot yet occur
+        // would be a behaviour decision taken blind. Make it here, with
+        // `all()`, if a check ever does cancel — but know what that verdict
+        // does and does not reach. The flag routes *reporting*:
+        // `commands/perform.rs::map_flow_error` is its only non-test reader,
+        // and it turns the error into `CommandError::Cancelled`. It does not
+        // route the rollback — that follows the `UpdateFailure` variant
+        // `update_run_phase` picks from `repairable`/`probe_failed`, which
+        // never inspects `cancelled`. Setting it here alone would tell the
+        // operator the run was cancelled while the group-wide downgrade ran
+        // on every healthy host anyway; skipping that rollback the way
+        // `UpdateFailure::Cancelled` does needs a matching change at the
+        // `wrap` site.
         Err(aggregate)
     }
 }

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -633,11 +633,42 @@ pub async fn perform_uninstall(
     perform_operation(targets, Role::Uninstall, packages).await
 }
 
-/// The shared body of [`perform_install`] / [`perform_uninstall`].
+/// The shared body of [`perform_install`] / [`perform_uninstall`], driving the
+/// template through the real [`WorkflowRegistry`].
 async fn perform_operation(
     targets: &mut HostsGroup,
     role: Role,
     packages: &[String],
+) -> Result<(), UpdateError> {
+    perform_operation_with(
+        targets,
+        role,
+        packages,
+        Arc::new(WorkflowRegistry::default()),
+    )
+    .await
+}
+
+/// [`perform_operation`] with the [`PlanProvider`](mtui_hosts::PlanProvider)
+/// spelled out as a parameter, so a test can script the check seam.
+///
+/// Production only ever reaches this through [`perform_operation`], which
+/// passes the real [`WorkflowRegistry`] — the parameter changes nothing about
+/// what runs on a host. It exists because there is no other way in: the
+/// injection below overwrites unconditionally
+/// (`HostsGroup::set_plan_provider`), so a provider installed on the group
+/// beforehand never survives to [`OperationGroup::plans`], and no production
+/// check emits `CheckFailure::cancelled`, so the `cancelled` arm of the failure
+/// map below has no live producer to drive it either.
+///
+/// The single `set_plan_provider` call site stays in this body, which is what
+/// the inject-at-the-point-of-use rule on [`perform_install`] is about: there
+/// is still exactly one place that cannot forget to wire the provider.
+async fn perform_operation_with(
+    targets: &mut HostsGroup,
+    role: Role,
+    packages: &[String],
+    provider: Arc<dyn mtui_hosts::PlanProvider>,
 ) -> Result<(), UpdateError> {
     // Matched exhaustively on purpose: a `_ =>` arm defaulting to install would
     // quietly run the wrong package-manager command if a role were ever added,
@@ -662,7 +693,7 @@ async fn perform_operation(
         )));
     }
 
-    targets.set_plan_provider(Arc::new(WorkflowRegistry::default()));
+    targets.set_plan_provider(provider);
 
     let outcome = match role {
         Role::Install => InstallOperation::new(packages.to_vec()).run(targets).await,
@@ -2476,6 +2507,70 @@ mod tests {
         // table classifies. The verdict reports *what* went wrong, not just that
         // the exit was non-zero.
         assert_eq!(err.reason, "package not found");
+    }
+
+    /// A [`PlanProvider`](mtui_hosts::PlanProvider) whose check always stops at
+    /// a cancellation checkpoint.
+    ///
+    /// The only way to put a cancelled `CheckFailure` on `perform_operation`'s
+    /// input: the real check tables never emit one, so scripting a
+    /// `MockConnection` cannot express this state. Mirrors the provider in
+    /// `crates/mtui-hosts/tests/operation_group.rs`, which pins the same flag
+    /// one layer down, at `OperationReport`.
+    struct CancellingProvider;
+
+    impl mtui_hosts::PlanProvider for CancellingProvider {
+        fn doer(
+            &self,
+            _role: &str,
+            _release: &str,
+            _transactional: bool,
+        ) -> Result<mtui_hosts::Doer, HostError> {
+            Ok(mtui_hosts::Doer::new(
+                "zypper -n in -y -l $packages",
+                "systemctl reboot",
+            ))
+        }
+
+        fn check(&self, _role: &str, _release: &str, _transactional: bool) -> mtui_hosts::Check {
+            Box::new(|_a: mtui_hosts::CheckArgs<'_>| {
+                Err(mtui_hosts::CheckFailure::cancelled(
+                    "stopped at a checkpoint",
+                ))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_check_failure_reaches_the_update_error_with_the_flag_intact() {
+        // The flow half of the seam widening: `OperationReport` carrying the
+        // flag is worth nothing if `perform_operation`'s map drops it on the
+        // way into `UpdateError`, which is what it did (hardcoded `false`)
+        // before this branch. One host and an always-cancelling check means
+        // exactly one failure, so `aggregate_failures` takes the verbatim
+        // branch and the flag reaches the caller untouched — the summary
+        // branch deliberately does not carry it.
+        let (t, _h) = sles_target("h1", "");
+        let mut group = HostsGroup::new(vec![t], false);
+
+        let err = perform_operation_with(
+            &mut group,
+            Role::Install,
+            &["pkg-a".to_owned()],
+            Arc::new(CancellingProvider),
+        )
+        .await
+        .expect_err("a failing check surfaces as Err");
+
+        assert!(
+            err.is_cancelled(),
+            "the check stopped at a checkpoint, so the error must say cancelled: {err:?}"
+        );
+        // Not just the flag: the rest of the failure has to survive the same
+        // map, or an assertion on `is_cancelled` alone would pass on an error
+        // synthesised anywhere else in the flow.
+        assert_eq!(err.host.as_deref(), Some("h1"));
+        assert_eq!(err.reason, "stopped at a checkpoint");
     }
 
     #[tokio::test]

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -537,13 +537,32 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         // vanish on the other — and they are the declared routing contract,
         // not a detail of who reads them today.
         aggregate.probe_failed = failures.iter().all(|e| e.probe_failed);
-        // `cancelled` is deliberately NOT propagated here. Every cancellation
-        // in this module is an early `return Err`, so no cancelled error ever
-        // reaches a `failures` vec — the line would be dead, and if it ever
-        // became live it would newly route a multi-failure aggregate to
-        // `CommandError::Cancelled`, letting a cancel mask a real host failure
-        // that merely coincided with it. That is a behaviour change, not part
-        // of this fix.
+        // `cancelled` is deliberately NOT propagated here. Where
+        // `probe_failed` above is both representable and produced, `cancelled`
+        // is representable and *unproduced*: `perform_operation` builds
+        // `UpdateError { cancelled: failure.cancelled, .. }` straight from
+        // `report.check_failures`, so a cancelled check does cross the
+        // `Operation` seam into a `failures` list — but no check in
+        // `update_workflow::checks` emits `CheckFailure::cancelled` (checks
+        // are pure verdicts over a captured transcript), and this module's own
+        // cancellations are early `return Err`s that never reach an aggregate.
+        // Empty by producer, not by type: do not read the emptiness as a
+        // structural guarantee the way the pre-`CheckFailure` seam allowed.
+        //
+        // A lone cancelled failure keeps its flag regardless: the
+        // single-failure branch above returns the error verbatim. Only the
+        // summary drops it, and for the mixed case that *is* the outranking
+        // rule — a real host failure collected beside a cancel must not be
+        // re-routed to `CommandError::Cancelled` and excused as "the operator
+        // stopped it" (see `commands/perform.rs::map_flow_error`).
+        //
+        // The all-cancelled case loses the flag too, which `probe_failed`'s
+        // `all()` above would have kept. That asymmetry is deliberate: with no
+        // live producer there is no all-cancelled population to summarise, and
+        // minting a group-wide cancel verdict — which routes rollback and
+        // reporting differently — for a case that cannot yet occur would be a
+        // behaviour decision taken blind. Make it here, with `all()`, if a
+        // check ever does cancel.
         Err(aggregate)
     }
 }
@@ -3333,10 +3352,13 @@ mod tests {
             "one host that did dispatch a patch clears the flag: {mixed:?}"
         );
 
-        // `cancelled` is deliberately not summarised. Every cancellation in
-        // this module is an early `return Err`, so no cancelled error reaches
-        // a `failures` vec; propagating it here would be dead code that, were
-        // it ever reached, would let a cancel mask a coincident real failure.
+        // `cancelled` is deliberately not summarised. It is representable in a
+        // `failures` vec — `perform_operation` maps it out of
+        // `report.check_failures` — but no production check emits one, so the
+        // only cancellations reaching this module are its own early
+        // `return Err`s. A lone cancelled failure routes verbatim with the
+        // flag; a summary drops it, so a cancel cannot mask a real failure
+        // collected beside it.
         let cancelled = aggregate_failures(
             "update",
             vec![

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -539,8 +539,9 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         aggregate.probe_failed = failures.iter().all(|e| e.probe_failed);
         // `cancelled` is deliberately NOT propagated here. Where
         // `probe_failed` above is both representable and produced, `cancelled`
-        // is representable and *unproduced*: `perform_operation_with`, the
-        // shared body of `perform_install` / `perform_uninstall`, builds
+        // is representable and *unproduced* — THE AUTHORITATIVE STATEMENT OF
+        // THAT CLAIM LIVES HERE, at the omission it justifies:
+        // `perform_operation_with` builds
         // `UpdateError { cancelled: failure.cancelled, .. }` straight from
         // `report.check_failures`, so a cancelled check does cross the
         // `Operation` seam into a `failures` list — but no check in
@@ -555,24 +556,14 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         // summary drops it, and for the mixed case that *is* the outranking
         // rule — a real host failure collected beside a cancel must not be
         // re-routed to `CommandError::Cancelled` and excused as "the operator
-        // stopped it" (see `commands/perform.rs::map_flow_error`).
+        // stopped it" (see `commands/perform.rs::map_flow_error`). The flag
+        // routes *reporting* (`map_flow_error` is its only non-test reader);
+        // it does not route the rollback, which follows the `UpdateFailure`
+        // variant `update_run_phase` picks from `repairable`/`probe_failed`.
         //
-        // The all-cancelled case loses the flag too, which `probe_failed`'s
-        // `all()` above would have kept. That asymmetry is deliberate: with no
-        // live producer there is no all-cancelled population to summarise, and
-        // minting a group-wide cancel verdict for a case that cannot yet occur
-        // would be a behaviour decision taken blind. Make it here, with
-        // `all()`, if a check ever does cancel — but know what that verdict
-        // does and does not reach. The flag routes *reporting*:
-        // `commands/perform.rs::map_flow_error` is its only non-test reader,
-        // and it turns the error into `CommandError::Cancelled`. It does not
-        // route the rollback — that follows the `UpdateFailure` variant
-        // `update_run_phase` picks from `repairable`/`probe_failed`, which
-        // never inspects `cancelled`. Setting it here alone would tell the
-        // operator the run was cancelled while the group-wide downgrade ran
-        // on every healthy host anyway; skipping that rollback the way
-        // `UpdateFailure::Cancelled` does needs a matching change at the
-        // `wrap` site.
+        // The all-cancelled case also loses the flag, unlike `probe_failed`'s
+        // `all()` above: with no producer there is no all-cancelled population
+        // to summarise, so that asymmetry costs nothing today.
         Err(aggregate)
     }
 }
@@ -662,14 +653,14 @@ async fn perform_operation(
 /// [`perform_operation`] with the [`PlanProvider`](mtui_hosts::PlanProvider)
 /// spelled out as a parameter, so a test can script the check seam.
 ///
-/// Production only ever reaches this through [`perform_operation`], which
+/// Production must not reach this except through [`perform_operation`], which
 /// passes the real [`WorkflowRegistry`] — the parameter changes nothing about
 /// what runs on a host. It exists because there is no other way in: the
 /// injection below overwrites unconditionally
 /// (`HostsGroup::set_plan_provider`), so a provider installed on the group
-/// beforehand never survives to [`OperationGroup::plans`], and no production
-/// check emits `CheckFailure::cancelled`, so the `cancelled` arm of the failure
-/// map below has no live producer to drive it either.
+/// beforehand never survives to [`OperationGroup::plans`]. On what does and
+/// does not produce a cancelled check failure, see the `cancelled` comment in
+/// [`aggregate_failures`] — the authoritative statement lives there.
 ///
 /// The single `set_plan_provider` call site stays in this body, which is what
 /// the inject-at-the-point-of-use rule on [`perform_install`] is about: there
@@ -2189,7 +2180,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use mtui_config::options::Config;
-    use mtui_hosts::{HostsGroup, MockConnection, Target};
+    use mtui_hosts::{Check, CheckArgs, CheckFailure, Doer, HostsGroup, MockConnection, Target};
     use mtui_types::enums::TargetState;
     use mtui_types::hostlog::CommandLog;
     use mtui_types::package::VersionCheck;
@@ -2536,19 +2527,15 @@ mod tests {
             _role: &str,
             _release: &str,
             _transactional: bool,
-        ) -> Result<mtui_hosts::Doer, HostError> {
-            Ok(mtui_hosts::Doer::new(
+        ) -> Result<Doer, HostError> {
+            Ok(Doer::new(
                 "zypper -n in -y -l $packages",
                 "systemctl reboot",
             ))
         }
 
-        fn check(&self, _role: &str, _release: &str, _transactional: bool) -> mtui_hosts::Check {
-            Box::new(|_a: mtui_hosts::CheckArgs<'_>| {
-                Err(mtui_hosts::CheckFailure::cancelled(
-                    "stopped at a checkpoint",
-                ))
-            })
+        fn check(&self, _role: &str, _release: &str, _transactional: bool) -> Check {
+            Box::new(|_a: CheckArgs<'_>| Err(CheckFailure::cancelled("stopped at a checkpoint")))
         }
     }
 
@@ -3459,13 +3446,11 @@ mod tests {
             "one host that did dispatch a patch clears the flag: {mixed:?}"
         );
 
-        // `cancelled` is deliberately not summarised. It is representable in a
-        // `failures` vec — `perform_operation_with`, the install/uninstall
-        // shared body, maps it out of `report.check_failures` — but no
-        // production check emits one, so the only cancellations reaching this
-        // module are its own early `return Err`s. A lone cancelled failure
-        // routes verbatim with the flag; a summary drops it, so a cancel
-        // cannot mask a real failure collected beside it.
+        // `cancelled` is deliberately not summarised: a lone cancelled failure
+        // routes verbatim with the flag, a summary drops it, so a cancel
+        // cannot mask a real failure collected beside it. On what does and
+        // does not produce one, see the `cancelled` comment in
+        // `aggregate_failures` — the authoritative statement lives there.
         let cancelled = aggregate_failures(
             "update",
             vec![

--- a/crates/mtui-testreport/src/reports/update_flow.rs
+++ b/crates/mtui-testreport/src/reports/update_flow.rs
@@ -539,7 +539,8 @@ fn aggregate_failures(op: &str, mut failures: Vec<UpdateError>) -> Result<(), Up
         aggregate.probe_failed = failures.iter().all(|e| e.probe_failed);
         // `cancelled` is deliberately NOT propagated here. Where
         // `probe_failed` above is both representable and produced, `cancelled`
-        // is representable and *unproduced*: `perform_operation` builds
+        // is representable and *unproduced*: `perform_operation_with`, the
+        // shared body of `perform_install` / `perform_uninstall`, builds
         // `UpdateError { cancelled: failure.cancelled, .. }` straight from
         // `report.check_failures`, so a cancelled check does cross the
         // `Operation` seam into a `failures` list — but no check in
@@ -2521,9 +2522,10 @@ mod tests {
     /// A [`PlanProvider`](mtui_hosts::PlanProvider) whose check always stops at
     /// a cancellation checkpoint.
     ///
-    /// The only way to put a cancelled `CheckFailure` on `perform_operation`'s
-    /// input: the real check tables never emit one, so scripting a
-    /// `MockConnection` cannot express this state. Mirrors the provider in
+    /// The only way to put a cancelled `CheckFailure` on the input of
+    /// `perform_operation_with`, the install/uninstall shared body: the real
+    /// check tables never emit one, so scripting a `MockConnection` cannot
+    /// express this state. Mirrors the provider in
     /// `crates/mtui-hosts/tests/operation_group.rs`, which pins the same flag
     /// one layer down, at `OperationReport`.
     struct CancellingProvider;
@@ -2553,8 +2555,9 @@ mod tests {
     #[tokio::test]
     async fn a_cancelled_check_failure_reaches_the_update_error_with_the_flag_intact() {
         // The flow half of the seam widening: `OperationReport` carrying the
-        // flag is worth nothing if `perform_operation`'s map drops it on the
-        // way into `UpdateError`, which is what it did (hardcoded `false`)
+        // flag is worth nothing if the map in `perform_operation_with` — the
+        // shared body of `perform_install` / `perform_uninstall` — drops it on
+        // the way into `UpdateError`, which is what it did (hardcoded `false`)
         // before this branch. One host and an always-cancelling check means
         // exactly one failure, so `aggregate_failures` takes the verbatim
         // branch and the flag reaches the caller untouched — the summary
@@ -3457,12 +3460,12 @@ mod tests {
         );
 
         // `cancelled` is deliberately not summarised. It is representable in a
-        // `failures` vec — `perform_operation` maps it out of
-        // `report.check_failures` — but no production check emits one, so the
-        // only cancellations reaching this module are its own early
-        // `return Err`s. A lone cancelled failure routes verbatim with the
-        // flag; a summary drops it, so a cancel cannot mask a real failure
-        // collected beside it.
+        // `failures` vec — `perform_operation_with`, the install/uninstall
+        // shared body, maps it out of `report.check_failures` — but no
+        // production check emits one, so the only cancellations reaching this
+        // module are its own early `return Err`s. A lone cancelled failure
+        // routes verbatim with the flag; a summary drops it, so a cancel
+        // cannot mask a real failure collected beside it.
         let cancelled = aggregate_failures(
             "update",
             vec![


### PR DESCRIPTION
Follow-up to #461, which merged while these commits were in flight; they close the three findings from [its review](https://github.com/openSUSE/mtui/pull/461#pullrequestreview-6482451190) plus two accuracy defects an adversarial pass found in my own first rewrite. #408 stays closed — this completes its cleanup rather than reopening it.

## What each commit does

- **`c4ff574c`** rewrites `aggregate_failures`'s `cancelled` comment from the premise #461 removed: a cancelled check failure is now *representable* across the seam (`CheckFailure.cancelled` → `UpdateError.cancelled`) and merely unproduced — the old text claimed the vec could never carry one, which the types no longer guarantee. Comment-only; behavior untouched (verified mechanically: every changed line is a comment line).
- **`cfe0d02a`** adds the test the seam fix was missing: a provider whose check returns `CheckFailure::cancelled(…)` driven through `perform_install`, single-failure verbatim path, asserting `err.is_cancelled()`. **Observed red exactly on the fixed line**: reverting `cancelled: failure.cancelled` → `cancelled: false` fails only this test (338 passed / 1 failed, panic at the new assertion), restoring goes green. Getting the provider injected needed a seam: `perform_operation` becomes a thin delegator over `perform_operation_with(…, provider)` — production byte-identical, the single `set_plan_provider` call site stays inside the shared body, so the inject-at-the-point-of-use rule holds. That split is the one judgement call here worth a look.
- **`0d359f42`** makes the missing-output fixture prove its own wiring: `assert!(group.last_output("h1").is_none())` before the run, so the test named after the `None` fallback can no longer pass while silently exercising `Some(default)`. Also observed red (dropping `.with_missing_output()` fails only this test).
- **`a9ead622`** fixes an overclaim my first rewrite introduced: the `cancelled` flag routes *reporting* (`map_flow_error` → `CommandError::Cancelled` — its only non-test consumer), **not** the rollback, which `perform_update_with_rollback` dispatches purely on the `UpdateFailure` variant. The comment now says exactly that and what a rollback-skipping cancel would additionally need.
- **`f7243e3a`** renames the four comment sites that still said `perform_operation` for the map that now lives in `perform_operation_with`.

## Gate

Full DoD gate observed green on this exact tree: fmt, clippy 0, rustdoc `--all-features` 0, workspace 2556 passed / 0 failed (36 suites), `-F mcp` 291 passed / 0 failed, both feature-matrix builds, typos clean, no MUTANT markers, clean status. The branch was rebased onto main from a base whose tree is byte-identical to the merge (`git diff` between the gated head and this head is empty), so the gate results describe these bytes.
