### PR TITLE
feat(testreport): list_metadata reports RRID, Rating and Gitea PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   update-repository URL layout for a git-served `SLFO:1.1` update (previously
   always treated as OBS-served) and restores the approve-time Gitea
   checkout-hash comparison for it (previously always skipped).
+- `list_metadata` now reports `ReviewRequestID`, `Rating` and the Gitea PR
+  where the template carries one, and no longer emits the always-empty
+  `Hosts` row.
 
 ### Fixed
 

--- a/crates/mtui-core/src/commands/removehost.rs
+++ b/crates/mtui-core/src/commands/removehost.rs
@@ -17,8 +17,8 @@ use crate::session::Session;
 /// [`TestReport::release_pool_claim`](mtui_testreport::TestReport::release_pool_claim)
 /// (without which a scarce-pool host stays marked busy in the process-global
 /// [`HostArbiter`](mtui_hosts::HostArbiter) for the rest of a long-lived MCP
-/// session), removes it from the group, and drops its `systems` entry. With no
-/// `-t` argument every host is removed.
+/// session), and removes it from the group. With no `-t` argument every host
+/// is removed.
 pub struct RemoveHost;
 
 #[async_trait]
@@ -63,12 +63,6 @@ impl Command for RemoveHost {
             // Release the in-process arbiter claim + prune slot candidates;
             // no-op when unpooled.
             session.metadata_mut().release_pool_claim(name);
-            // Drop the per-host system entry.
-            session
-                .metadata_mut()
-                .base_mut()
-                .systems
-                .remove(name.as_str());
         }
         session
             .display

--- a/crates/mtui-testreport/src/testreport.rs
+++ b/crates/mtui-testreport/src/testreport.rs
@@ -56,8 +56,6 @@ pub struct TestReportBase {
     pub workflow: Workflow,
     /// Path to the loaded testreport file, or `None` when nothing is loaded.
     pub path: Option<PathBuf>,
-    /// `hostname -> system` mapping.
-    pub systems: HashMap<String, String>,
     /// Connected reference-host targets.
     pub targets: HostsGroup,
     /// `SystemProduct -> repository` map for the update repositories.
@@ -165,7 +163,6 @@ impl TestReportBase {
             config,
             workflow: Workflow::Manual,
             path: None,
-            systems: HashMap::new(),
             targets: HostsGroup::new(Vec::new(), false),
             update_repos: HashMap::new(),
             hostnames: HashSet::new(),
@@ -513,14 +510,6 @@ pub trait TestReport {
     /// label. The caller renders each surviving row as `{label:15}: {value}`.
     fn show_yourself_data(&self) -> Vec<(String, String)> {
         let base = self.base();
-        let mut systems: Vec<&String> = base.systems.keys().collect();
-        systems.sort();
-        let hosts = systems
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<_>>()
-            .join(" ");
-
         let mut bug_ids: Vec<&String> = base.bugs.keys().collect();
         bug_ids.sort();
         let mut jira_ids: Vec<&String> = base.jira.keys().collect();
@@ -534,7 +523,18 @@ pub trait TestReport {
 
         let mut rows: Vec<(String, String)> = vec![
             ("Category".to_owned(), base.category.clone()),
-            ("Hosts".to_owned(), hosts),
+            (
+                "ReviewRequestID".to_owned(),
+                base.rrid
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            ),
+            ("Rating".to_owned(), base.rating.clone().unwrap_or_default()),
+            (
+                "Gitea PR".to_owned(),
+                base.giteapr.clone().unwrap_or_default(),
+            ),
             ("Reviewer".to_owned(), base.reviewer.clone()),
             (
                 "Slack Review".to_owned(),
@@ -1055,7 +1055,6 @@ mod tests {
 
         assert_eq!(base.workflow, Workflow::Manual);
         assert!(base.path.is_none());
-        assert!(base.systems.is_empty());
         assert!(base.update_repos.is_empty());
         assert!(base.hostnames.is_empty());
         assert_eq!(base.lock_comment, "");
@@ -1219,8 +1218,10 @@ mod tests {
         base.reviewer = "alice".to_owned();
         base.bugs.insert("1200000".to_owned(), "boom".to_owned());
         base.jira.insert("PED-1".to_owned(), "epic".to_owned());
-        base.systems.insert("h1".to_owned(), "SLES-15.5".to_owned());
         base.testplatforms.push("base=sles".to_owned());
+        base.rrid = Some("SUSE:Maintenance:1:1".parse().unwrap());
+        base.rating = Some("moderate".to_owned());
+        base.giteapr = Some("42".to_owned());
         MetaReport { base }
     }
 
@@ -1256,6 +1257,9 @@ mod tests {
         assert!(has("Reviewer"));
         assert!(has("Bugs"));
         assert!(has("Testplatform"));
+        assert!(has("ReviewRequestID"));
+        assert!(has("Rating"));
+        assert!(has("Gitea PR"));
         assert!(!has("Packager"));
         // Build checks strips the trailing "log".
         let build = rows.iter().find(|(l, _)| l == "Build checks").unwrap();


### PR DESCRIPTION
## Summary

- Drop the `Hosts` row from `list_metadata`'s shared row set — it read `TestReportBase::systems`, a field no production code ever wrote (only `remove_host` cleared it), so the row was always empty and always dropped anyway.
- Delete `TestReportBase::systems` entirely now that nothing reads it.
- Add `ReviewRequestID`, `Rating` and `Gitea PR` rows, sourced from `base.rrid`/`base.rating`/`base.giteapr`. These are parsed from every metadata envelope but were previously displayed nowhere — for a git-served template that meant `list_metadata` showed neither its RRID nor the Gitea PR that distinguishes it from an OBS template.

No per-report override or `update_source` dispatch needed: the existing empty-value-drop behavior already does the right thing per template (Null report has no RRID → omitted; OBS/PI report has no Gitea PR → omitted).

## Test plan

- `cargo test -p mtui-testreport show_yourself` (extended fixture + assertions, observed red before the fix, green after)
- `cargo test -p mtui-core listmetadata`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items`
- `cargo test --workspace`
- `cargo test -p mtui-mcp -F mcp`
- `cargo build --workspace --no-default-features` / `--all-features`