### PR TITLE
refactor: name repeated magic-number literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- The zypper `install`/`uninstall` check now shares the `update` check's exit
+  code/marker classifier instead of restating it inline, so the two cannot
+  drift apart. Reason-string changes on `install`/`uninstall` for the
+  `("11"|"12"|"15"|"16", false)` keys: exit `4`/`5`/`8` now let a locked
+  update stack, dependency prompt or RPM error name the failure instead of
+  always answering "package not found" (only `104` still short-circuits to
+  it); a transcript carrying both a dependency prompt and an `Error:` line now
+  answers "Dependency Error" instead of "RPM Error"; and a command that never
+  produced an exit status now answers "command timed out or failed to run"
+  (previously "Unknown Error").
 - The REPL line editor moved to reedline 0.50. User-facing deltas: the
   terminal painter no longer misplaces the cursor once a line fills the full
   terminal width, a bottom-flush prompt no longer reuses a stale anchor after

--- a/crates/mtui-cli/src/shell.rs
+++ b/crates/mtui-cli/src/shell.rs
@@ -229,7 +229,10 @@ fn encode_key(key: KeyEvent) -> Option<Vec<u8>> {
 ///   the caller reports it and moves on to the next host).
 /// * Propagates a [`bridge`] failure.
 async fn run_bridge_on(target: &mut Target) -> anyhow::Result<()> {
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((
+        mtui_core::display::DEFAULT_TERM_COLS,
+        mtui_core::display::DEFAULT_TERM_ROWS,
+    ));
     // Enter raw mode *before* spawning so the guard restores it even if the
     // bridge fails partway; the spawn itself does not touch the local TTY.
     let _guard = RawModeGuard::new()?;

--- a/crates/mtui-core/src/commands/quit.rs
+++ b/crates/mtui-core/src/commands/quit.rs
@@ -7,22 +7,18 @@ use clap::{Arg, ArgMatches};
 
 use crate::command::{Command, Scope};
 use crate::error::CommandResult;
-use crate::session::Session;
+use crate::session::{HOST_CLOSE_TIMEOUT, Session};
 
 /// The two accepted boot actions, mirrored onto the CLI positional and reused
 /// for completion.
 const BOOT_ACTIONS: [&str; 2] = ["reboot", "poweroff"];
 
-/// Wall-clock budget for a template's host-close fan-out; quit must still
-/// exit if a host hangs during teardown.
-const CLOSE_TIMEOUT: Duration = Duration::from_secs(45);
-
 /// Resolves the per-template close budget. In tests it is overridable (via
 /// `tests::set_close_timeout`) so the straggler path can be exercised without
-/// waiting the full 45s; in production it is always [`CLOSE_TIMEOUT`].
+/// waiting the full budget; in production it is always [`HOST_CLOSE_TIMEOUT`].
 #[cfg(not(test))]
 fn close_timeout() -> Duration {
-    CLOSE_TIMEOUT
+    HOST_CLOSE_TIMEOUT
 }
 #[cfg(test)]
 fn close_timeout() -> Duration {
@@ -36,8 +32,8 @@ fn close_timeout() -> Duration {
 /// releases the report's host-arbitration pool claims (in-process arbiter
 /// ownership + remote pool locks) then closes its host group — rebooting
 /// (`reboot`), powering off (`poweroff` → shell `halt`), or simply
-/// disconnecting when no bootarg is given. Each template's close runs under a
-/// 45s budget so a hung host never blocks exit; a host that fails to disconnect
+/// disconnecting when no bootarg is given. Each template's close runs under
+/// [`HOST_CLOSE_TIMEOUT`] so a hung host never blocks exit; a host that fails to disconnect
 /// is named (`failed to disconnect from <host>: <err>`) and a host still
 /// disconnecting at the budget is named as a straggler
 /// (`still disconnecting from <host> after <secs> seconds`). Afterwards it
@@ -156,7 +152,7 @@ mod tests {
     };
 
     /// Test-only override for [`close_timeout`], in milliseconds. `u64::MAX`
-    /// means "use the production [`CLOSE_TIMEOUT`]". Serialised by
+    /// means "use the production [`HOST_CLOSE_TIMEOUT`]". Serialised by
     /// [`CLOSE_TIMEOUT_LOCK`] so a shrunk budget never leaks into a concurrent
     /// test.
     static CLOSE_TIMEOUT_MS: AtomicU64 = AtomicU64::new(u64::MAX);
@@ -164,7 +160,7 @@ mod tests {
 
     pub(super) fn close_timeout_override() -> Duration {
         match CLOSE_TIMEOUT_MS.load(Ordering::SeqCst) {
-            u64::MAX => CLOSE_TIMEOUT,
+            u64::MAX => HOST_CLOSE_TIMEOUT,
             ms => Duration::from_millis(ms),
         }
     }

--- a/crates/mtui-core/src/display.rs
+++ b/crates/mtui-core/src/display.rs
@@ -488,6 +488,11 @@ fn filter_ansi(text: &str) -> String {
     erase.replace_all(&no_sgr, "").into_owned()
 }
 
+/// The VT100 default geometry, used when the terminal size is unknowable.
+pub const DEFAULT_TERM_COLS: u16 = 80;
+/// The VT100 default geometry, used when the terminal size is unknowable.
+pub const DEFAULT_TERM_ROWS: u16 = 24;
+
 /// Returns the terminal size as `(cols, rows)`.
 ///
 /// Reads `TIOCGWINSZ` via `ioctl`,
@@ -514,7 +519,7 @@ fn termsize() -> (usize, usize) {
             }
         }
     }
-    termsize_from_env().unwrap_or((80, 24))
+    termsize_from_env().unwrap_or((DEFAULT_TERM_COLS as usize, DEFAULT_TERM_ROWS as usize))
 }
 
 /// Pure `ACCTEST_COLS`/`ACCTEST_ROWS` fallback, split out so the `(cols, rows)`

--- a/crates/mtui-core/src/lib.rs
+++ b/crates/mtui-core/src/lib.rs
@@ -48,5 +48,5 @@ pub use log_filter::{
     resolve_log_directives, resolve_log_directives_from,
 };
 pub use registry::{MCP_DENYLIST, Registry, register_all};
-pub use session::{LogLevel, LogLevelSink, NotifySink, Session};
+pub use session::{HOST_CLOSE_TIMEOUT, LogLevel, LogLevelSink, NotifySink, Session};
 pub use template_registry::TemplateRegistry;

--- a/crates/mtui-core/src/session.rs
+++ b/crates/mtui-core/src/session.rs
@@ -12,6 +12,7 @@
 //! registry grows past one entry.
 
 use std::sync::Mutex;
+use std::time::Duration;
 
 use mtui_config::Config;
 use mtui_datasources::HttpError;
@@ -28,6 +29,15 @@ use tracing::{info, warn};
 use crate::display::CommandPromptDisplay;
 use crate::error::CommandError;
 use crate::template_registry::TemplateRegistry;
+
+/// Wall-clock budget for a host-close fan-out.
+///
+/// A wedged host teardown (a dead peer with no RST whose close never returns)
+/// must not block whatever is waiting on it: the REPL `quit` command, template
+/// replacement/removal, or the MCP idle-sweep's `close`. Each of those bounds
+/// its own fan-out with this budget and abandons a straggler rather than
+/// hanging forever.
+pub const HOST_CLOSE_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// The explicitly-passed state every command operates on.
 pub struct Session {

--- a/crates/mtui-core/src/template_registry.rs
+++ b/crates/mtui-core/src/template_registry.rs
@@ -34,6 +34,8 @@ use mtui_hosts::get_arbiter;
 use mtui_testreport::TestReport;
 use tokio::sync::Mutex;
 
+use crate::session::HOST_CLOSE_TIMEOUT;
+
 /// A loaded report behind its own lock.
 ///
 /// Each registry entry is individually lockable:
@@ -45,17 +47,12 @@ use tokio::sync::Mutex;
 /// different-RRID dispatch overlap is step 5, out of scope here.
 pub type ReportEntry = Arc<Mutex<Box<dyn TestReport + Send + Sync>>>;
 
-/// Wall-clock budget for one removed report's host-close fan-out (matches
-/// `quit`'s `CLOSE_TIMEOUT`); removal must still complete if a host hangs
-/// during teardown.
-const REMOVE_CLOSE_TIMEOUT: Duration = Duration::from_secs(45);
-
 /// Resolves the per-report close budget. Overridable in tests (via
 /// `tests::set_close_timeout`) so the wedged-host path can be exercised without
-/// waiting the full 45s; always [`REMOVE_CLOSE_TIMEOUT`] in production.
+/// waiting the full budget; always [`HOST_CLOSE_TIMEOUT`] in production.
 #[cfg(not(test))]
 fn remove_close_timeout() -> Duration {
-    REMOVE_CLOSE_TIMEOUT
+    HOST_CLOSE_TIMEOUT
 }
 #[cfg(test)]
 fn remove_close_timeout() -> Duration {
@@ -346,7 +343,7 @@ mod tests {
     use crate::commands::testkit::{fake_report, fake_report_from_base};
 
     /// Test-only override for [`remove_close_timeout`], in milliseconds.
-    /// `u64::MAX` means "use the production [`REMOVE_CLOSE_TIMEOUT`]". Serialised
+    /// `u64::MAX` means "use the production [`HOST_CLOSE_TIMEOUT`]". Serialised
     /// by [`CLOSE_TIMEOUT_LOCK`] so a shrunk budget never leaks into a concurrent
     /// test (the whole integration suite shares one process).
     static CLOSE_TIMEOUT_MS: AtomicU64 = AtomicU64::new(u64::MAX);
@@ -354,7 +351,7 @@ mod tests {
 
     pub(super) fn close_timeout_override() -> Duration {
         match CLOSE_TIMEOUT_MS.load(Ordering::SeqCst) {
-            u64::MAX => REMOVE_CLOSE_TIMEOUT,
+            u64::MAX => HOST_CLOSE_TIMEOUT,
             ms => Duration::from_millis(ms),
         }
     }

--- a/crates/mtui-datasources/src/http.rs
+++ b/crates/mtui-datasources/src/http.rs
@@ -327,6 +327,12 @@ fn load_ca_bundle(path: &Path) -> Result<Vec<reqwest::Certificate>> {
     reqwest::Certificate::from_pem_bundle(&pem).map_err(HttpError::from)
 }
 
+/// The bound both source-chain walks below use to guard against a
+/// self-referential chain looping forever. Shared so the two cannot drift
+/// apart — see [`root_cause`]'s doc for how the two loops differ in effect
+/// while sharing this bound.
+const MAX_ERROR_SOURCE_LINKS: usize = 64;
+
 /// Return `true` if `err` is (or was caused by) a TLS certificate-verification
 /// failure.
 ///
@@ -341,7 +347,7 @@ pub(crate) fn is_ssl_verification_error(err: &(dyn std::error::Error + 'static))
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
     while let Some(e) = current {
         // Guard against a self-referential source chain looping forever.
-        if seen > 64 {
+        if seen > MAX_ERROR_SOURCE_LINKS {
             break;
         }
         seen += 1;
@@ -438,16 +444,16 @@ pub(crate) fn ssl_error_detail(e: &HttpError) -> String {
 ///
 /// Returns `None` if `e` carries no source at all, so callers fall back to the
 /// outer error's own `Display`. A self-referential source chain is bounded like
-/// [`is_ssl_verification_error`]'s walk, though not identically: that one
-/// inspects at most 65 links, this one advances at most 66 times past the first
-/// source. Either bound only has to terminate. (The openQA copy this was hoisted
-/// from had no bound at all.)
+/// [`is_ssl_verification_error`]'s walk, sharing [`MAX_ERROR_SOURCE_LINKS`],
+/// though not identically: that one inspects at most 65 links, this one
+/// advances at most 66 times past the first source. Either bound only has to
+/// terminate. (The openQA copy this was hoisted from had no bound at all.)
 #[must_use]
 pub(crate) fn root_cause(e: &dyn std::error::Error) -> Option<String> {
     let mut deepest = e.source()?;
     let mut seen = 0usize;
     while let Some(next) = deepest.source() {
-        if seen > 64 {
+        if seen > MAX_ERROR_SOURCE_LINKS {
             break;
         }
         seen += 1;

--- a/crates/mtui-hosts/src/connection/ssh.rs
+++ b/crates/mtui-hosts/src/connection/ssh.rs
@@ -110,6 +110,10 @@ pub const MAX_TOTAL_BYTES: usize = 2 * MAX_STREAM_BYTES;
 /// long, chatty commands (large `zypper` transactions) still complete.
 const COMMAND_DEADLINE_FACTOR: u32 = 12;
 
+/// The standard SSH port, used when neither `~/.ssh/config` nor the refhost
+/// entry names one.
+const DEFAULT_SSH_PORT: u16 = 22;
+
 /// Accumulates a command's stdout/stderr under fixed per-stream and combined
 /// byte caps, discarding overflow instead of buffering it.
 ///
@@ -662,7 +666,7 @@ fn resolve(hostname: &str, port: u16) -> Resolved {
         connect_host: cfg_host,
         port: cfg_port
             .or(if port == 0 { None } else { Some(port) })
-            .unwrap_or(22),
+            .unwrap_or(DEFAULT_SSH_PORT),
         user: cfg_user.unwrap_or_else(|| DEFAULT_USER.to_owned()),
         identity_files,
     }
@@ -712,7 +716,7 @@ fn persist_host_key_inner(
     let openssh = pubkey
         .to_openssh()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-    let entry = if port == 22 {
+    let entry = if port == DEFAULT_SSH_PORT {
         format!("{host} {openssh}\n")
     } else {
         format!("[{host}]:{port} {openssh}\n")

--- a/crates/mtui-mcp/src/provider.rs
+++ b/crates/mtui-mcp/src/provider.rs
@@ -50,12 +50,12 @@ use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::Duration;
 
 use mtui_config::Config;
-use mtui_core::Registry;
+use mtui_core::{HOST_CLOSE_TIMEOUT, Registry};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::server::McpServer;
-use crate::session::{DISCONNECT_TIMEOUT, McpSession};
+use crate::session::McpSession;
 
 /// A monotonic clock reading in milliseconds, for last-touch bookkeeping.
 ///
@@ -359,7 +359,7 @@ impl SessionRegistry {
     ///
     /// Snapshots the live sessions, removes them from the live set, and closes
     /// them concurrently under [`sweep_parallel`](Self::sweep_parallel) with a
-    /// single overall deadline (`DISCONNECT_TIMEOUT + 1s`) so one wedged host
+    /// single overall deadline (`HOST_CLOSE_TIMEOUT + 1s`) so one wedged host
     /// close cannot hang process exit. Best-effort and idempotent: a second call
     /// finds an empty set.
     pub(crate) async fn close_all(&self) {
@@ -377,7 +377,7 @@ impl SessionRegistry {
 }
 
 /// Close a batch of sessions concurrently under `parallel`, bounded by a single
-/// overall deadline (`DISCONNECT_TIMEOUT + 1s`).
+/// overall deadline (`HOST_CLOSE_TIMEOUT + 1s`).
 ///
 /// Shared by the idle sweep ([`sweep_once`]) and graceful shutdown
 /// ([`SessionRegistry::close_all`]): one budget (not N×) guarantees the batch
@@ -393,7 +393,7 @@ async fn close_sessions(sessions: Vec<Arc<McpSession>>, parallel: usize) {
         futures::stream::iter(sessions).for_each_concurrent(parallel, |session| async move {
             session.close().await;
         });
-    let deadline = DISCONNECT_TIMEOUT + Duration::from_secs(1);
+    let deadline = HOST_CLOSE_TIMEOUT + Duration::from_secs(1);
     if tokio::time::timeout(deadline, batch).await.is_err() {
         tracing::warn!(
             ?deadline,

--- a/crates/mtui-mcp/src/session.rs
+++ b/crates/mtui-mcp/src/session.rs
@@ -67,7 +67,7 @@
 //! teardown the http `SessionRegistry` calls on
 //! eviction. For **every** loaded template it releases the report's pool claims
 //! then disconnects its host group, best-effort + idempotent, under a bounded
-//! `DISCONNECT_TIMEOUT` so a wedged host close cannot block the idle-sweep.
+//! [`HOST_CLOSE_TIMEOUT`] so a wedged host close cannot block the idle-sweep.
 //! It does not empty each `HostsGroup` (a closed `Target` is left in the group
 //! with a dead connection, dropped whole with the report) and it bounds the
 //! wait with [`tokio::time::timeout`].
@@ -81,8 +81,8 @@ use std::time::{Duration, Instant};
 
 use mtui_config::Config;
 use mtui_core::{
-    ColorMode, CommandError, CommandPromptDisplay, EngineError, Registry, Session, dispatch_argv,
-    dispatch_command, resolve_command_rrids,
+    ColorMode, CommandError, CommandPromptDisplay, EngineError, HOST_CLOSE_TIMEOUT, Registry,
+    Session, dispatch_argv, dispatch_command, resolve_command_rrids,
 };
 use mtui_hosts::LockOutcome;
 use tokio::sync::Mutex;
@@ -93,14 +93,6 @@ use tokio_util::sync::CancellationToken;
 use crate::capture::{self, SharedBuf};
 use crate::concurrency::{ExclusiveGuard, RwGate, SharedGuard};
 use crate::slim::{cap_output, truncation_notice};
-
-/// Wall-clock budget for the whole [`close`](McpSession::close) host-disconnect
-/// fan-out.
-///
-/// A wedged host teardown (a dead peer with no RST whose close never returns)
-/// must not block the http registry's idle-sweep behind it; a close that
-/// overruns this bound is logged and abandoned so `close()` always returns.
-pub(crate) const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Default interval between `notifications/progress` heartbeat frames while a
 /// long-running foreground tool call runs.
@@ -793,7 +785,7 @@ impl McpSession {
     /// remote pool locks; a no-op when pool selection was never used) then closes
     /// its host group. A second call re-runs both over already-released claims and
     /// already-closed targets, both no-ops. The fan-out is bounded by
-    /// `DISCONNECT_TIMEOUT`: a wedged host close is logged and abandoned so
+    /// [`HOST_CLOSE_TIMEOUT`]: a wedged host close is logged and abandoned so
     /// `close()` — and the registry idle-sweep awaiting it — always returns.
     ///
     /// `HostsGroup::close` (like the REPL `quit`) closes each `Target` but leaves
@@ -802,13 +794,14 @@ impl McpSession {
     /// empty the groups; a closed target simply reports its connection
     /// inactive/closed.
     pub async fn close(&self) {
-        self.close_with_timeout(DISCONNECT_TIMEOUT).await;
+        self.close_with_timeout(HOST_CLOSE_TIMEOUT).await;
     }
 
     /// [`close`](Self::close) with an explicit fan-out budget.
     ///
     /// The timeout seam exists so the (colocated) wedged-close unit test can
-    /// bound the wait to a fraction of a second instead of 45s.
+    /// bound the wait to a fraction of a second instead of the full
+    /// [`HOST_CLOSE_TIMEOUT`].
     async fn close_with_timeout(&self, timeout: Duration) {
         // Snapshot every loaded entry's lockable handle under the session lock,
         // then drop the session guard *before* the teardown awaits: holding the

--- a/crates/mtui-testreport/src/update_workflow/checks/downgrade.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/downgrade.rs
@@ -1,7 +1,10 @@
 //! Post-downgrade check.
 
 use crate::update_workflow::UpdateError;
-use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed};
+use crate::update_workflow::checks::{
+    CheckArgs, CheckFn, Diagnostic, EXIT_NOT_RUN, ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+    ZYPPER_EXIT_INF_REPO_SKIPPED, log_failed,
+};
 
 /// The zypper downgrade check.
 ///
@@ -18,7 +21,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     // command records. Continuing past it turns an interrupted rollback into a
     // silent half-rollback: the remaining packages stay at the update version
     // while the flow ends looking done.
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "downgrade command timed out or failed to run",
@@ -44,7 +47,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
         );
         return Err(UpdateError::new("Dependency Error", args.hostname));
     }
-    if args.exitcode == 104 {
+    if args.exitcode == ZYPPER_EXIT_INF_CAP_NOT_FOUND {
         tracing::error!(
             host = args.hostname,
             stderr = args.stderr,
@@ -52,7 +55,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
         );
         return Err(UpdateError::new("Unspecified Error", args.hostname));
     }
-    if args.exitcode == 106 {
+    if args.exitcode == ZYPPER_EXIT_INF_REPO_SKIPPED {
         tracing::warn!(
             host = args.hostname,
             stderr = args.stderr,
@@ -75,7 +78,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// Returns [`UpdateError`] with a reason of "downgrade command timed out or
 /// failed to run" when the command recorded exit `-1`.
 fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "downgrade command timed out or failed to run",
@@ -101,7 +104,7 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// Returns [`UpdateError`] with a reason of "downgrade command timed out or
 /// failed to run" when the command recorded exit `-1`.
 fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "downgrade command timed out or failed to run",
@@ -146,7 +149,7 @@ mod tests {
     fn zypper_exitcode_minus_one_raises() {
         // Exit -1 (a timed-out or unrunnable command) raises instead of letting
         // the flow continue past an interrupted rollback.
-        let err = zypper(args("", "", -1)).unwrap_err();
+        let err = zypper(args("", "", EXIT_NOT_RUN)).unwrap_err();
         assert_eq!(err.reason, "downgrade command timed out or failed to run");
         assert_eq!(err.host.as_deref(), Some("h1"));
     }
@@ -155,7 +158,7 @@ mod tests {
     fn transactional_update_exitcode_minus_one_raises() {
         // Without this the registry falls back to a no-op and a dead
         // transactional-update sails on to the reboot with no snapshot staged.
-        let err = transactional_update(args("", "", -1)).unwrap_err();
+        let err = transactional_update(args("", "", EXIT_NOT_RUN)).unwrap_err();
         assert_eq!(err.reason, "downgrade command timed out or failed to run");
         assert_eq!(err.host.as_deref(), Some("h1"));
     }
@@ -192,14 +195,16 @@ mod tests {
     #[test]
     fn exit_104_is_unspecified_error() {
         assert_eq!(
-            zypper(args("", "boom", 104)).unwrap_err().reason,
+            zypper(args("", "boom", ZYPPER_EXIT_INF_CAP_NOT_FOUND))
+                .unwrap_err()
+                .reason,
             "Unspecified Error"
         );
     }
 
     #[test]
     fn exit_106_warns_but_passes() {
-        assert!(zypper(args("", "warn", 106)).is_ok());
+        assert!(zypper(args("", "warn", ZYPPER_EXIT_INF_REPO_SKIPPED)).is_ok());
     }
 
     #[test]
@@ -211,14 +216,14 @@ mod tests {
         // are not this transcript's vocabulary — but a rollback command that
         // never ran leaves the host on the update version while the flow ends
         // looking done.
-        let err = yum(args("", "", -1)).unwrap_err();
+        let err = yum(args("", "", EXIT_NOT_RUN)).unwrap_err();
         assert_eq!(err.reason, "downgrade command timed out or failed to run");
         assert_eq!(err.host.as_deref(), Some("h1"));
 
         // Everything the check cannot justify judging still passes.
         assert!(yum(args("", "", 1)).is_ok());
         assert!(yum(args("", "Error: nothing to downgrade", 0)).is_ok());
-        assert!(yum(args("", "", 104)).is_ok());
+        assert!(yum(args("", "", ZYPPER_EXIT_INF_CAP_NOT_FOUND)).is_ok());
     }
 
     #[test]
@@ -233,7 +238,7 @@ mod tests {
             stdout: "",
             stdin: "yum -y downgrade pkg-a",
             stderr: "",
-            exitcode: -1,
+            exitcode: EXIT_NOT_RUN,
         })
         .unwrap_err();
         assert_eq!(err.reason, "downgrade command timed out or failed to run");
@@ -250,7 +255,7 @@ mod tests {
             stdout: "",
             stdin: "tu pkg in",
             stderr: "",
-            exitcode: -1,
+            exitcode: EXIT_NOT_RUN,
         })
         .unwrap_err();
         assert_eq!(err.reason, "downgrade command timed out or failed to run");

--- a/crates/mtui-testreport/src/update_workflow/checks/install.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/install.rs
@@ -5,60 +5,32 @@
 //! `UpdateError("Unknown Error")`.
 
 use crate::update_workflow::UpdateError;
-use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed};
+use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, EXIT_NOT_RUN, log_failed};
 
 /// The zypper install check.
 ///
-/// The three exit-code sets are the same ones
-/// [`classify_exit`](super::classify_exit) expresses for the `update` check,
-/// but they are spelled out inline here because this check interleaves them
-/// with its stderr markers in a different order: the markers sit *between* the
-/// package-not-found set and the "Unknown Error" fallback, where `update` now
-/// gives them first refusal on everything except `104`. So the same transcript
-/// can read differently across the two checks — an exit `5` carrying
-/// `System management is locked` is "package not found" here and "update stack
-/// locked" there, pinned on both sides so the divergence stays deliberate.
-/// Folding this onto the shared helper is a behaviour-preserving refactor only
-/// if that ordering is preserved exactly — worth doing on its own, not as a
-/// rider.
+/// Below its own role-neutral `-1` gate, this is [`super::update::classified`]:
+/// the install and update keys share one exit-code/marker classifier, so the
+/// two cannot drift into two different verdicts for the same transcript the
+/// way they once did.
 ///
 /// # Errors
 ///
-/// Returns [`UpdateError`] with a reason of "package not found", "update stack
-/// locked", "RPM Error", "Dependency Error", or "Unknown Error" depending on
-/// the exit code and stderr/stdout markers. Exit codes `0, 100, 101, 102,
-/// 103, 106, 107` are success. This check surfaces no [`Diagnostic`]s (only
-/// `update` does).
+/// Returns [`UpdateError`] with a reason of "command timed out or failed to
+/// run" (exit `-1`), "package not found", "update stack locked", "RPM Error",
+/// "Dependency Error", or "Unknown Error" depending on the exit code and
+/// stderr/stdout markers. Exit codes `0, 100, 101, 102, 103, 106, 107` are
+/// success. This check surfaces the same [`Diagnostic`]s `update` does on a
+/// clean transcript.
 fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if matches!(args.exitcode, 0 | 100 | 101 | 102 | 103 | 106 | 107) {
-        return Ok(Vec::new());
-    }
-    if matches!(args.exitcode, 104 | 4 | 5 | 8) {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
-        return Err(UpdateError::new("package not found", args.hostname));
+        return Err(UpdateError::new(
+            "command timed out or failed to run",
+            args.hostname,
+        ));
     }
-    if args
-        .stderr
-        .contains("A ZYpp transaction is already in progress.")
-        || args.stderr.contains("System management is locked")
-    {
-        log_failed(args);
-        return Err(UpdateError::new("update stack locked", args.hostname));
-    }
-    if args.stderr.contains("Error:") {
-        log_failed(args);
-        return Err(UpdateError::new("RPM Error", args.hostname));
-    }
-    if args.stdout.contains("(c): c") {
-        tracing::error!(
-            host = args.hostname,
-            stdout = args.stdout,
-            "unresolved dependency problem. please resolve manually"
-        );
-        return Err(UpdateError::new("Dependency Error", args.hostname));
-    }
-    log_failed(args);
-    Err(UpdateError::new("Unknown Error", args.hostname))
+    super::update::classified(args)
 }
 
 /// The transactional-update (`slmicro`) install/uninstall check.
@@ -88,7 +60,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// run" (exit `-1`), "update stack locked", "Dependency Error", "RPM Error",
 /// "package not found" or "Unknown Error".
 fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "command timed out or failed to run",
@@ -129,7 +101,7 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// Returns [`UpdateError`] with a reason of "command timed out or failed to
 /// run" (exit `-1`) or "Unknown Error" (any other non-zero exit).
 fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "command timed out or failed to run",
@@ -161,6 +133,12 @@ pub(crate) fn install_check(release: &str, transactional: bool) -> Option<CheckF
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update_workflow::checks::{
+        ZYPPER_EXIT_ERR_COMMIT, ZYPPER_EXIT_ERR_PRIVILEGES, ZYPPER_EXIT_ERR_ZYPP,
+        ZYPPER_EXIT_INF_CAP_NOT_FOUND, ZYPPER_EXIT_INF_REBOOT_NEEDED, ZYPPER_EXIT_INF_REPO_SKIPPED,
+        ZYPPER_EXIT_INF_RESTART_NEEDED, ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED,
+        ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED, ZYPPER_EXIT_INF_UPDATE_NEEDED,
+    };
 
     fn args<'a>(stdout: &'a str, stderr: &'a str, exitcode: i32) -> CheckArgs<'a> {
         CheckArgs {
@@ -180,7 +158,15 @@ mod tests {
         // returned an error. These packages were successfully unpacked to disk
         // and are registered in the rpm database". It was missing, so a
         // routine `%posttrans` hiccup failed the install.
-        for code in [0, 100, 101, 102, 103, 106, 107] {
+        for code in [
+            0,
+            ZYPPER_EXIT_INF_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_REBOOT_NEEDED,
+            ZYPPER_EXIT_INF_RESTART_NEEDED,
+            ZYPPER_EXIT_INF_REPO_SKIPPED,
+            ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED,
+        ] {
             assert!(
                 zypper(args("", "", code)).is_ok(),
                 "code {code} should pass"
@@ -189,8 +175,25 @@ mod tests {
     }
 
     #[test]
+    fn successful_install_now_returns_the_additional_rpm_output_diagnostic() {
+        // Before the fold this check always returned `Ok(Vec::new())` on
+        // success. Sharing `classified` means a successful install now
+        // surfaces the same "Additional rpm output" section `update` does.
+        let stdout = "before Additional rpm output:\nwarning: stuff\nRetrieving repo\nafter";
+        let diags = zypper(args(stdout, "", 0)).unwrap();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].highlight_warning);
+        assert_eq!(diags[0].text, "\nwarning: stuff\n");
+    }
+
+    #[test]
     fn package_not_found_codes() {
-        for code in [104, 4, 5, 8] {
+        for code in [
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+            ZYPPER_EXIT_ERR_ZYPP,
+            ZYPPER_EXIT_ERR_PRIVILEGES,
+            ZYPPER_EXIT_ERR_COMMIT,
+        ] {
             let err = zypper(args("", "", code)).unwrap_err();
             assert_eq!(err.reason, "package not found");
             assert_eq!(err.host.as_deref(), Some("h1"));
@@ -198,28 +201,41 @@ mod tests {
     }
 
     #[test]
-    fn the_not_found_set_still_outranks_the_markers_here() {
-        // The install check keeps its own ordering: the whole `104 | 4 | 5 | 8`
-        // set short-circuits ahead of the stderr markers, where the `update`
-        // check now lets them speak first on everything but `104`. So the same
-        // transcript reads differently across the two, deliberately — pinned
-        // here and in `update`'s `only_104_outranks_the_markers` so neither
-        // side can drift without a test saying so.
-        //
-        // Every other fixture in this module passes an empty transcript, which
-        // is why hoisting the marker block above the set used to break nothing.
-        for (stdout, stderr, code) in [
-            ("", "System management is locked", 5),
-            ("", "A ZYpp transaction is already in progress.", 4),
-            ("", "Error: something", 8),
-            ("choose (c): c", "", 4),
-        ] {
-            let err = zypper(args(stdout, stderr, code)).unwrap_err();
-            assert_eq!(
-                err.reason, "package not found",
-                "install exit {code} must outrank its markers"
-            );
-        }
+    fn only_104_outranks_the_markers_here() {
+        // The install check now shares `update`'s ordering, having folded onto
+        // its `classified` verdict: only `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`)
+        // literally means "capability not found" and short-circuits ahead of
+        // the stderr markers; `4`/`5`/`8` (`ERR_ZYPP`, `ERR_PRIVILEGES`,
+        // `ERR_COMMIT`) let the transcript name the failure instead. The two
+        // checks can no longer disagree on the same transcript — this test and
+        // `update`'s `only_104_outranks_the_markers` assert the identical
+        // verdicts, so neither side can drift apart again.
+        let err = zypper(args(
+            "",
+            "System management is locked",
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "package not found", "104 outranks the marker");
+
+        let err = zypper(args(
+            "",
+            "System management is locked",
+            ZYPPER_EXIT_ERR_PRIVILEGES,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "update stack locked", "5 + lock marker");
+        let err = zypper(args(
+            "",
+            "A ZYpp transaction is already in progress.",
+            ZYPPER_EXIT_ERR_ZYPP,
+        ))
+        .unwrap_err();
+        assert_eq!(err.reason, "update stack locked", "4 + ZYpp marker");
+        let err = zypper(args("choose (c): c", "", ZYPPER_EXIT_ERR_ZYPP)).unwrap_err();
+        assert_eq!(err.reason, "Dependency Error", "4 + dependency prompt");
+        let err = zypper(args("", "Error: something", ZYPPER_EXIT_ERR_COMMIT)).unwrap_err();
+        assert_eq!(err.reason, "RPM Error", "8 + rpm marker");
     }
 
     #[test]
@@ -239,6 +255,17 @@ mod tests {
     #[test]
     fn dependency_error_from_stdout_marker() {
         let err = zypper(args("choose (c): c", "", 1)).unwrap_err();
+        assert_eq!(err.reason, "Dependency Error");
+    }
+
+    #[test]
+    fn both_markers_present_favors_the_dependency_prompt() {
+        // Unpinned before the fold, and would have flipped silently: the old
+        // inline order checked stderr's `Error:` before stdout's `(c): c`, so
+        // a transcript carrying both read as "RPM Error". `classified`'s
+        // shared `markers` checks the dependency prompt first, so the same
+        // transcript now reads "Dependency Error" — matching `update`.
+        let err = zypper(args("choose (c): c", "Error: boom", 1)).unwrap_err();
         assert_eq!(err.reason, "Dependency Error");
     }
 
@@ -327,9 +354,20 @@ mod tests {
             "transactional-update -n pkg install pkg-a",
             "",
             "",
-            -1,
+            EXIT_NOT_RUN,
         ))
         .expect_err("a command that never ran must fail the check");
+        assert_eq!(err.reason, "command timed out or failed to run");
+        assert_eq!(err.host.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn install_timed_out_reason_is_role_neutral_not_updates() {
+        // Mirrors `slmicro_timed_out_reason_is_its_own_not_updates`: this
+        // table also serves `uninstall`, so its own `-1` gate must answer in
+        // role-neutral wording, not the *update* check's vocabulary.
+        let err = zypper(args("", "", EXIT_NOT_RUN))
+            .expect_err("a command that never ran must fail the check");
         assert_eq!(err.reason, "command timed out or failed to run");
         assert_eq!(err.host.as_deref(), Some("h1"));
     }
@@ -356,14 +394,21 @@ mod tests {
         // documented `100` belongs to `check-update`, which no install or
         // uninstall doer runs), so routing this key through the shared
         // classifier would pass a failed transaction.
-        for code in [100, 101, 102, 103, 106, 107] {
+        for code in [
+            ZYPPER_EXIT_INF_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_REBOOT_NEEDED,
+            ZYPPER_EXIT_INF_RESTART_NEEDED,
+            ZYPPER_EXIT_INF_REPO_SKIPPED,
+            ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED,
+        ] {
             assert!(
                 yum(args_for("yum -y install pkg-a", "", "", code)).is_err(),
                 "zypper's informational exit {code} is not yum's"
             );
         }
         // (d) And the never-ran sentinel keeps its own reason.
-        let err = yum(args_for("yum -y install pkg-a", "", "", -1)).unwrap_err();
+        let err = yum(args_for("yum -y install pkg-a", "", "", EXIT_NOT_RUN)).unwrap_err();
         assert_eq!(err.reason, "command timed out or failed to run");
     }
 
@@ -408,9 +453,14 @@ mod tests {
         // and a failed transaction to yum/dnf, so this separates the YUM arm
         // from the zypper one, which (a) cannot.
         assert_eq!(
-            yum_fn(args_for("yum -y install pkg-a", "", "", 100))
-                .expect_err("zypper's informational band is not yum's")
-                .reason,
+            yum_fn(args_for(
+                "yum -y install pkg-a",
+                "",
+                "",
+                ZYPPER_EXIT_INF_UPDATE_NEEDED
+            ))
+            .expect_err("zypper's informational band is not yum's")
+            .reason,
             "Unknown Error"
         );
 

--- a/crates/mtui-testreport/src/update_workflow/checks/mod.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/mod.rs
@@ -91,6 +91,20 @@ pub struct CheckArgs<'a> {
 /// stable reason string otherwise.
 pub type CheckFn = Box<dyn Fn(CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> + Send + Sync>;
 
+/// zypper's documented exit codes, by their `zypper(8)` names.
+pub(crate) const ZYPPER_EXIT_ERR_ZYPP: i32 = 4;
+pub(crate) const ZYPPER_EXIT_ERR_PRIVILEGES: i32 = 5;
+pub(crate) const ZYPPER_EXIT_ERR_COMMIT: i32 = 8;
+pub(crate) const ZYPPER_EXIT_INF_UPDATE_NEEDED: i32 = 100;
+pub(crate) const ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: i32 = 101;
+pub(crate) const ZYPPER_EXIT_INF_REBOOT_NEEDED: i32 = 102;
+pub(crate) const ZYPPER_EXIT_INF_RESTART_NEEDED: i32 = 103;
+pub(crate) const ZYPPER_EXIT_INF_CAP_NOT_FOUND: i32 = 104;
+pub(crate) const ZYPPER_EXIT_INF_REPO_SKIPPED: i32 = 106;
+pub(crate) const ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED: i32 = 107;
+/// mtui's own "the command never produced a status" sentinel — *not* zypper's.
+pub(crate) const EXIT_NOT_RUN: i32 = -1;
+
 /// What a package manager's exit status says about the run.
 ///
 /// zypper's status is not a boolean. Quoting `man zypper` (verified against
@@ -100,13 +114,13 @@ pub type CheckFn = Box<dyn Fn(CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// information"* is not the same as *"the transaction committed"*. Two members
 /// of the band are not successes:
 ///
-/// * `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) — the requested capability was
+/// * `104` ([`ZYPPER_EXIT_INF_CAP_NOT_FOUND`]) — the requested capability was
 ///   not found, so nothing was installed. Classified [`PackageNotFound`].
 /// * `105` (`ZYPPER_EXIT_ON_SIGNAL`) — *"Returned upon exiting after receiving
 ///   a SIGINT or SIGTERM"*, i.e. aborted mid-flight. Classified [`Unknown`].
 ///
 /// Getting the band's *extent* wrong is not academic: `107`
-/// (`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`) sat outside it in the first version of
+/// ([`ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`]) sat outside it in the first version of
 /// this enum, which made a routine kernel/dracut `%posttrans` hiccup a failed
 /// update — and an `update` check failure fires the **group-wide** rollback
 /// downgrade, reverting every host in the group, not just the one that
@@ -160,7 +174,7 @@ pub(crate) enum ExitClass {
 /// bent into this shape (see the note there).
 ///
 /// The `104 | 4 | 5 | 8` grouping is the install check's, reproduced exactly:
-/// only `104` (`ZYPPER_EXIT_INF_CAP_NOT_FOUND`) literally means "capability not
+/// only `104` ([`ZYPPER_EXIT_INF_CAP_NOT_FOUND`]) literally means "capability not
 /// found", while `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT`.
 /// The grouping is preserved rather than re-derived, so that one exit code
 /// cannot be sorted into two different classes by two checks. What a check
@@ -183,9 +197,18 @@ pub(crate) enum ExitClass {
 /// [`Unknown`]: ExitClass::Unknown
 pub(crate) fn classify_exit(exitcode: i32) -> ExitClass {
     match exitcode {
-        0 | 100 | 101 | 102 | 103 | 106 | 107 => ExitClass::Success,
-        104 | 4 | 5 | 8 => ExitClass::PackageNotFound,
-        -1 => ExitClass::NotRun,
+        0
+        | ZYPPER_EXIT_INF_UPDATE_NEEDED
+        | ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED
+        | ZYPPER_EXIT_INF_REBOOT_NEEDED
+        | ZYPPER_EXIT_INF_RESTART_NEEDED
+        | ZYPPER_EXIT_INF_REPO_SKIPPED
+        | ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED => ExitClass::Success,
+        ZYPPER_EXIT_INF_CAP_NOT_FOUND
+        | ZYPPER_EXIT_ERR_ZYPP
+        | ZYPPER_EXIT_ERR_PRIVILEGES
+        | ZYPPER_EXIT_ERR_COMMIT => ExitClass::PackageNotFound,
+        EXIT_NOT_RUN => ExitClass::NotRun,
         _ => ExitClass::Unknown,
     }
 }
@@ -220,7 +243,15 @@ mod tests {
         // band, which is where it got missed the first time.
         //
         // Each of these failing would fire the group-wide rollback downgrade.
-        for code in [0, 100, 101, 102, 103, 106, 107] {
+        for code in [
+            0,
+            ZYPPER_EXIT_INF_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_REBOOT_NEEDED,
+            ZYPPER_EXIT_INF_RESTART_NEEDED,
+            ZYPPER_EXIT_INF_REPO_SKIPPED,
+            ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED,
+        ] {
             assert_eq!(
                 classify_exit(code),
                 ExitClass::Success,
@@ -231,7 +262,12 @@ mod tests {
 
     #[test]
     fn package_not_found_codes() {
-        for code in [104, 4, 5, 8] {
+        for code in [
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+            ZYPPER_EXIT_ERR_ZYPP,
+            ZYPPER_EXIT_ERR_PRIVILEGES,
+            ZYPPER_EXIT_ERR_COMMIT,
+        ] {
             assert_eq!(
                 classify_exit(code),
                 ExitClass::PackageNotFound,
@@ -270,6 +306,6 @@ mod tests {
         // (as it would be easy to assume) a wrong rollback: `never_ran` in
         // `reports::update_flow` vetoes the group-wide downgrade from the
         // target's `lastexit()`, not from anything a check returns.
-        assert_eq!(classify_exit(-1), ExitClass::NotRun);
+        assert_eq!(classify_exit(EXIT_NOT_RUN), ExitClass::NotRun);
     }
 }

--- a/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/prepare.rs
@@ -1,7 +1,7 @@
 //! Post-prepare check.
 
 use crate::update_workflow::UpdateError;
-use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, log_failed};
+use crate::update_workflow::checks::{CheckArgs, CheckFn, Diagnostic, EXIT_NOT_RUN, log_failed};
 
 /// The zypper prepare check.
 ///
@@ -80,7 +80,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// failed to run" (exit `-1`), "update stack locked", "Dependency Error", or
 /// "RPM Error".
 fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "prepare command timed out or failed to run",
@@ -115,7 +115,7 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 /// Returns [`UpdateError`] with a reason of "prepare command timed out or
 /// failed to run" when the command recorded exit `-1`.
 fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         log_failed(args);
         return Err(UpdateError::new(
             "prepare command timed out or failed to run",
@@ -140,6 +140,7 @@ pub(crate) fn prepare_check(release: &str, transactional: bool) -> Option<CheckF
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update_workflow::checks::ZYPPER_EXIT_INF_CAP_NOT_FOUND;
 
     fn args<'a>(stdout: &'a str, stderr: &'a str) -> CheckArgs<'a> {
         CheckArgs {
@@ -299,7 +300,7 @@ mod tests {
             ("slmicro", prepare_check("slmicro", true).unwrap()),
             ("yum", prepare_check("YUM", false).unwrap()),
         ] {
-            let Err(err) = check(args_for("some prepare command", "", "", -1)) else {
+            let Err(err) = check(args_for("some prepare command", "", "", EXIT_NOT_RUN)) else {
                 panic!("{name} must fail on exit -1");
             };
             assert_eq!(
@@ -337,10 +338,10 @@ mod tests {
         // Nor are zypper's exit-code classes transferable: `104` is
         // `ZYPPER_EXIT_INF_CAP_NOT_FOUND`, which means nothing to yum. Reusing
         // the shared classifier here would fail this host.
-        assert!(yum(args_for(&plain, "", "", 104)).is_ok());
+        assert!(yum(args_for(&plain, "", "", ZYPPER_EXIT_INF_CAP_NOT_FOUND)).is_ok());
 
         // What it does catch: the command never ran to completion.
-        let err = yum(args_for(&plain, "", "", -1)).unwrap_err();
+        let err = yum(args_for(&plain, "", "", EXIT_NOT_RUN)).unwrap_err();
         assert_eq!(err.reason, "prepare command timed out or failed to run");
     }
 

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -10,7 +10,8 @@
 
 use crate::update_workflow::UpdateError;
 use crate::update_workflow::checks::{
-    CheckArgs, CheckFn, Diagnostic, ExitClass, classify_exit, log_failed,
+    CheckArgs, CheckFn, Diagnostic, EXIT_NOT_RUN, ExitClass, ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+    ZYPPER_EXIT_INF_REPO_SKIPPED, classify_exit, log_failed,
 };
 
 /// The zypper update check.
@@ -64,7 +65,7 @@ fn zypper(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     if !args.stdin.contains("zypper") {
         return markers(args);
     }
-    if args.exitcode == 106 {
+    if args.exitcode == ZYPPER_EXIT_INF_REPO_SKIPPED {
         tracing::warn!(
             host = args.hostname,
             stderr = args.stderr,
@@ -199,7 +200,7 @@ fn transactional_update(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateEr
 pub(super) fn classified(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
     match classify_exit(args.exitcode) {
         ExitClass::Success => markers(args),
-        ExitClass::PackageNotFound if args.exitcode == 104 => {
+        ExitClass::PackageNotFound if args.exitcode == ZYPPER_EXIT_INF_CAP_NOT_FOUND => {
             log_failed(args);
             Err(UpdateError::new("package not found", args.hostname))
         }
@@ -274,7 +275,7 @@ fn yum(args: CheckArgs<'_>) -> Result<Vec<Diagnostic>, UpdateError> {
 /// Returns [`UpdateError`] with a reason of "update command timed out or
 /// failed to run".
 fn not_run(args: CheckArgs<'_>) -> Result<(), UpdateError> {
-    if args.exitcode == -1 {
+    if args.exitcode == EXIT_NOT_RUN {
         return Err(not_run_error(args));
     }
     Ok(())
@@ -468,6 +469,12 @@ pub(crate) fn update_check(release: &str, transactional: bool) -> Option<CheckFn
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update_workflow::checks::{
+        ZYPPER_EXIT_ERR_COMMIT, ZYPPER_EXIT_ERR_PRIVILEGES, ZYPPER_EXIT_ERR_ZYPP,
+        ZYPPER_EXIT_INF_REBOOT_NEEDED, ZYPPER_EXIT_INF_RESTART_NEEDED,
+        ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED, ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED,
+        ZYPPER_EXIT_INF_UPDATE_NEEDED,
+    };
 
     fn args<'a>(stdin: &'a str, stdout: &'a str, stderr: &'a str, exitcode: i32) -> CheckArgs<'a> {
         CheckArgs {
@@ -483,7 +490,13 @@ mod tests {
     fn zypper_104_is_package_not_found() {
         // zypper + exit 104 is "package not found"
         // (ZYPPER_EXIT_INF_CAP_NOT_FOUND), matching the install check.
-        let err = zypper(args("zypper -n patch", "", "", 104)).unwrap_err();
+        let err = zypper(args(
+            "zypper -n patch",
+            "",
+            "",
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+        ))
+        .unwrap_err();
         assert_eq!(err.reason, "package not found");
     }
 
@@ -492,7 +505,7 @@ mod tests {
         // 104 only means "package not found" when the command was a zypper
         // invocation. (The old name said "lock branch"; there is no such
         // branch on 104 — the lock verdict comes from the stderr markers.)
-        assert!(zypper(args("yum update", "", "", 104)).is_ok());
+        assert!(zypper(args("yum update", "", "", ZYPPER_EXIT_INF_CAP_NOT_FOUND)).is_ok());
     }
 
     #[test]
@@ -534,13 +547,13 @@ mod tests {
     fn warnings_do_not_fail_the_check() {
         let stdout = "before Additional rpm output:\nwarning: stuff\nRetrieving repo\nafter";
         // exit 106 warn + additional rpm output warn, still Ok.
-        assert!(zypper(args("zypper", stdout, "", 106)).is_ok());
+        assert!(zypper(args("zypper", stdout, "", ZYPPER_EXIT_INF_REPO_SKIPPED)).is_ok());
     }
 
     #[test]
     fn additional_rpm_output_returned_as_highlighted_diagnostic() {
         let stdout = "before Additional rpm output:\nwarning: stuff\nRetrieving repo\nafter";
-        let diags = zypper(args("zypper", stdout, "", 106)).unwrap();
+        let diags = zypper(args("zypper", stdout, "", ZYPPER_EXIT_INF_REPO_SKIPPED)).unwrap();
         assert_eq!(diags.len(), 1);
         assert!(diags[0].highlight_warning);
         assert_eq!(diags[0].text, "\nwarning: stuff\n");
@@ -707,7 +720,15 @@ mod tests {
         // classifier's own test and this one are the two places a code can be
         // forgotten, and `107` was in fact missing from the band on the first
         // pass.
-        for code in [0, 100, 101, 102, 103, 106, 107] {
+        for code in [
+            0,
+            ZYPPER_EXIT_INF_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED,
+            ZYPPER_EXIT_INF_REBOOT_NEEDED,
+            ZYPPER_EXIT_INF_RESTART_NEEDED,
+            ZYPPER_EXIT_INF_REPO_SKIPPED,
+            ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED,
+        ] {
             assert!(
                 zypper(args("zypper -n in -t patch", "all good", "", code)).is_ok(),
                 "zypper must pass on informational exit {code}"
@@ -727,7 +748,12 @@ mod tests {
         // by two checks. The transcripts here are clean, which is when the
         // class label is also the message; see `only_104_outranks_the_markers`
         // for what the three inaccurate members say when it is not.
-        for code in [104, 4, 5, 8] {
+        for code in [
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+            ZYPPER_EXIT_ERR_ZYPP,
+            ZYPPER_EXIT_ERR_PRIVILEGES,
+            ZYPPER_EXIT_ERR_COMMIT,
+        ] {
             let err = zypper(args("zypper -n in -t patch", "", "", code)).unwrap_err();
             assert_eq!(err.reason, "package not found", "zypper exit {code}");
             let err = transactional_update(args("transactional-update -n pkg in", "", "", code))
@@ -760,12 +786,12 @@ mod tests {
                 .render_command(&vars.into_iter().collect())
                 .expect("safe substitution never fails");
 
-            let err = check(args(&rendered, "", "", 104)).unwrap_err();
+            let err = check(args(&rendered, "", "", ZYPPER_EXIT_INF_CAP_NOT_FOUND)).unwrap_err();
             assert_eq!(err.reason, "package not found", "{key}");
             let err = check(args(&rendered, "", "", 7)).unwrap_err();
             assert_eq!(err.reason, "Unknown Error", "{key}");
             assert!(
-                check(args(&rendered, "", "", 102)).is_ok(),
+                check(args(&rendered, "", "", ZYPPER_EXIT_INF_REBOOT_NEEDED)).is_ok(),
                 "{key}: 102 is 'reboot needed'"
             );
         }
@@ -776,7 +802,13 @@ mod tests {
         // `104` is the one member of its class that literally means "capability
         // not found", and the one whose verdict a marker cannot improve on: it
         // short-circuits even with a marker present.
-        let err = zypper(args("zypper", "", "System management is locked", 104)).unwrap_err();
+        let err = zypper(args(
+            "zypper",
+            "",
+            "System management is locked",
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+        ))
+        .unwrap_err();
         assert_eq!(err.reason, "package not found", "104 outranks the marker");
 
         // `4`/`5`/`8` are `ERR_ZYPP`, `ERR_PRIVILEGES` and `ERR_COMMIT` — the
@@ -784,20 +816,31 @@ mod tests {
         // headline real-world patch failures, so the transcript names them
         // rather than the class label. Restoring the blanket short-circuit
         // turns every one of these into "package not found".
-        let err = zypper(args("zypper", "", "System management is locked", 5)).unwrap_err();
+        let err = zypper(args(
+            "zypper",
+            "",
+            "System management is locked",
+            ZYPPER_EXIT_ERR_PRIVILEGES,
+        ))
+        .unwrap_err();
         assert_eq!(err.reason, "update stack locked", "5 + lock marker");
         let err = zypper(args(
             "zypper",
             "",
             "A ZYpp transaction is already in progress.",
-            4,
+            ZYPPER_EXIT_ERR_ZYPP,
         ))
         .unwrap_err();
         assert_eq!(err.reason, "update stack locked", "4 + ZYpp marker");
-        let err = zypper(args("zypper", "(c): c", "", 4)).unwrap_err();
+        let err = zypper(args("zypper", "(c): c", "", ZYPPER_EXIT_ERR_ZYPP)).unwrap_err();
         assert_eq!(err.reason, "Dependency Error", "4 + dependency prompt");
-        let err =
-            transactional_update(args("transactional-update", "", "Error: boom", 8)).unwrap_err();
+        let err = transactional_update(args(
+            "transactional-update",
+            "",
+            "Error: boom",
+            ZYPPER_EXIT_ERR_COMMIT,
+        ))
+        .unwrap_err();
         assert_eq!(err.reason, "RPM Error", "8 + rpm marker");
 
         // What the three say on a *clean* transcript is already pinned by
@@ -820,7 +863,12 @@ mod tests {
         // whose status the transport lost would otherwise be reported as a
         // clean update.
         let marker = format!("{PROBE_FAILURE_MARKER}: zypper -n patches exited 6");
-        for code in [0, 7, 104, 106] {
+        for code in [
+            0,
+            7,
+            ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+            ZYPPER_EXIT_INF_REPO_SKIPPED,
+        ] {
             for (name, check) in [
                 ("zypper", update_check("15", false).unwrap()),
                 ("transactional", update_check("slmicro", true).unwrap()),

--- a/crates/mtui-testreport/src/update_workflow/checks/update.rs
+++ b/crates/mtui-testreport/src/update_workflow/checks/update.rs
@@ -843,6 +843,37 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.reason, "RPM Error", "8 + rpm marker");
 
+        // The install check shares this classifier now, so it must answer
+        // identically on every one of the four rows above — asserted here so
+        // the two checks cannot re-diverge without this test catching it.
+        let install_zypper = crate::update_workflow::checks::install::install_check("15", false)
+            .expect("the zypper key has an install check");
+        for (stdout, stderr, code, expected) in [
+            (
+                "",
+                "System management is locked",
+                ZYPPER_EXIT_INF_CAP_NOT_FOUND,
+                "package not found",
+            ),
+            (
+                "",
+                "System management is locked",
+                ZYPPER_EXIT_ERR_PRIVILEGES,
+                "update stack locked",
+            ),
+            (
+                "",
+                "A ZYpp transaction is already in progress.",
+                ZYPPER_EXIT_ERR_ZYPP,
+                "update stack locked",
+            ),
+            ("(c): c", "", ZYPPER_EXIT_ERR_ZYPP, "Dependency Error"),
+            ("", "Error: boom", ZYPPER_EXIT_ERR_COMMIT, "RPM Error"),
+        ] {
+            let err = install_zypper(args("zypper", stdout, stderr, code)).unwrap_err();
+            assert_eq!(err.reason, expected, "install exit {code}");
+        }
+
         // What the three say on a *clean* transcript is already pinned by
         // `package_not_found_codes_on_both_zypper_keys`, which passes empty
         // stdout and stderr for all four codes. Repeating it here would


### PR DESCRIPTION
## Summary

Names the repeated numeric literals in `mtui-testreport`'s zypper
exit-code checks, plus a handful of smaller repeated magic numbers
elsewhere in the workspace, and folds the zypper `install` check onto
`update`'s exit-code/marker classifier so the two cannot silently
diverge on the same transcript.

## Changes

- **Exit-code constants** (`checks::mod`): `ZYPPER_EXIT_*` and
  `EXIT_NOT_RUN` replace bare `100`-`107`/`4`/`5`/`8`/`-1` literals
  across the update/downgrade/prepare/install checks — pure
  literal-to-name, no behaviour change.
- **`install::zypper` now delegates to `update::classified`** instead
  of restating the same three exit-code sets inline in a different
  order. This is a real behaviour change on the zypper release keys
  (`11`/`12`/`15`/`16`, `install`/`uninstall`): reason strings for
  `4`/`5`/`8` and for a command that never ran now match `update`'s;
  see the CHANGELOG entry for the exact deltas.
- **Small repeated constants**: `MAX_ERROR_SOURCE_LINKS`
  (mtui-datasources), `DEFAULT_SSH_PORT` (mtui-hosts),
  `DEFAULT_TERM_COLS`/`DEFAULT_TERM_ROWS` (mtui-core, shared with
  mtui-cli's shell resize fallback).
- **One host-close timeout**: `quit`'s, `template_registry`'s and
  `mtui-mcp`'s separately-declared 45s `Duration` constants are now a
  single `Session::HOST_CLOSE_TIMEOUT`.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features`
- `cargo build --workspace --all-features`
- New/changed behaviour in the install-check fold was verified red
  before green (a role-neutral timeout gate, a both-markers ordering
  case, and the install/update reason-string convergence).