### PR TITLE
test(testreport): make an empty probe.ran diagnosable

### DIFF
--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -478,7 +478,8 @@ mod tests {
         /// Every arm records its invocation, which is the liveness signal the
         /// negative assertions rest on.
         const ZYPPER_STUB: &str = r#"#!/bin/sh
-printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran"
+# A failed append must not look like a healthy probe (no set -e in the stub).
+printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran" || exit 97
 case "$2" in
 se)
     if [ -n "$MTUI_STUB_SE_ROWS" ]; then printf '%s\n' "$MTUI_STUB_SE_ROWS"; fi
@@ -575,6 +576,8 @@ exit 0
             /// The script's stdout — what the flow parses into the version map,
             /// and what `show_log` shows the operator.
             stdout: String,
+            /// The script's stderr, captured for sentinel-miss diagnostics.
+            stderr: String,
         }
 
         impl Ran {
@@ -627,7 +630,20 @@ exit 0
                     .code()
                     .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status)),
                 stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
             }
+        }
+
+        fn assert_reached_stub(name: &str, stubs: &Stubs, ran: &Ran, expected: &str) {
+            let invocations = stubs.probe_invocations();
+            assert!(
+                invocations.iter().any(|c| c == expected),
+                "{name}: the script never reached the stub zypper at all: {invocations:?}\n\
+                 code: {}\nstdout: {}\nstderr: {}",
+                ran.code,
+                ran.stdout,
+                ran.stderr,
+            );
         }
 
         #[test]
@@ -653,11 +669,7 @@ exit 0
                 );
                 // Liveness first: the negative below is also what an empty
                 // `PATH` produces.
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "se"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "se");
                 assert_eq!(
                     ran.marker(),
                     Some(format!("{PROBE_MARKER}: zypper -n se exited 7").as_str()),
@@ -783,11 +795,7 @@ exit 0
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "se"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "se");
                 assert_eq!(
                     ran.marker(),
                     Some(format!("{PROBE_MARKER}: awk exited 2").as_str()),
@@ -838,11 +846,7 @@ exit 0
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "se"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "se");
                 assert_eq!(
                     ran.marker(),
                     None,
@@ -959,11 +963,7 @@ exit 0
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "se"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "se");
                 assert_eq!(
                     ran.marker(),
                     None,
@@ -976,6 +976,29 @@ exit 0
                     ran.versions()
                 );
                 assert_eq!(ran.code, 0, "{name}: and it must not fail");
+            }
+        }
+
+        #[test]
+        fn a_failed_sentinel_append_exits_97() {
+            // The stub has no `set -e`; a failed `>> probe.ran` must not look
+            // like a healthy probe.
+            for (name, cmds) in downgraders() {
+                let stubs = Stubs::new();
+                fs::create_dir(stubs.dir.path().join("probe.ran"))
+                    .expect("pre-create probe.ran as a directory so the append fails");
+                let ran = run_script(&cmds, &stubs, Knobs::default());
+                assert_eq!(
+                    ran.code, 97,
+                    "{name}: a failed sentinel append must exit 97, not look healthy: \
+                     stdout: {}\nstderr: {}",
+                    ran.stdout, ran.stderr,
+                );
+                assert!(
+                    stubs.probe_invocations().is_empty(),
+                    "{name}: the append failed, so the log must stay empty: {:?}",
+                    stubs.probe_invocations()
+                );
             }
         }
     }

--- a/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/downgrade.rs
@@ -634,6 +634,7 @@ exit 0
             }
         }
 
+        #[track_caller]
         fn assert_reached_stub(name: &str, stubs: &Stubs, ran: &Ran, expected: &str) {
             let invocations = stubs.probe_invocations();
             assert!(
@@ -994,10 +995,16 @@ exit 0
                      stdout: {}\nstderr: {}",
                     ran.stdout, ran.stderr,
                 );
-                assert!(
-                    stubs.probe_invocations().is_empty(),
-                    "{name}: the append failed, so the log must stay empty: {:?}",
-                    stubs.probe_invocations()
+                // `probe.ran` is a directory here, so `probe_invocations()`
+                // swallows EISDIR and would stay empty with the stub or guard
+                // removed. The marker names the probe and the stub's 97, which
+                // is the path `mtui_probe_ok` must have seen.
+                assert_eq!(
+                    ran.marker(),
+                    Some(format!("{PROBE_MARKER}: zypper -n se exited 97").as_str()),
+                    "{name}: the marker must start a line and name the probe and its \
+                     status: {}",
+                    ran.stdout
                 );
             }
         }

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -823,6 +823,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
             }
         }
 
