### PR TITLE
chore(release): open the 26.3.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [26.2.1] - 2026-08-21
+
 ### Added
 
 - `updates` gained osc-qam-style field selection and a scripting output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-cli"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-config"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "directories",
  "mtui-types",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-core"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-datasources"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "async-trait",
  "base64ct",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-hosts"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-mcp"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-testreport"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "mtui-types"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "insta",
  "sandogasa-rpmvercmp",
@@ -5445,7 +5445,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "26.2.0"
+version = "26.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "xtask"]
 
 [workspace.package]
-version = "26.2.0"
+version = "26.3.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-or-later"   # intentional deviation from upstream mtui (GPL-2.0-only); see LICENSE

--- a/dist/man/mtui-mcp.1
+++ b/dist/man/mtui-mcp.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui-mcp 1  "mtui-mcp 26.2.0" 
+.TH mtui-mcp 1  "mtui-mcp 26.3.0" 
 .SH NAME
 mtui\-mcp \- MCP server for mtui (tools synthesised from the command registry)
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.2.0
+v26.3.0

--- a/dist/man/mtui.1
+++ b/dist/man/mtui.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH mtui 1  "mtui 26.2.0" 
+.TH mtui 1  "mtui 26.3.0" 
 .SH NAME
 mtui \- Maintenance Test Update Installer
 .SH SYNOPSIS
@@ -63,4 +63,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v26.2.0
+v26.3.0


### PR DESCRIPTION
## Why

`26.2.x` forked from `58f41c05` and owns the patch line (it has already cut
`26.2.1`). The main line therefore opens its next development cycle at
**26.3.0**, and needs the changelog reconciled with what the release branch
actually shipped.

## What

- **`chore(release): cut 26.2.1`** — cherry-picked from `bbd764bf` on
  `26.2.x`, so `CHANGELOG.md` is byte-identical across the two branches and
  `[Unreleased]` opens empty for 26.3.0 work.
- **`chore(release): bump version to 26.3.0`** — `[workspace.package] version`
  in `Cargo.toml` (the single source; every crate inherits it), the 9
  workspace-member entries in `Cargo.lock` restamped via `cargo check
  --workspace` (no third-party churn), and `dist/man/{mtui,mtui-mcp}.1`
  regenerated with `cargo xtask gen`. `docs/src/{cli,invocation}.md`
  (`cargo xtask gen-docs`) produced no diff — already up to date.

No tag and no packaging change: this is a development-version bump, not a
release.

**Note for reviewers:** `26.2.1`'s Unreleased section carried a
`1a0ae6b0 feat(types)!` breaking-change marker and a full `### Added` block,
yet shipped as a patch release. That is intentional — the minor bump already
happened when main opened `26.2.0` — not a numbering mistake to fix here.

## Verification

Full gate, observed green locally:

| check | result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace` | 0 failed |
| `cargo test -p mtui-mcp -F mcp` | 53 passed, 0 failed |
| `cargo build --workspace --no-default-features` | ok |
| `cargo build --workspace --all-features` | ok |

`git diff 26.2.x -- CHANGELOG.md` is empty.

## Changelog

None. A version bump is not a user-visible change; the only `CHANGELOG.md`
edit here is the 26.2.1 reconciliation itself.