### PR TITLE
docs: reconcile the README with the code, and regenerate the stale bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ authenticated boundary trusted to operate the remaining maintenance tools.
 
 - Parallel SSH command execution across reference hosts (`run`, `update`,
   `install`, `prepare`, `downgrade`, …) with per-host `enabled`/`disabled`
-  states and `parallel`/`serial` modes. **Pubkey auth only.**
+  states. **Pubkey auth only.**
 - OBS/IBS and Gitea maintenance-request workflow (`assign`, `approve`, `reject`,
   `comment`, …) via the native OBS/IBS API (no `osc` subprocess).
 - Optional Slack review-request integration (`request_review`, off by default):
@@ -57,8 +57,10 @@ authenticated boundary trusted to operate the remaining maintenance tools.
   regeneration (`regenerate`).
 - Reference-host discovery via `refhosts.yml` (HTTPS- or filesystem-resolved,
   cached) and offline inventory search (`list_refhosts`).
-- Cooperative reference-host locking (`/var/lock/mtui.lock`) so concurrent
-  testers can share a fleet.
+- Cooperative reference-host locking so concurrent testers can share a fleet: a
+  PID-based operation lock (`/var/lock/mtui.lock`) serializing repository
+  transactions, and an RRID-based pool claim (`/var/lock/mtui-pool.lock`)
+  reserving a host for a template.
 - Test-report lifecycle: `load_template`, `checkout`, `commit`, `edit`, `export`
   (SVN and Gitea backends).
 - File transfer (`put`/`get`) over SFTP.
@@ -75,7 +77,7 @@ build-from-source, install, and packaging details.
 ```sh
 cargo build --workspace              # build all crates
 cargo run -p mtui-cli -- --help      # run the REPL binary (mtui)
-cargo run -p mtui-mcp -- --help      # run the MCP server (mtui-mcp)
+cargo run -p mtui-mcp --features mcp -- --help   # run the MCP server (mtui-mcp)
 cargo test --workspace               # run tests
 cargo fmt --all --check              # formatting gate
 cargo clippy --workspace --all-targets -- -D warnings   # lint gate

--- a/dist/completions/bash/mtui-mcp.bash
+++ b/dist/completions/bash/mtui-mcp.bash
@@ -1,4 +1,4 @@
-_mtui-mcp() {
+_mtui__mcp() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -92,7 +92,7 @@ _mtui-mcp() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _mtui-mcp -o nosort -o bashdefault -o default mtui-mcp
+    complete -F _mtui__mcp -o nosort -o bashdefault -o default mtui-mcp
 else
-    complete -F _mtui-mcp -o bashdefault -o default mtui-mcp
+    complete -F _mtui__mcp -o bashdefault -o default mtui-mcp
 fi


### PR DESCRIPTION
A documentation pass over the README, which last moved 144 commits ago
(`f2798759`, spanning 26.1.2 through 26.3.0) and had drifted. Every claim was
checked against the code; only the ones that were actually wrong were touched.

## `docs(readme)` — three corrections

**The MCP build line did not work.** `mtui-mcp` declares no default features,
so `cargo run -p mtui-mcp -- --help` prints the *"built without the `mcp`
feature"* stub rather than the server's help. Every other doc —
`installation.md`, `developer.md`, `mcp.md`, `CONTRIBUTING.md`, `AGENTS.md` —
already carried the `--features mcp` form; the README was the sole outlier.
Both spellings were run to confirm which reaches the parser.

**`parallel`/`serial` host modes do not exist.** `TargetState` is
`enabled`/`disabled` only, no command exposes a serial flag, and the token
appears nowhere in the generated `cli.md`.

**The locking bullet named only `/var/lock/mtui.lock`.** Both lock files are
cross-process wire-format contracts, and the pool claim is what actually lets
concurrent testers share a fleet — the property the bullet claims. Wording
follows `locks.rs`.

## `chore(dist)` — regenerate the `mtui-mcp` bash completion

`cargo xtask gen` should be reproducible against the checked-in tree, and for
every other artifact it is: both man pages, the zsh and fish completions, and
the two generated mdBook pages all came back byte-identical. Only this file
did not — it predates a `clap_complete` change that mangles the binary's
hyphen when deriving the shell function name, so regenerating `dist/` always
surfaced an unrelated diff. No CI job checks generated-artifact freshness, so
this drifted silently; `dist/*` is shipped by `release.yml`, so it does reach
users.

The function is now `_mtui__mcp`; the definition and both `complete -F`
registrations move together, so completion behaves identically.

## Verification

- `cargo run -p mtui-mcp --features mcp -- --help` — reaches the parser; the
  bare form reproduces the stub.
- `cargo xtask gen-docs` + `cargo xtask gen` — tree now regenerates clean.
- `bash -n` on the completion; no stale `_mtui-mcp` reference remains.
- `cargo test -p xtask` — passes (its assertions pin generated *filenames*,
  not the function identifier).

No Rust source changed, so the compile/clippy/test gates are unaffected.

## Deliberately out of scope

- **`docs/src/**`** — actively maintained across the change set (`faq.md`
  covers the Ctrl-C contract #441, `mcp.md` the in-band `get`/`put` override
  #434 and forced-cancel lock release #405). Spot-checked `concepts.md`,
  `introduction.md`, `installation.md`; no drift found.
- **`updates` / openQA-`ruoqa` flag detail** — the README's coarse
  descriptions remain accurate; flag-level detail belongs in the generated
  reference, where it already is.
- **`vim-plugin` naming** — the README's phrasing versus the
  `mtui-vim-plugin` subpackage name is ambiguous rather than wrong.

## Changelog

No entry on either commit: documentation-only, and the completion
regeneration carries no user-visible behaviour change.