+        #[track_caller]
         fn assert_reached_stub(name: &str, stubs: &Stubs, ran: &Ran, expected: &str) {
             let invocations = stubs.probe_invocations();
             assert!(
@@ -1354,10 +1355,16 @@ exit "$MTUI_STUB_PATCH_EXIT"
                      stdout: {}\nstderr: {}",
                     ran.stdout, ran.stderr,
                 );
+                // `probe.ran` is a directory here, so `probe_invocations()`
+                // swallows EISDIR and would stay empty with the stub or guard
+                // removed. The marker names the probe and the stub's 97, which
+                // is the path `mtui_probe_ok` must have seen.
                 assert!(
-                    stubs.probe_invocations().is_empty(),
-                    "{name}: the append failed, so the log must stay empty: {:?}",
-                    stubs.probe_invocations()
+                    ran.stdout.contains(&format!(
+                        "{PROBE_FAILURE_MARKER}: zypper -n patches exited 97"
+                    )),
+                    "{name}: the marker must name the failed probe and its status: {}",
+                    ran.stdout
                 );
             }
         }

--- a/crates/mtui-testreport/src/update_workflow/actions/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/actions/update.rs
@@ -631,7 +631,8 @@ mod tests {
         /// status cannot distinguish a broken issue repo from an unrelated
         /// broken repo; see the module docs).
         const ZYPPER_STUB: &str = r#"#!/bin/sh
-printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran"
+# A failed append must not look like a healthy probe (no set -e in the stub).
+printf '%s\n' "$2" >> "$MTUI_STUB_DIR/probe.ran" || exit 97
 case "$2" in
 patches)
     if [ -n "$MTUI_STUB_PATCH_ROW" ]; then printf '%s\n' "$MTUI_STUB_PATCH_ROW"; fi
@@ -644,11 +645,11 @@ lr)
     if [ -n "$MTUI_STUB_REPO_ROW" ]; then printf '%s\n' "$MTUI_STUB_REPO_ROW"; fi
     ;;
 rr)
-    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/cleanup.ran"
+    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/cleanup.ran" || exit 97
     exit "$MTUI_STUB_CLEANUP_EXIT"
     ;;
 in)
-    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran"
+    printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran" || exit 97
     exit "$MTUI_STUB_PATCH_EXIT"
     ;;
 esac
@@ -658,7 +659,7 @@ exit 0
         /// The stub `transactional-update`: the slmicro patch command, and the
         /// only thing that binary is called for in `SLM_UPDATE`.
         const TU_STUB: &str = r#"#!/bin/sh
-printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran"
+printf '%s\n' "$*" >> "$MTUI_STUB_DIR/patch.ran" || exit 97
 exit "$MTUI_STUB_PATCH_EXIT"
 "#;
 
@@ -779,6 +780,8 @@ exit "$MTUI_STUB_PATCH_EXIT"
             /// The script's stdout — where the probe guard's marker line
             /// lands, and so what the update check would classify.
             stdout: String,
+            /// The script's stderr, captured for sentinel-miss diagnostics.
+            stderr: String,
         }
 
         /// Renders `cmds` and runs it under `/bin/sh -c`.
@@ -816,7 +819,20 @@ exit "$MTUI_STUB_PATCH_EXIT"
                     .code()
                     .unwrap_or_else(|| panic!("script died on a signal: {:?}", out.status)),
                 stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
             }
+        }
+
+        fn assert_reached_stub(name: &str, stubs: &Stubs, ran: &Ran, expected: &str) {
+            let invocations = stubs.probe_invocations();
+            assert!(
+                invocations.iter().any(|c| c == expected),
+                "{name}: the script never reached the stub zypper at all: {invocations:?}\n\
+                 code: {}\nstdout: {}\nstderr: {}",
+                ran.code,
+                ran.stdout,
+                ran.stderr,
+            );
         }
 
         #[test]
@@ -940,11 +956,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                 // Liveness first. The headline assertion here is a *negative*,
                 // and an empty `PATH` produces exactly the same observation —
                 // so show the script actually reached the stub.
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "patches"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "patches");
                 assert!(
                     stubs.patch_invocations().is_empty(),
                     "{name}: with no matching patch the patch command must not run: {:?}",
@@ -989,11 +1001,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "patches"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "patches");
                 assert!(
                     stubs.patch_invocations().is_empty(),
                     "{name}: a whitespace-only list must not run the patch: {:?}",
@@ -1031,11 +1039,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "patches"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "patches");
                 assert!(
                     stubs.patch_invocations().is_empty(),
                     "{name}: a failed probe must not be followed by a patch: {:?}",
@@ -1277,11 +1281,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "patches"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "patches");
                 assert!(
                     stubs.patch_invocations().is_empty(),
                     "{name}: a broken awk must not be followed by a patch: {:?}",
@@ -1320,11 +1320,7 @@ exit "$MTUI_STUB_PATCH_EXIT"
                         ..Knobs::default()
                     },
                 );
-                assert!(
-                    stubs.probe_invocations().iter().any(|c| c == "patches"),
-                    "{name}: the script never reached the stub zypper at all: {:?}",
-                    stubs.probe_invocations()
-                );
+                assert_reached_stub(name, &stubs, &ran, "patches");
                 assert!(
                     stubs.patch_invocations().is_empty(),
                     "{name}: no row matches this update, so no patch may run: {:?}",
@@ -1339,6 +1335,29 @@ exit "$MTUI_STUB_PATCH_EXIT"
                 assert_eq!(
                     ran.code, 0,
                     "{name}: a host with nothing of ours to patch passes"
+                );
+            }
+        }
+
+        #[test]
+        fn a_failed_sentinel_append_exits_97() {
+            // The stub has no `set -e`; a failed `>> probe.ran` must not look
+            // like a healthy probe.
+            for (name, cmds) in templates() {
+                let stubs = Stubs::new();
+                fs::create_dir(stubs.dir.path().join("probe.ran"))
+                    .expect("pre-create probe.ran as a directory so the append fails");
+                let ran = run_script(&cmds, &stubs, Knobs::default());
+                assert_eq!(
+                    ran.code, 97,
+                    "{name}: a failed sentinel append must exit 97, not look healthy: \
+                     stdout: {}\nstderr: {}",
+                    ran.stdout, ran.stderr,
+                );
+                assert!(
+                    stubs.probe_invocations().is_empty(),
+                    "{name}: the append failed, so the log must stay empty: {:?}",
+                    stubs.probe_invocations()
                 );
             }
         }


### PR DESCRIPTION
Closes #464.

The one CI occurrence of `rows_filtered_to_nothing_is_a_noop` (slmicro leg) discarded the only evidence: `probe.ran` was empty, and the sentinel panic printed only the empty invocation list. The stub's first act is an unguarded `>>` with no `set -e`, so a failed append still looks like a healthy probe. `run_script` also dropped stderr, which is where `zypper: not found` / `Is a directory` would have been.

This does not retry the unknown runner glitch. It makes the next occurrence diagnosable, and pins "recording broke" so it cannot look like "never ran".

## What changed (test harness only)

- Stub appends now `|| exit 97` (`downgrade.rs` `ZYPPER_STUB`; `update.rs` `ZYPPER_STUB` `probe.ran`/`cleanup.ran`/`patch.ran` and `TU_STUB`). 97 is outside zypper's space and not in the probe-guard accepted set (`0`/`104`/`106`).
- `Ran` keeps `stderr`. The nine copy-pasted "never reached the stub" asserts go through `assert_reached_stub`, which dumps invocations plus `code`/`stdout`/`stderr`.
- `a_failed_sentinel_append_exits_97` in both `rendered_script` modules: `probe.ran` is pre-created as a directory, healthy knobs, both templates; asserts code 97 and empty invocations.

No CHANGELOG (test-only). Production `LIST_COMMAND` / templates are untouched.

## Proof

Red-then-green of the pinning tests (AGENTS.md): with `|| exit 97` dropped, both tests failed `left: 0` / `right: 97` (healthy stdout, stderr `Is a directory`). Restored, green.

Local gate observed green (not predicted):

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features`
- `cargo build --workspace --all-features`

Adversarial review of the diff: 0 issues.